### PR TITLE
fix(runtime): propagate StudioKV write/delete failures instead of swallowing them

### DIFF
--- a/packages/runtime/src/trigger-storage.test.ts
+++ b/packages/runtime/src/trigger-storage.test.ts
@@ -52,6 +52,39 @@ describe("StudioKV.get", () => {
   });
 });
 
+describe("StudioKV.set/delete", () => {
+  const kv = new StudioKV({ url: "https://studio.test", apiKey: "key" });
+
+  it("throws instead of silently swallowing a failed PUT", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("nope", { status: 500, statusText: "Internal Error" }),
+    );
+
+    await expect(
+      kv.set("conn_1", {
+        credentials: { callbackUrl: "https://x", callbackToken: "tok" },
+        activeTriggerTypes: ["github.push"],
+      }),
+    ).rejects.toThrow(/PUT failed/);
+  });
+
+  it("throws instead of silently swallowing a failed DELETE", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("nope", { status: 500, statusText: "Internal Error" }),
+    );
+
+    await expect(kv.delete("conn_1")).rejects.toThrow(/DELETE failed/);
+  });
+
+  it("treats a 404 DELETE as success (already gone)", async () => {
+    spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("not found", { status: 404 }),
+    );
+
+    await expect(kv.delete("conn_1")).resolves.toBeUndefined();
+  });
+});
+
 describe("JsonFileStorage", () => {
   const state = (token: string) => ({
     credentials: { callbackUrl: "https://x", callbackToken: token },

--- a/packages/runtime/src/trigger-storage.ts
+++ b/packages/runtime/src/trigger-storage.ts
@@ -111,7 +111,10 @@ export class StudioKV implements TriggerStorage {
     );
 
     if (!res.ok) {
-      console.error(`[StudioKV] PUT failed: ${res.status} ${res.statusText}`);
+      // Callers (TriggerStateManager.persist) await this — throwing lets
+      // TRIGGER_CONFIGURE surface the failure instead of reporting
+      // `{ success: true }` for credentials that never reached storage.
+      throw new Error(`[StudioKV] PUT failed: ${res.status} ${res.statusText}`);
     }
   }
 
@@ -125,7 +128,7 @@ export class StudioKV implements TriggerStorage {
     );
 
     if (!res.ok && res.status !== 404) {
-      console.error(
+      throw new Error(
         `[StudioKV] DELETE failed: ${res.status} ${res.statusText}`,
       );
     }


### PR DESCRIPTION
## Source
Bug found while auditing `packages/runtime/src/trigger-storage.ts` for missing error propagation (focus area: runtime trigger-storage cleanup). Not a duplicate of open PR #5386 (`refactor/trigger-storage-stale-cleanup-w2`), which adds a separate opt-in `prune()` for stale entries — this fix is about a silent write failure on the live enable/disable path.

## Why a maintainer wants this
`TriggerStateManager.persist()` is awaited directly from `TRIGGER_CONFIGURE`'s handler (`enable()`/`disable()` in `packages/runtime/src/triggers.ts`). `StudioKV.set()` and `StudioKV.delete()` only did `console.error` on a non-2xx response and then returned normally — so a failed persist (Studio's KV API returning e.g. a 500) still made `TRIGGER_CONFIGURE` respond `{ success: true }`, even though the trigger's callback credentials never made it to storage. The connection silently loses its trigger config on the next restart, with no error ever surfaced to the caller.

## Failure scenario + fix
Call `TRIGGER_CONFIGURE` with `enabled: true` while Studio's KV endpoint is returning 500s: today the tool call succeeds and the MCP client believes the trigger is configured, but nothing was persisted. After this fix, `StudioKV.set()`/`delete()` throw on a non-ok response (404 on delete is still treated as already-gone, not an error), so the failure propagates up through `enable()`/`disable()` and the tool call actually fails instead of lying about success.

## Verify
`bun test packages/runtime/src/trigger-storage.test.ts` — 3 new tests cover the PUT-failure throw, DELETE-failure throw, and the 404-is-success case; 5 existing tests still pass (8/8 total).

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` (packages/runtime)
- `bun test packages/runtime/src/trigger-storage.test.ts` (8 pass)
- `bunx oxlint packages/runtime/src/trigger-storage.ts packages/runtime/src/trigger-storage.test.ts` (0 warnings/errors)

Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates `StudioKV` write/delete failures so trigger configuration doesn’t report success when storage fails. `TRIGGER_CONFIGURE` now surfaces errors instead of silently swallowing them.

- **Bug Fixes**
  - `StudioKV.set()`/`delete()` now throw on non-ok responses (DELETE 404 is treated as already gone).
  - Errors propagate through `TriggerStateManager.persist()` to `enable()`/`disable()`, preventing false `{ success: true }`.
  - Added tests for PUT/DELETE failure and 404 delete behavior in `packages/runtime/src/trigger-storage.test.ts`.

<sup>Written for commit 9c89e1c32c631d550021516fedd0b08b135a5f8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

