### PR TITLE
fix(sandbox-env): fail fast on warmPool.enabled with size 0

### DIFF
--- a/deploy/helm/sandbox-env/templates/_helpers.tpl
+++ b/deploy/helm/sandbox-env/templates/_helpers.tpl
@@ -192,6 +192,22 @@ worth catching at template time rather than letting the API server reject
 {{- end }}
 {{- end }}
 
+{{/*
+Catch warmPool.enabled=true left at the default warmPool.size (0): the
+SandboxWarmPool renders with replicas: 0, a no-op that pre-warms nothing
+while still looking "enabled" — the same balloon-with-0-replicas trap
+validateNodePlaceholder already guards against below. Skipped when
+autoscaling is on, since the HPA drives replicas post-render regardless of
+this static value.
+*/}}
+{{- define "sandbox-env.validateWarmPoolSize" -}}
+{{- if and .Values.warmPool.enabled (not .Values.warmPool.autoscaling.enabled) }}
+{{- if lt (int .Values.warmPool.size) 1 }}
+{{- fail (printf "sandbox-env: warmPool.enabled=true requires warmPool.size >= 1 (got %v) — a pool with 0 replicas pre-warms nothing." .Values.warmPool.size) -}}
+{{- end }}
+{{- end }}
+{{- end }}
+
 {{- define "sandbox-env.housekeeperName" -}}
 {{- printf "sandbox-housekeeper-%s" (include "sandbox-env.envName" .) -}}
 {{- end }}

--- a/deploy/helm/sandbox-env/templates/validations.yaml
+++ b/deploy/helm/sandbox-env/templates/validations.yaml
@@ -11,6 +11,7 @@ only really matters for Helm's own bookkeeping.
 */ -}}
 {{- include "sandbox-env.validatePreviewGateway" . -}}
 {{- include "sandbox-env.validateWarmPoolAutoscaling" . -}}
+{{- include "sandbox-env.validateWarmPoolSize" . -}}
 {{- include "sandbox-env.validateNodePlaceholder" . -}}
 {{- /* Force envName validation to run at template time even when no
 resource references it directly (pure-validation render). Discard the


### PR DESCRIPTION
**Source**: bug found while auditing the sandbox-size-tiers focus area (`deploy/helm/sandbox-env`). The per-(org,repo) size-tier feature itself (#5361) is still an open PR and untouched here — this is an unrelated, pre-existing validation gap in the same chart.

**Why a maintainer wants this**: `warmPool.enabled: true` left at the default `warmPool.size: 0` renders a `SandboxWarmPool` with `replicas: 0` — silently a no-op that pre-warms nothing while looking enabled in values. The sibling `nodePlaceholder` block already guards the identical `replicas < 1` trap (`sandbox-env.validateNodePlaceholder`, with the same rationale in its comment); `warmPool` had no equivalent check, so a config mistake (forgetting to set `size`) fails silently instead of at `helm template`/`helm install` time.

**Fix**: adds `sandbox-env.validateWarmPoolSize` in `_helpers.tpl`, following the exact same fail-fast pattern as `validateNodePlaceholder`/`validateWarmPoolAutoscaling`, and wires it into `templates/validations.yaml`. Skipped when `warmPool.autoscaling.enabled` is true, since the HPA drives `replicas` post-render regardless of the static `size` value (mirrors how `validateWarmPoolAutoscaling` already treats autoscaling as authoritative).

**Command a reviewer runs to confirm**:
```
helm template sandbox-env deploy/helm/sandbox-env --namespace agent-sandbox-system --set envName=ci --set warmPool.enabled=true
# now fails with: "warmPool.enabled=true requires warmPool.size >= 1 (got 0)"

helm template sandbox-env deploy/helm/sandbox-env --namespace agent-sandbox-system --set envName=ci --set warmPool.enabled=true --set warmPool.size=2
# still renders fine (matches the existing CI "Render (warm pool enabled)" step, which already sets size=2)
```

**Locally verified**: `helm lint deploy/helm/sandbox-env --namespace agent-sandbox-system --set envName=ci` (clean), `helm template` against all four scenarios above (default, size=2, size=0-should-fail, autoscaling-on-size=0-should-pass), and `bun run fmt` (no changes). Full CI (`helm-test.yml`'s sandbox-env job) validates the rest — its existing "warm pool enabled" render step already passes `warmPool.size=2`, so this change doesn't touch CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a fail-fast validation to prevent `warmPool.enabled=true` with `warmPool.size=0` from rendering a no-op pool in the sandbox-env Helm chart. The check is skipped when warm pool autoscaling is enabled.

- **Bug Fixes**
  - Added `sandbox-env.validateWarmPoolSize` in `_helpers.tpl`.
  - Included the validation in `templates/validations.yaml`.
  - Skips when `warmPool.autoscaling.enabled` is true.
  - Aligns with the existing `validateNodePlaceholder` guard.

- **Migration**
  - `helm template/install` now fails if `warmPool.enabled=true` and `warmPool.size<1`.
  - Set `warmPool.size>=1` or enable `warmPool.autoscaling`.

<sup>Written for commit 2a4fde2c1c7ca04909e0b169c7615ccc3d4b2a12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

