### PR TITLE
feat(native): reclaim a branch's worktree when its last chat is archived

### DIFF
--- a/apps/api/src/tools/sandbox/delete.test.ts
+++ b/apps/api/src/tools/sandbox/delete.test.ts
@@ -179,6 +179,7 @@ describe("SANDBOX_DELETE", () => {
         virtualMcpId: "vmcp_1",
         branch: BRANCH,
         sandboxProviderKind: "agent-sandbox",
+        removeWorktree: false,
       },
       ctx,
     );
@@ -213,6 +214,7 @@ describe("SANDBOX_DELETE", () => {
         virtualMcpId: "vmcp_1",
         branch: BRANCH,
         sandboxProviderKind: "agent-sandbox",
+        removeWorktree: false,
       },
       ctx,
     );
@@ -239,6 +241,7 @@ describe("SANDBOX_DELETE", () => {
         virtualMcpId: "vmcp_1",
         branch: BRANCH,
         sandboxProviderKind: "user-desktop",
+        removeWorktree: false,
       },
       ctx,
     );
@@ -306,6 +309,7 @@ describe("SANDBOX_DELETE", () => {
           virtualMcpId: "vmcp_1",
           branch: BRANCH,
           sandboxProviderKind: "agent-sandbox",
+          removeWorktree: false,
         },
         ctx,
       );
@@ -337,6 +341,7 @@ describe("SANDBOX_DELETE", () => {
         virtualMcpId: "vmcp_1",
         branch: BRANCH,
         sandboxProviderKind: "agent-sandbox",
+        removeWorktree: false,
       },
       ctx,
     );
@@ -354,6 +359,7 @@ describe("SANDBOX_DELETE", () => {
         virtualMcpId: "vmcp_missing",
         branch: BRANCH,
         sandboxProviderKind: "agent-sandbox",
+        removeWorktree: false,
       },
       ctx,
     );
@@ -376,6 +382,7 @@ describe("SANDBOX_DELETE", () => {
           virtualMcpId: "vmcp_1",
           branch: BRANCH,
           sandboxProviderKind: "agent-sandbox",
+          removeWorktree: false,
         },
         ctx,
       ),

