### PR TITLE
fix(auth): reject non-positive-integer AUTH_EMAIL_OTP_LENGTH/EXPIRES_IN

### DIFF
--- a/apps/api/src/auth/auth-env.test.ts
+++ b/apps/api/src/auth/auth-env.test.ts
@@ -77,6 +77,32 @@ describe("authEnvSchema", () => {
     ).toThrow(/AUTH_SSO_GOOGLE_CLIENT_SECRET/);
   });
 
+  it("rejects a negative AUTH_EMAIL_OTP_LENGTH", () => {
+    expect(() => authEnvSchema.parse({ AUTH_EMAIL_OTP_LENGTH: "-5" })).toThrow(
+      /AUTH_EMAIL_OTP_LENGTH/,
+    );
+  });
+
+  it("rejects a non-integer AUTH_EMAIL_OTP_LENGTH", () => {
+    expect(() => authEnvSchema.parse({ AUTH_EMAIL_OTP_LENGTH: "6.5" })).toThrow(
+      /AUTH_EMAIL_OTP_LENGTH/,
+    );
+  });
+
+  it("rejects a zero or negative AUTH_EMAIL_OTP_EXPIRES_IN", () => {
+    expect(() =>
+      authEnvSchema.parse({ AUTH_EMAIL_OTP_EXPIRES_IN: "0" }),
+    ).toThrow(/AUTH_EMAIL_OTP_EXPIRES_IN/);
+  });
+
+  it("accepts valid AUTH_EMAIL_OTP_LENGTH and AUTH_EMAIL_OTP_EXPIRES_IN", () => {
+    const config = authEnvSchema.parse({
+      AUTH_EMAIL_OTP_LENGTH: "8",
+      AUTH_EMAIL_OTP_EXPIRES_IN: "600",
+    });
+    expect(config).toBeTruthy();
+  });
+
   it("accepts Microsoft SSO when fully configured", () => {
     const config = authEnvSchema.parse({
       AUTH_SSO_DOMAIN: "acme.com",

--- a/apps/api/src/auth/auth-env.ts
+++ b/apps/api/src/auth/auth-env.ts
@@ -143,6 +143,30 @@ export const authEnvSchema = z
           "AUTH_SSO_GOOGLE_CLIENT_ID and AUTH_SSO_DOMAIN are set but AUTH_SSO_GOOGLE_CLIENT_SECRET is not",
       });
     }
+
+    if (
+      env.AUTH_EMAIL_OTP_LENGTH !== undefined &&
+      (!Number.isInteger(env.AUTH_EMAIL_OTP_LENGTH) ||
+        env.AUTH_EMAIL_OTP_LENGTH < 1)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["AUTH_EMAIL_OTP_LENGTH"],
+        message: "AUTH_EMAIL_OTP_LENGTH must be a positive integer",
+      });
+    }
+
+    if (
+      env.AUTH_EMAIL_OTP_EXPIRES_IN !== undefined &&
+      (!Number.isInteger(env.AUTH_EMAIL_OTP_EXPIRES_IN) ||
+        env.AUTH_EMAIL_OTP_EXPIRES_IN < 1)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["AUTH_EMAIL_OTP_EXPIRES_IN"],
+        message: "AUTH_EMAIL_OTP_EXPIRES_IN must be a positive integer",
+      });
+    }
   })
   .transform((env) => {
     // ── Social providers ───────────────────────────────────────────


### PR DESCRIPTION
**Source:** hardening gap in `apps/api/src/auth/auth-env.ts` (this session's "api-auth-env-hardening" focus area). The exact hinted gap — missing Google/GitHub OAuth client-secret validation — is already covered by open PR #5542, so this targets a distinct, un-covered validation hole in the same file.

**Why a maintainer wants this:** `AUTH_EMAIL_OTP_LENGTH` and `AUTH_EMAIL_OTP_EXPIRES_IN` are parsed with a bare `z.coerce.number().optional()` — any number (including negative or fractional) passes schema validation silently. `email-otp.ts` only special-cases `0`/falsy (falls back to the default), so a negative value like `-5` is truthy and gets passed straight into Better Auth's `otpLength`/`expiresIn` options.

**Failure scenario:** deploy with `AUTH_EMAIL_OTP_LENGTH=-5` (e.g. a typo'd env var) — the server boots fine, and OTP generation misbehaves or throws confusingly at runtime, not at the startup boundary where the value was actually set. Same for a zero/negative `AUTH_EMAIL_OTP_EXPIRES_IN`.

**Fix:** two `superRefine` checks mirroring the file's existing pattern (SSO/email-provider validation) — reject at config-parse time (which runs at server boot via `getConfig()` → `loadAuthConfig()`) when either field is set but isn't a positive integer. Added 4 regression tests: negative length, non-integer length, zero expiry, and a valid-values acceptance case.

**Reviewer check:** `bun test apps/api/src/auth/auth-env.test.ts`

**Locally verified:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bun test apps/api/src/auth/auth-env.test.ts` (14 pass), `bunx oxlint apps/api/src/auth/auth-env.ts apps/api/src/auth/auth-env.test.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces positive integers for `AUTH_EMAIL_OTP_LENGTH` and `AUTH_EMAIL_OTP_EXPIRES_IN` at startup to catch misconfigurations early. Blocks negative, zero, and fractional values from reaching runtime.

- **Bug Fixes**
  - Added validation in `apps/api/src/auth/auth-env.ts` to reject non-positive-integer values when set.
  - Added tests for negative/non-integer length, zero expiry, and a valid-case acceptance.
  - Matches the file’s existing validation pattern for consistent config checks.

<sup>Written for commit 21e309c1060a2740c50fbb1690004b6c514d8d47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5623?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

