### PR TITLE
refactor(connection): dedupe fetch-tools' header-building into one helper

### DIFF
--- a/apps/api/src/tools/connection/fetch-tools.test.ts
+++ b/apps/api/src/tools/connection/fetch-tools.test.ts
@@ -1,5 +1,37 @@
 import { describe, expect, it } from "bun:test";
-import { fetchToolsFromMCP } from "./fetch-tools";
+import {
+  buildConnectionRequestHeaders,
+  fetchToolsFromMCP,
+} from "./fetch-tools";
+
+describe("buildConnectionRequestHeaders", () => {
+  it("merges bearer token and custom headers for an HTTP connection", () => {
+    const headers = buildConnectionRequestHeaders({
+      id: "conn-1",
+      title: "http",
+      connection_type: "HTTP",
+      connection_token: "secret",
+      connection_headers: { headers: { "X-Custom": "value" } },
+    });
+
+    expect(headers).toEqual({
+      "Content-Type": "application/json",
+      Authorization: "Bearer secret",
+      "X-Custom": "value",
+    });
+  });
+
+  it("ignores STDIO-shaped connection_headers instead of misreading them", () => {
+    const headers = buildConnectionRequestHeaders({
+      id: "conn-2",
+      title: "stdio-shaped",
+      connection_type: "HTTP",
+      connection_headers: { command: "npx", args: ["some-mcp"] },
+    });
+
+    expect(headers).toEqual({ "Content-Type": "application/json" });
+  });
+});
 
 describe("fetchToolsFromMCP SSRF guard", () => {
   it("blocks an HTTP connection URL targeting a private/loopback address", async () => {

--- a/apps/api/src/tools/connection/fetch-tools.ts
+++ b/apps/api/src/tools/connection/fetch-tools.ts
@@ -15,11 +15,7 @@ import {
   createNoRedirectFetch,
   guardAgainstPrivateUrl,
 } from "../registry/discover-tools";
-import type {
-  ConnectionParameters,
-  HttpConnectionParameters,
-  ToolDefinition,
-} from "./schema";
+import type { ConnectionParameters, ToolDefinition } from "./schema";
 import { isStdioParameters } from "./schema";
 
 /**
@@ -68,6 +64,30 @@ export async function fetchToolsFromMCP(
     default:
       return null;
   }
+}
+
+/**
+ * Builds the request headers (bearer token + custom headers) shared by the
+ * HTTP and SSE transports. `connection_headers` is typed as a union with
+ * STDIO params, so narrow it with `isStdioParameters` instead of casting.
+ */
+export function buildConnectionRequestHeaders(
+  connection: ConnectionForToolFetch,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  if (connection.connection_token) {
+    headers.Authorization = `Bearer ${connection.connection_token}`;
+  }
+
+  const params = connection.connection_headers;
+  if (params && !isStdioParameters(params) && params.headers) {
+    Object.assign(headers, params.headers);
+  }
+
+  return headers;
 }
 
 /**
@@ -123,20 +143,7 @@ async function fetchToolsFromHttpMCP(
   let client: Client | null = null;
 
   try {
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-    };
-
-    if (connection.connection_token) {
-      headers.Authorization = `Bearer ${connection.connection_token}`;
-    }
-
-    // Add custom headers from connection_headers
-    const httpParams =
-      connection.connection_headers as HttpConnectionParameters | null;
-    if (httpParams?.headers) {
-      Object.assign(headers, httpParams.headers);
-    }
+    const headers = buildConnectionRequestHeaders(connection);
 
     const transport = new StreamableHTTPClientTransport(
       new URL(connection.connection_url),
@@ -214,19 +221,7 @@ async function fetchToolsFromSSEMCP(
   let client: Client | null = null;
 
   try {
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-    };
-
-    if (connection.connection_token) {
-      headers.Authorization = `Bearer ${connection.connection_token}`;
-    }
-
-    const httpParams =
-      connection.connection_headers as HttpConnectionParameters | null;
-    if (httpParams?.headers) {
-      Object.assign(headers, httpParams.headers);
-    }
+    const headers = buildConnectionRequestHeaders(connection);
 
     const transport = new SSEClientTransport(
       new URL(connection.connection_url),


### PR DESCRIPTION
**Source**: reduction found while auditing `apps/api/src/tools/connection/fetch-tools.ts` (assigned focus area: connection schema deduplication). Note: open PR #5555 already dedupes the tool-mapping block and fixes STDIO output-schema leniency in this same file — this PR targets a different, untouched duplication (header-building) and does not overlap those hunks.

**Why**: `fetchToolsFromHttpMCP` and `fetchToolsFromSSEMCP` each hand-rolled an identical block building the Content-Type/Authorization/custom-headers object, including `connection.connection_headers as HttpConnectionParameters | null` — an unchecked cast on a value whose real type is a union with `StdioConnectionParameters`. The repo already has a proper discriminant for this exact union, `isStdioParameters()` (used correctly in the STDIO branch a few lines below), just not applied here.

**What changed**: extracted `buildConnectionRequestHeaders()` and narrow with `!isStdioParameters(params)` instead of casting. Behavior-preserving — same three header-building steps (Content-Type, bearer token, custom headers merge), just written once and correctly typed. Net: -33/+59 across the two files but the duplicated logic itself shrinks from two ~12-line inline blocks to one 12-line function reused twice, plus two small regression tests for the new helper (bearer+custom-header merge, and STDIO-shaped params being ignored rather than misread).

**Reviewer check**: `cd apps/api && bunx tsc --noEmit` (clean) and `bun test apps/api/src/tools/connection/fetch-tools.test.ts` (4 pass, including the 2 new tests plus the 2 pre-existing SSRF-guard tests, unchanged).

**Verified locally**: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bun test apps/api/src/tools/connection/fetch-tools.test.ts`, `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates request header construction for MCP HTTP and SSE transports via `buildConnectionRequestHeaders`. Replaces an unsafe cast with `isStdioParameters` to improve type-safety and avoid misreading STDIO-shaped params.

- **Refactors**
  - Extracted `buildConnectionRequestHeaders` and reused it in both fetch paths.
  - Switched to `isStdioParameters` for narrowing; added tests for bearer+custom header merge and for ignoring STDIO-shaped `connection_headers`.

<sup>Written for commit 2ca0f90779c87d930ba44b913bd9cf19a26acabc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

