### PR TITLE
fix(web): stop main-panel loads from blanking the chat

### DIFF
--- a/apps/web/src/layouts/agent-shell-layout/workspace-panel-group.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/workspace-panel-group.tsx
@@ -10,6 +10,7 @@
  */
 
 import {
+  Suspense,
   useEffect,
   useRef,
   type PropsWithChildren,
@@ -30,6 +31,7 @@ import {
   type WorkspaceVisibility,
 } from "@/hooks/use-layout-state";
 import { MainPanelWithDrawer } from "@/layouts/main-panel-tabs/main-panel-with-drawer";
+import { ShellRouteLoading } from "@/layouts/shell-route-loading";
 import { MainPanelTabsBar } from "@/layouts/main-panel-tabs/main-panel-tabs-bar";
 import { CmsTour } from "@/components/cms-tour/cms-tour";
 import { headerLayout } from "./header-layout";
@@ -80,6 +82,14 @@ function PanelCard({
  * The agent's main-panel controls: the view tab bar, which also folds in the
  * agent-independent overlays (Library / Tasks) and caps itself at 3 buttons
  * plus a stack popover. Rendered in whichever header hosts the main panel.
+ *
+ * Own Suspense boundary, deliberately. `useMainPanelTabs` suspends on
+ * main-panel data (the task row, the GitHub MCP client, and the dev MCP client
+ * — whose query key carries the sandbox `previewUrl`, so it re-suspends every
+ * time a sandbox starts). Without a boundary here those reads escape to the
+ * one in `DesktopTaskWorkspace`, whose fallback is <Chat.Skeleton /> — blanking
+ * the CHAT for main-panel data it has nothing to do with. The tab bar simply
+ * yields its own strip of header until it resolves.
  */
 function MainControls({
   virtualMcpId,
@@ -93,12 +103,14 @@ function MainControls({
   maxVisible?: number;
 }) {
   return (
-    <MainPanelTabsBar
-      virtualMcpId={virtualMcpId}
-      taskId={taskId}
-      disableActiveMainToggle={disableActiveMainToggle}
-      maxVisible={maxVisible}
-    />
+    <Suspense fallback={null}>
+      <MainPanelTabsBar
+        virtualMcpId={virtualMcpId}
+        taskId={taskId}
+        disableActiveMainToggle={disableActiveMainToggle}
+        maxVisible={maxVisible}
+      />
+    </Suspense>
   );
 }
 
@@ -150,7 +162,14 @@ export function WorkspacePanelGroup({
   const agentCrumb = sidebarCollapsed ? <AgentSwitcherCrumb /> : null;
   const newChatCrumb = sidebarCollapsed ? <NewChatCrumb /> : null;
 
-  const publishActions = <VirtualMcpHeaderInfo virtualMcp={entity} />;
+  // Own boundary, same reasoning as MainControls: these read PR/check state
+  // through the GitHub MCP client, and that client's connect must not be able
+  // to blank the chat.
+  const publishActions = (
+    <Suspense fallback={null}>
+      <VirtualMcpHeaderInfo virtualMcp={entity} />
+    </Suspense>
+  );
 
   // Branch selector lives in the workspace header (top-right, next to publish),
   // NOT in the chat composer — it's a workspace-level concern (which branch the
@@ -159,7 +178,9 @@ export function WorkspacePanelGroup({
   // context (this tree is inside Chat.ActiveTaskProvider).
   const currentBranch = useOptionalChatTask()?.currentBranch ?? null;
   const branchSelector = (
-    <ChatModeRow virtualMcp={entity} currentBranch={currentBranch} />
+    <Suspense fallback={null}>
+      <ChatModeRow virtualMcp={entity} currentBranch={currentBranch} />
+    </Suspense>
   );
 
   // oxlint-disable-next-line ban-use-effect/ban-use-effect -- syncs URL-derived visibility with the resizable panels' imperative layout API
@@ -310,7 +331,16 @@ export function WorkspacePanelGroup({
           className="min-w-0 overflow-hidden bg-sidebar"
         >
           <PanelCard testId="main-panel" header={mainOpen ? mainHeader : null}>
-            <MainPanelWithDrawer taskId={taskId} virtualMcpId={virtualMcpId} />
+            {/* Same reasoning as MainControls: the main panel's own loads stay
+                in the main panel. Its spinner is the panel-scoped one, so a
+                view swap or a sandbox coming up never reaches the chat's
+                boundary. */}
+            <Suspense fallback={<ShellRouteLoading />}>
+              <MainPanelWithDrawer
+                taskId={taskId}
+                virtualMcpId={virtualMcpId}
+              />
+            </Suspense>
           </PanelCard>
         </ResizablePanel>
       </ResizablePanelGroup>

--- a/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -142,6 +142,16 @@ function useTaskMetadata(taskId: string): ThreadMetadata | null {
     },
     select: (task) => task?.metadata ?? null,
     staleTime: 30_000,
+    // Seeded from the store so the suspense read resolves synchronously in the
+    // common case. Without it, this blanks the WHOLE DesktopTaskWorkspace
+    // subtree (main panel + chat) to <Chat.Skeleton /> for a round-trip whose
+    // result is then discarded — `localHit` wins below. That flash recurs on
+    // every cache miss: first open of a task, after the 5-minute gcTime elapses
+    // while you're on another task, or any remount with an evicted entry.
+    //
+    // Cold/archived threads (the case this query exists for) have no localHit,
+    // so initialData is undefined and the fetch-and-suspend path is unchanged.
+    initialData: localHit ?? undefined,
   });
   return localHit?.metadata ?? fetchedMetadata ?? null;
 }


### PR DESCRIPTION
## Summary

The chat and the main panel shared **one** `<Suspense fallback={<Chat.Skeleton />}>` in `DesktopTaskWorkspace`, so any suspense read anywhere in that subtree replaced the chat with its loading skeleton — for data the chat has nothing to do with. Every read that tripped it is a main-panel concern, reached through `useMainPanelTabs` or the panel headers:

- **the dev MCP client**, whose query key carries the sandbox `previewUrl` — so it re-suspends every time a sandbox starts, and again when a failed connect retries. This is the flash on sandbox start.
- **the GitHub MCP client** behind the PR/check state in Submit / Publish.
- **the task row read**.

Rather than dropping the suspense reads, this scopes the boundaries. The tab bar, the main panel body, the publish actions, and the branch selector each get their own `Suspense`, so a main-panel load yields its own strip of header (or the panel's spinner) and **the chat stays mounted**.

`useTaskMetadata` additionally seeds its query from the thread-manager store via `initialData`: it suspended on `COLLECTION_THREADS_GET` even when the store already held the row, then discarded the fetched value because `localHit` wins. Cold/archived threads have no `localHit`, so the fetch path that query exists for is unchanged.

## How it was diagnosed

Temporary main-thread instrumentation (not in this PR) logged Suspense fallback renders with React 19 owner stacks next to query-cache events. Every skeleton carried the same signature — `query:added` → dataless fetch → `suspense:ChatSkeleton` owned by `DesktopTaskWorkspace` — and never an error-boundary catch, ruling out a thrown error wearing the same fallback (the chat skeleton is also an `ErrorBoundary` fallback in `side-panel-chat.tsx`).

## Testing

- Verified live in the Tauri dev app: a **cold boot with a running sandbox now renders 0 chat skeletons**, where it previously rendered 2. The main panel shows its own spinner instead, and the header widgets (tabs, branch pill, Submit for review, Publish) all still render.
- Warm task switches — including a key change to a different branch's sandbox `previewUrl` — also render 0.
- `bun run fmt`, `bun run --cwd=apps/web check`, `bun run lint`, `bun run knip` clean; 626 unit tests pass.

No test added: this is React data-loading behavior in hooks needing a QueryClient plus the thread-manager store, which isn't unit-testable under the repo's no-mocks rule. The honest tier is e2e (assert the chat skeleton does not appear while the main panel loads), flagged here rather than faked at the unit tier.

## Follow-ups (not in this PR)

Two unrelated problems found while profiling this, both reproducible and neither addressed here:

- **Main-thread freeze (seconds to indefinite).** `drainOutput` in `terminal-panel.tsx` re-enters `terminal.write()` from inside xterm's write-completion callback, so xterm's `_innerWrite` keeps being handed more data while draining and the microtask queue never empties. `sample` put **3340/3340** samples in `performMicrotaskCheckpoint`, with the stuck timer's stack naming `drainOutput`. RSS reached 1.08 GB.
- **Sustained ~100% CPU with no long block.** Continuous relayout: `Page::updateRendering → resolveStyle → interleavedLayout` through deeply nested flex (1298/1874 timer samples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)