### PR TITLE
fix(task-board): close a reassignment race in conflict-resolution claim

### DIFF
--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -18,6 +18,7 @@ import type {
   TaskBoardItemThreadRef,
 } from "./types";
 import { generatePrefixedId } from "@decocms/shared/utils/generate-id";
+import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
 
 /** Text of a folded/persisted text part payload (`{ type: "text", text }`). */
 function extractPartText(payload: unknown): string | null {
@@ -447,14 +448,20 @@ export class TaskBoardStorage {
 
   /**
    * Atomically claim a task for merge-conflict auto-resolution: move it from In
-   * Review to In Progress ONLY if it's still In Review, returning the updated
-   * item to the single winner and null to everyone else. The auto-resolve
-   * reaction fires from two triggers that can coincide — a reviewer's approval
-   * (`review-decision`) and the PR modal's poll (`prs-get`) — so, like
-   * `claimReviewer`, this fence must be atomic: a read-then-write would let both
-   * dispatch a Super Agent run on the same PR. A single conditional UPDATE is
-   * atomic under READ COMMITTED — the second writer re-checks `status` against
-   * the first's committed row and matches nothing.
+   * Review to In Progress ONLY if it's still In Review AND still assigned to
+   * the Super Agent, returning the updated item to the single winner and null
+   * to everyone else. The auto-resolve reaction fires from two triggers that
+   * can coincide — a reviewer's approval (`review-decision`) and the PR
+   * modal's poll (`prs-get`) — so, like `claimReviewer`, this fence must be
+   * atomic: a read-then-write would let both dispatch a Super Agent run on the
+   * same PR. The assignee re-check closes a second race: the caller's
+   * assignee check runs against a read taken before this write, so a human
+   * reassigning the task away from the Super Agent in between must still stop
+   * the claim — checking it only in the WHERE, not after, means neither
+   * caller can slip a stale-assignee claim through. A single conditional
+   * UPDATE is atomic under READ COMMITTED — the second writer re-checks
+   * `status`/`assignee_id` against the first's committed row and matches
+   * nothing.
    */
   async claimConflictResolution(
     id: string,
@@ -471,6 +478,7 @@ export class TaskBoardStorage {
       .where("id", "=", id)
       .where("organization_id", "=", organizationId)
       .where("status", "=", "in_review")
+      .where("assignee_id", "=", SUPER_AGENT_ASSIGNEE_ID)
       .returningAll()
       .executeTakeFirst();
     if (!row) return null;


### PR DESCRIPTION
Bug found while auditing the conflict-reaction path in `apps/api/src/tools/task-board/conflict-reaction.ts` and its storage fence in `TaskBoardStorage.claimConflictResolution`.

**Why a maintainer wants this:** `reactToApprovedPrConflict` gates on `item.assigneeId === SUPER_AGENT_ASSIGNEE_ID` using a read taken before the atomic claim, then calls `claimConflictResolution`, which only re-checks `status = 'in_review'` in its conditional UPDATE — not the assignee. If a human reassigns the task away from the Super Agent (via `TASK_BOARD_ITEM_UPDATE`) in the window between that read and the claim's commit, the task can still remain `in_review` (reassignment alone doesn't force a status change), so the claim still succeeds. The task then gets silently bounced back to In Progress and `enqueueSuperAgentForTask` (which itself has no assignee guard, unlike its sibling `reactToSuperAgentDelegation`) dispatches a Super Agent run on a PR the human just took ownership of.

**Failure scenario:** task T is `in_review`, assigned to the Super Agent, all reviewers approved, conflict detected by the poll (`prs-get`). A human reassigns T to themselves at nearly the same instant. Both the reassignment write and the conflict-claim's UPDATE only filter on `status`, so if the reassignment commits first the claim still matches (status still `in_review`) and fires a Super Agent run against the human's task.

**Fix:** add `.where("assignee_id", "=", SUPER_AGENT_ASSIGNEE_ID)` to the same conditional UPDATE that already gates on `status = 'in_review'`, so the fence is atomic on both columns under READ COMMITTED — a concurrent reassignment now always loses the race and the claim returns null.

**Command to verify:** `cd apps/api && bunx tsc --noEmit` (green). This function reads/writes `task_board_items` in Postgres directly, so it isn't unit-testable without a live DB (no existing test does — see `apps/api/src/storage/task-board.test.ts`, which only covers the pure `shouldAdvanceToReview` helper); the change is a single additional WHERE clause on an already-atomic conditional UPDATE, so behavior for the non-race path (assignee still Super Agent) is unchanged.

**Local checks run:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bunx oxlint apps/api/src/storage/task-board.ts` — all clean. Full CI (including any storage-integration suite) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Super Agent runs after a human reassignment by making the conflict-resolution claim atomic on both status and assignee. The claim now checks `assignee_id = SUPER_AGENT_ASSIGNEE_ID` alongside `status = 'in_review'` in the conditional UPDATE so reassignment wins the race and the claim returns null.

<sup>Written for commit 6d37c05f8ef55d43d68669b33b494b1b40f56eb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

