### PR TITLE
fix(vault): stop the batch lease endpoint masking a configuration decrypt failure as empty

### DIFF
--- a/apps/api/src/api/routes/credential-vault.integration.test.ts
+++ b/apps/api/src/api/routes/credential-vault.integration.test.ts
@@ -550,6 +550,18 @@ describe("Credential Vault Routes", () => {
       expect(body.conn_does_not_exist?.error).toBe("Connection not found");
     });
 
+    it("does not return empty configuration when saved configuration cannot be decrypted", async () => {
+      const res = await app.fetch(
+        batchRequest("svc-secret", ["conn_invalid_configuration_target"]),
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, { error?: string }>;
+      expect(body.conn_invalid_configuration_target?.error).toBe(
+        "MCP configuration could not be decrypted",
+      );
+    });
+
     it("rejects workload tokens — the batch lane is service-only", async () => {
       const res = await app.fetch(batchRequest(workloadToken, ["conn_target"]));
       expect(res.status).toBe(401);

--- a/apps/api/src/api/routes/credential-vault.ts
+++ b/apps/api/src/api/routes/credential-vault.ts
@@ -168,6 +168,19 @@ export const createCredentialVaultRoutes = () => {
           .execute()
       ).map((row) => row.connectionId),
     );
+    // Raw (still-encrypted) configuration_state, so a decrypt failure can be
+    // told apart from "no configuration set" below — `connections.list()`
+    // silently maps a decrypt failure to `null`, same as an unset value.
+    const rawConfigStateById = new Map(
+      (
+        await ctx.db
+          .selectFrom("connections")
+          .select(["id", "configuration_state"])
+          .where("id", "in", ids)
+          .where("organization_id", "=", organizationId)
+          .execute()
+      ).map((row) => [row.id, row.configuration_state]),
+    );
 
     const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
     const out: Record<string, unknown> = {};
@@ -177,6 +190,12 @@ export const createCredentialVaultRoutes = () => {
           const target = byId.get(id);
           if (!target || target.status !== "active") {
             out[id] = { error: "Connection not found" };
+            return;
+          }
+          if (rawConfigStateById.get(id) && !target.configuration_state) {
+            // Mirrors the single-connection /configuration route: don't mask
+            // a decrypt failure as an empty configuration.
+            out[id] = { error: "MCP configuration could not be decrypted" };
             return;
           }
           const configuration = {


### PR DESCRIPTION
The single-connection `POST /vault/connections/:id/configuration` route already has tested, deliberate behavior for a `configuration_state` ciphertext that fails to decrypt: it returns `424 { error: "MCP configuration could not be decrypted" }` rather than pretending the configuration is empty (see the existing test `does not return empty configuration when saved configuration cannot be decrypted`). The newer batch lease endpoint (`POST /vault/connections/batch`, added in #5613) doesn't mirror this: it reuses `connections.list()`'s decrypted entity, and `deserializeConnection` silently maps a decrypt failure to `configuration_state: null` (it only logs + feeds the per-connection decrypt-failure tracker) — identical to a connection that legitimately has no configuration set. A downstream service consuming the batch lease (e.g. decocms/reports resolving several providers per run) would silently get `{ state: {} }` for a connection whose config actually failed to decrypt, instead of the explicit error the singular route already gives, and could proceed as if no configuration were required.

Failure scenario: a connection's `configuration_state` ciphertext can't be authenticated (bad/rotated vault key, corrupted row) — reproduced by the existing `conn_invalid_configuration_target` fixture (`configuration_state: "not-valid-ciphertext"`). Before this fix, batching that id returned `200` with `configuration.state: {}`; after, it returns `200` with a per-item `{ error: "MCP configuration could not be decrypted" }`, matching the singular route.

Fix: the batch handler now also fetches the raw (still-encrypted) `configuration_state` for the requested ids, and if it's present but the decrypted value came back `null`, reports the decrypt-failure error for that item instead of falling through to `{}`.

Regression test added: `does not return empty configuration when saved configuration cannot be decrypted` under the existing `batch (service token)` describe block in `credential-vault.integration.test.ts`, reusing the same fixture as the singular-route test of the same name.

Reviewer command: `bun test apps/api/src/api/routes/credential-vault.integration.test.ts` (requires local Postgres).

Locally verified: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted integration test file above (16/16 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the batch lease endpoint so a failed configuration decrypt is reported instead of being treated as empty. This matches the single-connection configuration route behavior.

- **Bug Fixes**
  - Batch now checks the raw encrypted `configuration_state` and, if present but decrypted to null, returns `{ error: "MCP configuration could not be decrypted" }` per item.
  - Added an integration test to ensure the batch route does not return an empty configuration when decrypt fails.

<sup>Written for commit d3d84f366b871787ae5bbb02f767c1087f404cf5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

