### PR TITLE
fix(ai-providers): stop leaking the Google API key into trace spans

### DIFF
--- a/apps/api/src/ai-providers/adapters/google.test.ts
+++ b/apps/api/src/ai-providers/adapters/google.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { googleAdapter } from "./google";
+
+const realFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+describe("googleAdapter.listModels", () => {
+  test("sends the API key via header, never in the URL", async () => {
+    let capturedUrl = "";
+    let capturedHeaders: Headers | undefined;
+    globalThis.fetch = (async (
+      url: unknown,
+      init?: RequestInit,
+    ): Promise<Response> => {
+      capturedUrl = String(url);
+      capturedHeaders = new Headers(init?.headers);
+      return new Response(JSON.stringify({ models: [] }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as unknown as typeof fetch;
+
+    const provider = googleAdapter.create("secret-api-key");
+    await provider.listModels();
+
+    // The key must never land in the URL: outbound fetches are OTel-traced
+    // with the full URL (including query string), so a `?key=` param would
+    // leak the credential into every trace span.
+    expect(capturedUrl).not.toContain("secret-api-key");
+    expect(capturedHeaders?.get("x-goog-api-key")).toBe("secret-api-key");
+  });
+});

--- a/apps/api/src/ai-providers/adapters/google.ts
+++ b/apps/api/src/ai-providers/adapters/google.ts
@@ -89,8 +89,14 @@ export const googleAdapter: ProviderAdapter = {
       },
 
       async listModels(): Promise<ModelInfo[]> {
+        // Pass the key via header, not the `?key=` query param: outbound fetch
+        // calls are OTel-traced with the full URL (including query string,
+        // see observability/instrumentations/fetch.ts), so a query-param key
+        // would leak into every trace span. gemini-interactions.ts already
+        // uses this same header for the sibling Gemini API.
         const res = await fetch(
-          `https://generativelanguage.googleapis.com/v1beta/models?key=${apiKey}`,
+          "https://generativelanguage.googleapis.com/v1beta/models",
+          { headers: { "x-goog-api-key": apiKey } },
         );
         if (!res.ok) {
           throw new Error(`Google listModels failed: ${res.status}`);


### PR DESCRIPTION
**Source:** a real credential-leak bug found while auditing `apps/api/src/ai-providers` for the LLM-governance focus area (cost tracking / provider config hardening).

**What's wrong:** `googleAdapter.listModels()` (`apps/api/src/ai-providers/adapters/google.ts`) sends the API key as a `?key=...` query parameter on the Google Generative Language `listModels` request. Every outbound `fetch` in this process is OTel-instrumented (`apps/api/src/observability/instrumentations/fetch.ts`), and that instrumentation records `url.full` and `url.query` — the *entire* URL, including the query string — as span attributes on every request. That means the org's Google API key gets exported into every trace span sent to the OTLP backend, a real secret leak into observability tooling. The sibling `gemini-interactions.ts` (used by the same adapter for async-research calls) already avoids this by sending the key via the `x-goog-api-key` header instead — `listModels()` was the one inconsistent caller.

**Fix:** switch `listModels()` to send the key via the `x-goog-api-key` header (an officially supported auth method for this API), matching the existing pattern in `gemini-interactions.ts`. Behavior-preserving — same auth, same response shape, just a different transport for the credential.

**Regression test:** `apps/api/src/ai-providers/adapters/google.test.ts` mocks `fetch` and asserts the captured URL never contains the key while the `x-goog-api-key` header does. This is a credential-leak fix (security/privacy — real vuln class if it regresses), so it clears the standalone-test bar as a fix-paired regression test.

**Reviewer command:** `bun test apps/api/src/ai-providers/adapters/google.test.ts`

**Local checks run:** `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), `bunx oxlint` on both changed files (0 warnings/errors), and the targeted test above (1 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop leaking the Google API key into OTel traces by moving `listModels()` to header-based auth. The key now goes in `x-goog-api-key` instead of `?key=`, so `url.full`/`url.query` never include secrets.

- **Bug Fixes**
  - Updated `apps/api/src/ai-providers/adapters/google.ts` to send the key via header; behavior remains the same.
  - Added `apps/api/src/ai-providers/adapters/google.test.ts` to ensure the key never appears in the URL and is present only in the header.

<sup>Written for commit de40f6a407f27fbf05af55f100b5f82d2ff3f06b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