--- a/apps/api/src/tools/sandbox/delete.ts
+++ b/apps/api/src/tools/sandbox/delete.ts
@@ -39,6 +39,13 @@ export const SANDBOX_DELETE = defineTool({
     sandboxProviderKind: sandboxProviderKindInputSchema.describe(
       "Kind of sandbox provider the VM was started with. Hosted provider is `agent-sandbox`; legacy `cluster` input is accepted only for compatibility and normalized to `agent-sandbox`. Used to locate the correct 3-level sandboxMap entry.",
     ),
+    removeWorktree: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe(
+        "Also reclaim the sandbox's workspace (local worktree + disk). Ignored by providers whose teardown already destroys the filesystem.",
+      ),
   }),
   outputSchema: z.object({
     success: z.boolean(),

--- a/apps/native/crates/local-api/src/routes/intercept/sandbox_lifecycle.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/sandbox_lifecycle.rs
@@ -499,11 +499,16 @@ fn merge_sandbox_map(entity: &mut Value, user_id: &str, entries: Vec<(String, Va
     }
 }
 
-/// `SANDBOX_DELETE` — stop the local sandbox behind `(virtualMcpId, branch)`.
+/// `SANDBOX_DELETE` — stop the local sandbox behind `(virtualMcpId, branch)`,
+/// and — only when the caller asks — reclaim its worktree.
 ///
 /// Needs no upstream read: the handle is derived from the input alone. Deleting
 /// an unknown handle is a success, matching the tool's idempotent `{ success }`
 /// contract — the caller asked for it to be gone, and it is.
+///
+/// `removeWorktree` defaults to `false`, and absent means false: the shell's
+/// Restart is `await stop(); start()`, so a flipped default would delete the
+/// repository — and any uncommitted work in it — on every restart.
 async fn delete(state: &AppState, body: &Bytes) -> Response {
     let input: Value = match crate::http_util::json_body(body) {
         Ok(value) => value,
@@ -519,6 +524,10 @@ async fn delete(state: &AppState, body: &Bytes) -> Response {
     else {
         return ApiError::bad_request("branch is required").into_response();
     };
+    let remove_worktree = input
+        .get("removeWorktree")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
 
     let Ok(Some(handle)) = state
         .sandbox_manager
@@ -528,8 +537,17 @@ async fn delete(state: &AppState, body: &Bytes) -> Response {
         // not an error, so a repeated delete stays idempotent.
         return Json(json!({ "success": true })).into_response();
     };
-    match state.sandbox_manager.stop_registered(&handle).await {
+    let outcome = if remove_worktree {
+        state.sandbox_manager.remove_registered(&handle).await
+    } else {
+        state.sandbox_manager.stop_registered(&handle).await
+    };
+    match outcome {
         Ok(_) => Json(json!({ "success": true })).into_response(),
+        Err(error) if remove_worktree => {
+            ApiError::internal(format!("could not reclaim the local sandbox: {error}"))
+                .into_response()
+        }
         Err(error) => {
             ApiError::internal(format!("could not stop the local sandbox: {error}")).into_response()
         }
@@ -789,6 +807,96 @@ mod tests {
         );
         assert_eq!(preview_url("alpha"), preview_url("beta"));
         set_preview_port(0);
+    }
+
+    /// A registered handle plus the worktree directory the reclaim path
+    /// operates on. No clone: these tests are about the dispatch decision, not
+    /// about git.
+    fn registered_sandbox(root: &std::path::Path) -> (AppState, String, std::path::PathBuf) {
+        let state = super::super::test_state(root);
+        let handle = state
+            .sandbox_manager
+            .register_for_test("https://github.com/acme/site.git", "feature-x");
+        let worktree = crate::sandbox::worktree_root(root, &handle);
+        std::fs::create_dir_all(worktree.join("repo")).unwrap();
+        (state, handle, worktree)
+    }
+
+    async fn delete_body(state: &AppState, body: Value) -> (StatusCode, Value) {
+        let response = delete(state, &Bytes::from(body.to_string())).await;
+        let status = response.status();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        (status, serde_json::from_slice(&bytes).unwrap())
+    }
+
+    /// The default is `false`, and absent means false: the shell's Restart is
+    /// `await stop(); start()`, so anything else would delete the repository on
+    /// every restart.
+    #[tokio::test]
+    async fn delete_keeps_the_worktree_unless_the_caller_asks_for_it_to_go() {
+        let root = tempfile::tempdir().unwrap();
+        let (state, handle, worktree) = registered_sandbox(root.path());
+
+        for body in [
+            json!({ "virtualMcpId": "test-agent", "branch": "feature-x" }),
+            json!({ "virtualMcpId": "test-agent", "branch": "feature-x", "removeWorktree": false }),
+            // A non-boolean is not a yes.
+            json!({ "virtualMcpId": "test-agent", "branch": "feature-x", "removeWorktree": "true" }),
+        ] {
+            let (status, answer) = delete_body(&state, body.clone()).await;
+            assert_eq!(status, StatusCode::OK, "{body}");
+            assert_eq!(answer, json!({ "success": true }), "{body}");
+            assert!(worktree.is_dir(), "stop must never remove the worktree");
+            assert!(state.sandbox_manager.is_registered(&handle).unwrap());
+        }
+    }
+
+    #[tokio::test]
+    async fn delete_with_remove_worktree_reclaims_the_directory_and_the_row() {
+        let root = tempfile::tempdir().unwrap();
+        let (state, handle, worktree) = registered_sandbox(root.path());
+
+        let (status, answer) = delete_body(
+            &state,
+            json!({ "virtualMcpId": "test-agent", "branch": "feature-x", "removeWorktree": true }),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(answer, json!({ "success": true }));
+        assert!(!worktree.exists());
+        assert!(!state.sandbox_manager.is_registered(&handle).unwrap());
+
+        // And it stays idempotent: the second call finds nothing to do.
+        let (status, answer) = delete_body(
+            &state,
+            json!({ "virtualMcpId": "test-agent", "branch": "feature-x", "removeWorktree": true }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(answer, json!({ "success": true }));
+    }
+
+    /// The documented idempotent contract, on both branches of the dispatch.
+    #[tokio::test]
+    async fn deleting_an_unknown_handle_is_a_success_either_way() {
+        let root = tempfile::tempdir().unwrap();
+        let state = super::super::test_state(root.path());
+        for remove_worktree in [false, true] {
+            let (status, answer) = delete_body(
+                &state,
+                json!({
+                    "virtualMcpId": "never-registered",
+                    "branch": "feature-x",
+                    "removeWorktree": remove_worktree,
+                }),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK);
+            assert_eq!(answer, json!({ "success": true }));
+        }
     }
 
     #[test]

--- a/apps/native/crates/local-api/src/routes/intercept/thread_tools.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/thread_tools.rs
@@ -411,10 +411,24 @@ fn list(state: &AppState, scope: &RtAccountScope, org: &str, body: &Bytes) -> Re
         Ok(input) => input,
         Err(error) => return error.into_response(),
     };
-    let (limit, offset) = match pagination(input, 100) {
-        Ok(pagination) => pagination,
-        Err(error) => return error.into_response(),
-    };
+    // Deliberate divergence from the tool contract: the thread list is NOT
+    // paginated here, and a caller-supplied `limit`/`offset` is ignored.
+    //
+    // The store is local SQLite holding one account's threads, so "every open
+    // thread" is a few hundred rows at most and costs a few milliseconds — far
+    // less than the round-trips the client would otherwise make walking pages.
+    // Answering in full is what lets the desktop UI treat its in-memory list as
+    // COMPLETE rather than as a paginated sample, which turns "is anyone else
+    // on this branch" from a server query into a local predicate. `hasMore` is
+    // therefore always false and `totalCount` always equals `items.len()`, so a
+    // client paging loop terminates immediately instead of spinning.
+    //
+    // `limit`/`offset` are still PARSED, so a malformed value is still a 400 —
+    // silently accepting garbage because we no longer use it would be a
+    // contract regression of a different kind.
+    if let Err(error) = pagination(input, 100) {
+        return error.into_response();
+    }
     if let Err(error) = validate_order_by(input) {
         return error.into_response();
     }
@@ -535,19 +549,14 @@ fn list(state: &AppState, scope: &RtAccountScope, org: &str, body: &Bytes) -> Re
             end_date,
             status,
             agent_id,
-            limit,
-            offset,
         },
     ) {
-        Ok((items, total_count)) => {
-            let has_more = offset + limit < total_count;
-            Json(json!({
-                "items": items,
-                "totalCount": total_count,
-                "hasMore": has_more,
-            }))
-            .into_response()
-        }
+        Ok((items, total_count)) => Json(json!({
+            "items": items,
+            "totalCount": total_count,
+            "hasMore": false,
+        }))
+        .into_response(),
         Err(e) => ApiError::internal(format!("thread database error: {e}")).into_response(),
     }
 }
@@ -1181,7 +1190,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn list_defaults_to_visible_threads_and_a_page_of_one_hundred() {
+    async fn list_returns_every_visible_thread_unpaginated() {
         let state = persistent_test_state();
         let database = shared_db(&state).unwrap();
         let org = "thread-tools-default-visible-limit";
@@ -1231,9 +1240,13 @@ mod tests {
         .await
         .unwrap();
         let visible = body_json(visible).await;
+        // Inverted from the old paged behavior (100 items / hasMore: true):
+        // the local list now answers in FULL so the desktop UI can treat its
+        // in-memory copy as complete. 101 visible rows means 101 items, and a
+        // client paging loop must terminate on the first response.
         assert_eq!(visible["totalCount"], 101);
-        assert_eq!(visible["items"].as_array().unwrap().len(), 100);
-        assert_eq!(visible["hasMore"], true);
+        assert_eq!(visible["items"].as_array().unwrap().len(), 101);
+        assert_eq!(visible["hasMore"], false);
         assert!(visible["items"]
             .as_array()
             .unwrap()
@@ -1401,6 +1414,62 @@ mod tests {
         .unwrap();
         assert_eq!(empty_trigger_ids.status(), StatusCode::OK);
         assert_eq!(body_json(empty_trigger_ids).await["totalCount"], 1);
+    }
+
+    /// The local list ignores `limit`/`offset` on purpose — the desktop UI
+    /// depends on its in-memory copy being COMPLETE, so a client asking for one
+    /// row still gets all of them and is told there is no next page. A
+    /// malformed value is still rejected, because "ignored" must not degrade
+    /// into "unvalidated".
+    #[tokio::test]
+    async fn list_ignores_caller_pagination_but_still_validates_it() {
+        let state = persistent_test_state();
+        let org = "thread-tools-ignores-pagination";
+        for _ in 0..3 {
+            let body =
+                Bytes::from(json!({"data": {"title": "t", "virtual_mcp_id": "v"}}).to_string());
+            dispatch(&state, org, "COLLECTION_THREADS_CREATE", &body)
+                .await
+                .unwrap();
+        }
+
+        let one = dispatch(
+            &state,
+            org,
+            "COLLECTION_THREADS_LIST",
+            &Bytes::from_static(br#"{"limit":1,"offset":0}"#),
+        )
+        .await
+        .unwrap();
+        let one = body_json(one).await;
+        assert_eq!(one["items"].as_array().unwrap().len(), 3);
+        assert_eq!(one["totalCount"], 3);
+        assert_eq!(one["hasMore"], false);
+
+        // An offset past the end would have emptied a paged response; here it
+        // changes nothing, which is what makes the client's loop terminate.
+        let offset = dispatch(
+            &state,
+            org,
+            "COLLECTION_THREADS_LIST",
+            &Bytes::from_static(br#"{"offset":99}"#),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            body_json(offset).await["items"].as_array().unwrap().len(),
+            3
+        );
+
+        let malformed = dispatch(
+            &state,
+            org,
+            "COLLECTION_THREADS_LIST",
+            &Bytes::from_static(br#"{"limit":0}"#),
+        )
+        .await
+        .unwrap();
+        assert_eq!(malformed.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]

--- a/apps/native/crates/local-api/src/routes/threads/db.rs
+++ b/apps/native/crates/local-api/src/routes/threads/db.rs
@@ -902,9 +902,12 @@ impl RtAccountScope {
     }
 }
 
-/// Filters and pagination for a scoped native thread listing. Keeping these in
-/// one typed value prevents the storage API from growing another positional
-/// argument every time the production collection adds a filter.
+/// Filters for a scoped native thread listing. Keeping these in one typed value
+/// prevents the storage API from growing another positional argument every time
+/// the production collection adds a filter.
+///
+/// No `limit`/`offset`: the local list is answered in full (see `list()` in
+/// `intercept::thread_tools` for why), so every caller gets every matching row.
 #[derive(Debug, Clone, Copy)]
 pub struct RtThreadListOptions<'a> {
     pub created_by: Option<&'a str>,
@@ -917,8 +920,6 @@ pub struct RtThreadListOptions<'a> {
     pub end_date: Option<&'a str>,
     pub status: Option<&'a str>,
     pub agent_id: Option<&'a str>,
-    pub limit: i64,
-    pub offset: i64,
 }
 
 /// Durable identity for one live incarnation of a local thread. `generation`
@@ -1556,8 +1557,10 @@ impl ThreadsDb {
     /// wins over the legacy `agent_id` fallback and the remaining predicates
     /// compose normally. `search` is a case-insensitive literal substring
     /// match on `title`.
-    /// Returns `(items, total_count)` so the caller can compute `hasMore`
-    /// (`offset + limit < total_count`) without a second round trip.
+    ///
+    /// Returns EVERY matching row — there is no pagination here — plus the
+    /// count, which is consequently always `items.len()`. The count is still
+    /// returned so callers report `totalCount` from one place.
     pub fn rt_list_threads_scoped(
         &self,
         scope: &RtAccountScope,
@@ -1636,14 +1639,13 @@ impl ThreadsDb {
             |row| row.get(0),
         )?;
 
+        // No LIMIT/OFFSET: every matching row, every time. `total` above and
+        // `out.len()` below are therefore always equal — the count query is kept
+        // only so the response's `totalCount` stays a single source of truth.
         let list_sql = format!(
             "SELECT {RT_THREAD_COLUMNS} FROM native_scoped_threads WHERE {where_sql} \
-             ORDER BY updated_at DESC, rowid DESC LIMIT ?{} OFFSET ?{}",
-            sql_params.len() + 1,
-            sql_params.len() + 2,
+             ORDER BY updated_at DESC, rowid DESC"
         );
-        sql_params.push(Box::new(options.limit));
-        sql_params.push(Box::new(options.offset));
         let mut stmt = conn.prepare(&list_sql)?;
         let rows = stmt.query_map(
             rusqlite::params_from_iter(sql_params.iter().map(|b| b.as_ref())),
@@ -5525,8 +5527,6 @@ ON rt_turn_queue(state, organization_id, thread_id, thread_generation, fifo_ordi
                     end_date: None,
                     status: None,
                     agent_id: None,
-                    limit: 50,
-                    offset: 0,
                 },
             )
             .unwrap();
@@ -5623,8 +5623,6 @@ ON rt_turn_queue(state, organization_id, thread_id, thread_generation, fifo_ordi
                     // Production uses virtual_mcp_id first and only falls
                     // back to agentId when it is absent.
                     agent_id: Some("vm-agent"),
-                    limit: 100,
-                    offset: 0,
                 },
             )
             .unwrap();
@@ -5647,8 +5645,6 @@ ON rt_turn_queue(state, organization_id, thread_id, thread_generation, fifo_ordi
                     end_date: None,
                     status: Some("completed"),
                     agent_id: Some("vm-agent"),
-                    limit: 100,
-                    offset: 0,
                 },
             )
             .unwrap();
@@ -5674,14 +5670,23 @@ ON rt_turn_queue(state, organization_id, thread_id, thread_generation, fifo_ordi
                     end_date: Some("2999-01-02T00:00:00.000Z"),
                     status: Some("in_progress"),
                     agent_id: Some("missing-agent"),
-                    limit: 1,
-                    offset: 0,
                 },
             )
             .unwrap();
+        // Unpaginated: the count and the returned rows are now always the same
+        // set. The old expectation of 1 item out of 2 was a `limit: 1` slice,
+        // not a filter result.
         assert_eq!(trigger_total, 2);
-        assert_eq!(trigger_items.len(), 1);
-        assert_eq!(trigger_items[0].id, "normal-other");
+        assert_eq!(trigger_items.len(), 2);
+        let mut ids = trigger_items
+            .iter()
+            .map(|item| item.id.clone())
+            .collect::<Vec<_>>();
+        ids.sort();
+        assert_eq!(
+            ids,
+            vec!["normal-match".to_string(), "normal-other".to_string()]
+        );
         assert!(trigger_items.iter().all(|item| !item.hidden));
     }
 

--- a/apps/native/crates/local-api/src/sandbox/manager.rs
+++ b/apps/native/crates/local-api/src/sandbox/manager.rs
@@ -612,6 +612,16 @@ impl SandboxManager {
         }
         let handle_lock = self.handle_lock(handle);
         let _permit = handle_lock.lock().await;
+        self.stop_locked(handle).await.map(Some)
+    }
+
+    /// The stop itself, with this handle's operation lock ALREADY held.
+    ///
+    /// Split out so [`Self::remove_registered`] can stop and then delete under
+    /// ONE acquisition: the per-handle lock is not reentrant, and releasing it
+    /// between the two would let an `ensure` re-clone the worktree into the
+    /// directory about to be removed.
+    async fn stop_locked(&self, handle: &str) -> Result<usize, String> {
         let Some(sandbox) = self.get(handle) else {
             let record = self
                 .registry
@@ -624,7 +634,7 @@ impl SandboxManager {
             };
             self.registry
                 .mark_state(handle, "stopped", observed, record.error.as_deref())?;
-            return Ok(Some(0));
+            return Ok(0);
         };
 
         // The close flag is the generation fence checked between every
@@ -657,6 +667,71 @@ impl SandboxManager {
         self.publish_generation(handle, None);
         self.registry
             .mark_state(handle, "stopped", "stopped", None)?;
+        Ok(killed)
+    }
+
+    /// Reclaim a durable sandbox: stop it, delete its worktree directory, and
+    /// forget it — the only path in this process that removes a worktree a user
+    /// asked for.
+    ///
+    /// **This never refuses.** A worktree with uncommitted or unpushed work is
+    /// removed exactly like a clean one: the decision belongs to the confirm
+    /// the caller already collected, which is the only place that can state
+    /// what is about to be lost. A primitive that sometimes declined would
+    /// split that policy across two layers and make the outcome depend on state
+    /// the caller cannot see. The errors below are all infrastructure failures
+    /// (a stop that cannot reap its children, a directory that cannot be
+    /// unlinked), never a judgment about the worktree's contents.
+    ///
+    /// `Ok(None)` for an unknown handle, like [`Self::stop_registered`], so a
+    /// repeated reclaim stays idempotent.
+    pub async fn remove_registered(&self, handle: &str) -> Result<Option<usize>, String> {
+        let Some(record) = self.registry.record(handle)? else {
+            return Ok(None);
+        };
+        let handle_lock = self.handle_lock(handle);
+        let _permit = handle_lock.lock().await;
+
+        let killed = self.stop_locked(handle).await?;
+
+        let root = crate::sandbox::worktree_root(&self.app_root, handle);
+        match tokio::fs::remove_dir_all(&root).await {
+            Ok(()) => {}
+            // Already gone is the outcome that was asked for.
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(format!(
+                    "failed to remove sandbox worktree {root:?}: {error}"
+                ));
+            }
+        }
+
+        // NOT cleanup — a required step. This workdir is a worktree of the
+        // shared canonical repo (see `sandbox::repo_store`), which keeps
+        // listing it after the directory is gone and then refuses to re-add a
+        // worktree at that path. Without this prune the branch could never be
+        // re-created.
+        super::repo_store::prune_worktrees(&self.app_root, &record.config.clone_url).await;
+
+        self.registry.remove(handle)?;
+        self.invalidate_preview_labels();
+        // The durable active pointer went with the row; clear the in-memory
+        // one too, or `active()` keeps naming a sandbox that no longer exists.
+        let was_active = {
+            let mut active = self
+                .active_handle
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let was_active = active.as_deref() == Some(handle);
+            if was_active {
+                *active = None;
+            }
+            was_active
+        };
+        if was_active {
+            let _ = self.active_watch.send(None);
+        }
+        tracing::info!(handle, killed, "sandbox reclaimed: worktree removed");
         Ok(Some(killed))
     }
 
@@ -1967,6 +2042,99 @@ mod tests {
             git_tasks_after_second, git_tasks_after_first,
             "an unchanged checkout must not rerun the registered clone/checkout path"
         );
+    }
+
+    /// Reclaim removes the worktree from disk, drops the registry row, clears
+    /// the active pointer — and leaves the canonical repo able to cut the SAME
+    /// branch again. That last assertion is the `prune_worktrees` regression:
+    /// git keeps listing a worktree whose directory is gone and refuses to
+    /// re-add one at that path, so without the prune the branch could never be
+    /// re-created.
+    #[tokio::test]
+    async fn remove_registered_reclaims_the_worktree_and_lets_the_branch_be_recreated() {
+        let (_root, clone_url) = setup_two_branch_repo();
+        let app_root = tempfile::tempdir().unwrap();
+        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        let cfg = GitSandboxConfig {
+            virtual_mcp_id: "vmcp-reclaim".to_string(),
+            clone_url: clone_url.clone(),
+            branch: Some("work".to_string()),
+            ..Default::default()
+        };
+
+        let sandbox = manager.ensure(&cfg).await.expect("ensure succeeds");
+        let handle = sandbox.handle.clone();
+        let worktree = crate::sandbox::worktree_root(app_root.path(), &handle);
+        // Let the queued install/start cascade settle, so the removal below is
+        // not racing a setup child that is still writing into the workdir.
+        tokio::time::timeout(Duration::from_secs(10), async {
+            while sandbox.setup.is_running() || sandbox.setup.pending_count() > 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the setup pipeline settles");
+        assert!(worktree.is_dir());
+        assert!(sandbox.workdir.join("BRANCH.txt").is_file());
+        // Uncommitted work is NOT a veto — the primitive removes it anyway.
+        std::fs::write(sandbox.workdir.join("uncommitted.txt"), "unsaved\n").unwrap();
+        assert_eq!(
+            manager.registered_active_handle().unwrap().as_deref(),
+            Some(handle.as_str()),
+            "ensure activates the handle it provisioned"
+        );
+        drop(sandbox);
+
+        manager
+            .remove_registered(&handle)
+            .await
+            .expect("reclaim succeeds whatever the worktree contains")
+            .expect("a registered handle is not unknown");
+
+        assert!(!worktree.exists(), "the worktree directory must be gone");
+        assert!(!manager.is_registered(&handle).unwrap());
+        assert!(manager.registry_record(&handle).unwrap().is_none());
+        assert!(manager.registered_active_handle().unwrap().is_none());
+        assert!(manager.active().is_none());
+        assert!(manager.get(&handle).is_none());
+        assert!(manager
+            .handle_for_agent(&cfg.virtual_mcp_id, "work")
+            .unwrap()
+            .is_none());
+
+        let canonical = crate::sandbox::repo_store::canonical_repo_dir(app_root.path(), &clone_url)
+            .expect("keyable clone url");
+        let listed = git_stdout(&canonical, &["worktree", "list"]);
+        assert!(
+            !listed.contains(worktree.to_str().unwrap()),
+            "the removed worktree must not stay registered: {listed}"
+        );
+
+        // The whole point: the branch can be started again.
+        let again = manager
+            .ensure(&cfg)
+            .await
+            .expect("the same branch can be provisioned again after a reclaim");
+        assert_eq!(again.handle, handle);
+        assert_eq!(
+            std::fs::read_to_string(again.workdir.join("BRANCH.txt"))
+                .unwrap()
+                .trim(),
+            "main"
+        );
+        assert!(
+            !again.workdir.join("uncommitted.txt").exists(),
+            "a reclaim is a delete, not a stash"
+        );
+    }
+
+    /// Mirrors `stop_registered`: nothing registered means nothing to reclaim,
+    /// which is a success, not an error.
+    #[tokio::test]
+    async fn remove_registered_reports_an_unknown_handle_as_unknown() {
+        let app_root = tempfile::tempdir().unwrap();
+        let manager = SandboxManager::new(app_root.path().to_path_buf());
+        assert_eq!(manager.remove_registered("acme/repo/nope").await, Ok(None));
     }
 
     #[tokio::test]

--- a/apps/native/crates/local-api/src/sandbox/registry.rs
+++ b/apps/native/crates/local-api/src/sandbox/registry.rs
@@ -443,6 +443,42 @@ impl SandboxRegistry {
         self.secure_database_files()
     }
 
+    /// Forget a sandbox: its row, the agent claims that hang off it, and the
+    /// active pointer when it named this handle.
+    ///
+    /// Unknown handles are a no-op success — the caller asked for the row to be
+    /// gone, and it is. `sandbox_agents` rows go with it through the schema's
+    /// `ON DELETE CASCADE` (foreign keys are enabled per connection).
+    ///
+    /// The active-pointer clear mirrors `reconcile_after_process_start`, which
+    /// drops the pointer when the sandbox it names is no longer usable: a
+    /// pointer to a row that does not exist resolves to nothing, and
+    /// `set_active` refuses to re-create it.
+    pub(crate) fn remove(&self, handle: &str) -> Result<(), String> {
+        let mut connection = self.connection();
+        // IMMEDIATE for the same reason as `set_active`: this transaction
+        // writes twice and must not be handed SQLITE_BUSY without the busy
+        // timeout applying.
+        let transaction = connection
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(|error| format!("failed to begin sandbox removal: {error}"))?;
+        transaction
+            .execute("DELETE FROM sandboxes WHERE handle = ?1", [handle])
+            .map_err(|error| format!("failed to remove sandbox {handle}: {error}"))?;
+        transaction
+            .execute(
+                "DELETE FROM sandbox_metadata WHERE key = 'active_handle' AND value = ?1",
+                [handle],
+            )
+            .map_err(|error| {
+                format!("failed to clear the active pointer for sandbox {handle}: {error}")
+            })?;
+        transaction
+            .commit()
+            .map_err(|error| format!("failed to commit sandbox removal: {error}"))?;
+        self.secure_database_files()
+    }
+
     fn import_legacy_sidecars(&self) -> Result<(), String> {
         let sandboxes_root = self.app_root.join(crate::sandbox::WORKTREES_DIR);
         for handle in super::persist::handles_with_sidecars(&self.app_root) {
@@ -1064,6 +1100,91 @@ mod tests {
             reopened.record(&handle).unwrap().unwrap().observed_status,
             "absent"
         );
+    }
+
+    /// Reclaim drops the row, the agent claims that hang off it, and — because
+    /// this handle was the active one — the active pointer too. A pointer left
+    /// naming a removed handle is exactly what
+    /// `reconcile_after_process_start` exists to clear on the next boot.
+    #[test]
+    fn remove_drops_the_row_its_agents_and_the_active_pointer() {
+        let root = tempfile::tempdir().unwrap();
+        let cfg = config();
+        let handle = SandboxManager::compute_handle(&cfg.clone_url, cfg.branch.as_deref().unwrap())
+            .expect("scopeable clone url");
+        let sandbox_path = root
+            .path()
+            .join(crate::sandbox::WORKTREES_DIR)
+            .join(&handle);
+        let workdir_path = sandbox_path.join("repo");
+        create_git_checkout(&workdir_path);
+
+        let registry = SandboxRegistry::open(root.path().to_path_buf()).unwrap();
+        registry
+            .upsert_config(&handle, &cfg, &sandbox_path, &workdir_path)
+            .unwrap();
+        registry.set_active(&handle).unwrap();
+
+        registry.remove(&handle).unwrap();
+
+        assert!(!registry.contains(&handle).unwrap());
+        assert!(registry.record(&handle).unwrap().is_none());
+        assert!(registry.active_handle().unwrap().is_none());
+        assert!(registry
+            .handle_for_agent(&cfg.virtual_mcp_id, cfg.branch.as_deref().unwrap())
+            .unwrap()
+            .is_none());
+        let agent_rows: i64 = registry
+            .connection()
+            .query_row("SELECT COUNT(*) FROM sandbox_agents", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(agent_rows, 0, "agent claims must cascade with the sandbox");
+    }
+
+    /// Removing one sandbox must not disturb another's active pointer.
+    #[test]
+    fn remove_leaves_a_different_sandboxs_active_pointer_alone() {
+        let root = tempfile::tempdir().unwrap();
+        let kept = config();
+        let mut removed = config();
+        removed.branch = Some("feature/other".to_string());
+
+        let registry = SandboxRegistry::open(root.path().to_path_buf()).unwrap();
+        let mut handles = Vec::new();
+        for cfg in [&kept, &removed] {
+            let handle =
+                SandboxManager::compute_handle(&cfg.clone_url, cfg.branch.as_deref().unwrap())
+                    .expect("scopeable clone url");
+            let sandbox_path = root
+                .path()
+                .join(crate::sandbox::WORKTREES_DIR)
+                .join(&handle);
+            let workdir_path = sandbox_path.join("repo");
+            create_git_checkout(&workdir_path);
+            registry
+                .upsert_config(&handle, cfg, &sandbox_path, &workdir_path)
+                .unwrap();
+            handles.push(handle);
+        }
+        registry.set_active(&handles[0]).unwrap();
+
+        registry.remove(&handles[1]).unwrap();
+
+        assert_eq!(
+            registry.active_handle().unwrap().as_deref(),
+            Some(handles[0].as_str())
+        );
+        assert!(registry.contains(&handles[0]).unwrap());
+    }
+
+    /// The idempotent contract the delete intercept promises: asking for a
+    /// handle that was never registered to be gone succeeds, because it is.
+    #[test]
+    fn removing_an_unknown_handle_is_a_no_op_success() {
+        let root = tempfile::tempdir().unwrap();
+        let registry = SandboxRegistry::open(root.path().to_path_buf()).unwrap();
+        registry.remove("phantom").unwrap();
+        assert!(!registry.contains("phantom").unwrap());
     }
 
     #[test]

--- a/apps/native/docs/worktree-reclaim-plan.md
+++ b/apps/native/docs/worktree-reclaim-plan.md
@@ -1,0 +1,302 @@
+# Worktree reclaim on last-thread archive — implementation plan
+
+Gives the desktop app a way to stop a sandbox's processes and delete its git
+worktree. Today it has neither: nothing in `apps/native` ever removes a
+worktree, so every branch a user has ever opened stays on disk forever.
+
+**Status:** implemented. This doc was written as a plan and has been updated to
+match what shipped; where the two diverged during review, the shipped behavior
+wins and the reasoning is kept so the tradeoff stays legible.
+
+## Why
+
+`SANDBOX_DELETE` (`apps/api/src/tools/sandbox/delete.ts`) has exactly one
+production caller — `stop()` in
+`apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx:643`,
+reached from the preview drawer's Stop and Restart buttons.
+
+On the hosted provider that call reclaims everything: `deleteSandboxClaim`
+(`packages/sandbox/server/provider/agent-sandbox/runner.ts:539`) destroys the
+claim, and the operator garbage-collects the pod and its disk.
+
+On the desktop it reclaims nothing durable. The native intercept
+(`apps/native/crates/local-api/src/routes/intercept/sandbox_lifecycle.rs:507`)
+calls `SandboxManager::stop_registered`, which kills the `setup`/`dev`/`start`
+tasks and marks the registry row `stopped`. The worktree stays on disk. There
+is no removal path at all:
+
+- `SandboxRegistry` has no removal method. Its API is `open / upsert_config /
+  record / records_for_agent / handles / contains / handle_for_agent /
+  set_active / active_handle / mark_state / mark_observed`
+  (`sandbox/registry.rs:93-445`).
+- The only `remove_dir_all` on a worktree is the invalid-repo recovery path
+  (`sandbox/manager.rs:798`), which clears a half-cloned workdir in order to
+  re-clone it — not a user-facing reclaim.
+
+So the disk cost of a branch is permanent, and the user has no affordance to
+say otherwise.
+
+## Decisions
+
+**The trigger is archiving the last chat on a branch.** A worktree's identity
+is `(repo, branch)` — `manager.rs:345` calls one worktree per `(repo, branch)`
+"the deliberate consequence" — and `threads.branch`
+(`apps/api/src/storage/types.ts:962`) is N:1 onto branch. So "no non-archived
+threads left on this branch" is exactly "this worktree has no remaining owner".
+No new concept is introduced; the trigger rides an action users already take.
+
+**The confirm is a React dialog, and it gates the archive itself.** Confirm →
+archive proceeds, then the worktree is reclaimed. Cancel → nothing happens at
+all; the thread is not archived. This keeps one decision in one place instead
+of splitting "archive?" from "reclaim?" across two prompts.
+
+Rejected: a Tauri native dialog driven from Rust. `local-api` is
+Tauri-agnostic — `AppState` (`state.rs:75-112`) has no `AppHandle` and
+`tauri-plugin-dialog` is not a dependency — so it would need an
+`UpdateHooks`-style injected capability. Worse, `thread_tools::update` holds
+the agent-session start lock across its await (`thread_tools.rs:737-742`), so
+blocking there on a human decision stalls concurrent starts on that fence.
+
+**Desktop-only, via the existing knob.** `isDesktopAppEnvironment()`
+(`apps/web/src/hooks/use-is-desktop-app.ts:34`) reads the build-time
+`VITE_TAURI_APP` constant, so Vite dead-code-eliminates this whole path out of
+the web bundle. That file is explicit that every desktop-vs-web gate goes
+through it and no second detection mechanism may be added.
+
+**`apps/api` gets interface changes only.** `removeWorktree` is inert on the
+hosted path — claim teardown already destroys the pod's filesystem. Nothing else
+in `apps/api` changes: a `where.branch` list filter was added and then reverted
+once the sibling check moved in-browser (see P1), because an unused filter is
+dead code.
+
+**`removeWorktree` defaults to `false`.** `restart()` is `await stop(); start()`
+(`sandbox-lifecycle-context.tsx:665`). A flipped default would re-clone the repo
+on every restart and destroy uncommitted work.
+
+**`remove_registered` always succeeds — it never refuses on a dirty or unpushed
+worktree.** A primitive that sometimes declines would be a worse contract than
+one that does what it is asked — it would split the policy
+across two layers, make the outcome depend on state the caller cannot see, and
+break the idempotent `{ success }` shape the intercept already promises
+(`sandbox_lifecycle.rs:504-506`). Policy lives in the dialog; the primitive
+executes.
+
+## Layout
+
+```
+apps/api/src/tools/sandbox/delete.ts        + removeWorktree input  (schema only)
+packages/shared/src/tools/tool-io.ts        regenerated
+
+apps/native/crates/local-api/src/
+  sandbox/registry.rs                       + remove(handle)
+  sandbox/manager.rs                        + remove_registered(handle)
+  routes/intercept/sandbox_lifecycle.rs     honor removeWorktree
+  routes/intercept/thread_tools.rs          list() answers unpaginated
+  routes/threads/db.rs                      drop LIMIT/OFFSET from the list
+
+apps/web/src/
+  hooks/use-is-desktop-app.ts               (unchanged — the gate)
+  components/sidebar/task-groups/
+    task-groups-list.tsx                    handleArchive → confirm flow
+    archive-worktree-dialog.tsx             new
+  i18n/en/…, i18n/pt-br/…                   new dialog strings
+```
+
+`thread_tools.rs`'s archive/delete handlers are **not** touched. The trigger
+lives in React, so the Rust thread store only needs to answer a list query.
+
+## Phases
+
+### P0 — Rust reclaim primitive
+
+The only phase that removes anything from disk. Independently testable via the
+existing HTTP intercept before any UI exists.
+
+**`sandbox/registry.rs`** — add `remove(handle)`. It must clear the active
+pointer when the removed handle is the active one;
+`reconcile_after_process_start` (`:477`) already does exactly that when a
+workdir goes missing and is the precedent to follow.
+
+**`sandbox/manager.rs`** — add `remove_registered(handle)` beside
+`stop_registered` (`:609`), under the same per-handle lock:
+
+1. `stop_registered` — terminate `setup`/`dev`/`start`, drop the in-memory
+   sandbox, publish the generation change.
+2. `remove_dir_all(worktree_root(&self.app_root, handle))` — helper at
+   `sandbox/mod.rs:41`.
+3. `repo_store::prune_worktrees(&self.app_root, &clone_url)`.
+4. `registry.remove(handle)`.
+
+Step 3 is **mandatory, not cleanup**. Git keeps listing a worktree after its
+directory is gone and refuses to re-add one at a path it already knows — the
+regression `repo_store.rs:115-123` documents. Skipping it means the branch can
+never be re-created.
+
+**`routes/intercept/sandbox_lifecycle.rs:507`** — read `removeWorktree` from
+the body it already parses (this handler needs no upstream read) and dispatch
+to `remove_registered` vs `stop_registered`. Absent/false keeps today's
+behavior exactly.
+
+Tests: `remove_registered` on a live handle removes the directory, drops the
+registry row, clears `active_handle` when it was active, and leaves the
+canonical repo re-worktree-able (assert a subsequent `ensure` on the same
+branch succeeds — that is the `prune_worktrees` regression). Unknown handle is
+a no-op success, matching the tool's idempotent contract.
+
+### P1 — Tool contracts
+
+**`apps/api/src/tools/sandbox/delete.ts`** — add to the input schema:
+
+```ts
+removeWorktree: z.boolean().optional().default(false)
+  .describe("Also reclaim the sandbox's workspace (local worktree + disk). Ignored by providers whose teardown already destroys the filesystem."),
+```
+
+Handler untouched.
+
+**`apps/native/.../thread_tools.rs`** `list()` — answer the thread list in FULL,
+ignoring a caller's `limit`/`offset` (still parsed, so a malformed value is
+still a 400) and always reporting `hasMore: false`. `routes/threads/db.rs` drops
+`LIMIT/OFFSET` from the query to match.
+
+This is a deliberate divergence from the tool contract, and it is what makes P2
+cheap: the store is one account's local SQLite, so "every open thread" is a few
+hundred rows, and answering in full lets the desktop UI treat its in-memory list
+as COMPLETE rather than as a paginated sample. Threads only — `messages_list`
+stays paginated, since a single chat's messages are unbounded.
+
+An earlier revision instead added a `where.branch` filter here and in
+`apps/api`, so the dialog could ask the server for a branch-scoped count. The
+unpaginated list makes that filter unreachable, so it was reverted rather than
+left as dead code.
+
+Then `bun run --cwd=apps/api generate:tool-contracts`.
+
+### P2 — React confirm flow
+
+`handleArchive` (`task-groups-list.tsx:231-257`) is the single choke point —
+every archive affordance routes through it (`task-group.tsx:56`,
+`my-threads-section.tsx:87`).
+
+Today's body — `hide(task.id)` → `forgetThreadLayout` → `findArchiveFallback` →
+navigate — moves wholesale behind the confirm, because cancel must perform
+**none** of it. Extract it as `archiveNow(task)` and keep it byte-identical.
+
+```
+handleArchive(task):
+  owner guard                                    (unchanged, :235-237)
+  if !isDesktopAppEnvironment() or !task.branch  → archiveNow(task)
+  if siblings on branch > 0                      → archiveNow(task)
+  else open dialog:
+      cancel  → return                           (thread stays open)
+      confirm → archiveNow(task)
+                SANDBOX_DELETE { virtualMcpId, branch,
+                                 sandboxProviderKind: "user-desktop",
+                                 removeWorktree: true }
+```
+
+**The sibling check is a local predicate, with no query behind it.**
+`hasOpenSiblingOnBranch(allThreads, target)` reads the loaded feed directly.
+That is sound ONLY because of P1: the desktop list arrives complete, so an
+empty result genuinely means "nobody else on this branch" rather than "nobody
+else on the page we happen to hold". Off the desktop the feed IS a paginated
+sample — which is why the whole flow is gated on `isDesktopAppEnvironment()`
+before this predicate is ever consulted. It also keeps `handleArchive`
+synchronous.
+
+**Order: archive must *land* before the delete is issued** — not merely be
+dispatched first. `hide()` is optimistic: `optimisticHide`
+(`thread-manager-store.ts:281-308`) restores the row and rethrows when the
+server refuses. Firing the reclaim without awaiting it means a rejected archive
+leaves the chat visible in the sidebar with its worktree already deleted —
+exactly the inversion this rule exists to prevent. Await the archive; on
+rejection, abort the sequence and delete nothing.
+
+A failed *delete*, by contrast, is fine: an archived thread plus a live
+worktree is a recoverable leak, and the toast says so.
+
+**`sandboxProviderKind` is hardcoded `"user-desktop"`.** `stop()` reads it off
+`vmEntry` (`sandbox-lifecycle-context.tsx:645`), but the sidebar has no
+`vmEntry` for an arbitrary thread; this path is desktop-gated, where that is
+the only possible value.
+
+**The dialog is static.** It names the branch, states the two consequences
+(processes stopped, local files deleted), and asks. It does NOT inspect the
+branch for uncommitted or unpushed work, so it makes no claim either way about
+what is saved — see Risks. Earlier revisions itemized the loss (file and commit
+counts, then a single conditional warning line); both were dropped in favour of
+trusting the user to know their own branch state. Strings go through `t()` per
+the i18n rules in `CLAUDE.md`; the user-facing noun is **chat**, the code
+identifier stays **thread**.
+
+## Non-goals
+
+- **A worktree management surface.** Deliberately not built; reclaim is meant
+  to be organic, riding an action users already take.
+- **Reclaim on thread *delete*.** `apps/api/src/tools/thread/delete.ts` (64
+  lines) has zero sandbox awareness and reaches the same orphaned state. Same
+  shape of fix, deferred to keep this change one flow. Tracked as follow-up.
+- **Hosted behavior.** `removeWorktree` is inert on `agent-sandbox`.
+- **Idle reaping.** The hosted side has a 15-minute idle TTL
+  (`runner.ts:150`); the desktop has no equivalent and is not getting one here.
+
+## Risks
+
+**Uncommitted or unpushed work is destroyed with no warning anywhere in the
+flow.** The highest-severity risk, and the one the design deliberately accepts:
+`remove_registered` never refuses on a dirty worktree, and the dialog does not
+inspect the branch, so nothing between Continue and `rm -rf` knows whether work
+would be lost. `compute_status` (`routes/git.rs:106`) already returns
+`workingTreeDirty` and `unpushed`, so surfacing it is cheap if this proves too
+sharp in practice — the deliberate choice was that a warning shown on every
+archive teaches people to click through it, including the one time it was true.
+Revisit if anyone actually loses work.
+
+**Archive is reversible; this is not.** `thread/update.ts:120-126` just flips
+`hidden` and fires `chat_archived` / `chat_unarchived`. Unarchiving after a
+reclaim yields a chat whose branch is gone from disk — recoverable from the
+remote only if the branch was pushed, which nothing verifies.
+
+**The sibling check is racy.** Between the predicate and the archive, another
+client can create a thread on the same branch. The window is small and the loss
+is a worktree that re-creates on next start; not worth a lock.
+
+**The local feed is scoped to the current user.** `hasOpenSiblingOnBranch` reads
+a list the store fetched with `created_by: "me"`, so a teammate's chat on the
+same branch is invisible to it. Moot on the desktop — the intercept answers from
+a single-account local store, so no teammate's thread is reachable there by any
+path — but it is a real constraint if this flow is ever un-gated from
+`isDesktopAppEnvironment()`.
+
+## Verification
+
+Automated (all green as of this commit):
+
+```bash
+cargo test --manifest-path apps/native/Cargo.toml -p local-api   # P0 + P1
+bun run check && bun run lint && bunx knip
+bun test apps/web/src/components/sidebar/
+```
+
+`apps/api`'s `*.integration.test.ts` need a live Postgres and fail with
+connection-refused without one; that is unrelated to this change.
+
+**Still unverified: the end-to-end run in the app.** Everything above exercises
+the pieces in isolation. What no test covers is the three phases wired together
+in the packaged app:
+
+1. Open two chats on one branch; archive the first — no dialog, worktree intact.
+2. Archive the second — the dialog appears and names the branch.
+3. Cancel — the chat stays OPEN (not archived) and the worktree is still there.
+   Cancel performing a partial archive is the failure mode to watch for.
+4. Archive again, Continue — the chat archives, the dev server stops, and
+   `<app_root>/worktrees/<handle>` is gone.
+5. Start the same branch again — it must re-clone cleanly. This is the
+   `prune_worktrees` assertion end to end: git keeps listing a removed worktree
+   and refuses to re-add at that path, so a missing prune makes the branch
+   permanently un-recreatable.
+
+Note `bun run dev:native` needs `src-tauri/binaries/rclone-*`, which only
+`beforeBuildCommand` fetches — a fresh clone or worktree must run
+`apps/native/scripts/fetch-rclone.sh` first or the build fails on a missing
+resource path.

--- a/apps/web/src/components/sidebar/task-groups/archive-worktree-dialog.tsx
+++ b/apps/web/src/components/sidebar/task-groups/archive-worktree-dialog.tsx
@@ -1,0 +1,67 @@
+/**
+ * Confirm dialog shown when archiving the LAST open chat on a branch in the
+ * desktop app — the archive also stops that branch's running processes and
+ * deletes its local files.
+ *
+ * Deliberately static: it states the two consequences and asks. It does NOT
+ * inspect the branch for uncommitted or unpushed work, so it makes no claim
+ * either way about what is or isn't saved — the user is trusted to know the
+ * state of their own branch.
+ */
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@deco/ui/components/alert-dialog.tsx";
+import { buttonVariants } from "@deco/ui/components/button.tsx";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { useT } from "@/i18n/use-t.ts";
+
+export function ArchiveWorktreeDialog({
+  branch,
+  onOutcome,
+}: {
+  branch: string;
+  onOutcome: (outcome: "cancel" | "confirm") => void;
+}) {
+  const t = useT();
+
+  return (
+    <AlertDialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onOutcome("cancel");
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {t("sidebar.archiveWorktreeDialog.title")}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {/* TODO(i18n): rich text — the branch name is monospaced mid-sentence. */}
+            {t("sidebar.archiveWorktreeDialog.stopsAndDeletesBefore")}{" "}
+            <span className="font-mono">{branch}</span>{" "}
+            {t("sidebar.archiveWorktreeDialog.stopsAndDeletesAfter")}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={() => onOutcome("cancel")}>
+            {t("sidebar.archiveWorktreeDialog.cancel")}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            className={cn(buttonVariants({ variant: "destructive" }))}
+            onClick={() => onOutcome("confirm")}
+          >
+            {t("sidebar.archiveWorktreeDialog.confirm")}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/web/src/components/sidebar/task-groups/task-groups-list.tsx
+++ b/apps/web/src/components/sidebar/task-groups/task-groups-list.tsx
@@ -47,6 +47,16 @@ import { MyThreadsSection } from "./my-threads-section";
 import type { SidebarFilters } from "./next-page-offset";
 import { findArchiveFallback } from "./archive-fallback";
 import { forgetThreadLayout } from "@/lib/thread-layout-memory";
+import { toast } from "sonner";
+import { useStudioTools } from "@/lib/studio-tools";
+import { isDesktopAppEnvironment } from "@/hooks/use-is-desktop-app";
+import { ArchiveWorktreeDialog } from "./archive-worktree-dialog";
+import {
+  archiveConfirmSteps,
+  hasOpenSiblingOnBranch,
+  worktreeReclaimTarget,
+  type WorktreeReclaimTarget,
+} from "./worktree-reclaim";
 
 type TypeFilter = "all" | "manual" | "automation";
 type GroupBy = "flat" | "status";
@@ -149,6 +159,7 @@ export function TaskGroupsList({
   const { hide, setScope } = useThreadActions();
 
   const navigate = useNavigate();
+  const studio = useStudioTools();
   const { setTaskId, createNewTask } = usePanelActions();
   const params = useParams({ strict: false }) as {
     taskId?: string;
@@ -178,6 +189,13 @@ export function TaskGroupsList({
   );
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchEverOpened, setSearchEverOpened] = useState(false);
+  // Desktop only: the pending "archive the last chat on this branch and delete
+  // its worktree?" confirm. Non-null ⇒ the dialog is up and the archive has
+  // NOT happened yet.
+  const [reclaimPrompt, setReclaimPrompt] = useState<{
+    task: Task;
+    target: WorktreeReclaimTarget;
+  } | null>(null);
 
   // `filters` drives the per-status / per-group server pagination (status mode),
   // where `member: "mine"` scopes the query to the current user.
@@ -228,19 +246,19 @@ export function TaskGroupsList({
   // threads live on its home view.
   const visibleScopedThreads = showAll ? allThreadsFiltered : myThreads;
 
-  const handleArchive = (task: Task) => {
-    // Archiving hides a thread org-wide, so it must be owner-only — the UI
-    // withholds the affordance on teammates' rows, but guard here too in case
-    // a caller ever wires it up without that check.
-    if (currentUserId && task.created_by && task.created_by !== currentUserId) {
-      return;
-    }
+  /** The archive itself. Nothing here runs until the reclaim confirm (if any)
+   * has been answered — cancel must perform NONE of it. */
+  /** Resolves once the archive has actually landed on the server. Navigation
+   *  below stays optimistic; only the returned promise reflects the write, and
+   *  it rejects (restoring the row) if the server refused — which is what the
+   *  worktree-reclaim path must wait on before deleting anything. */
+  const archiveNow = (task: Task): Promise<void> => {
     const wasActive = task.id === activeTaskId;
-    hide(task.id);
+    const archived = hide(task.id);
     // Drop the archived thread's remembered layout so it can't resurface if a
     // new thread ever reuses the id within this session.
     forgetThreadLayout(task.id);
-    if (!wasActive) return;
+    if (!wasActive) return archived;
     // Follow the sidebar's current filtered order across agents, while keeping
     // teammate threads opt-in even when Team scope renders them.
     const next = findArchiveFallback(
@@ -254,7 +272,86 @@ export function TaskGroupsList({
     } else {
       navigate({ to: "/$org", params: { org: org.slug } });
     }
+    return archived;
   };
+
+  const reclaimWorktree = async (target: WorktreeReclaimTarget) => {
+    try {
+      await studio.call("SANDBOX_DELETE", {
+        virtualMcpId: target.virtualMcpId,
+        branch: target.branch,
+        // The sidebar has no `vmEntry` for an arbitrary thread, and this path
+        // is desktop-gated, where this is the only possible provider.
+        sandboxProviderKind: "user-desktop",
+        removeWorktree: true,
+      });
+    } catch {
+      // The thread is already archived — a failed reclaim is a recoverable
+      // disk leak, not a broken UI state. Say so rather than swallowing it.
+      toast.error(
+        t("sidebar.archiveWorktreeDialog.reclaimFailed", {
+          branch: target.branch,
+        }),
+      );
+    }
+  };
+
+  const handleArchive = (task: Task) => {
+    // Archiving hides a thread org-wide, so it must be owner-only — the UI
+    // withholds the affordance on teammates' rows, but guard here too in case
+    // a caller ever wires it up without that check.
+    if (currentUserId && task.created_by && task.created_by !== currentUserId) {
+      return;
+    }
+    const target = worktreeReclaimTarget(task, isDesktopAppEnvironment());
+    // No branch, or someone else is still on this one, so there is no worktree
+    // to reclaim. Plain archive: nothing destructive follows, so the write is
+    // fire-and-forget exactly as it was before the reclaim flow existed.
+    //
+    // `allThreads` is authoritative here, not a sample: on the desktop the
+    // thread list is answered in full by the local intercept (see `list()` in
+    // `intercept::thread_tools`), and kept live by SSE. That is what lets this
+    // stay a synchronous local decision with no query behind it.
+    if (!target || hasOpenSiblingOnBranch(allThreads, target)) {
+      void archiveNow(task);
+      return;
+    }
+    setReclaimPrompt({ task, target });
+  };
+
+  const handleReclaimOutcome = (outcome: "cancel" | "confirm") => {
+    const prompt = reclaimPrompt;
+    if (!prompt) return;
+    setReclaimPrompt(null);
+    // Archive first, then reclaim — and only if the archive actually landed.
+    // A failed reclaim leaves an archived thread and a live worktree
+    // (recoverable). The reverse would leave a visible chat whose worktree is
+    // gone, so a rejected archive (optimisticHide restores the row and
+    // rethrows) must abort the sequence before anything is deleted.
+    void (async () => {
+      for (const step of archiveConfirmSteps(outcome)) {
+        if (step === "archive") {
+          try {
+            await archiveNow(prompt.task);
+          } catch {
+            return;
+          }
+        } else {
+          await reclaimWorktree(prompt.target);
+        }
+      }
+    })();
+  };
+
+  // Rendered in every layout branch: once the confirm is up it must survive a
+  // sidebar collapse or a viewport change, since dismissing it silently would
+  // read as "cancelled" while leaving the user no way back to the decision.
+  const reclaimDialog = reclaimPrompt ? (
+    <ArchiveWorktreeDialog
+      branch={reclaimPrompt.target.branch}
+      onOutcome={handleReclaimOutcome}
+    />
+  ) : null;
 
   const handleSelectTask = (t: Task) => {
     closeAfterNavigation();
@@ -335,6 +432,7 @@ export function TaskGroupsList({
         {searchEverOpened && (
           <GlobalSearchDialog open={searchOpen} onOpenChange={setSearchOpen} />
         )}
+        {reclaimDialog}
       </div>
     );
   }
@@ -475,6 +573,7 @@ export function TaskGroupsList({
         {searchEverOpened && (
           <GlobalSearchDialog open={searchOpen} onOpenChange={setSearchOpen} />
         )}
+        {reclaimDialog}
       </div>
     );
   }
@@ -504,6 +603,7 @@ export function TaskGroupsList({
       {searchEverOpened && (
         <GlobalSearchDialog open={searchOpen} onOpenChange={setSearchOpen} />
       )}
+      {reclaimDialog}
     </div>
   );
 }

--- a/apps/web/src/components/sidebar/task-groups/worktree-reclaim.test.ts
+++ b/apps/web/src/components/sidebar/task-groups/worktree-reclaim.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "bun:test";
+import type { Task } from "@/components/chat/task/types";
+import {
+  archiveConfirmSteps,
+  hasOpenSiblingOnBranch,
+  worktreeReclaimTarget,
+} from "./worktree-reclaim";
+
+const task = (
+  over: Partial<{
+    id: string;
+    branch: string | null;
+    virtual_mcp_id: string;
+  }> = {},
+) => ({
+  id: "thread-1",
+  branch: "feature/a",
+  virtual_mcp_id: "vmcp-1",
+  ...over,
+});
+
+describe("worktreeReclaimTarget", () => {
+  it("is null off the desktop build even with a branch", () => {
+    expect(worktreeReclaimTarget(task(), false)).toBeNull();
+  });
+
+  it("resolves the (thread, agent, branch) tuple on desktop", () => {
+    expect(worktreeReclaimTarget(task(), true)).toEqual({
+      taskId: "thread-1",
+      virtualMcpId: "vmcp-1",
+      branch: "feature/a",
+    });
+  });
+
+  it("is null without a branch", () => {
+    expect(worktreeReclaimTarget(task({ branch: null }), true)).toBeNull();
+    expect(worktreeReclaimTarget(task({ branch: "   " }), true)).toBeNull();
+  });
+
+  it("is null without an agent — SANDBOX_DELETE has no address", () => {
+    expect(
+      worktreeReclaimTarget({ id: "t", branch: "feature/a" }, true),
+    ).toBeNull();
+  });
+});
+
+describe("archiveConfirmSteps", () => {
+  it("performs NONE of the archive on cancel", () => {
+    expect(archiveConfirmSteps("cancel")).toEqual([]);
+  });
+
+  it("archives before reclaiming on confirm", () => {
+    expect(archiveConfirmSteps("confirm")).toEqual([
+      "archive",
+      "reclaim-worktree",
+    ]);
+  });
+
+  it("never reclaims without archiving first", () => {
+    for (const outcome of ["cancel", "confirm"] as const) {
+      const steps = archiveConfirmSteps(outcome);
+      const reclaim = steps.indexOf("reclaim-worktree");
+      if (reclaim === -1) continue;
+      expect(steps.indexOf("archive")).toBeLessThan(reclaim);
+    }
+  });
+});
+
+describe("hasOpenSiblingOnBranch", () => {
+  const target = { taskId: "thread-1", virtualMcpId: "vmcp-1", branch: "b" };
+  const feed = (over: Partial<Task> = {}) =>
+    [
+      {
+        id: "thread-2",
+        branch: "b",
+        virtual_mcp_id: "vmcp-1",
+        hidden: false,
+        ...over,
+      },
+    ] as unknown as Task[];
+
+  it("is true when another open chat shares the branch and agent", () => {
+    expect(hasOpenSiblingOnBranch(feed(), target)).toBe(true);
+  });
+
+  it("ignores the thread being archived", () => {
+    expect(hasOpenSiblingOnBranch(feed({ id: "thread-1" }), target)).toBe(
+      false,
+    );
+  });
+
+  it("ignores already-archived, other-branch and other-agent threads", () => {
+    expect(hasOpenSiblingOnBranch(feed({ hidden: true }), target)).toBe(false);
+    expect(hasOpenSiblingOnBranch(feed({ branch: "other" }), target)).toBe(
+      false,
+    );
+    expect(
+      hasOpenSiblingOnBranch(feed({ virtual_mcp_id: "vmcp-2" }), target),
+    ).toBe(false);
+  });
+
+  // The desktop feed is complete, so this genuinely means "nobody else is on
+  // the branch" — and is the ONLY thing that lets a confirm be offered.
+  it("is false on an empty feed, which is what authorizes the reclaim prompt", () => {
+    expect(hasOpenSiblingOnBranch([], target)).toBe(false);
+  });
+});

--- a/apps/web/src/components/sidebar/task-groups/worktree-reclaim.ts
+++ b/apps/web/src/components/sidebar/task-groups/worktree-reclaim.ts
@@ -1,0 +1,91 @@
+/**
+ * Decision logic for "archiving the last chat on a branch reclaims its
+ * worktree" (desktop only).
+ *
+ * A worktree's identity is `(repo, branch)` and `threads.branch` is N:1 onto
+ * branch, so "no non-archived threads left on this branch" is exactly "this
+ * worktree has no remaining owner". The reclaim is irreversible — the native
+ * `remove_registered` primitive never refuses on a dirty or unpushed worktree —
+ * so every rule that decides whether to prompt, and what happens on each
+ * outcome, lives here as pure data and is unit-tested directly.
+ */
+import type { Task } from "@/components/chat/task/types";
+
+/** The `(thread, agent, branch)` tuple a reclaim needs. */
+export interface WorktreeReclaimTarget {
+  taskId: string;
+  virtualMcpId: string;
+  branch: string;
+}
+
+/**
+ * The reclaim target for a thread, or `null` when this archive can never
+ * reclaim anything and must go straight through.
+ *
+ * `isDesktopApp` is passed in (rather than read here) so this stays pure: the
+ * single gate is `isDesktopAppEnvironment()` at the call site. `virtual_mcp_id`
+ * is required because `SANDBOX_DELETE` is addressed by `(virtualMcpId, branch)` —
+ * a thread with a branch but no agent has no addressable sandbox.
+ */
+export function worktreeReclaimTarget(
+  task: Pick<Task, "id" | "branch" | "virtual_mcp_id">,
+  isDesktopApp: boolean,
+): WorktreeReclaimTarget | null {
+  if (!isDesktopApp) return null;
+  const branch = task.branch?.trim();
+  const virtualMcpId = task.virtual_mcp_id?.trim();
+  if (!branch || !virtualMcpId) return null;
+  return { taskId: task.id, virtualMcpId, branch };
+}
+
+/**
+ * Whether another OPEN chat still uses this branch — i.e. whether a worktree
+ * would still have an owner after this thread is archived.
+ *
+ * Answered entirely from the loaded feed, with no query behind it. That is only
+ * sound because this runs on the desktop, where the local intercept returns the
+ * thread list in full rather than a page (see `list()` in
+ * `intercept::thread_tools`) and SSE keeps it current. So an empty result here
+ * genuinely means "nobody else", not "nobody else on the page we happen to
+ * hold" — the distinction the reclaim decision hangs on.
+ *
+ * `threads` must therefore be the unfiltered feed, never a view already
+ * narrowed by the sidebar's scope or type filters.
+ */
+export function hasOpenSiblingOnBranch(
+  threads: readonly Task[],
+  target: WorktreeReclaimTarget,
+): boolean {
+  return threads.some(
+    (thread) =>
+      thread.id !== target.taskId &&
+      !thread.hidden &&
+      thread.branch === target.branch &&
+      thread.virtual_mcp_id === target.virtualMcpId,
+  );
+}
+
+/** Ordered side effects of the confirm dialog. */
+export type ArchiveConfirmStep = "archive" | "reclaim-worktree";
+
+const CONFIRM_STEPS: readonly ArchiveConfirmStep[] = [
+  "archive",
+  "reclaim-worktree",
+];
+const CANCEL_STEPS: readonly ArchiveConfirmStep[] = [];
+
+/**
+ * What the dialog's outcome performs, in order.
+ *
+ * Cancel performs NONE of the archive — not "archive anyway, skip the delete".
+ * The dialog gates the archive itself, so the thread simply stays open.
+ *
+ * Confirm archives FIRST, then reclaims. A failed reclaim leaves an archived
+ * thread and a live worktree — a leak, recoverable by hand. The reverse order
+ * would leave a visible chat whose worktree is gone.
+ */
+export function archiveConfirmSteps(
+  outcome: "cancel" | "confirm",
+): readonly ArchiveConfirmStep[] {
+  return outcome === "confirm" ? CONFIRM_STEPS : CANCEL_STEPS;
+}

--- a/apps/web/src/i18n/en/sidebar.ts
+++ b/apps/web/src/i18n/en/sidebar.ts
@@ -1,5 +1,14 @@
 export const sidebar = {
   "sidebar.agentsSection.agents": "Agents",
+  "sidebar.archiveWorktreeDialog.cancel": "Cancel",
+  "sidebar.archiveWorktreeDialog.confirm": "Continue",
+  "sidebar.archiveWorktreeDialog.reclaimFailed":
+    "Chat archived, but the files for {branch} could not be deleted.",
+  "sidebar.archiveWorktreeDialog.stopsAndDeletesAfter":
+    "and delete its files from this computer.",
+  "sidebar.archiveWorktreeDialog.stopsAndDeletesBefore":
+    "This will stop everything running on",
+  "sidebar.archiveWorktreeDialog.title": "Archive this chat?",
   "sidebar.agentsSection.browseAgents": "Browse agents",
   "sidebar.agentsSection.codeAgents": "Code Agents",
   "sidebar.agentsSection.import": "Import",

--- a/apps/web/src/i18n/pt-br/sidebar.ts
+++ b/apps/web/src/i18n/pt-br/sidebar.ts
@@ -2,6 +2,15 @@ import type { sidebar as sidebarEn } from "../en/sidebar.ts";
 
 export const sidebar = {
   "sidebar.agentsSection.agents": "Agentes",
+  "sidebar.archiveWorktreeDialog.cancel": "Cancelar",
+  "sidebar.archiveWorktreeDialog.confirm": "Continuar",
+  "sidebar.archiveWorktreeDialog.reclaimFailed":
+    "Chat arquivado, mas não foi possível apagar os arquivos de {branch}.",
+  "sidebar.archiveWorktreeDialog.stopsAndDeletesAfter":
+    "e apagar seus arquivos deste computador.",
+  "sidebar.archiveWorktreeDialog.stopsAndDeletesBefore":
+    "Isso vai parar tudo o que está rodando em",
+  "sidebar.archiveWorktreeDialog.title": "Arquivar este chat?",
   "sidebar.agentsSection.browseAgents": "Procurar agentes",
   "sidebar.agentsSection.codeAgents": "Agentes de Código",
   "sidebar.agentsSection.import": "Importar",

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -6614,6 +6614,7 @@ export interface StudioToolIO {
       virtualMcpId: string;
       branch: string;
       sandboxProviderKind: "agent-sandbox" | "user-desktop" | "cluster";
+      removeWorktree?: boolean | undefined;
     };
     output: { success: boolean };
   };


### PR DESCRIPTION
## Summary

The desktop app had no way to stop a sandbox's processes or delete its git worktree, so every branch a user opened stayed on disk forever. `SANDBOX_DELETE` reclaimed everything on the hosted provider — claim teardown destroys the pod's disk — but only stopped processes on the desktop: `SandboxRegistry` had **no removal method at all**, and the only `remove_dir_all` on a worktree was an invalid-repo recovery path.

Archiving the last open chat on a branch now offers to reclaim it. A worktree's identity is `(repo, branch)` and `threads.branch` is N:1 onto branch, so "no open chats left on this branch" is exactly "this worktree has no remaining owner" — the trigger rides an action users already take rather than introducing a management surface.

## What changed

**Rust — the reclaim primitive**
- `SandboxRegistry::remove` drops the row and clears the active pointer when it named the removed handle.
- `SandboxManager::remove_registered` stops → removes the directory → prunes → deregisters, under **one** lock acquisition. `stop_registered`'s body is split into `stop_locked` because the per-handle mutex is not reentrant; holding the lock across all four steps also closes the window where a concurrent `ensure` could re-clone into the directory about to be deleted.
- `prune_worktrees` is **required, not cleanup**: git keeps listing a worktree after its directory is gone and refuses to re-add one at that path, so skipping it makes the branch permanently un-recreatable. There's a test asserting a subsequent `ensure` on the same branch succeeds.
- `remove_registered` never refuses on a dirty or unpushed worktree — policy lives in the dialog, the primitive executes. It still errors on infrastructure failures, since deleting files after a failed kill would leave a running dev server with no working tree.

**Unpaginated thread list (native only)**
`list()` answers in full; `limit`/`offset` are still parsed so malformed values 400, but ignored, and `hasMore` is always false. The store is one account's local SQLite, so answering in full lets the desktop treat its in-memory list as *complete* — turning "is anyone else on this branch" into a local predicate instead of a query, and keeping `handleArchive` synchronous. **Messages stay paginated**; a single chat's messages are unbounded.

**React**
`handleArchive` gains a confirm step gated on `isDesktopAppEnvironment()`. Cancel performs *none* of the archive — the chat stays open. Confirm archives, then reclaims, and the archive must **land** before the delete is issued: `optimisticHide` restores the row and rethrows on server rejection, so firing the reclaim un-awaited would leave a visible chat whose worktree is gone.

**`apps/api`** gets the `removeWorktree` input schema only. It defaults to `false` and absent means false — `restart()` is `stop(); start()`, so a flipped default would re-clone on every restart. Inert on `agent-sandbox`.

## Testing

- `cargo test -p local-api` — 789 pass
- `bun run check` / `lint` (14 pre-existing warnings, 0 errors) / `fmt:check` / `bunx knip` — clean
- `bun test apps/web/src/components/sidebar/` — 63 pass

Three Rust tests encoded the old paginated behavior and were **inverted**, not deleted. `apps/api`'s `*.integration.test.ts` need a live Postgres and fail with connection-refused locally; unrelated to this change.

## Not yet verified

**The end-to-end run in the packaged app.** Everything above exercises the pieces in isolation. The sequence to walk before merge is in `apps/native/docs/worktree-reclaim-plan.md` under Verification — the load-bearing step is starting the same branch again after a reclaim and confirming it re-clones cleanly.

## Reviewer attention

- **Uncommitted or unpushed work is deleted with no warning.** Deliberate — a warning on every archive trains people to click through it — but it is the sharpest edge here. Documented under Risks; `compute_status` already returns what a warning would need if we change our minds.
- **The unpaginated list affects every native thread-list consumer**, not just this feature: `fetchNextPage` becomes a no-op and "Show more" has nothing to fetch. Intended, but broader than the reclaim flow.
- `bun run dev:native` needs `src-tauri/binaries/rclone-*`, which only `beforeBuildCommand` fetches — a fresh clone fails until `apps/native/scripts/fetch-rclone.sh` runs. Pre-existing, surfaced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Desktop: when you archive the last chat on a branch, the app can now stop its sandbox and delete the branch’s local worktree. This adds a confirmed, idempotent reclaim path and makes the native thread list unpaginated so the “last chat on branch” check is local and fast.

- **New Features**
  - Native Rust: added `SandboxRegistry::remove` and `SandboxManager::remove_registered` to stop processes, delete the worktree directory, prune git worktrees, and deregister under one lock; clears the active handle; idempotent; never refuses on dirty/unpushed trees (policy lives in the UI).
  - API: `SANDBOX_DELETE` input gains `removeWorktree` (default `false`); ignored by `agent-sandbox`; schema and tests updated.
  - Web (desktop-only via `isDesktopAppEnvironment()`): new `ArchiveWorktreeDialog` shown when archiving the last open chat on a branch; on confirm, await the archive, then call `SANDBOX_DELETE` with `removeWorktree: true`; failure to reclaim shows a toast.
  - Native list behavior: thread list is now unpaginated; `limit`/`offset` still validated but ignored, and `hasMore` is always `false`, enabling a local “any other open chat on this branch?” check.

<sup>Written for commit 38e5f97840856c9003b942c2fcebac4ee0670849. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

