### PR TITLE
feat(vault): batch lease endpoint for the service lane

### DIFF
--- a/apps/api/src/api/routes/credential-vault.integration.test.ts
+++ b/apps/api/src/api/routes/credential-vault.integration.test.ts
@@ -481,4 +481,87 @@ describe("Credential Vault Routes", () => {
 
     expect(res.status).toBe(401);
   });
+
+  describe("batch (service token)", () => {
+    const prevServiceToken = process.env.VAULT_SERVICE_TOKEN;
+    beforeEach(() => {
+      process.env.VAULT_SERVICE_TOKEN = "svc-secret";
+    });
+    afterEach(() => {
+      if (prevServiceToken === undefined)
+        delete process.env.VAULT_SERVICE_TOKEN;
+      else process.env.VAULT_SERVICE_TOKEN = prevServiceToken;
+    });
+
+    const batchRequest = (bearer: string, connectionIds: unknown): Request =>
+      new Request("http://test/api/org_1/vault/connections/batch", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${bearer}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({ connectionIds }),
+      });
+
+    it("leases configuration + token for N connections in one round-trip, per-item errors", async () => {
+      const res = await app.fetch(
+        batchRequest("svc-secret", [
+          "conn_target",
+          "conn_static_token_target",
+          "conn_configuration_target",
+          "conn_inactive_granted",
+          "conn_does_not_exist",
+        ]),
+      );
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Cache-Control")).toBe("no-store");
+      const body = (await res.json()) as Record<
+        string,
+        {
+          configuration?: { state: Record<string, unknown> };
+          accessToken?: { type: string; accessToken: string } | null;
+          error?: string;
+        }
+      >;
+
+      // OAuth connection: valid downstream token comes back as oauth lane.
+      expect(body.conn_target?.accessToken?.type).toBe("oauth_access_token");
+      expect(body.conn_target?.accessToken?.accessToken).toBe(
+        "downstream_access_token",
+      );
+
+      // Static-token connection: the connection_token fallback lane.
+      expect(body.conn_static_token_target?.accessToken?.type).toBe(
+        "static_token",
+      );
+      expect(body.conn_static_token_target?.accessToken?.accessToken).toBe(
+        "static-admin-api-token",
+      );
+
+      // Configuration-bearing connection: decrypted state, no token ⇒ null.
+      expect(body.conn_configuration_target?.configuration?.state.apiKey).toBe(
+        "configuration-secret",
+      );
+      expect(body.conn_configuration_target?.accessToken).toBeNull();
+
+      // Inactive and unknown connections: per-item error, batch still 200.
+      expect(body.conn_inactive_granted?.error).toBe("Connection not found");
+      expect(body.conn_does_not_exist?.error).toBe("Connection not found");
+    });
+
+    it("rejects workload tokens — the batch lane is service-only", async () => {
+      const res = await app.fetch(batchRequest(workloadToken, ["conn_target"]));
+      expect(res.status).toBe(401);
+    });
+
+    it("rejects an empty or non-array connectionIds", async () => {
+      expect((await app.fetch(batchRequest("svc-secret", []))).status).toBe(
+        400,
+      );
+      expect(
+        (await app.fetch(batchRequest("svc-secret", "conn_target"))).status,
+      ).toBe(400);
+    });
+  });
 });

--- a/apps/api/src/api/routes/credential-vault.ts
+++ b/apps/api/src/api/routes/credential-vault.ts
@@ -149,17 +149,32 @@ export const createCredentialVaultRoutes = () => {
       );
     }
 
