### PR TITLE
fix(task-board): stop a conflict-resolution dispatch failure from failing the review decision

### DIFF
--- a/apps/api/src/tools/task-board/review-decision.ts
+++ b/apps/api/src/tools/task-board/review-decision.ts
@@ -221,10 +221,19 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
       // The newest linked PR is the one under review (the same one
       // `mergeLinkedPr` just tried to merge) — detect and act on it.
       const pr = prs[0];
+      // Best-effort, like the poll path in `prs-get` — a dispatch failure (no
+      // model configured, queue error) must never fail this decision: the
+      // approval + bounce-to-in_progress + activity write already committed,
+      // so surfacing an error here would report failure on an otherwise-
+      // successful reviewer decision while burning a conflict-resolution
+      // attempt with no run enqueued.
       const resolving = pr
         ? await reactToApprovedPrConflict(ctx, organizationId, current, {
             pr: { number: pr.number, url: pr.url },
             conflict: await fetchPrConflict(ctx, organizationId, pr),
+          }).catch((err) => {
+            console.error("[task-board] conflict auto-resolve failed", err);
+            return false;
           })
         : false;
       if (resolving) {


### PR DESCRIPTION
Follows #5590 (merge-conflict auto-resolution).

`reactToApprovedPrConflict`'s own docstring says it is "best-effort at the seams; the caller wraps it" — and its poll-path caller (`prs-get.ts`) does wrap it in `.catch()`. Its other caller, the reviewer-approval path in `review-decision.ts`, did not, so the two call sites of the exact same function had inconsistent error handling.

**Failure scenario:** a reviewer approves the last required review on a task whose PR conflicts with its base branch, auto-merge is on, and dispatch fails inside `reactToApprovedPrConflict` (e.g. `resolveTier` throws because no model is configured for the org, or the durable-queue enqueue fails). By that point the function has already: recorded the reviewer's approval, atomically claimed the task (moved In Review → In Progress via `claimConflictResolution`), written a `merge_conflict_resolution` activity entry (consuming one of the task's 3 lifetime auto-resolve attempts), and broadcast the SSE update — then the enqueue throws, propagating uncaught out of the `TASK_BOARD_REVIEW_DECISION` tool handler (`defineTool` rethrows post-span). The reviewer's approve action reports a hard error even though it actually succeeded server-side, and the task is left silently stuck In Progress with no run behind it, having burned one of its three auto-resolve attempts for nothing.

The fix mirrors the `prs-get.ts` poll path exactly: wrap the call in `.catch()`, log, and resolve to `false` so the tool call still returns its normal success response with the task correctly reported as bounced to In Progress (matching the already-committed DB state), instead of surfacing a spurious tool-call error.

**How to verify:** `cd apps/api && bunx tsc --noEmit` (green — no type change) and `bunx oxlint apps/api/src/tools/task-board/review-decision.ts` (0 warnings/errors). This orchestration path needs a real StudioContext/Postgres to exercise end-to-end per this repo's testing tiers (TESTING.md), so it isn't unit-testable; I verified via typecheck + lint only, full CI validates the rest.

Checks run locally: `bun run fmt` (clean), `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint apps/api/src/tools/task-board/review-decision.ts` (clean).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented conflict auto-resolution dispatch failures from causing the reviewer approval decision to error. Errors are now caught and logged so the approval still succeeds and task state stays consistent.

- **Bug Fixes**
  - In `review-decision.ts`, wrap `reactToApprovedPrConflict(...)` in `.catch()`, log the error, and return `false` (matching `prs-get.ts`).
  - Stops spurious tool errors when model/queue dispatch fails; the approval, move to In Progress, and activity write are preserved.

<sup>Written for commit 406c5e28e56c4d5ac9a9449cc6ff3c49709e4469. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

