### PR TITLE
fix(chat): update the model details panel on keyboard focus, not just hover

### DIFF
--- a/apps/web/src/components/chat/select-model/decopilot.test.tsx
+++ b/apps/web/src/components/chat/select-model/decopilot.test.tsx
@@ -63,4 +63,21 @@ describe("ModelTierSection", () => {
     fireEvent.click(getByRole("button", { name: /Claude Sonnet 5/ }));
     expect(onSelect).toHaveBeenCalledWith(model);
   });
+
+  it("calls onHover when the row receives keyboard focus, not just a mouse hover", () => {
+    const onHover = mock((_m: AiProviderModel) => {});
+    const model = makeModel();
+    const { getByRole } = render(
+      <ModelTierSection
+        label="Smarter"
+        models={[model]}
+        onSelect={() => {}}
+        onHover={onHover}
+      />,
+    );
+    // Keyboard users tabbing through rows never trigger onMouseEnter, so the
+    // details panel would otherwise stay blank until Enter is pressed.
+    fireEvent.focus(getByRole("button", { name: /Claude Sonnet 5/ }));
+    expect(onHover).toHaveBeenCalledWith(model);
+  });
 });

--- a/apps/web/src/components/chat/select-model/decopilot.tsx
+++ b/apps/web/src/components/chat/select-model/decopilot.tsx
@@ -320,6 +320,7 @@ export function ModelTierSection({
           key={m.modelId}
           type="button"
           onClick={() => onSelect(m)}
+          onFocus={() => onHover(m)}
           className="w-full text-left cursor-pointer"
         >
           <ModelItemContent model={m} onHover={onHover} />


### PR DESCRIPTION
Follows #5612 (merged this tick), which turned each model row in the Decopilot model selector into a real `<button>` so keyboard users can Tab through the list and activate a row with Enter/Space.

**Why a maintainer wants this**: #5612 fixed reachability/activation but left `onHover` wired only to `onMouseEnter`. A keyboard-only user tabbing through the model list never triggers it, so the right-hand details panel (`ModelDetailsPanel`) stays blank (or stuck on the previously-hovered/selected model) the whole time they're browsing with the keyboard — they only see details after committing to a selection with Enter. Mouse users already get this live preview per row.

**Fix**: add `onFocus={() => onHover(m)}` to the row `<button>` in `ModelTierSection` (`apps/web/src/components/chat/select-model/decopilot.tsx`), mirroring the existing `onMouseEnter` behavior in `ModelItemContent`. Pure addition, no existing behavior changed.

**Regression test**: added a test to `decopilot.test.tsx` asserting `fireEvent.focus` on a row button calls `onHover` with that model — this encodes the exact interaction the bug affects.

**Reviewer check**: `bun test ./apps/web/src/components/chat/select-model/decopilot.test.tsx` (4 pass).

**Locally verified**: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean), the targeted test file above (4/4 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Model details panel now updates when a model row gets keyboard focus, not just on mouse hover. This improves accessibility for keyboard users in the Decopilot model selector.

- **Bug Fixes**
  - Trigger details preview on focus by adding `onFocus={() => onHover(m)}` to the row `<button>` in `decopilot.tsx`.
  - Add a regression test in `decopilot.test.tsx` to ensure focus calls `onHover` with the focused model.

<sup>Written for commit e45e659e74a612fe53b3cd264160c54b4d4c0cba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5617?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

