### PR TITLE
fix(commerce-onboarding): translate Shopify config form validation messages

### DIFF
--- a/apps/web/src/i18n/en/commerce-onboarding.ts
+++ b/apps/web/src/i18n/en/commerce-onboarding.ts
@@ -70,8 +70,12 @@ export const commerceOnboarding = {
   "commerceOnboarding.shopifyConfigForm.storeDomainLabel": "Store domain",
   "commerceOnboarding.shopifyConfigForm.storeDomainPlaceholder":
     "my-store.myshopify.com",
+  "commerceOnboarding.shopifyConfigForm.storeDomainRequired":
+    "Enter the store domain",
   "commerceOnboarding.shopifyConfigForm.accessTokenLabel":
     "Admin API access token",
+  "commerceOnboarding.shopifyConfigForm.accessTokenRequired":
+    "Enter the Admin API access token",
   "commerceOnboarding.shopifyConfigForm.accessTokenPlaceholder": "shpat_...",
   "commerceOnboarding.shopifyConfigForm.apiVersionLabel":
     "API version (optional)",

--- a/apps/web/src/i18n/pt-br/commerce-onboarding.ts
+++ b/apps/web/src/i18n/pt-br/commerce-onboarding.ts
@@ -73,8 +73,12 @@ export const commerceOnboarding = {
   "commerceOnboarding.shopifyConfigForm.storeDomainLabel": "Domínio da loja",
   "commerceOnboarding.shopifyConfigForm.storeDomainPlaceholder":
     "minha-loja.myshopify.com",
+  "commerceOnboarding.shopifyConfigForm.storeDomainRequired":
+    "Informe o domínio da loja",
   "commerceOnboarding.shopifyConfigForm.accessTokenLabel":
     "Access token da Admin API",
+  "commerceOnboarding.shopifyConfigForm.accessTokenRequired":
+    "Informe o Admin API access token",
   "commerceOnboarding.shopifyConfigForm.accessTokenPlaceholder": "shpat_...",
   "commerceOnboarding.shopifyConfigForm.apiVersionLabel":
     "Versão da API (opcional)",

--- a/apps/web/src/routes/commerce-onboarding/companion-forms/shopify-config-form.tsx
+++ b/apps/web/src/routes/commerce-onboarding/companion-forms/shopify-config-form.tsx
@@ -14,7 +14,7 @@ import { Input } from "@deco/ui/components/input.tsx";
 import { PasswordInput } from "@deco/ui/components/password-input.tsx";
 import { Button } from "@deco/ui/components/button.tsx";
 import { DialogFooter } from "@deco/ui/components/dialog.tsx";
-import { useT } from "@/i18n/use-t.ts";
+import { useT, type TFunction } from "@/i18n/use-t.ts";
 import { useSaveCompanionConfig } from "./use-save-companion-config.ts";
 import type { CompanionFormProps } from "./types.ts";
 
@@ -23,16 +23,18 @@ import type { CompanionFormProps } from "./types.ts";
 // connection's `connection_token`, never in configuration_state. See
 // use-save-companion-config.ts for the split.
 // Token: required on first configure; blank on edit keeps the stored one.
-const makeSchema = (configured: boolean) =>
+const makeSchema = (configured: boolean, t: TFunction) =>
   z
     .object({
-      storeDomain: z.string().min(1, "Informe o domínio da loja"),
+      storeDomain: z
+        .string()
+        .min(1, t("commerceOnboarding.shopifyConfigForm.storeDomainRequired")),
       accessToken: z.string().optional(),
       apiVersion: z.string().optional(),
     })
     .refine((data) => configured || Boolean(data.accessToken?.trim()), {
       path: ["accessToken"],
-      message: "Informe o Admin API access token",
+      message: t("commerceOnboarding.shopifyConfigForm.accessTokenRequired"),
     });
 
 type FormData = z.infer<ReturnType<typeof makeSchema>>;
@@ -47,7 +49,7 @@ export function ShopifyConfigForm({
 }: CompanionFormProps) {
   const t = useT();
   const form = useForm<FormData>({
-    resolver: zodResolver(makeSchema(card.configured)),
+    resolver: zodResolver(makeSchema(card.configured, t)),
     defaultValues: {
       storeDomain: (card.configurationState?.storeDomain as string) || "",
       // Write-only: never prefilled; blank on edit keeps the stored token.


### PR DESCRIPTION
Follows #5599 (Shopify companion source) hardening: audited the new commerce-onboarding flow for missing i18n coverage.

The Shopify config form's zod schema hardcoded its required-field error messages in Portuguese (`"Informe o domínio da loja"`, `"Informe o Admin API access token"`), so an English-locale user leaving `storeDomain` or `accessToken` blank saw pt-br text instead of a translated message — the rest of the form (labels, placeholders, buttons) is already correctly translated via `useT()`, only these two validation messages were missed.

Fix: thread the `TFunction` into `makeSchema(configured, t)` and add `commerceOnboarding.shopifyConfigForm.storeDomainRequired` / `accessTokenRequired` to both `en` and `pt-br` dictionaries, mirroring the existing pattern already used in `edit-provider-dialog.tsx` (`createEditFormSchema(t)`).

To confirm: open the Shopify companion config form with the app language set to English, submit with both fields blank — the field errors now read in English (`"Enter the store domain"` / `"Enter the Admin API access token"`) instead of Portuguese.

Locally verified: `bun run fmt` (no changes), `bunx tsc --noEmit` in `apps/web` (clean), `bunx oxlint` on the 3 touched files (0 warnings/errors). No existing test file covers this component; full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes required-field validation messages in the Shopify companion config form to match the app language. Fixes Portuguese messages showing for English users when `storeDomain` or `accessToken` are left blank.

- **Bug Fixes**
  - Pass `t` into `makeSchema(configured, t)` and use it for `storeDomain` and `accessToken` validation.
  - Add `commerceOnboarding.shopifyConfigForm.storeDomainRequired` and `commerceOnboarding.shopifyConfigForm.accessTokenRequired` keys to `en` and `pt-br`.

<sup>Written for commit d0e9afda6ad8528135e31ebc1c998b148c487354. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

