### PR TITLE
fix(chat): translate remaining hardcoded strings in prompt-arguments dialog

### DIFF
--- a/apps/web/src/components/chat/dialog-prompt-arguments.tsx
+++ b/apps/web/src/components/chat/dialog-prompt-arguments.tsx
@@ -37,11 +37,13 @@ interface PromptArgsDialogProps {
   defaultValues?: PromptArgumentValues;
 }
 
-function buildArgumentSchema(prompt: Prompt | null) {
+function buildArgumentSchema(prompt: Prompt | null, requiredMessage: string) {
   const shape: Record<string, z.ZodString> = {};
 
   for (const arg of prompt?.arguments ?? []) {
-    shape[arg.name] = arg.required ? z.string().min(1, "Required") : z.string();
+    shape[arg.name] = arg.required
+      ? z.string().min(1, requiredMessage)
+      : z.string();
   }
 
   return z.object(shape);
@@ -66,7 +68,10 @@ export function PromptArgsDialog({
 }: PromptArgsDialogProps) {
   const id = useId();
   const t = useT();
-  const schema = buildArgumentSchema(prompt);
+  const schema = buildArgumentSchema(
+    prompt,
+    t("chat.dialogPromptArguments.required"),
+  );
   const form = useForm<PromptArgumentValues>({
     resolver: zodResolver(schema),
     defaultValues: prompt ? buildDefaultValues(prompt, defaultValues) : {},
@@ -129,7 +134,7 @@ export function PromptArgsDialog({
                       {arg.required ? null : (
                         <span className="text-muted-foreground font-normal">
                           {" "}
-                          (optional)
+                          {t("chat.dialogPromptArguments.optional")}
                         </span>
                       )}
                     </FormLabel>

--- a/apps/web/src/i18n/en/chat.ts
+++ b/apps/web/src/i18n/en/chat.ts
@@ -167,6 +167,8 @@ export const chat = {
   "chat.decopilot.tryAnotherProviderOrRetry": "Try another provider or retry.",
   "chat.dialogPromptArguments.cancel": "Cancel",
   "chat.dialogPromptArguments.loading": "Loading...",
+  "chat.dialogPromptArguments.optional": "(optional)",
+  "chat.dialogPromptArguments.required": "Required",
   "chat.dialogPromptArguments.usePrompt": "Use prompt",
   "chat.generateImage.failed": "Failed",
   "chat.generateImage.generatedImage": "Generated image",

--- a/apps/web/src/i18n/pt-br/chat.ts
+++ b/apps/web/src/i18n/pt-br/chat.ts
@@ -173,6 +173,8 @@ export const chat = {
     "Tente outro provedor ou tente novamente.",
   "chat.dialogPromptArguments.cancel": "Cancelar",
   "chat.dialogPromptArguments.loading": "Carregando...",
+  "chat.dialogPromptArguments.optional": "(opcional)",
+  "chat.dialogPromptArguments.required": "Obrigatório",
   "chat.dialogPromptArguments.usePrompt": "Usar prompt",
   "chat.generateImage.failed": "Falhou",
   "chat.generateImage.generatedImage": "Imagem gerada",


### PR DESCRIPTION
PR #5607 (merged this tick) translated the Cancel/Loading/Use prompt strings in `dialog-prompt-arguments.tsx` but missed two other user-facing strings in the same component: the `(optional)` suffix shown next to non-required argument labels, and the `"Required"` zod validation message shown via `FormMessage` when a required argument is left blank.

A pt-br user filling out an MCP prompt-arguments form still sees these two strings in English even after #5607 — a real (if small) i18n gap in a file that PR just touched.

- Added `chat.dialogPromptArguments.optional` / `chat.dialogPromptArguments.required` keys to `en/chat.ts` and `pt-br/chat.ts`.
- Threaded the translated "Required" message into `buildArgumentSchema` (previously hardcoded in the zod schema) and swapped the raw `(optional)` JSX text for `t(...)`.

Reviewer check: `cd apps/web && bunx tsc --noEmit` (passes — i18n dictionaries stay in sync via `satisfies`).

Locally verified: `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, `bunx oxlint` on the 3 touched files. No existing test covers this component's copy, so nothing to run there; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes the last hardcoded strings in the prompt-arguments dialog: "(optional)" and the "Required" validation message. Users now see fully translated labels and errors (e.g., pt-br), matching the rest of the dialog.

- **Bug Fixes**
  - Added `chat.dialogPromptArguments.optional` and `chat.dialogPromptArguments.required` keys in `en/chat.ts` and `pt-br/chat.ts`.
  - Passed the translated "Required" into the zod schema via `buildArgumentSchema`; replaced the raw "(optional)" label with `t(...)`.
  - No behavior changes; UI copy is now localized.

<sup>Written for commit 2738a6c42825a9860f4510653eb3cd07111acbeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5609?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

