### PR TITLE
refactor(api): dedupe kv route's org-id + reserved-key gate

### DIFF
--- a/apps/api/src/api/routes/kv.ts
+++ b/apps/api/src/api/routes/kv.ts
@@ -2,9 +2,10 @@
  * KV API Routes
  *
  * Org-scoped key-value store accessible via API key auth.
- * Routes: GET/PUT/DELETE /api/kv/:key
+ * Routes: GET/PUT/DELETE /api/:org/kv/:key
  */
 
+import type { Context } from "hono";
 import { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import type { StudioContext } from "@/core/studio-context";
@@ -29,22 +30,33 @@ const RESERVED_KEY_PREFIXES = [INTERESTS_KEY_PREFIX];
 const isReservedKey = (key: string) =>
   RESERVED_KEY_PREFIXES.some((prefix) => key.startsWith(prefix));
 
+/** Shared org-id + reserved-key gate for every kv handler below. Returns the
+ *  resolved orgId/key, or a Response to short-circuit the request with. */
+function resolveKvRequest(
+  c: Context<{ Variables: Variables }, "/kv/:key">,
+): { orgId: string; key: string } | Response {
+  const orgId = c.get("studioContext").organization?.id;
+  if (!orgId) {
+    return c.json({ error: "Organization required" }, 400);
+  }
+
+  const key = c.req.param("key");
+  if (isReservedKey(key)) {
+    return c.json({ error: "Reserved key" }, 403);
+  }
+
+  return { orgId, key };
+}
+
 export function createKVRoutes(deps: KVRouteDeps) {
   const app = new Hono<{ Variables: Variables }>();
 
   app.get("/kv/:key", async (c) => {
-    const studioContext = c.get("studioContext");
-    const orgId = studioContext.organization?.id;
-    if (!orgId) {
-      return c.json({ error: "Organization required" }, 400);
-    }
+    const resolved = resolveKvRequest(c);
+    if (resolved instanceof Response) return resolved;
+    const { orgId, key } = resolved;
 
-    const key = c.req.param("key");
-    if (isReservedKey(key)) {
-      return c.json({ error: "Reserved key" }, 403);
-    }
     const value = await deps.kvStorage.get(orgId, key);
-
     if (value === null) {
       return c.json({ error: "Not found" }, 404);
     }
@@ -59,16 +71,9 @@ export function createKVRoutes(deps: KVRouteDeps) {
       onError: (c) => c.json({ error: "Payload too large" }, 413),
     }),
     async (c) => {
-      const studioContext = c.get("studioContext");
-      const orgId = studioContext.organization?.id;
-      if (!orgId) {
-        return c.json({ error: "Organization required" }, 400);
-      }
-
-      const key = c.req.param("key");
-      if (isReservedKey(key)) {
-        return c.json({ error: "Reserved key" }, 403);
-      }
+      const resolved = resolveKvRequest(c);
+      if (resolved instanceof Response) return resolved;
+      const { orgId, key } = resolved;
 
       let body: Record<string, unknown>;
       try {
@@ -83,16 +88,10 @@ export function createKVRoutes(deps: KVRouteDeps) {
   );
 
   app.delete("/kv/:key", async (c) => {
-    const studioContext = c.get("studioContext");
-    const orgId = studioContext.organization?.id;
-    if (!orgId) {
-      return c.json({ error: "Organization required" }, 400);
-    }
+    const resolved = resolveKvRequest(c);
+    if (resolved instanceof Response) return resolved;
+    const { orgId, key } = resolved;
 
-    const key = c.req.param("key");
-    if (isReservedKey(key)) {
-      return c.json({ error: "Reserved key" }, 403);
-    }
     await deps.kvStorage.delete(orgId, key);
     return c.json({ ok: true });
   });


### PR DESCRIPTION
**Source:** reduction found while auditing the org-scoped route migration area (`apps/api/src/api/routes/kv.ts`, mounted under `/api/:org/kv/:key` via `org-scoped.ts`).

**Why:** all three handlers (GET/PUT/DELETE) repeated the identical three-step gate — resolve `orgId` from `studioContext.organization`, 400 if missing, then reject reserved key prefixes with 403 — verbatim. Collapsing it into one `resolveKvRequest` helper removes ~15 duplicated lines and means the next reserved-key or org-check change only has to happen once. Also fixed the file's top-of-file doc comment, which still said `/api/kv/:key` — a leftover from before this route was migrated under the `/api/:org` prefix; it now correctly reads `/api/:org/kv/:key`.

**Net delta:** -30 / +29 lines (dedup, not a net line reduction, but removes 3x-duplicated logic into 1 call site).

**Behavior preserved:** each handler's control flow is unchanged — same 400/403/404 responses in the same order, just routed through a shared helper that returns either the resolved `{orgId, key}` or an early `Response`. No route, schema, or storage-call signature changed.

**How a reviewer confirms:** read the diff — `resolveKvRequest` is a straight extraction of the three branches that used to appear inline in each handler; `git diff` shows no logic changes beyond the doc comment.

**Verified locally:**
- `bunx tsc --noEmit` in `apps/api` — clean
- `bunx oxlint apps/api/src/api/routes/kv.ts` — 0 warnings/errors
- `bun run fmt` — no changes needed

No existing test file covers `kv.ts` (nothing to run/invert); full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated the org-id and reserved-key gate in the KV API by introducing a shared `resolveKvRequest` used by GET/PUT/DELETE under `/api/:org/kv/:key`. Behavior is unchanged (same 400/403/404 responses); also corrected the route comment to the current path.

<sup>Written for commit adef2cdf9b5a6eeb7677eb8bb5ff7c50419b5a3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

