### PR TITLE
perf(sandbox): stop reallocating the full SSE replay buffer on every log chunk

### DIFF
--- a/packages/sandbox/daemon-go/internal/events/replay.go
+++ b/packages/sandbox/daemon-go/internal/events/replay.go
@@ -3,30 +3,34 @@ package events
 type ReplayBuffer struct {
 	maxBytes int
 	order    []string
-	buffers  map[string]string
+	buffers  map[string][]byte
 }
 
 func NewReplayBuffer(maxBytes int) *ReplayBuffer {
-	return &ReplayBuffer{maxBytes: maxBytes, buffers: map[string]string{}}
+	return &ReplayBuffer{maxBytes: maxBytes, buffers: map[string][]byte{}}
 }
 
+// Append grows the source's buffer in place (amortized O(len(data)) via
+// Go's slice growth) instead of reallocating and copying up to maxBytes on
+// every call, which mattered here since BroadcastChunk holds Broadcaster.mu
+// while appending on every log chunk.
 func (r *ReplayBuffer) Append(source, data string) {
 	if data == "" {
 		return
 	}
-	prev, ok := r.buffers[source]
+	buf, ok := r.buffers[source]
 	if !ok {
 		r.order = append(r.order, source)
 	}
-	next := prev + data
-	if len(next) > r.maxBytes {
-		next = next[len(next)-r.maxBytes:]
+	buf = append(buf, data...)
+	if len(buf) > r.maxBytes {
+		buf = buf[len(buf)-r.maxBytes:]
 	}
-	r.buffers[source] = next
+	r.buffers[source] = buf
 }
 
 func (r *ReplayBuffer) Read(source string) string {
-	return r.buffers[source]
+	return string(r.buffers[source])
 }
 
 func (r *ReplayBuffer) Sources() []string {

--- a/packages/sandbox/daemon-go/internal/events/replay_test.go
+++ b/packages/sandbox/daemon-go/internal/events/replay_test.go
@@ -1,0 +1,44 @@
+package events
+
+import "testing"
+
+func TestReplayBufferTrimsToMaxBytes(t *testing.T) {
+	r := NewReplayBuffer(10)
+	r.Append("stdout", "0123456789") // exactly maxBytes
+	if got := r.Read("stdout"); got != "0123456789" {
+		t.Fatalf("got %q, want %q", got, "0123456789")
+	}
+	r.Append("stdout", "AB") // pushes past maxBytes, drops from the front
+	if got := r.Read("stdout"); got != "23456789AB" {
+		t.Fatalf("got %q, want %q", got, "23456789AB")
+	}
+}
+
+func TestReplayBufferManySmallAppendsStaysBounded(t *testing.T) {
+	r := NewReplayBuffer(5)
+	for i := 0; i < 1000; i++ {
+		r.Append("stdout", "x")
+	}
+	got := r.Read("stdout")
+	if got != "xxxxx" {
+		t.Fatalf("got %q, want 5 x's", got)
+	}
+}
+
+func TestReplayBufferSourcesPreservesInsertionOrder(t *testing.T) {
+	r := NewReplayBuffer(100)
+	r.Append("stderr", "e")
+	r.Append("stdout", "o")
+	r.Append("stderr", "e2")
+	if got := r.Sources(); len(got) != 2 || got[0] != "stderr" || got[1] != "stdout" {
+		t.Fatalf("got %v, want [stderr stdout]", got)
+	}
+}
+
+func TestReplayBufferEmptyAppendNoop(t *testing.T) {
+	r := NewReplayBuffer(10)
+	r.Append("stdout", "")
+	if got := r.Sources(); len(got) != 0 {
+		t.Fatalf("empty append should not register a source, got %v", got)
+	}
+}


### PR DESCRIPTION
Sandbox daemon SSE robustness sweep (no specific issue) — `ReplayBuffer.Append` (`packages/sandbox/daemon-go/internal/events/replay.go`) is on the hot path for every daemon log chunk broadcast to SSE clients.

**The payoff**: `Append` rebuilt the entire per-source buffer via `prev + data` on every call — up to 256KB (`ReplayBytesCapacity`) copied per single chunk, regardless of how small the new chunk was. This runs while `BroadcastChunk` holds `Broadcaster.mu` (`packages/sandbox/daemon-go/internal/events/broadcast.go`), the same lock `Register`/`Unregister`/`Size` (the `MaxSseClients` check in `events.go`) need — so continuous log output (a long `bun install`/build streaming stdout) means every chunk both wastes CPU and holds the lock other SSE-connection bookkeeping needs longer than necessary. Input is large enough to matter: builds/installs in the sandbox commonly stream many chunks/sec for minutes, each potentially re-copying the full 256KB buffer.

**Fix**: switch the per-source buffer from `string` to `[]byte` and grow it with `append()`, which Go grows with amortized O(1) cost per appended byte (doubling capacity) instead of allocating+copying the full buffer on every call. Trimming to `maxBytes` is still a cheap re-slice (no copy). `Read`/`Sources`/external callers are unchanged — same string-in, string-out contract, same trim-to-tail semantics.

**Verify**: `cd packages/sandbox/daemon-go && go test ./internal/events/...` — includes a new `replay_test.go` covering exact-boundary trim, many-small-appends staying bounded, source insertion order, and the empty-append no-op (previously untested).

**Locally ran**: `gofmt -l` (clean), `go vet ./internal/events/...` (clean), `go test ./internal/events/...` (pass). Full CI validates the rest of the daemon-go build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimize the SSE replay buffer to avoid reallocating up to 256KB per log chunk, reducing CPU use and time spent holding the broadcaster mutex during heavy log streams.

- **Refactors**
  - Use byte slices with append and front-slicing to enforce max size, instead of rebuilding strings on each append.
  - Keep the external API identical: same inputs/outputs and tail-trim behavior.
  - Add tests for trimming, bounded small appends, source order, and empty-append no-op.

<sup>Written for commit 2678f5e82f7f9463da3492073ef79943a949156f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

