### PR TITLE
fix(commerce-onboarding): translate hardcoded Portuguese strings in the Google Search Console config form

### DIFF
--- a/apps/web/src/i18n/en/commerce-onboarding.ts
+++ b/apps/web/src/i18n/en/commerce-onboarding.ts
@@ -85,4 +85,22 @@ export const commerceOnboarding = {
   "commerceOnboarding.shopifyConfigForm.savingButton": "Saving...",
   "commerceOnboarding.shopifyConfigForm.savingError":
     "Couldn't save the configuration",
+  "commerceOnboarding.googleSearchConsoleConfigForm.loadingSites":
+    "Loading sites...",
+  "commerceOnboarding.googleSearchConsoleConfigForm.loadSitesError":
+    "Couldn't load Google Search Console sites.",
+  "commerceOnboarding.googleSearchConsoleConfigForm.noSitesFound":
+    "No verified site found. Verify a site in Google Search Console.",
+  "commerceOnboarding.googleSearchConsoleConfigForm.siteAriaLabel":
+    "Verified site",
+  "commerceOnboarding.googleSearchConsoleConfigForm.siteRequired":
+    "Select a site",
+  "commerceOnboarding.googleSearchConsoleConfigForm.savingError":
+    "Couldn't save the configuration",
+  "commerceOnboarding.googleSearchConsoleConfigForm.cancelButton": "Cancel",
+  "commerceOnboarding.googleSearchConsoleConfigForm.saveButton": "Save",
+  "commerceOnboarding.googleSearchConsoleConfigForm.savingButton": "Saving...",
+  "commerceOnboarding.selectableList.searchPlaceholder": "Search...",
+  "commerceOnboarding.selectableList.searchAriaLabel": "Search {label}",
+  "commerceOnboarding.selectableList.noResults": "No results",
 } as const;

--- a/apps/web/src/i18n/pt-br/commerce-onboarding.ts
+++ b/apps/web/src/i18n/pt-br/commerce-onboarding.ts
@@ -88,4 +88,23 @@ export const commerceOnboarding = {
   "commerceOnboarding.shopifyConfigForm.savingButton": "Salvando...",
   "commerceOnboarding.shopifyConfigForm.savingError":
     "Não foi possível salvar a configuração",
+  "commerceOnboarding.googleSearchConsoleConfigForm.loadingSites":
+    "Carregando sites...",
+  "commerceOnboarding.googleSearchConsoleConfigForm.loadSitesError":
+    "Não foi possível carregar os sites do Google Search Console.",
+  "commerceOnboarding.googleSearchConsoleConfigForm.noSitesFound":
+    "Nenhum site verificado foi encontrado. Verifique um site no Google Search Console.",
+  "commerceOnboarding.googleSearchConsoleConfigForm.siteAriaLabel":
+    "Site verificado",
+  "commerceOnboarding.googleSearchConsoleConfigForm.siteRequired":
+    "Selecione um site",
+  "commerceOnboarding.googleSearchConsoleConfigForm.savingError":
+    "Não foi possível salvar a configuração",
+  "commerceOnboarding.googleSearchConsoleConfigForm.cancelButton": "Cancelar",
+  "commerceOnboarding.googleSearchConsoleConfigForm.saveButton": "Salvar",
+  "commerceOnboarding.googleSearchConsoleConfigForm.savingButton":
+    "Salvando...",
+  "commerceOnboarding.selectableList.searchPlaceholder": "Buscar...",
+  "commerceOnboarding.selectableList.searchAriaLabel": "Buscar {label}",
+  "commerceOnboarding.selectableList.noResults": "Nenhum resultado",
 } satisfies Record<keyof typeof commerceOnboardingEn, string>;

--- a/apps/web/src/routes/commerce-onboarding/companion-forms/google-search-console-config-form.tsx
+++ b/apps/web/src/routes/commerce-onboarding/companion-forms/google-search-console-config-form.tsx
@@ -18,12 +18,19 @@ import { useSaveCompanionConfig } from "./use-save-companion-config.ts";
 import { SelectableList } from "./selectable-list.tsx";
 import { LoadingIndicator } from "../loading-indicator.tsx";
 import type { CompanionFormProps } from "./types.ts";
+import { useT, type TFunction } from "@/i18n/use-t.ts";
 
-const schema = z.object({
-  siteUrl: z.string().min(1, "Selecione um site"),
-});
+const makeSchema = (t: TFunction) =>
+  z.object({
+    siteUrl: z
+      .string()
+      .min(
+        1,
+        t("commerceOnboarding.googleSearchConsoleConfigForm.siteRequired"),
+      ),
+  });
 
