### PR TITLE
fix(chat): make model selector list rows keyboard-accessible

### DIFF
--- a/apps/web/src/components/chat/select-model/decopilot.test.tsx
+++ b/apps/web/src/components/chat/select-model/decopilot.test.tsx
@@ -1,0 +1,66 @@
+import { setupComponentTest } from "../../../../test/setup"; // happy-dom + jest-dom matchers
+setupComponentTest();
+import { describe, expect, it, mock } from "bun:test";
+import { fireEvent, render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { ModelTierSection } from "./decopilot";
+import type { AiProviderModel } from "../../../hooks/collections/use-ai-providers";
+
+function makeModel(overrides: Partial<AiProviderModel> = {}): AiProviderModel {
+  return {
+    providerId: "anthropic",
+    modelId: "anthropic/claude-sonnet-5",
+    title: "Anthropic: Claude Sonnet 5",
+    description: null,
+    logo: null,
+    capabilities: ["text"],
+    limits: null,
+    costs: null,
+    ...overrides,
+  };
+}
+
+describe("ModelTierSection", () => {
+  it("renders nothing for an empty tier", () => {
+    const { container } = render(
+      <ModelTierSection
+        label="Smarter"
+        models={[]}
+        onSelect={() => {}}
+        onHover={() => {}}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders each model as a focusable, keyboard-operable button", () => {
+    const model = makeModel();
+    const { getByRole } = render(
+      <ModelTierSection
+        label="Smarter"
+        models={[model]}
+        onSelect={() => {}}
+        onHover={() => {}}
+      />,
+    );
+    // A real <button> — not a div with onClick — is what makes the row
+    // reachable via Tab and activatable via Enter/Space for keyboard users.
+    const row = getByRole("button", { name: /Claude Sonnet 5/ });
+    expect(row).toHaveAttribute("type", "button");
+  });
+
+  it("calls onSelect with the clicked model", () => {
+    const onSelect = mock((_m: AiProviderModel) => {});
+    const model = makeModel();
+    const { getByRole } = render(
+      <ModelTierSection
+        label="Smarter"
+        models={[model]}
+        onSelect={onSelect}
+        onHover={() => {}}
+      />,
+    );
+    fireEvent.click(getByRole("button", { name: /Claude Sonnet 5/ }));
+    expect(onSelect).toHaveBeenCalledWith(model);
+  });
+});

--- a/apps/web/src/components/chat/select-model/decopilot.tsx
+++ b/apps/web/src/components/chat/select-model/decopilot.tsx
@@ -298,7 +298,7 @@ function ModelListSkeleton() {
 // ConnectionModelList — browse + manage modes
 // ============================================================================
 
-function ModelTierSection({
+export function ModelTierSection({
   label,
   models,
   onSelect,
@@ -316,13 +316,14 @@ function ModelTierSection({
         {label}
       </div>
       {models.map((m) => (
-        <div
+        <button
           key={m.modelId}
+          type="button"
           onClick={() => onSelect(m)}
-          className="cursor-pointer"
+          className="w-full text-left cursor-pointer"
         >
           <ModelItemContent model={m} onHover={onHover} />
-        </div>
+        </button>
       ))}
     </div>
   );


### PR DESCRIPTION
Source: accessibility bug found while reviewing the chat model selector (`apps/web/src/components/chat/select-model/decopilot.tsx`), no linked issue.

Why a maintainer wants this: each model row in the model picker's browse list (`ModelTierSection`) was rendered as a plain `<div onClick=...>` — divs are not in the tab order and don't respond to Enter/Space, so a keyboard-only or screen-reader user could open the model picker but had no way to actually select a model from the list. This is an accessibility-basics gap, not a cosmetic one.

Failure scenario: focus the model selector trigger, open it with Enter/Space, then try to Tab into the model list and press Enter on a row — nothing happens, because the row was never a focusable element. Fix: swap the wrapping `<div>` for a real `<button type="button">` (same `onClick`, same visual output via the unchanged `ModelItemContent` child) — buttons are focusable and natively handle Enter/Space activation, matching the pattern already used elsewhere in the same file (e.g. the "Manage models" / "Manage API keys" footer buttons). No other behavior changes.

Regression test added in `decopilot.test.tsx` (new file): exports `ModelTierSection` for direct testing and asserts (1) each model row has an accessible `button` role with `type="button"`, and (2) clicking it still calls `onSelect` with the right model — inverts the old "div with onClick, no role" shape.

Reviewer command: `bun test apps/web/src/components/chat/select-model/decopilot.test.tsx`

Locally verified: `bun run fmt` (clean), `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint` on both changed files (0 warnings/errors), and the targeted test file above (3 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the chat model selector list keyboard-accessible by rendering each row as a real button. Users can now Tab to a model and activate it with Enter/Space without changing visuals or click behavior.

- **Bug Fixes**
  - Swapped the row wrapper in `ModelTierSection` from a `<div>` to a `<button type="button">` for native focus and keyboard activation.
  - Exported `ModelTierSection` and added `decopilot.test.tsx` to verify button role/type and that `onSelect` is called with the correct model.

<sup>Written for commit 352217ded1b49cf0596dcf2b7bf7fc376dad3099. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

