### PR TITLE
fix(virtual-mcp): warn when an attached file exceeds the 25MB limit

### DIFF
--- a/apps/web/src/i18n/en/virtual-mcp.ts
+++ b/apps/web/src/i18n/en/virtual-mcp.ts
@@ -88,6 +88,9 @@ export const virtualMcp = {
   "virtualMcp.filesSection.description":
     "Attach files and skills the agent can always reference.",
   "virtualMcp.filesSection.failedUploadFile": "Failed to upload file.",
+  "virtualMcp.filesSection.fileTooLargeDescription":
+    "Exceeds the 25MB limit, not uploaded: {names}",
+  "virtualMcp.filesSection.fileTooLargeTitle": "File too large",
   "virtualMcp.filesSection.filesAndSkills": "Files and skills",
   "virtualMcp.filesSection.kindFile": "File",
   "virtualMcp.filesSection.kindSkill": "Skill",

--- a/apps/web/src/i18n/pt-br/virtual-mcp.ts
+++ b/apps/web/src/i18n/pt-br/virtual-mcp.ts
@@ -91,6 +91,9 @@ export const virtualMcp = {
   "virtualMcp.filesSection.description":
     "Anexe arquivos e skills que o agente sempre pode consultar.",
   "virtualMcp.filesSection.failedUploadFile": "Falha ao enviar arquivo.",
+  "virtualMcp.filesSection.fileTooLargeDescription":
+    "Excede o limite de 25MB, não enviado: {names}",
+  "virtualMcp.filesSection.fileTooLargeTitle": "Arquivo muito grande",
   "virtualMcp.filesSection.filesAndSkills": "Arquivos e skills",
   "virtualMcp.filesSection.kindFile": "Arquivo",
   "virtualMcp.filesSection.kindSkill": "Skill",

--- a/apps/web/src/views/virtual-mcp/files-section.tsx
+++ b/apps/web/src/views/virtual-mcp/files-section.tsx
@@ -101,9 +101,16 @@ export function FilesSection({ form }: { form: VirtualMcpFormReturn }) {
 
   const handleUpload = async (fileList: FileList | null) => {
     if (!fileList || fileList.length === 0) return;
-    const toUpload = Array.from(fileList).filter(
-      (file) => file.size <= MAX_FILE_BYTES,
-    );
+    const all = Array.from(fileList);
+    const toUpload = all.filter((file) => file.size <= MAX_FILE_BYTES);
+    const rejected = all.filter((file) => file.size > MAX_FILE_BYTES);
+    if (rejected.length > 0) {
+      toast.warning(t("virtualMcp.filesSection.fileTooLargeTitle"), {
+        description: t("virtualMcp.filesSection.fileTooLargeDescription", {
+          names: rejected.map((file) => file.name).join(", "),
+        }),
+      });
+    }
     if (toUpload.length === 0) return;
     try {
       await upload.mutateAsync({ dir: KNOWLEDGE_DIR, files: toUpload });


### PR DESCRIPTION
Bug found while auditing the agent "Files and skills" section (apps/web/src/views/virtual-mcp/files-section.tsx).

Why: `handleUpload` filters out any file over `MAX_FILE_BYTES` (25MB) before uploading, but the filter result was silently discarded — the user gets no toast, no error, nothing. A user who drags in a 30MB PDF alongside a few small files sees the small files attach and the large one just vanish, with no indication anything went wrong.

Failure scenario: drag-and-drop or file-picker select a file >25MB (alone or mixed with valid files) into the Files and skills picker on the agent settings page — the file is dropped from `toUpload` and never uploaded, and prior to this fix the function returned early with zero user feedback.

Fix: compute the rejected (oversized) files alongside the accepted ones and surface a `toast.warning` naming the skipped file(s) before continuing with any valid uploads. Added the two new i18n strings (en + pt-br) following the existing toast.warning(title, { description }) pattern used elsewhere in this same file's dialogs.

How to verify: open the agent settings "Files and skills" section, attach a file larger than 25MB (with browser dev tools or a large test file) — a toast should now appear naming the skipped file, instead of it silently disappearing.

Checks run locally: `bun run fmt` (clean), `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint` on all three touched files (0 warnings/errors). No existing test file covers this component (none exist in this directory), so this is a straightforward UX/correctness fix — full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a warning toast when a file over 25MB is selected in the agent’s “Files and skills” section. Skipped files are named in the toast, and valid files still upload.

- **Bug Fixes**
  - Split selected files into accepted and rejected and surface a `toast.warning` with localized title and description.
  - Added `virtualMcp.filesSection.fileTooLargeTitle` and `virtualMcp.filesSection.fileTooLargeDescription` in `en` and `pt-br`.

<sup>Written for commit 99c81e5dbf62a4447bf342ff389baa02a758fc6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5626?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