-type FormData = z.infer<typeof schema>;
+type FormData = z.infer<ReturnType<typeof makeSchema>>;
 
 export function GoogleSearchConsoleConfigForm({
   card,
@@ -35,6 +42,7 @@ export function GoogleSearchConsoleConfigForm({
   onDone,
   onIsPendingChange,
 }: CompanionFormProps) {
+  const t = useT();
   const sitesQuery = useQuery({
     queryKey: KEYS.commerceDiscoveryCompanionGscSites(org.id, connectionId),
     queryFn: async () => {
@@ -50,7 +58,7 @@ export function GoogleSearchConsoleConfigForm({
   });
 
   const form = useForm<FormData>({
-    resolver: zodResolver(schema),
+    resolver: zodResolver(makeSchema(t)),
     defaultValues: {
       siteUrl: (card.configurationState?.siteUrl as string) || "",
     },
@@ -104,7 +112,11 @@ export function GoogleSearchConsoleConfigForm({
   if (sitesQuery.isLoading) {
     return (
       <div className="flex min-h-[200px] items-center justify-center">
-        <LoadingIndicator label="Carregando sites..." />
+        <LoadingIndicator
+          label={t(
+            "commerceOnboarding.googleSearchConsoleConfigForm.loadingSites",
+          )}
+        />
       </div>
     );
   }
@@ -113,7 +125,7 @@ export function GoogleSearchConsoleConfigForm({
     return (
       <div className="space-y-4">
         <p className="text-sm text-destructive">
-          Não foi possível carregar os sites do Google Search Console.
+          {t("commerceOnboarding.googleSearchConsoleConfigForm.loadSitesError")}
         </p>
       </div>
     );
@@ -125,8 +137,7 @@ export function GoogleSearchConsoleConfigForm({
     return (
       <div className="space-y-4">
         <p className="text-sm text-muted-foreground">
-          Nenhum site verificado foi encontrado. Verifique um site no Google
-          Search Console.
+          {t("commerceOnboarding.googleSearchConsoleConfigForm.noSitesFound")}
         </p>
       </div>
     );
@@ -149,7 +160,9 @@ export function GoogleSearchConsoleConfigForm({
                   value={field.value}
                   onChange={field.onChange}
                   disabled={isPending}
-                  ariaLabel="Site verificado"
+                  ariaLabel={t(
+                    "commerceOnboarding.googleSearchConsoleConfigForm.siteAriaLabel",
+                  )}
                 />
               </FormControl>
               <FormMessage />
@@ -162,7 +175,7 @@ export function GoogleSearchConsoleConfigForm({
         <p role="alert" className="text-sm text-destructive">
           {error instanceof Error
             ? error.message
-            : "Não foi possível salvar a configuração"}
+            : t("commerceOnboarding.googleSearchConsoleConfigForm.savingError")}
         </p>
       )}
 
@@ -173,10 +186,12 @@ export function GoogleSearchConsoleConfigForm({
           onClick={onDone}
           disabled={isPending}
         >
-          Cancelar
+          {t("commerceOnboarding.googleSearchConsoleConfigForm.cancelButton")}
         </Button>
         <Button type="submit" disabled={isPending}>
-          {isPending ? "Salvando..." : "Salvar"}
+          {isPending
+            ? t("commerceOnboarding.googleSearchConsoleConfigForm.savingButton")
+            : t("commerceOnboarding.googleSearchConsoleConfigForm.saveButton")}
         </Button>
       </DialogFooter>
     </form>

--- a/apps/web/src/routes/commerce-onboarding/companion-forms/selectable-list.test.tsx
+++ b/apps/web/src/routes/commerce-onboarding/companion-forms/selectable-list.test.tsx
@@ -1,9 +1,23 @@
 import { setupComponentTest } from "../../../../test/setup";
 setupComponentTest();
 import { describe, expect, it, mock } from "bun:test";
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render as renderBare } from "@testing-library/react";
 import "@testing-library/jest-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
 import { SelectableList } from "./selectable-list";
+
+// SelectableList resolves its search placeholder/aria-label via useT(), which
+// reads the language preference through TanStack Query — renders need a
+// QueryClientProvider.
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+const render = (ui: Parameters<typeof renderBare>[0]) =>
+  renderBare(ui, { wrapper });
 
 const OPTIONS = [
   { value: "a", label: "Alpha" },

--- a/apps/web/src/routes/commerce-onboarding/companion-forms/selectable-list.tsx
+++ b/apps/web/src/routes/commerce-onboarding/companion-forms/selectable-list.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { Input } from "@deco/ui/components/input.tsx";
 import { CheckCircle, SearchSm } from "@untitledui/icons";
+import { useT } from "@/i18n/use-t.ts";
 
 export interface SelectableOption {
   value: string;
@@ -15,7 +16,7 @@ export function SelectableList({
   onChange,
   disabled,
   ariaLabel,
-  searchPlaceholder = "Buscar...",
+  searchPlaceholder,
   hideSearch = false,
 }: {
   options: SelectableOption[];
@@ -30,6 +31,7 @@ export function SelectableList({
   // itself (e.g. a server-side repo search). Options are then rendered as-is.
   hideSearch?: boolean;
 }): ReactElement {
+  const t = useT();
   const [query, setQuery] = useState("");
 
   const normalizedQuery = query.trim().toLowerCase();
@@ -97,8 +99,13 @@ export function SelectableList({
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             disabled={disabled}
-            placeholder={searchPlaceholder}
-            aria-label={`Buscar ${ariaLabel}`}
+            placeholder={
+              searchPlaceholder ??
+              t("commerceOnboarding.selectableList.searchPlaceholder")
+            }
+            aria-label={t("commerceOnboarding.selectableList.searchAriaLabel", {
+              label: ariaLabel,
+            })}
             className="h-8 pl-8"
           />
         </div>
@@ -111,7 +118,7 @@ export function SelectableList({
       >
         {filtered.length === 0 ? (
           <div className="px-2 py-2 text-sm text-muted-foreground">
-            Nenhum resultado
+            {t("commerceOnboarding.selectableList.noResults")}
           </div>
         ) : (
           filtered.map((option) => {


### PR DESCRIPTION
**Source:** bug found while hunting the commerce-onboarding-i18n-sync area. `GoogleSearchConsoleConfigForm` (a sibling of `shopify-config-form.tsx`, fixed for the same class of bug in #5610) had zero i18n coverage — every label, button, loading/error message, empty state, and the `SelectableList` picker's aria-label were hardcoded in Portuguese ("Carregando sites...", "Selecione um site", "Site verificado", "Não foi possível salvar a configuração", etc), regardless of the user's selected locale. The shared `SelectableList` component (also used by the GitHub and Google Analytics config forms) had the same problem for its default search placeholder, search-box aria-label, and "no results" text.

**Payoff:** English-locale users configuring the Search Console companion currently see Portuguese UI text throughout the dialog — this fixes that for this form and for `SelectableList`'s own defaults.

**What changed:**
- `google-search-console-config-form.tsx`: replaced every hardcoded Portuguese string (labels, buttons, loading/error states, empty state, Zod validation message, `SelectableList` aria-label) with `t()` calls, following the same `makeSchema(t)` pattern already used in `shopify-config-form.tsx` for the Zod resolver.
- `selectable-list.tsx`: the shared picker's default search placeholder, the `Buscar {label}` search-box aria-label template, and the "Nenhum resultado" empty-state text are now sourced from `t()` instead of being hardcoded Portuguese defaults (this is the component GSC, GitHub, and Google Analytics config forms all render through).
- Added the new keys to both `i18n/en/commerce-onboarding.ts` and `i18n/pt-br/commerce-onboarding.ts` (the pt-br file's `satisfies Record<keyof typeof commerceOnboardingEn, string>` guarantees key parity).
- `selectable-list.test.tsx`: since `SelectableList` now calls `useT()` (which reads the language preference via TanStack Query), wrapped the existing tests in a `QueryClientProvider`, matching the established pattern in `tier-trigger.test.tsx`. Behavior asserted by the tests (click/keyboard selection) is unchanged.

**Verify:** `bun test apps/web/src/routes/commerce-onboarding/companion-forms/selectable-list.test.tsx` (5/5 pass, previously would fail after this change without the QueryClientProvider fix). `cd apps/web && bunx tsc --noEmit` is clean.

**Locally ran:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on every touched file (0 warnings/errors). Full CI validates the rest.

Out of scope (left for a follow-up, same bug pattern, different files): `vtex-config-form.tsx`'s hardcoded Portuguese Zod message, `github-config-form.tsx`'s untranslated Zod message key and hardcoded aria-label, and `google-analytics-config-form.tsx`'s full lack of i18n — each is its own single-concern PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced hardcoded Portuguese text in the Google Search Console config form and the shared SelectableList with i18n. English users now see correct labels, placeholders, validation, and messages.

- **Bug Fixes**
  - Google Search Console form: all labels, buttons, loading/error/empty messages, aria-labels, and the Zod validation now use `t()`; schema built with `makeSchema(t)`.
  - SelectableList: search placeholder, search input aria-label template, and “no results” now come from `t()` (existing `searchPlaceholder` prop still works).
  - i18n: added keys in `i18n/en/commerce-onboarding.ts` and `i18n/pt-br/commerce-onboarding.ts` with parity.
  - Tests: wrapped SelectableList tests in `QueryClientProvider` from `@tanstack/react-query`; behavior unchanged.

<sup>Written for commit 9bed730bf5cd974698cf6828ce780cca21dac2bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

