### PR TITLE
fix(native): reap stray processes when boot-smoke fails

### DIFF
--- a/apps/native/scripts/boot-smoke.ts
+++ b/apps/native/scripts/boot-smoke.ts
@@ -262,6 +262,29 @@ function livingProcessesMatching(pattern: string): number[] {
     .filter((n) => Number.isFinite(n));
 }
 
+/** SIGKILLs `pid`, swallowing the case where it has already exited. */
+function killIfAlive(pid: number): void {
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    // already exited — nothing to clean up
+  }
+}
+
+/** Kills every process matched by `sweepForBinaries` that wasn't already
+ *  running before this smoke run (`preExisting`). `fail()` throws as soon as
+ *  a failure is detected — deadline timeout, non-zero exit, or a detected
+ *  orphan — well before the code that would otherwise notice these
+ *  processes, so a failed run needs its own reap or it leaks the app/
+ *  local-api/rclone processes it spawned into the next run. */
+function reapStrayProcesses(preExisting: Set<number>): void {
+  const stray = sweepForBinaries().filter((p) => !preExisting.has(p));
+  for (const p of stray) killIfAlive(p);
+  if (stray.length > 0) {
+    log(`reaped ${stray.length} stray process(es): ${stray.join(", ")}`);
+  }
+}
+
 async function main(): Promise<void> {
   const options = parseBootSmokeOptions(process.argv.slice(2));
 
@@ -273,13 +296,14 @@ async function main(): Promise<void> {
   const smokePaths = resolveBootSmokePaths(outDir, tmpdir());
   const outFile = smokePaths.reportFile;
 
-  try {
-    // Snapshot matching PIDs that exist BEFORE our launch: another dev's
-    // running app, a parallel CI job, or a manually-started local-api must
-    // not fail OUR orphan check. Only processes that appear during the smoke
-    // and survive it count as orphans.
-    const preExisting = new Set(sweepForBinaries());
+  // Snapshot matching PIDs that exist BEFORE our launch: another dev's
+  // running app, a parallel CI job, or a manually-started local-api must
+  // not fail OUR orphan check. Only processes that appear during the smoke
+  // and survive it count as orphans.
+  const preExisting = new Set(sweepForBinaries());
+  let pid: number | undefined;
 
+  try {
     log(`isolated app data: ${smokePaths.appDataDir}`);
     log("launching with DESKTOP_SELFTEST=1 …");
     const proc = spawn(bin, [], {
@@ -308,7 +332,7 @@ async function main(): Promise<void> {
       },
       stdio: ["ignore", "pipe", "pipe"],
     });
-    const pid = proc.pid;
+    pid = proc.pid;
     let stdout = "";
     let stderr = "";
     proc.stdout?.on("data", (c) => {
@@ -410,6 +434,8 @@ async function main(): Promise<void> {
     log(`  allPass:       ${report.allPass}`);
     log(`  orphan check:  clean`);
   } finally {
+    if (pid !== undefined) killIfAlive(pid);
+    reapStrayProcesses(preExisting);
     cleanupSmokeDir(smokePaths);
   }
 }


### PR DESCRIPTION
Bug found while auditing `apps/native/scripts/boot-smoke.ts` for stray-process robustness.

**The bug**: `fail()` throws a plain `Error` the moment any failure is detected — deadline timeout, non-zero app exit, missing self-test report, `allPass=false`, or the orphan check itself finding a leaked descendant. Every one of those paths unwinds straight past the orphan-check/report code into the `finally` block, which only calls `cleanupSmokeDir()` (removes the temp report dir). It never kills the app process or any `local-api`/`rclone` descendants it spawned, so a *failed* smoke run leaks OS processes that outlive the script — including, ironically, the very orphans the orphan-check exists to catch.

**The fix**: hoist the `preExisting` PID snapshot and `pid` above the `try`, and in `finally` (which always runs, success or failure) SIGKILL the main pid if still alive and sweep-and-kill any `sweepForBinaries()` PID not in `preExisting`. This is additive cleanup only — the existing pass/fail logic, logging, and orphan-detection assertions are unchanged.

**Why a maintainer wants this**: `bun run smoke:boot` runs locally during native dev and (per `.github/workflows/native.yml`) in CI. A failed run today leaves a real `deco`/`local-api` process running in the background — on a dev machine that's an annoyance (port/Keychain-namespace collisions on the next run); on a CI runner it's a leaked process on a reused box.

**Command a reviewer runs**: `cd apps/native && bunx tsc --noEmit` (green). The full behavior (spawn a failing self-test run, confirm no `deco`/`local-api` process survives) needs an actual `.app` bundle + macOS process spawn, which isn't cheaply testable outside the real smoke run itself — this script has no existing unit-test file for `main()` for that reason, only its `boot-smoke-options`/`boot-smoke-paths` helpers are unit-tested.

**Checks run locally**: `bun run fmt`, `cd apps/native && bunx tsc --noEmit`, `bunx oxlint apps/native/scripts/boot-smoke.ts` — all clean. Full CI (including the real native boot-smoke job) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes leaked processes from failed native boot-smoke runs by always killing the app and any spawned helpers, preventing stray `deco`/`local-api`/`rclone` processes between runs and in CI.

- **Bug Fixes**
  - Snapshot pre-existing PIDs before launch and hoist `pid` outside `try`.
  - In `finally`, `SIGKILL` the main pid (if alive) and reap `sweepForBinaries()` PIDs not in the snapshot; log reaped count.
  - Add `killIfAlive` and `reapStrayProcesses`; existing pass/fail logic and reporting stay the same.

<sup>Written for commit 0de16cfa455acb18e5c78a3d5aadd9b11a74ead8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

