### PR TITLE
fix(web): fix TaskBoardItem shared type drifting from its wire shape

### DIFF
--- a/apps/web/src/hooks/use-task-board-items.ts
+++ b/apps/web/src/hooks/use-task-board-items.ts
@@ -28,11 +28,10 @@ export function useTaskBoardItems() {
     orgSlug: org.slug,
     onUpdate: (item) => {
       queryClient.setQueryData<TaskBoardItem[]>(queryKey, (prev) => {
-        const next = (prev ?? []) as TaskBoardItem[];
-        const patched = item as unknown as TaskBoardItem;
-        return next.some((t) => t.id === patched.id)
-          ? next.map((t) => (t.id === patched.id ? patched : t))
-          : [patched, ...next];
+        const next = prev ?? [];
+        return next.some((t) => t.id === item.id)
+          ? next.map((t) => (t.id === item.id ? item : t))
+          : [item, ...next];
       });
       // Every pushed item change also appends to its timeline — refetch the
       // activity feed so a task dialog left open during a live transition

--- a/packages/shared/src/entities.ts
+++ b/packages/shared/src/entities.ts
@@ -83,6 +83,18 @@ export interface TaskBoardItemThreadRef {
   title: string | null;
   lastMessage: string | null;
   hasPreview: boolean;
+  /** False when the thread was created and never used — see
+   *  `TaskBoardItemThreadRef` in `apps/api/src/storage/types.ts`. */
+  hasMessages: boolean;
+  createdAt: string;
+}
+
+/** A tag attached to a task, plus who attached it and when. */
+export interface TaskBoardItemTagRef {
+  id: string;
+  name: string;
+  color: string | null;
+  createdBy: string;
   createdAt: string;
 }
 
@@ -96,7 +108,10 @@ export interface TaskBoardItem {
   assigneeId: string | null;
   assignedBy: string | null;
   dueDate: string | null;
+  /** Manual drag-to-reorder position within a lane, ascending. */
+  sortOrder: number;
   threads: TaskBoardItemThreadRef[];
+  tags: TaskBoardItemTagRef[];
   createdBy: string;
   createdAt: string;
   updatedBy: string;


### PR DESCRIPTION
Type mismatch found while auditing the task-board area for lingering type drift (part of the task-board feature-parity hardening).

The shared `TaskBoardItem`/`TaskBoardItemThreadRef` types in `packages/shared/src/entities.ts` — the type used to describe the payload of the `task-board.item.updated` SSE event — were missing `sortOrder`, `tags`, and `hasMessages`. Those three fields have been part of the API's `TaskBoardItemSchema` / storage `TaskBoardItem` row since the kanban feature-parity and tags work (#5258, #5365), but `entities.ts` was never updated to match.

Because the two shapes no longer lined up, the only consumer of the shared type (`apps/web/src/hooks/use-task-board-items.ts`) had to route every SSE-pushed item through `item as unknown as TaskBoardItem` to patch it into the react-query cache — the `unknown` hop exists specifically because the narrower shared type can't be assigned to the wider local (schema-derived) type otherwise. That cast silently defeats type-checking on this path: a future field rename/removal on either side would go uncaught until runtime.

Fix: bring `entities.ts`'s `TaskBoardItem`/`TaskBoardItemThreadRef` back in sync with the storage/schema shape (mirroring `apps/api/src/storage/types.ts`'s `TaskBoardItemThreadRef`/`TaskBoardItemTagRef`), which makes the two types structurally identical again — so the `as unknown as` cast in `use-task-board-items.ts` is no longer needed and has been removed.

Behavior-preserving: no runtime logic changed, only type declarations plus dropping a now-redundant cast. Confirmed via `grep` that `apps/web/src/hooks/use-task-board-events.ts` is the sole consumer of the touched `entities.ts` exports, so widening the interface can't break another caller.

To confirm: `cd apps/web && bunx tsc --noEmit` and `cd packages/shared && bunx tsc --noEmit` (both pass).

Locally ran: `bun run fmt`, `bunx tsc --noEmit` in both `apps/web` and `packages/shared`, and `bunx oxlint` on both changed files (all clean). No existing test covers this hook, so none needed changing; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore shared task-board item types to match the API/storage shape, fixing type drift and removing an unsafe cast in the web hook. No runtime behavior changes.

- **Bug Fixes**
  - Updated `TaskBoardItem`/`TaskBoardItemThreadRef` in `packages/shared/src/entities.ts` to include `sortOrder`, `tags` (with `TaskBoardItemTagRef`), and `hasMessages`.
  - Removed `as unknown as TaskBoardItem` cast in `apps/web/src/hooks/use-task-board-items.ts` now that SSE payload types align with the local schema.
  - Keeps `task-board.item.updated` SSE payloads structurally identical to the API/storage types used in `apps/api`.

<sup>Written for commit 11955d91776339c8ec7fbc14acd66843e46703ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

