### PR TITLE
fix(ai-providers): reject a non-finite credits balance from the gateway

### DIFF
--- a/apps/api/src/tools/ai-providers/credits.test.ts
+++ b/apps/api/src/tools/ai-providers/credits.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "bun:test";
+import { isValidBalanceCents } from "./credits";
+
+describe("isValidBalanceCents", () => {
+  it("accepts a normal balance", () => {
+    expect(isValidBalanceCents(1000)).toBe(true);
+  });
+
+  it("accepts a zero balance", () => {
+    expect(isValidBalanceCents(0)).toBe(true);
+  });
+
+  it("rejects NaN (e.g. from a malformed gateway response)", () => {
+    expect(isValidBalanceCents(Number.NaN)).toBe(false);
+  });
+
+  it("rejects Infinity", () => {
+    expect(isValidBalanceCents(Number.POSITIVE_INFINITY)).toBe(false);
+  });
+
+  it("rejects undefined coerced to a number position", () => {
+    expect(isValidBalanceCents(undefined as unknown as number)).toBe(false);
+  });
+});

--- a/apps/api/src/tools/ai-providers/credits.ts
+++ b/apps/api/src/tools/ai-providers/credits.ts
@@ -9,6 +9,12 @@ import { HOSTED_PROVIDER_IDS } from "../../ai-providers/provider-ids";
 import { getProviders } from "../../ai-providers/registry";
 import { mintGatewayJwt } from "../../auth/jwt";
 
+/** Guards against a malformed upstream gateway response (missing/NaN/Infinity
+ *  balance) silently reaching billing UI as an unusable number. */
+export function isValidBalanceCents(balanceCents: number): boolean {
+  return Number.isFinite(balanceCents);
+}
+
 export const AI_PROVIDER_CREDITS = defineTool({
   name: "AI_PROVIDER_CREDITS",
   description:
@@ -41,6 +47,16 @@ export const AI_PROVIDER_CREDITS = defineTool({
 
     const studioJwt = await mintGatewayJwt(userId);
 
-    return adapter.getCreditsBalance(studioJwt, org.id);
+    const result = await adapter.getCreditsBalance(studioJwt, org.id);
+    if (!isValidBalanceCents(result.balanceCents)) {
+      console.error(
+        `AI provider "${input.providerId}" returned a non-finite credits balance for org ${org.id}: ${result.balanceCents}`,
+      );
+      throw new Error(
+        `Provider ${input.providerId} returned an invalid credits balance`,
+      );
+    }
+
+    return result;
   },
 });


### PR DESCRIPTION
**Source:** bug found while hardening `apps/api/src/tools/ai-providers/credits.ts` (this tick's assigned focus area).

**Why:** `AI_PROVIDER_CREDITS` returns `adapter.getCreditsBalance(...)`'s result straight through with zero validation. `defineTool`'s `outputSchema` (`apps/api/src/core/define-tool.ts`) is only used to build the MCP JSON schema — it is never `.parse()`'d against the handler's return value at runtime — so a malformed upstream response from the Deco AI Gateway (`apps/api/src/ai-providers/adapters/deco-ai-gateway.ts` does a raw `as { balance_cents: number }` cast on the JSON body with no check) can hand back `null`/a string/`NaN` as `balanceCents`, and it flows straight to the client as if it were a valid dollar amount. The web side does real arithmetic on it: `apps/web/src/hooks/use-deco-credits.ts` computes `balanceCents / 100`, compares `balanceCents > previous`, and reports `delta_cents` to analytics — a non-finite value there produces `NaN` UI/analytics instead of a clear failure.

**Fix:** extract the check into an exported pure helper `isValidBalanceCents()` (`Number.isFinite`) and fail closed with a logged `console.error` + thrown error when the gateway's balance isn't a finite number, instead of silently passing bad data through.

**Regression test:** `apps/api/src/tools/ai-providers/credits.test.ts` — unit tests the new pure helper directly (no mocks) against normal/zero/NaN/Infinity/undefined balances.

**Reviewer command:** `bun test apps/api/src/tools/ai-providers/credits.test.ts`

**Locally verified:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (green), the targeted test above (5/5 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject non‑finite provider credits balances from the gateway to prevent NaN in UI and analytics. Fail closed with a clear error instead of passing bad data to clients.

- **Bug Fixes**
  - Added `isValidBalanceCents()` guard (`Number.isFinite`) and validate the gateway response before returning.
  - Log and throw when the balance is invalid.
  - Added unit tests covering normal, zero, NaN, Infinity, and undefined cases.

<sup>Written for commit 2534e48e87e5a32f50c4884202b5577e8ee27c88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

