### PR TITLE
fix(chat): restore autofocus on the model selector search input

### DIFF
--- a/apps/web/src/components/chat/select-model/decopilot.tsx
+++ b/apps/web/src/components/chat/select-model/decopilot.tsx
@@ -661,7 +661,6 @@ function ModelSelectorInner({
   );
   const [searchTerm, setSearchTerm] = useState("");
   const [managing, setManaging] = useState(false);
-  const searchInputRef = useRef<HTMLInputElement>(null);
   const aiProviders = useAiProviders();
   const keys = useHostedAiProviderKeys();
 
@@ -713,7 +712,7 @@ function ModelSelectorInner({
           <label className="flex items-center gap-2.5 h-12 px-4 pr-12 md:pr-4 cursor-text">
             <SearchMd size={16} className="text-muted-foreground shrink-0" />
             <Input
-              ref={searchInputRef}
+              autoFocus
               type="text"
               placeholder={
                 managing


### PR DESCRIPTION
**Source:** bug found while auditing `decopilot.tsx` (chat model selector resilience focus area).

**Why:** The AI-provider-keys refactor (#2685) replaced the old `useEffect`-based `searchInputRef.current?.focus()` autofocus with... nothing — the ref stayed attached to the search `<Input>` but was never read anywhere. Since then, opening the model selector Dialog/Drawer leaves the search box unfocused, so keyboard/power users have to click into it before they can type to filter models. This is a real UX regression on a hot path (every model switch).

**Fix:** Drop the dead `searchInputRef` and use the native `autoFocus` prop on the `Input` instead — no `useEffect` needed (banned in this repo anyway), and it's the same pattern already used by other in-repo dialogs (`create-page-modal.tsx`, `variant-rename-dialog.tsx`, etc.). Net effect: opening the model selector now focuses the search field immediately, like it used to.

**Net line delta:** -2 / +1. Behavior-preserving elsewhere: `searchInputRef` had zero other readers (`rg searchInputRef` in the file shows only the declaration and the removed `ref=`), so removing it can't affect anything else.

**How a reviewer confirms:** Open the chat, click the model selector — the search input should have focus (cursor blinking, ready to type) as soon as the dialog opens, without clicking it.

**Checks run locally:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean), `bun test apps/web/src/components/chat/select-model/decopilot.test.tsx` (4 pass), `bunx oxlint apps/web/src/components/chat/select-model/decopilot.tsx` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores autofocus on the chat model selector search input so the field is focused when the dialog opens. Users can type to filter models immediately, no click needed.

- **Bug Fixes**
  - Switched the search `Input` to `autoFocus` and removed the unused `searchInputRef`.

<sup>Written for commit 261d41afc64b5c793d4443c992be6f6e6cfae967. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

