### PR TITLE
refactor(decopilot): dedupe title-interceptor's ReadableStream variant

### DIFF
--- a/apps/api/src/api/routes/decopilot/title-interceptor.ts
+++ b/apps/api/src/api/routes/decopilot/title-interceptor.ts
@@ -97,74 +97,30 @@ export async function* interceptTitleChunks(
   }
 }
 
+function asReadableStream<T>(source: AsyncIterable<T>): ReadableStream<T> {
+  const iter = source[Symbol.asyncIterator]();
+  return new ReadableStream<T>({
+    async pull(controller) {
+      try {
+        const { value, done } = await iter.next();
+        if (done) controller.close();
+        else controller.enqueue(value);
+      } catch (err) {
+        controller.error(err);
+      }
+    },
+    async cancel(reason) {
+      await iter.return?.(reason);
+    },
+  });
+}
+
+// A ReadableStream is itself async-iterable, so this is just
+// `interceptTitleChunks` re-wrapped as a ReadableStream — same gating logic,
+// one tested implementation (see title-interceptor.test.ts).
 export function interceptTitleChunkStream(
   source: ReadableStream<UIMessageChunk>,
   deps: TitleInterceptorDeps,
 ): ReadableStream<UIMessageChunk> {
-  const persistTitleFn =
-    deps.persistTitle ??
-    ((threadId: string, title: string) =>
-      deps.ctx.storage.threads.update(threadId, { title }).then(() => {}));
-
-  let triggered = false;
-
-  return source.pipeThrough(
-    new TransformStream<UIMessageChunk, UIMessageChunk>({
-      async transform(chunk, controller) {
-        if (isTitleInputChunk(chunk)) {
-          console.warn(
-            "[title-interceptor] harness emitted deprecated data-title-input chunk; ignoring",
-          );
-          return;
-        }
-
-        if (isTitleResultChunk(chunk)) {
-          if (triggered) {
-            console.warn(
-              "[title-interceptor] harness emitted multiple data-title-result chunks; ignoring extra",
-            );
-            return;
-          }
-          triggered = true;
-
-          if (deps.currentThreadTitle !== DEFAULT_THREAD_TITLE) return;
-
-          const title = chunk.data.title;
-          if (!title) return;
-
-          await persistTitleFn(deps.threadId, title).catch((err) => {
-            console.error(
-              "[title-interceptor] persist failed for thread",
-              deps.threadId,
-              err,
-            );
-          });
-
-          try {
-            await deps.onTitleUpdated?.(title);
-          } catch (err) {
-            console.error(
-              "[title-interceptor] onTitleUpdated callback failed",
-              err,
-            );
-          }
-
-          if (!deps.isStreamFinished()) {
-            try {
-              deps.writer.write({
-                type: "data-thread-title",
-                data: { title },
-                transient: true,
-              } as UIMessageChunk);
-            } catch (err) {
-              console.error("[title-interceptor] writer.write failed", err);
-            }
-          }
-          return;
-        }
-
-        controller.enqueue(chunk);
-      },
-    }),
-  );
+  return asReadableStream(interceptTitleChunks(source, deps));
 }


### PR DESCRIPTION
**Source:** C1 code reduction found while sweeping `apps/api/src/api/routes/decopilot/` (the decopilot-routes area had already been deep-audited twice today for bugs/races per this bot's own memory, so this pass targeted duplication instead).

**What:** `title-interceptor.ts` had two near-identical implementations of the same title-chunk-gating logic (swallow deprecated `data-title-input`, persist once on `data-title-result` gated on `currentThreadTitle === DEFAULT_THREAD_TITLE`, invoke `onTitleUpdated`, write `data-thread-title` unless the stream finished) — `interceptTitleChunks` (async generator, tested in `title-interceptor.test.ts`) and `interceptTitleChunkStream` (a parallel `TransformStream` body with the exact same branches, untested). A `ReadableStream` is itself async-iterable, so `interceptTitleChunkStream` now just delegates to `interceptTitleChunks` and re-wraps the result as a `ReadableStream` via a small pull-based adapter (the same `asReadableStream` helper pattern already used in `consume-harness-stream.ts`).

**Payoff:** one gating implementation instead of two that had to be kept in sync by hand — the exact kind of copy-paste this repo's C1 guidance flags. Net: -44 lines (-66/+22), no behavior change.

**Why safe:** both branches in `consume-harness-stream.ts` (the only caller of either function) still get identical output — `interceptTitleChunkStream` is now provably running the same code path `interceptTitleChunks` already has full unit coverage for, rather than a hand-duplicated copy that had zero direct tests.

**Verification:**
- `bunx tsc --noEmit` in `apps/api` — clean.
- `bun test apps/api/src/api/routes/decopilot/title-interceptor.test.ts` — 8 pass.
- `bun test apps/api/src/api/routes/decopilot/consume-harness-stream.test.ts` (exercises both call sites of the two functions) — 14 pass.
- `bunx oxlint apps/api/src/api/routes/decopilot/title-interceptor.ts` — 0 warnings/errors.
- `bun run fmt` — clean.

Full CI (lint/typecheck across the monorepo, e2e) still runs as usual; a reviewer can re-run the two test files above plus `git diff` to confirm the two functions now share one implementation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduped the decopilot title gating: `interceptTitleChunkStream` now delegates to the tested `interceptTitleChunks` and re-emits via a small `ReadableStream` adapter. No behavior changes; one implementation to maintain and -44 LOC.

- **Refactors**
  - Removed duplicate TransformStream logic in `title-interceptor.ts`.
  - Added a small `asReadableStream` adapter to wrap the async generator.
  - Reuses the pattern from `consume-harness-stream.ts`; callers see identical output.

<sup>Written for commit bc00e5cb10699a69287c0c4f1cc215a04faac689. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

