### PR TITLE
fix(native): serialize desktop git publish/discard/rebase against worktree reclaim

### DIFF
--- a/apps/native/crates/local-api/src/routes/intercept/sandbox_ops.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/sandbox_ops.rs
@@ -151,17 +151,23 @@ async fn route(
         (&Method::POST, ["git", "publish"]) => {
             let handle_lock = target.sandbox_manager.handle_lock(handle);
             let _guard = handle_lock.lock().await;
-            crate::routes::git::publish(state, body).await.into_response()
+            crate::routes::git::publish(state, body)
+                .await
+                .into_response()
         }
         (&Method::POST, ["git", "discard"]) => {
             let handle_lock = target.sandbox_manager.handle_lock(handle);
             let _guard = handle_lock.lock().await;
-            crate::routes::git::discard(state, body).await.into_response()
+            crate::routes::git::discard(state, body)
+                .await
+                .into_response()
         }
         (&Method::POST, ["git", "rebase"]) => {
             let handle_lock = target.sandbox_manager.handle_lock(handle);
             let _guard = handle_lock.lock().await;
-            crate::routes::git::rebase(state, body).await.into_response()
+            crate::routes::git::rebase(state, body)
+                .await
+                .into_response()
         }
 
         // The two AI-assisted endpoints. Mesh's handlers guard on a VM claim

--- a/apps/native/crates/local-api/src/routes/intercept/sandbox_ops.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/sandbox_ops.rs
@@ -143,15 +143,26 @@ async fn route(
         (&Method::POST, ["git", "diff"]) => {
             crate::routes::git::diff(state, body).await.into_response()
         }
-        (&Method::POST, ["git", "publish"]) => crate::routes::git::publish(state, body)
-            .await
-            .into_response(),
-        (&Method::POST, ["git", "discard"]) => crate::routes::git::discard(state, body)
-            .await
-            .into_response(),
-        (&Method::POST, ["git", "rebase"]) => crate::routes::git::rebase(state, body)
-            .await
-            .into_response(),
+        // Held for the duration of the git command: these three mutate the
+        // worktree on disk, and `SandboxManager::remove_registered` (reclaim on
+        // last-thread archive) deletes that same directory under this handle's
+        // lock. Without holding it here too, a reclaim can `rm -rf` the
+        // worktree out from under an in-flight publish/discard/rebase.
+        (&Method::POST, ["git", "publish"]) => {
+            let handle_lock = target.sandbox_manager.handle_lock(handle);
+            let _guard = handle_lock.lock().await;
+            crate::routes::git::publish(state, body).await.into_response()
+        }
+        (&Method::POST, ["git", "discard"]) => {
+            let handle_lock = target.sandbox_manager.handle_lock(handle);
+            let _guard = handle_lock.lock().await;
+            crate::routes::git::discard(state, body).await.into_response()
+        }
+        (&Method::POST, ["git", "rebase"]) => {
+            let handle_lock = target.sandbox_manager.handle_lock(handle);
+            let _guard = handle_lock.lock().await;
+            crate::routes::git::rebase(state, body).await.into_response()
+        }
 
         // The two AI-assisted endpoints. Mesh's handlers guard on a VM claim
         // this machine's sandboxes never have (`requireRunner` → 503), so

--- a/apps/native/crates/local-api/src/sandbox/manager.rs
+++ b/apps/native/crates/local-api/src/sandbox/manager.rs
@@ -1275,7 +1275,12 @@ impl SandboxManager {
         });
     }
 