+    // ONE query for all connections (decrypted entities: configuration_state
+    // + connection_token) and one for which of them hold a downstream OAuth
+    // token — only those go through the per-token refresh path; static-token
+    // connections resolve with no further reads.
+    const { items } = await ctx.storage.connections.list(organizationId, {
+      includeVirtual: true,
+      where: { field: ["id"], operator: "in", value: ids },
+      limit: ids.length,
+    });
+    const byId = new Map(items.map((item) => [item.id, item]));
+    const withDownstreamToken = new Set(
+      (
+        await ctx.db
+          .selectFrom("downstream_tokens")
+          .select("connectionId")
+          .where("connectionId", "in", ids)
+          .execute()
+      ).map((row) => row.connectionId),
+    );
+
     const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
     const out: Record<string, unknown> = {};
     await Promise.all(
       ids.map(async (id) => {
         try {
-          // findById returns the DECRYPTED entity (configuration_state +
-          // connection_token), so one storage read covers both halves.
-          const target = await ctx.storage.connections.findById(
-            id,
-            organizationId,
-          );
+          const target = byId.get(id);
           if (!target || target.status !== "active") {
             out[id] = { error: "Connection not found" };
             return;
@@ -169,22 +184,27 @@ export const createCredentialVaultRoutes = () => {
             state: target.configuration_state ?? {},
             scopes: target.configuration_scopes ?? [],
           };
-          const result = await getValidDownstreamAccessToken({
-            connectionId: id,
-            connectionUrl: target.connection_url,
-            tokenStorage,
-          });
           let accessToken: Record<string, unknown> | null = null;
-          if (result.state === "valid" || result.state === "refreshed") {
-            const downstreamToken = await tokenStorage.get(id);
-            accessToken = {
-              type: "oauth_access_token",
-              tokenType: "Bearer",
-              accessToken: result.accessToken,
-              expiresAt: serializeExpiresAt(downstreamToken?.expiresAt ?? null),
-              scope: downstreamToken?.scope ?? null,
-            };
-          } else if (result.state === "missing" && target.connection_token) {
+          if (withDownstreamToken.has(id)) {
+            const result = await getValidDownstreamAccessToken({
+              connectionId: id,
+              connectionUrl: target.connection_url,
+              tokenStorage,
+            });
+            if (result.state === "valid" || result.state === "refreshed") {
+              const downstreamToken = await tokenStorage.get(id);
+              accessToken = {
+                type: "oauth_access_token",
+                tokenType: "Bearer",
+                accessToken: result.accessToken,
+                expiresAt: serializeExpiresAt(
+                  downstreamToken?.expiresAt ?? null,
+                ),
+                scope: downstreamToken?.scope ?? null,
+              };
+            }
+            // refresh_failed/expired ⇒ null, same as the single route's 424.
+          } else if (target.connection_token) {
             // Static-token MCPs (e.g. Shopify): bearer on the connection.
             accessToken = {
               type: "static_token",

--- a/apps/api/src/api/routes/credential-vault.ts
+++ b/apps/api/src/api/routes/credential-vault.ts
@@ -119,6 +119,95 @@ async function authorizeVaultRequest(
 export const createCredentialVaultRoutes = () => {
   const app = new Hono<{ Variables: Variables }>();
 
+  // Batch lease for the vault SERVICE lane only (decocms/reports resolves up
+  // to five providers per run): configuration + access token for N connections
+  // in one round-trip. Per-item failures never fail the batch — every requested
+  // id gets an entry, with `error` set when that connection can't be leased.
+  app.post("/vault/connections/batch", async (c) => {
+    const token = bearerToken(c.req.header("authorization"));
+    if (!token || !isVaultServiceToken(token)) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+    const ctx = c.get("studioContext");
+    const organizationId = ctx.organization?.id;
+    if (!organizationId) {
+      return c.json({ error: "Organization context required" }, 403);
+    }
+
+    const body = (await c.req.json().catch(() => null)) as {
+      connectionIds?: unknown;
+    } | null;
+    const ids = Array.isArray(body?.connectionIds)
+      ? [...new Set(body.connectionIds)].filter(
+          (id): id is string => typeof id === "string" && id.length > 0,
+        )
+      : [];
+    if (ids.length === 0 || ids.length > 20) {
+      return c.json(
+        { error: "connectionIds must be a non-empty string array (max 20)" },
+        400,
+      );
+    }
+
+    const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
+    const out: Record<string, unknown> = {};
+    await Promise.all(
+      ids.map(async (id) => {
+        try {
+          // findById returns the DECRYPTED entity (configuration_state +
+          // connection_token), so one storage read covers both halves.
+          const target = await ctx.storage.connections.findById(
+            id,
+            organizationId,
+          );
+          if (!target || target.status !== "active") {
+            out[id] = { error: "Connection not found" };
+            return;
+          }
+          const configuration = {
+            type: "mcp_configuration",
+            state: target.configuration_state ?? {},
+            scopes: target.configuration_scopes ?? [],
+          };
+          const result = await getValidDownstreamAccessToken({
+            connectionId: id,
+            connectionUrl: target.connection_url,
+            tokenStorage,
+          });
+          let accessToken: Record<string, unknown> | null = null;
+          if (result.state === "valid" || result.state === "refreshed") {
+            const downstreamToken = await tokenStorage.get(id);
+            accessToken = {
+              type: "oauth_access_token",
+              tokenType: "Bearer",
+              accessToken: result.accessToken,
+              expiresAt: serializeExpiresAt(downstreamToken?.expiresAt ?? null),
+              scope: downstreamToken?.scope ?? null,
+            };
+          } else if (result.state === "missing" && target.connection_token) {
+            // Static-token MCPs (e.g. Shopify): bearer on the connection.
+            accessToken = {
+              type: "static_token",
+              tokenType: "Bearer",
+              accessToken: target.connection_token,
+              expiresAt: null,
+              scope: null,
+            };
+          }
+          out[id] = { configuration, accessToken };
+        } catch (err) {
+          out[id] = {
+            error: err instanceof Error ? err.message : String(err),
+          };
+        }
+      }),
+    );
+
+    c.header("Cache-Control", "no-store");
+    c.header("Pragma", "no-cache");
+    return c.json(out);
+  });
+
   app.post("/vault/connections/:connectionId/access-token", async (c) => {
     const targetConnectionId = c.req.param("connectionId");
     const authz = await authorizeVaultRequest(


### PR DESCRIPTION
## Summary

`POST /:org/vault/connections/batch` — configuration + access token for up to 20 connections in **one round-trip**. The consumer is `decocms/reports`: a credentialed run resolves up to five providers (vtex/shopify/ga4/gsc/github), each costing separate `/configuration` + `/access-token` calls today (~8 HTTP hops worst case). This collapses them into 1.

## Design

- **Service-token lane only.** `VAULT_SERVICE_TOKEN` already leases ANY connection in the org (org bounded by the path), so the batch route grants nothing new. The workload-token lane keeps the existing per-connection routes and per-connection grant checks — batch with grants would need a grant loop, and no workload consumer needs it.
- **Per-item semantics mirror the single routes exactly**: `oauth_access_token` when the downstream token is valid/refreshed (refresh still happens inside the lease), `static_token` fallback from `connection_token` when missing (#5599), `accessToken: null` when neither, `{ error }` for inactive/unknown ids.
- **A failing item never fails the batch** — every requested id gets an entry, so one broken provider can't blind the others (same isolation the per-provider resolvers have today on the reports side).
- One storage read per connection: `connections.findById` already returns the decrypted entity (configuration_state + connection_token), so config and token come from a single fetch + the downstream-token check.

## Testing

- `credential-vault.integration.test.ts` against real Postgres: **15 pass / 0 fail** (12 existing + 3 new: mixed batch with oauth/static/config-only/inactive/unknown items; workload token rejected; empty/non-array body 400).
- `tsc` (apps/api), `fmt`, `lint` clean.

## Pairing

The reports half (batch client with per-provider fallback when this route 404s — either side can deploy first) goes up as decocms/reports PR stacked on #298.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `POST /:org/vault/connections/batch` to fetch configuration and access tokens for up to 20 connections in a single request. This collapses multiple `/configuration` + `/access-token` calls in decocms/reports into one.

- **New Features**
  - Service-token lane only; workload tokens are rejected (401).
  - Per-id results match existing routes: `oauth_access_token`, `static_token` fallback only when no downstream token, `null` when none, or `{ error }` for inactive/unknown.
  - Item errors don’t fail the batch; every requested id returns a result.
  - Validates `connectionIds` as a non-empty array (max 20) and sets `Cache-Control: no-store` and `Pragma: no-cache`.
  - Performance: reads all connections in one query and uses a single `downstream_tokens` existence check to decide the OAuth refresh path; static-token connections resolve with no extra reads.

<sup>Written for commit fb307142e290ecb0344986e558598b6c28904a78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

