### PR TITLE
fix(vault): stop masking a connection_token decrypt failure as absent

### DIFF
--- a/apps/api/src/api/routes/credential-vault.integration.test.ts
+++ b/apps/api/src/api/routes/credential-vault.integration.test.ts
@@ -172,6 +172,19 @@ describe("Credential Vault Routes", () => {
           created_at: now,
           updated_at: now,
         },
+        {
+          id: "conn_invalid_token_target",
+          organization_id: "org_1",
+          created_by: "user_1",
+          title: "Invalid Token Target",
+          connection_type: "HTTP",
+          connection_url: "https://invalid-token.example.test/mcp",
+          connection_token: "not-valid-ciphertext",
+          status: "active",
+          pinned: false,
+          created_at: now,
+          updated_at: now,
+        },
       ])
       .execute();
 
@@ -201,6 +214,10 @@ describe("Credential Vault Routes", () => {
         },
         {
           targetConnectionId: "conn_static_token_target",
+          scope: CREDENTIAL_ACCESS_TOKEN_READ_SCOPE,
+        },
+        {
+          targetConnectionId: "conn_invalid_token_target",
           scope: CREDENTIAL_ACCESS_TOKEN_READ_SCOPE,
         },
         {
@@ -429,6 +446,23 @@ describe("Credential Vault Routes", () => {
     });
   });
 
+  it("does not report 'not found' when a static connection token cannot be decrypted", async () => {
+    const res = await app.fetch(
+      new Request(
+        "http://test/api/org_1/vault/connections/conn_invalid_token_target/access-token",
+        {
+          method: "POST",
+          headers: { Authorization: `Bearer ${workloadToken}` },
+        },
+      ),
+    );
+
+    expect(res.status).toBe(424);
+    await expect(res.json()).resolves.toEqual({
+      error: "Connection token could not be decrypted",
+    });
+  });
+
   it("rejects access when the subject lacks a grant to the target", async () => {
     const res = await app.fetch(
       new Request(
@@ -559,6 +593,18 @@ describe("Credential Vault Routes", () => {
       const body = (await res.json()) as Record<string, { error?: string }>;
       expect(body.conn_invalid_configuration_target?.error).toBe(
         "MCP configuration could not be decrypted",
+      );
+    });
+
+    it("does not report a null token when a static connection token cannot be decrypted", async () => {
+      const res = await app.fetch(
+        batchRequest("svc-secret", ["conn_invalid_token_target"]),
+      );
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as Record<string, { error?: string }>;
+      expect(body.conn_invalid_token_target?.error).toBe(
+        "Connection token could not be decrypted",
       );
     });
 

--- a/apps/api/src/api/routes/credential-vault.ts
+++ b/apps/api/src/api/routes/credential-vault.ts
@@ -168,18 +168,19 @@ export const createCredentialVaultRoutes = () => {
           .execute()
       ).map((row) => row.connectionId),
     );
-    // Raw (still-encrypted) configuration_state, so a decrypt failure can be
-    // told apart from "no configuration set" below — `connections.list()`
-    // silently maps a decrypt failure to `null`, same as an unset value.
-    const rawConfigStateById = new Map(
+    // Raw (still-encrypted) configuration_state + connection_token, so a
+    // decrypt failure can be told apart from "not set" below —
+    // `connections.list()` silently maps either decrypt failure to `null`,
+    // same as an unset value.
+    const rawById = new Map(
       (
         await ctx.db
           .selectFrom("connections")
-          .select(["id", "configuration_state"])
+          .select(["id", "configuration_state", "connection_token"])
           .where("id", "in", ids)
           .where("organization_id", "=", organizationId)
           .execute()
-      ).map((row) => [row.id, row.configuration_state]),
+      ).map((row) => [row.id, row]),
     );
 
     const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
@@ -192,7 +193,10 @@ export const createCredentialVaultRoutes = () => {
             out[id] = { error: "Connection not found" };
             return;
           }
-          if (rawConfigStateById.get(id) && !target.configuration_state) {
+          if (
+            rawById.get(id)?.configuration_state &&
+            !target.configuration_state
+          ) {
             // Mirrors the single-connection /configuration route: don't mask
             // a decrypt failure as an empty configuration.
             out[id] = { error: "MCP configuration could not be decrypted" };
@@ -232,6 +236,11 @@ export const createCredentialVaultRoutes = () => {
               expiresAt: null,
               scope: null,
             };
+          } else if (rawById.get(id)?.connection_token) {
+            // Same masking as configuration_state above, for the static-token
+            // lane: don't report "no token" when it's actually undecryptable.
+            out[id] = { error: "Connection token could not be decrypted" };
+            return;
           }
           out[id] = { configuration, accessToken };
         } catch (err) {
@@ -286,6 +295,21 @@ export const createCredentialVaultRoutes = () => {
           expiresAt: null,
           scope: null,
         });
+      }
+      // `connections.findById` decrypts eagerly and silently maps a
+      // connection_token decrypt failure to null, same as an unset value —
+      // check the raw ciphertext so that case reports 424, not "not found".
+      const raw = await ctx.db
+        .selectFrom("connections")
+        .select("connection_token")
+        .where("id", "=", targetConnectionId)
+        .where("organization_id", "=", organizationId)
+        .executeTakeFirst();
+      if (raw?.connection_token) {
+        return c.json(
+          { error: "Connection token could not be decrypted" },
+          424,
+        );
       }
       return c.json({ error: "Downstream token not found" }, 409);
     }


### PR DESCRIPTION
Follows #5629 (which fixed this exact masking pattern for `configuration_state` on the vault batch lease endpoint) — the sibling `connection_token` field, used by static-token MCPs like Shopify, had the identical gap on **both** the batch endpoint and the single-connection `/access-token` route.

**Why a maintainer wants this**: `connections.list()`/`connections.findById()` decrypt eagerly and silently map a decrypt failure to `null`, same as "no token configured". A downstream service consuming this vault lane (e.g. commerce-discovery) can't tell "this connection has no static token" apart from "this connection's token is corrupt and needs re-provisioning" — it just silently gets no credential, exactly the bug #5629 fixed for the configuration side.

**Failure scenario**: a connection has a `connection_token` ciphertext that fails to decrypt (e.g. after an `ENCRYPTION_KEY` rotation without re-encryption). Before this fix: the single route returns 409 "Downstream token not found" and the batch route returns `accessToken: null` — both indistinguishable from a connection that simply has no static token. After: both return a 424 "Connection token could not be decrypted" error, matching the existing `configuration_state` 424 pattern.

**Regression tests**: added `conn_invalid_token_target` (an unparseable ciphertext) to the integration fixtures and one test per route asserting the 424/`error` response instead of the prior masked "not found"/`null`.

**To verify**: `bun test apps/api/src/api/routes/credential-vault.integration.test.ts` (18 tests, all pass, including the 2 new ones).

**Locally ran**: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted integration test file above, and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop masking undecryptable `connection_token` values as “not set.” The batch lease and `/access-token` routes now return 424 with “Connection token could not be decrypted” when ciphertext exists but can’t be decrypted.

- **Bug Fixes**
  - Batch lease: checks raw `configuration_state` and `connection_token` to distinguish decrypt failures; returns an error instead of a null token.
  - `/access-token`: checks raw `connection_token`; returns 424 instead of 409 “Downstream token not found.”
  - Added integration tests with an invalid ciphertext fixture to assert 424/error on both routes.

<sup>Written for commit 33bfed7d0b397de2f14342e1cd016be477e4f057. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

