### PR TITLE
fix(sandbox): return 400 instead of 500 for an invalid discard path

### DIFF
--- a/packages/sandbox/daemon-go/internal/routes/git.go
+++ b/packages/sandbox/daemon-go/internal/routes/git.go
@@ -132,7 +132,10 @@ func GitDiscard(deps GitDeps) http.HandlerFunc {
 		for _, fp := range body.Filepaths {
 			rel, err := resolveRepoRelativePath(deps, fp)
 			if err != nil {
-				httpx.Error(w, 500, err.Error())
+				// resolveRepoRelativePath only ever fails on a client-supplied path
+				// that escapes the repo — a 400, not a 500 (matches fs.go's
+				// "Path escapes app root" handling for the same SafePath check).
+				httpx.Error(w, 400, err.Error())
 				return
 			}
 			validated = append(validated, rel)

--- a/packages/sandbox/daemon-go/internal/routes/git_test.go
+++ b/packages/sandbox/daemon-go/internal/routes/git_test.go
@@ -1,0 +1,48 @@
+package routes
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func initTestGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	for _, args := range [][]string{
+		{"init", "-q"},
+		{"config", "user.email", "t@example.com"},
+		{"config", "user.name", "t"},
+		{"commit", "-q", "--allow-empty", "-m", "init"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	return dir
+}
+
+// A path that escapes the repo is a client error (400), not a server error
+// (500) — matches how fs.go's routes report the same SafePath rejection.
+func TestGitDiscardEscapingPathReturns400(t *testing.T) {
+	repoDir := initTestGitRepo(t)
+	deps := GitDeps{AppRoot: filepath.Dir(repoDir), RepoDir: repoDir}
+
+	body, _ := json.Marshal(map[string]any{
+		"filepaths": []string{"../../etc/passwd"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/git/discard", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	GitDiscard(deps)(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusBadRequest, rec.Body.String())
+	}
+}


### PR DESCRIPTION
Bug found while auditing the Go sandbox daemon's git routes (`packages/sandbox/daemon-go/internal/routes/git.go`) — not tied to a specific issue.

`GitDiscard`'s `resolveRepoRelativePath` helper only ever fails for one reason: a client-supplied filepath that escapes the repo root, per `paths.SafePath`. That's a bad request from the client, not a server error, yet the handler mapped it to a 500. `fs.go` in the same package already treats the identical `SafePath` rejection as 400 (`"Path escapes app root"`) in every one of its routes (write/unlink/mkdir/move/edit/grep/download) — `git.go`'s discard route was the one holdout still returning 500. This matches the repo's established "sandbox HTTP-status correctness" lane (return 400/409 instead of 500 on malformed/invalid input).

Failure scenario: a client sends `POST /git/discard` with a `filepaths` entry like `"../../etc/passwd"` (or any path traversal attempt) — previously this surfaced as a 500 (implying a server bug) instead of a 400 (a rejected client request), which is what every other daemon route does for the same validation failure and what callers reasonably expect.

Fix: change the status code from 500 to 400 in the `resolveRepoRelativePath` error branch of `GitDiscard`. Added `git_test.go` (the package had no tests yet) with `TestGitDiscardEscapingPathReturns400`, which spins up a real temp git repo and asserts the handler now returns 400 for an escaping path — this test fails with the old code (verified locally: got 500) and passes with the fix.

To verify: `cd packages/sandbox/daemon-go && go test ./internal/routes/... -run TestGitDiscardEscapingPathReturns400 -v`

Locally ran: `go build ./...`, `go vet ./internal/routes/...`, `gofmt -l` (clean), and the new targeted test (pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 400 Bad Request instead of 500 when `POST /git/discard` receives a filepath that escapes the repo, aligning with fs routes and correctly treating it as client input. Added a test to ensure 400 is returned for path traversal.

- **Bug Fixes**
  - Update `GitDiscard` in `packages/sandbox/daemon-go/internal/routes/git.go` to return 400 on `resolveRepoRelativePath` failure (SafePath rejection).
  - Add `packages/sandbox/daemon-go/internal/routes/git_test.go` with `TestGitDiscardEscapingPathReturns400`.

<sup>Written for commit 296a9faa68aa788dce89eabc17a196f0cacf050e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5615?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