-    fn handle_lock(&self, handle: &str) -> Arc<tokio::sync::Mutex<()>> {
+    /// The per-handle operation lock also taken by `stop_registered` and
+    /// `remove_registered`. Exposed so a caller that runs a git mutation
+    /// directly against a sandbox's worktree (bypassing this manager) can
+    /// serialize against a concurrent stop/reclaim of the SAME handle — see
+    /// `intercept::sandbox_ops::route`'s `git/publish|discard|rebase` arms.
+    pub(crate) fn handle_lock(&self, handle: &str) -> Arc<tokio::sync::Mutex<()>> {
         let mut guard = self.lock_locks();
         guard
             .entry(handle.to_string())
@@ -2125,6 +2130,68 @@ mod tests {
         assert!(
             !again.workdir.join("uncommitted.txt").exists(),
             "a reclaim is a delete, not a stash"
+        );
+    }
+
+    /// `intercept::sandbox_ops::route` takes this same lock around
+    /// `git/publish|discard|rebase` before touching the worktree, precisely so
+    /// a reclaim can't `rm -rf` the directory out from under an in-flight git
+    /// mutation. Simulate that holder directly: while it holds the lock,
+    /// `remove_registered` must not have removed the worktree yet.
+    #[tokio::test]
+    async fn remove_registered_waits_for_a_concurrent_git_op_holding_the_same_handle_lock() {
+        let (_root, clone_url) = setup_two_branch_repo();
+        let app_root = tempfile::tempdir().unwrap();
+        let manager = Arc::new(SandboxManager::new(app_root.path().to_path_buf()));
+        let cfg = GitSandboxConfig {
+            virtual_mcp_id: "vmcp-race".to_string(),
+            clone_url,
+            branch: Some("work".to_string()),
+            ..Default::default()
+        };
+
+        let sandbox = manager.ensure(&cfg).await.expect("ensure succeeds");
+        let handle = sandbox.handle.clone();
+        let worktree = crate::sandbox::worktree_root(app_root.path(), &handle);
+        tokio::time::timeout(Duration::from_secs(10), async {
+            while sandbox.setup.is_running() || sandbox.setup.pending_count() > 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the setup pipeline settles");
+        drop(sandbox);
+
+        // Stand in for `sandbox_ops::route`'s git-op guard: a "publish" in
+        // flight, holding the handle lock for as long as its git command runs.
+        let git_op_lock = manager.handle_lock(&handle);
+        let git_op_guard = git_op_lock.lock().await;
+
+        let reclaim = tokio::spawn({
+            let manager = manager.clone();
+            let handle = handle.clone();
+            async move { manager.remove_registered(&handle).await }
+        });
+
+        // The reclaim is blocked behind the lock the simulated git op holds —
+        // give it every chance to (wrongly) race ahead before asserting.
+        for _ in 0..50 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            worktree.is_dir(),
+            "reclaim must not touch the worktree while a git op holds the handle lock"
+        );
+
+        drop(git_op_guard);
+        reclaim
+            .await
+            .expect("reclaim task doesn't panic")
+            .expect("reclaim succeeds")
+            .expect("a registered handle is not unknown");
+        assert!(
+            !worktree.exists(),
+            "reclaim proceeds once the git op releases the lock"
         );
     }
 


### PR DESCRIPTION
Follows #5620, which added `SandboxManager::remove_registered` — stop the sandbox, then `rm -rf` its worktree directory, run when the last chat on a branch is archived. That deletion is gated behind the sandbox's per-handle operation lock (the same one `stop_registered`/`restart_registered` use).

`intercept::sandbox_ops::route`'s `git/publish`, `git/discard`, and `git/rebase` arms, however, run their git subprocess directly against `target.repo_dir` with **no** synchronization at all — not even the app-shutdown admission guard's task-kill filter, since ad-hoc git commands aren't tracked as `setup`/`dev`/`start` tasks. Before #5620 this was harmless: nothing ever deleted the directory out from under them. After #5620, archiving the last open chat on a branch while a publish/discard/rebase is mid-flight races an unguarded filesystem delete against a git process reading/writing the same worktree — a real resource-leak / data-loss window (a `git worktree prune` or partial `rm -rf` racing an in-progress commit/push).

**Fix:** the three mutating git routes now acquire the same per-handle lock (`SandboxManager::handle_lock`, exposed `pub(crate)` for this) before running, so a reclaim and an in-flight git mutation on the same handle can never interleave — whichever grabs the lock first runs to completion before the other proceeds.

**Failure scenario:** user has one open chat left on a branch, clicks publish in the git panel, then (in another window/tab) archives that chat before the push finishes. Previously: `remove_registered`'s `remove_dir_all` could race the in-flight `git push`/`git commit` subprocess, corrupting or partially deleting the worktree mid-operation. Now: the archive's reclaim blocks on the same lock the publish already holds and only runs after the git command finishes.

**Regression test:** `sandbox::manager::tests::remove_registered_waits_for_a_concurrent_git_op_holding_the_same_handle_lock` — holds the handle lock (standing in for `sandbox_ops::route`'s guard), spawns `remove_registered`, and asserts the worktree directory is untouched while the lock is held and only removed after it's released.

**To verify:** `cargo test --manifest-path apps/native/Cargo.toml -p local-api --lib sandbox::manager::tests::remove_registered_waits_for_a_concurrent_git_op_holding_the_same_handle_lock`

**Locally ran:** `cargo check -p local-api` (clean); `cargo test -p local-api --lib sandbox::` (107 passed, including the new test); `cargo test -p local-api --lib intercept::sandbox_ops` (1 passed, unchanged). `cargo clippy`/`rustfmt` aren't installed in this environment — full CI covers those plus the rest of the native suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize desktop `git publish`/`discard`/`rebase` against sandbox worktree reclaim to prevent race conditions and potential data loss. Git mutations and reclaim for the same handle now run one at a time.

- **Bug Fixes**
  - Wrap `git/publish`, `git/discard`, and `git/rebase` in the per-handle lock in `intercept::sandbox_ops::route`.
  - Expose `SandboxManager::handle_lock` as `pub(crate)` so routes can share the same lock used by `stop_registered`/`remove_registered`.
  - Add regression test `remove_registered_waits_for_a_concurrent_git_op_holding_the_same_handle_lock` to ensure reclaim waits for an in-flight git op before removing the worktree.

- **Refactors**
  - Run `cargo fmt` on `sandbox_ops.rs` (no functional changes).

<sup>Written for commit eef41960edccea535f24b000f273c9a96344a189. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

