### PR TITLE
refactor(web): enforce thread owner authority

### DIFF
--- a/apps/web/src/components/chat/chat-context.tsx
+++ b/apps/web/src/components/chat/chat-context.tsx
@@ -51,7 +51,9 @@ import {
 import { useIsDesktopApp } from "@/hooks/use-is-desktop-app";
 import { shouldBlockHostedRuntime } from "./hosted-runtime-guard";
 import {
+  canMutateThread,
   isHostedFirstSubmit,
+  resolveThreadMutationAuthority,
   resolveThreadVirtualMcpId,
 } from "./thread-authority";
 import {
@@ -129,7 +131,6 @@ import {
   takePendingBody,
 } from "./message-queue-store";
 import { textFromParts } from "./queue-items";
-import { useMessageQueueActions } from "./use-message-queue";
 import { formatDeckTabId } from "@/layouts/main-panel-tabs/tab-id";
 import { useEffectiveSimpleMode } from "../../hooks/use-user-model-preferences";
 import {
@@ -150,13 +151,6 @@ export interface ChatStreamContextValue {
   sendMessage: (
     params: SendMessageParams | Metadata["tiptapDoc"],
   ) => Promise<void>;
-  /** Edit a QUEUED (not-yet-running) message: cancel its gate workflow and
-   *  re-POST the edited text as a fresh message (re-enqueues at the queue
-   *  tail — see the implementation). Resolves true when the edited message
-   *  was dispatched OK; false on ANY failure (latch drop, cancel failure,
-   *  failed re-POST) — callers must keep the user's draft alive on false.
-   *  Every failure path surfaces its own toast. */
-  editQueuedMessage: (messageId: string, text: string) => Promise<boolean>;
   stop: () => void;
   /** Single mutator entry point — new user message, tool output, or approval
    *  response. Patches local messages, clears finishReason, POSTs to /messages.
@@ -200,6 +194,9 @@ export interface ChatTaskContextValue {
     virtualMcpId?: string;
   }) => void;
   activeTask: Task | null;
+  /** Existing chats are mutable only by their creator. Unresolved route data
+   *  fails closed; only an explicit no-id creation state is writable. */
+  canMutateThread: boolean;
   /** True iff the thread row has captured a `harness_id` — i.e. the first
    *  message has been processed and the runtime is pinned for life. */
   isThreadLocked: boolean;
@@ -637,6 +634,10 @@ export function ChatContextProvider({
   // navigation by only honoring the prop when ids match.
   const activeTask =
     effectiveTaskId && task?.id === effectiveTaskId ? task : null;
+  const threadMutationsAllowed = canMutateThread(
+    resolveThreadMutationAuthority(effectiveTaskId, task),
+    user?.id,
+  );
 
   // An existing thread owns its agent identity. `virtualMcpId` is only the
   // creation hint supplied by the route while the row is missing.
@@ -677,7 +678,9 @@ export function ChatContextProvider({
       .create({
         id: newId,
         virtual_mcp_id: effectiveVirtualMcpId,
-        ...(currentBranch ? { branch: currentBranch } : {}),
+        ...(threadMutationsAllowed && currentBranch
+          ? { branch: currentBranch }
+          : {}),
       })
       .then(() =>
         navigateToTask(newId, { virtualMcpId: effectiveVirtualMcpId }),
@@ -703,7 +706,9 @@ export function ChatContextProvider({
     const newId = crypto.randomUUID();
     const targetVmcp = params.virtualMcpId ?? effectiveVirtualMcpId;
     const carryBranch =
-      targetVmcp === effectiveVirtualMcpId ? currentBranch : null;
+      threadMutationsAllowed && targetVmcp === effectiveVirtualMcpId
+        ? currentBranch
+        : null;
     writeStoredAutosend(sessionStorage, locator, newId, params.message);
     void threadActions
       .create({
@@ -734,12 +739,13 @@ export function ChatContextProvider({
     createTask,
     createTaskWithMessage,
     activeTask,
+    canMutateThread: threadMutationsAllowed,
     isThreadLocked,
     lockedHarness,
     lockedBranch,
     currentBranch,
     setCurrentTaskBranch: (branch: string | null) => {
-      if (effectiveTaskId) {
+      if (threadMutationsAllowed && effectiveTaskId) {
         threadActions.setBranch(effectiveTaskId, branch);
       }
     },
@@ -773,7 +779,7 @@ export function ActiveTaskProvider({
 }: PropsWithChildren<{ taskId: string }>) {
   const t = useT();
   const isDesktopApp = useIsDesktopApp();
-  const { activeTask, currentBranch } = useChatTask();
+  const { activeTask, canMutateThread, currentBranch } = useChatTask();
   const hostedRuntimeBlocked = shouldBlockHostedRuntime({
     isDesktopApp,
     harnessId: activeTask?.harness_id,
@@ -782,6 +788,7 @@ export function ActiveTaskProvider({
   const hostedRuntimeBlockedMessage = t(
     "chat.input.codingAgentRequiresDesktop",
   );
+  const readOnlyThreadMessage = t("chat.input.readOnlyOthersChat");
 
   // Fire chat_opened once per (page session × taskId). Runs during render, but
   // the Set gate keeps it idempotent. Fires for every thread a user views —
@@ -809,12 +816,14 @@ export function ActiveTaskProvider({
   const { user, contextPrompt, preferences, rawNavigateToTask } = internals;
 
   const { org, locator } = useProjectContext();
-  const queueActions = useMessageQueueActions();
 
   const [chatError, setChatError] = useState<Error | null>(null);
 
   const reportHostedLegacyDispatchBlocked = () => {
     setChatError(new Error(hostedRuntimeBlockedMessage));
+  };
+  const reportThreadMutationBlocked = () => {
+    setChatError(new Error(readOnlyThreadMessage));
   };
 
   const onToolCall = useInvalidateCollectionsOnToolCall();
@@ -848,6 +857,7 @@ export function ActiveTaskProvider({
   // Stable callback ref so the observer wrapper sees the latest consumer
   // callbacks without re-running the effect on every render.
   const cbRef = useRef({
+    canMutateThread,
     onToolCall,
     queryClient,
     rawNavigateToTask,
@@ -859,6 +869,7 @@ export function ActiveTaskProvider({
   });
   // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- TODO: refactor render-time .current access
   cbRef.current = {
+    canMutateThread,
     onToolCall,
     queryClient,
     rawNavigateToTask,
@@ -888,6 +899,7 @@ export function ActiveTaskProvider({
     taskId,
     onTaskStatus: (event) => {
       const cb = cbRef.current;
+      if (!cb.canMutateThread) return;
       const messageId = event.data.message_id;
       if (event.data.status === "in_progress" && messageId) {
         // The gate started executing this queued message — flip tray → body.
@@ -1007,7 +1019,9 @@ export function ActiveTaskProvider({
         const cb = cbRef.current;
         // Terminal event: the gate advanced — re-sync the queue so the
         // dequeued message drops and the next one surfaces.
-        if (cb.taskId) void refreshMessageQueue(cb.orgSlug, cb.taskId);
+        if (cb.canMutateThread && cb.taskId) {
+          void refreshMessageQueue(cb.orgSlug, cb.taskId);
+        }
         if (cb.taskId) {
           cb.manager.patchThread({
             id: cb.taskId,
@@ -1073,7 +1087,9 @@ export function ActiveTaskProvider({
 
     // Seed the frontend message queue from the gate on (re)mount so a reload
     // or thread switch still shows what's queued.
-    void refreshMessageQueue(cbRef.current.orgSlug, cbRef.current.taskId);
+    if (cbRef.current.canMutateThread) {
+      void refreshMessageQueue(cbRef.current.orgSlug, cbRef.current.taskId);
+    }
 
     // Keep the queue PANEL in sync on every local run start/end edge (the live
     // stream's own status). This is panel-only; the body reconcile for queued
@@ -1088,6 +1104,7 @@ export function ActiveTaskProvider({
       if (active === prevActive) return;
       prevActive = active;
       const cb = cbRef.current;
+      if (!cb.canMutateThread) return;
       void refreshMessageQueue(cb.orgSlug, cb.taskId);
     });
 
@@ -1114,22 +1131,19 @@ export function ActiveTaskProvider({
     connStatus.kind === "ready" &&
     messages.length > 0;
 
-  // Shared tail for dispatching a fresh user message — used by BOTH a plain
-  // composer send (sendMessageInternal) and a re-POSTed queued-message edit
-  // (editQueuedMessage). Builds requestOptions from the current thread/prefs
-  // state, then either queues the message behind an in-progress run or
-  // submits it immediately. Owns releasing the `sendInFlight` latch (finally):
-  // callers are responsible for the synchronous latch check + add BEFORE
-  // calling this, so a re-entrant call is rejected before any work happens.
-  //
-  // Resolves `true` when the message was handed off (queued or submitted).
-  // The enqueue branch handles its own errors (toast + chatError, never
-  // rethrows) and resolves `false` on failure so edit-flow callers can react;
-  // the immediate-submit branch still RETHROWS on failure — unchanged
-  // plain-send behavior (sendMessageInternal ignores the return value).
-  async function dispatchUserMessage(message: ChatMessage): Promise<boolean> {
+  // Shared tail for dispatching a fresh user message. Builds requestOptions
+  // from the current thread/prefs state, then either queues the message behind
+  // an in-progress run or submits it immediately. Owns releasing the
+  // `sendInFlight` latch (finally); the caller claims it synchronously first.
+  async function dispatchUserMessage(message: ChatMessage): Promise<void> {
     // Capture at dispatch time (frozen in closure)
     const capturedTaskId = taskId;
+
+    if (!canMutateThread) {
+      reportThreadMutationBlocked();
+      sendInFlight.delete(capturedTaskId);
+      return;
+    }
 
     // Coding-agent harnesses have no hosted AI SDK/headless dispatch contract.
     // A native row can still reach this shared provider, so fail closed before
@@ -1138,7 +1152,7 @@ export function ActiveTaskProvider({
     if (hostedRuntimeBlocked) {
       reportHostedLegacyDispatchBlocked();
       sendInFlight.delete(capturedTaskId);
-      return false;
+      return;
     }
 
     const appContextEntries = Object.entries(appContexts);
@@ -1200,7 +1214,6 @@ export function ActiveTaskProvider({
     // immediately.
     try {
       if (isStreaming || isRunInProgress) {
-        let queuedOk = true;
         try {
           stashPendingBody(capturedTaskId, message);
           await conn.enqueue(message, requestOptions);
@@ -1208,11 +1221,6 @@ export function ActiveTaskProvider({
             workflowId: `thread-run:${capturedTaskId}:${message.id}`,
             messageId: message.id,
             text: textFromParts(message.parts),
-            // Computed locally so the tray's edit affordance is correct from
-            // the first render — leaving this undefined for one server
-            // round-trip would offer "edit" on an attachment-bearing turn,
-            // and an edit taken in that window drops the attachment for good.
-            hasAttachments: message.parts.some((p) => p.type === "file"),
             status: "queued",
             enqueuedAt: Date.now(),
             optimistic: true,
@@ -1225,7 +1233,6 @@ export function ActiveTaskProvider({
         } catch (err) {
           // The POST never landed — nothing was appended to the body, so
           // just drop the stash and the optimistic tray entry.
-          queuedOk = false;
           dropPendingBody(capturedTaskId, message.id);
           removeMessage(capturedTaskId, message.id);
           setChatError(err instanceof Error ? err : new Error(String(err)));
@@ -1237,10 +1244,9 @@ export function ActiveTaskProvider({
         }
         // Reconcile the optimistic row against the gate's authoritative list.
         void refreshMessageQueue(org.slug, capturedTaskId);
-        return queuedOk;
+        return;
       }
       await conn.submit({ kind: "message", message }, requestOptions);
-      return true;
     } finally {
       sendInFlight.delete(capturedTaskId);
     }
@@ -1248,6 +1254,10 @@ export function ActiveTaskProvider({
 
   // sendMessage — captures context at call time
   async function sendMessageInternal(params: SendMessageParams): Promise<void> {
+    if (!canMutateThread) {
+      reportThreadMutationBlocked();
+      return;
+    }
     const parts = params.parts ?? derivePartsFromTiptapDoc(params.tiptapDoc);
     if (parts.length === 0) return;
 
@@ -1282,82 +1292,12 @@ export function ActiveTaskProvider({
     await dispatchUserMessage(userMessage);
   }
 
-  // Edit a QUEUED message: cancel the old gate workflow (server also deletes
-  // its persisted parts), then re-POST the edited text as a fresh message —
-  // which re-enqueues at the queue TAIL (DBOS workflow ids are once-ever; an
-  // accepted trade-off, only observable with 2+ queued). Text-only by design.
-  //
-  // Resolves `true` only when the edited message was dispatched OK; `false`
-  // on any failure (latch drop, cancel failure, failed re-POST) so the tray
-  // can keep the user's draft alive instead of discarding it. Every false
-  // path surfaces its own toast.
-  async function editQueuedMessage(
-    messageId: string,
-    text: string,
-  ): Promise<boolean> {
-    // Reject before cancelling the persisted original: the replacement cannot
-    // enter hosted dispatch, so cancelling first would silently lose the turn.
-    if (hostedRuntimeBlocked) {
-      reportHostedLegacyDispatchBlocked();
-      return false;
-    }
-
-    // Same synchronous per-thread latch sendMessageInternal uses — an edit
-    // is itself a dispatch, so it must not race a concurrent send/edit. The
-    // tray probes isSendInFlight() before calling, so this drop is a
-    // belt-and-braces guard — but report it honestly rather than resolving
-    // as if the edit happened.
-    if (sendInFlight.has(taskId)) {
-      toast.info(t("chat.chatContext.stillSendingPreviousMessage"));
-      return false;
-    }
-    sendInFlight.add(taskId);
-
-    const ok = await queueActions.cancel(taskId, messageId);
-    if (!ok) {
-      sendInFlight.delete(taskId);
-      toast.error(t("chat.chatContext.couldNotRemoveOriginalMessage"));
-      return false;
-    }
-    dropPendingBody(taskId, messageId);
-    // A reload/refetch may have preloaded the original queued message's
-    // persisted row into the local body store (render-hidden only while it
-    // stayed queued). The cancel just deleted its server parts and its
-    // queue entry — drop the stale local row too or the ORIGINAL text
-    // resurrects as a forever-unanswered bubble while the edited text is
-    // queued. Removing an absent id is a no-op, so call unconditionally.
-    conn.removeLocalMessage(messageId);
-
-    const edited: ChatMessage = {
-      id: crypto.randomUUID(),
-      role: "user",
-      parts: [{ type: "text", text }],
-      metadata: {
-        created_at: new Date().toISOString(),
-        user: {
-          avatar: user?.image ?? undefined,
-          name: user?.name ?? "you",
-        },
-      },
-    };
-    // Reuse the exact enqueue-or-submit branch sendMessageInternal runs.
-    // The enqueue branch resolves false on failure (it toasts internally);
-    // the immediate-submit branch rethrows instead — map that to false too
-    // (with its own toast) so the tray sees one honest boolean either way.
-    try {
-      return await dispatchUserMessage(edited);
-    } catch (err) {
-      toast.error(
-        err instanceof Error
-          ? err.message
-          : t("chat.chatContext.failedToSendEditedMessage"),
-      );
-      return false;
-    }
-  }
-
   // Cancel run
   const cancelRun = async () => {
+    if (!canMutateThread) {
+      reportThreadMutationBlocked();
+      return;
+    }
     conn.stop();
     try {
       const res = await fetch(`/api/${org.slug}/decopilot/cancel/${taskId}`, {
@@ -1406,6 +1346,7 @@ export function ActiveTaskProvider({
   useEffect(() => {
     if (!shouldAutosend) return;
     if (messages.length > 0) return;
+    if (!canMutateThread) return;
     if (hostedRuntimeBlocked) return;
 
     const payload = claimStoredAutosend(sessionStorage, locator, taskId);
@@ -1418,6 +1359,7 @@ export function ActiveTaskProvider({
   }, [
     shouldAutosend,
     messages.length,
+    canMutateThread,
     hostedRuntimeBlocked,
     locator,
     taskId,
@@ -1429,8 +1371,11 @@ export function ActiveTaskProvider({
     messages,
     status: statusToString(connStatus),
     sendMessage: sendMessagePublic,
-    editQueuedMessage,
     stop: () => {
+      if (!canMutateThread) {
+        reportThreadMutationBlocked();
+        return;
+      }
       if (hostedRuntimeBlocked) {
         reportHostedLegacyDispatchBlocked();
         return;
@@ -1438,6 +1383,10 @@ export function ActiveTaskProvider({
       void cancelRun();
     },
     submit: async (action, opts) => {
+      if (!canMutateThread) {
+        reportThreadMutationBlocked();
+        return;
+      }
       if (hostedRuntimeBlocked) {
         reportHostedLegacyDispatchBlocked();
         return;

--- a/apps/web/src/components/chat/highlight/index.tsx
+++ b/apps/web/src/components/chat/highlight/index.tsx
@@ -38,13 +38,13 @@ type StatusHighlightProps =
   | {
       variant: "error";
       error: Error;
-      onFixInChat: () => void;
+      onFixInChat?: () => void;
       onDismiss: () => void;
     }
   | {
       variant: "warning";
       finishReason: string;
-      onContinue: () => void;
+      onContinue?: () => void;
       onDismiss: () => void;
     };
 
@@ -87,15 +87,17 @@ function StatusHighlight(props: StatusHighlightProps) {
       onClose={onDismiss}
       footerRight={
         isError ? (
-          <Button
-            size="sm"
-            variant="outline"
-            onClick={props.onFixInChat}
-            className="h-7 text-xs"
-          >
-            {t("chat.highlight.fixInChat")}
-          </Button>
-        ) : (
+          props.onFixInChat ? (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={props.onFixInChat}
+              className="h-7 text-xs"
+            >
+              {t("chat.highlight.fixInChat")}
+            </Button>
+          ) : null
+        ) : props.onContinue ? (
           <Button
             size="sm"
             variant="outline"
@@ -104,7 +106,7 @@ function StatusHighlight(props: StatusHighlightProps) {
           >
             {t("chat.highlight.continue")}
           </Button>
-        )
+        ) : null
       }
     >
       {rawDetails ? (
@@ -173,7 +175,8 @@ export function ChatHighlight() {
     sendMessage,
   } = useChatStream();
   const [preferences, setPreferences] = usePreferences();
-  const { virtualMcpId, createTaskWithMessage } = useChatTask();
+  const { virtualMcpId, createTaskWithMessage, canMutateThread } =
+    useChatTask();
   const { chatMode, simpleModeTier } = useChatPrefs();
 
   // Build a fresh RequestOptions at call time so tier/mode reflect the
@@ -212,6 +215,7 @@ export function ChatHighlight() {
   );
 
   const handleFixInChat = () => {
+    if (!canMutateThread) return;
     if (error) {
       const text = t("chat.highlight.fixInChatMessage", {
         error: error.message,
@@ -225,6 +229,7 @@ export function ChatHighlight() {
   };
 
   const handleContinue = () => {
+    if (!canMutateThread) return;
     const doc = {
       type: "doc" as const,
       content: [
@@ -238,6 +243,7 @@ export function ChatHighlight() {
   };
 
   const handleUserAskSubmit = (part: UserAskToolPart, response: string) => {
+    if (!canMutateThread) return;
     void submit(
       {
         kind: "toolOutput",
@@ -249,6 +255,7 @@ export function ChatHighlight() {
   };
 
   const handlePlanApprove = (planText: string) => {
+    if (!canMutateThread) return;
     // Set approval level to auto and persist
     setPreferences({ ...preferences, toolApprovalLevel: "auto" });
 
@@ -267,6 +274,7 @@ export function ChatHighlight() {
   };
 
   const handlePlanDismiss = () => {
+    if (!canMutateThread) return;
     const editor = document.querySelector<HTMLElement>("[data-chat-input]");
     editor?.focus();
   };
@@ -277,6 +285,7 @@ export function ChatHighlight() {
     reason: string | undefined,
     toolApprovalLevel: ToolApprovalLevel,
   ) => {
+    if (!canMutateThread) return;
     void submit(
       {
         kind: "approval",
@@ -312,7 +321,7 @@ export function ChatHighlight() {
           variant="error"
           error={error as Error}
           onDismiss={clearError}
-          onFixInChat={handleFixInChat}
+          onFixInChat={canMutateThread ? handleFixInChat : undefined}
         />
       )}
       {showWarning && (
@@ -320,10 +329,10 @@ export function ChatHighlight() {
           variant="warning"
           finishReason={finishReason as string}
           onDismiss={clearFinishReason}
-          onContinue={handleContinue}
+          onContinue={canMutateThread ? handleContinue : undefined}
         />
       )}
-      {hasApprovals && (
+      {canMutateThread && hasApprovals && (
         <ApprovalHighlight
           key={approvalKey}
           approvals={pendingApprovals}
@@ -331,7 +340,7 @@ export function ChatHighlight() {
           onRespond={handleApprovalRespond}
         />
       )}
-      {flags.hasPlans && (
+      {canMutateThread && flags.hasPlans && (
         <ProposePlanHighlight
           key={planKey}
           plans={pendingPlans}
@@ -340,7 +349,7 @@ export function ChatHighlight() {
           onDismiss={handlePlanDismiss}
         />
       )}
-      {flags.isWaitingForUserInput && (
+      {canMutateThread && flags.isWaitingForUserInput && (
         <UserAskQuestionHighlight
           key={userAskKey}
           userAskParts={userAskParts}

--- a/apps/web/src/components/chat/ice-breakers.tsx
+++ b/apps/web/src/components/chat/ice-breakers.tsx
@@ -37,7 +37,7 @@ import { Suspense, useReducer, useState } from "react";
 import { toast } from "sonner";
 import { useT } from "@/i18n/use-t.ts";
 import { ErrorBoundary } from "../error-boundary";
-import { useChatStream, useChatPrefs } from "./context";
+import { useChatPrefs, useChatStream, useChatTask } from "./context";
 import {
   PromptArgsDialog,
   type PromptArgumentValues,
@@ -361,6 +361,7 @@ function iceBreakerReducer(
 function IceBreakersContent({ connectionId }: { connectionId: string | null }) {
   const t = useT();
   const { sendMessage } = useChatStream();
+  const { canMutateThread } = useChatTask();
   const { org } = useProjectContext();
 
   // Fetch prompts from the aggregated virtual MCP
@@ -378,6 +379,7 @@ function IceBreakersContent({ connectionId }: { connectionId: string | null }) {
   const [dialogPrompt, setDialogPrompt] = useState<Prompt | null>(null);
 
   const loadPrompt = async (prompt: Prompt, args?: PromptArgumentValues) => {
+    if (!canMutateThread) return;
     if (!client) {
       toast.error(t("chat.iceBreakers.mcpClientNotAvailable"));
       dispatch({ type: "RESET" });
@@ -428,6 +430,7 @@ function IceBreakersContent({ connectionId }: { connectionId: string | null }) {
   };
 
   const handlePromptSelection = async (prompt: Prompt) => {
+    if (!canMutateThread) return;
     if (prompt.arguments && prompt.arguments.length > 0) {
       dispatch({ type: "SELECT_PROMPT", prompt });
       setDialogPrompt(prompt);
@@ -439,6 +442,7 @@ function IceBreakersContent({ connectionId }: { connectionId: string | null }) {
   };
 
   const handleDialogSubmit = async (values: PromptArgumentValues) => {
+    if (!canMutateThread) return;
     if (!dialogPrompt) return;
 
     dispatch({
@@ -477,9 +481,12 @@ function IceBreakersContent({ connectionId }: { connectionId: string | null }) {
 
 export function IceBreakers({ className }: IceBreakersProps) {
   const { selectedVirtualMcp } = useChatPrefs();
+  const { canMutateThread } = useChatTask();
   const { org } = useProjectContext();
   const decopilotId = getWellKnownDecopilotVirtualMCP(org.id).id;
   const connectionId = selectedVirtualMcp?.id ?? decopilotId;
+
+  if (!canMutateThread) return null;
 
   return (
     <div className={cn("w-full @container", className)}>

--- a/apps/web/src/components/chat/input.tsx
+++ b/apps/web/src/components/chat/input.tsx
@@ -56,7 +56,6 @@ import {
 import { isTiptapDocEmpty } from "./tiptap/utils";
 import { ToolsPopover } from "./tools-popover";
 import { SessionStats } from "./usage-stats";
-import { authClient } from "@/lib/auth-client.ts";
 import { track } from "@/lib/posthog-client";
 import { useSound } from "@/hooks/use-sound.ts";
 import { question004Sound } from "@deco/ui/lib/question-004.ts";
@@ -367,8 +366,6 @@ export function ChatInput({
     chatMode,
     setChatMode,
   } = useChatPrefs();
-  const { data: session } = authClient.useSession();
-  const userId = session?.user?.id;
 
   const { org, locator } = useProjectContext();
   const decopilotId = getWellKnownDecopilotVirtualMCP(org.id).id;
@@ -567,7 +564,7 @@ export function ChatInput({
     }
   };
 
-  if (userId && task?.created_by && task.created_by !== userId) {
+  if (taskCtx && !taskCtx.canMutateThread) {
     return (
       <ChatInputDisabledState message={t("chat.input.readOnlyOthersChat")} />
     );

--- a/apps/web/src/components/chat/message/next-action-chip.tsx
+++ b/apps/web/src/components/chat/message/next-action-chip.tsx
@@ -35,7 +35,7 @@ export function NextActionChip() {
   });
   const [dialogPrompt, setDialogPrompt] = useState<Prompt | null>(null);
 
-  if (!virtualMcpId || isStreaming) return null;
+  if (!task?.canMutateThread || !virtualMcpId || isStreaming) return null;
   if (!isStudioPackAgent(virtualMcpId)) return null;
 
   // Only suggest a "next" once the user has actually done something in
@@ -61,6 +61,7 @@ export function NextActionChip() {
   if (!next) return null;
 
   const send = async (prompt: Prompt, args?: PromptArgumentValues) => {
+    if (!task.canMutateThread) return;
     if (!client) {
       toast.error(t("chat.nextActionChip.mcpClientNotAvailable"));
       return;
@@ -98,6 +99,7 @@ export function NextActionChip() {
   };
 
   const handleClick = () => {
+    if (!task.canMutateThread) return;
     const prompt: Prompt = {
       name: next.promptName,
       title: next.title,
@@ -133,6 +135,7 @@ export function NextActionChip() {
         prompt={dialogPrompt}
         setPrompt={(p) => setDialogPrompt(p)}
         onSubmit={async (values) => {
+          if (!task.canMutateThread) return;
           const prompt = dialogPrompt;
           setDialogPrompt(null);
           if (prompt) await send(prompt, values);

--- a/apps/web/src/components/chat/message/parts/tool-call-part/generic.tsx
+++ b/apps/web/src/components/chat/message/parts/tool-call-part/generic.tsx
@@ -54,6 +54,7 @@ import type React from "react";
 import { Suspense } from "react";
 import { ErrorBoundary } from "@/components/error-boundary.tsx";
 import { usePanelActions } from "@/layouts/shell-layout";
+import { canRenderInteractiveThreadApp } from "@/components/chat/thread-authority";
 
 import { getToolPartErrorText, safeStringifyFormatted } from "../utils.ts";
 import { ToolCallShell } from "./common.tsx";
@@ -246,7 +247,8 @@ export function GenericToolCallPart({
   const { openSidePanel } = usePanelActions();
   // Optional: the tool-call part is also rendered read-only in the Monitor
   // threads view, which has no ChatContextProvider / ThreadManagerProvider.
-  const taskId = useOptionalChatTask()?.taskId ?? null;
+  const task = useOptionalChatTask();
+  const taskId = task?.taskId ?? null;
   const { addOrReplaceEager } = useTaskExpandedTools(taskId);
   const navigate = useNavigate();
 
@@ -277,10 +279,11 @@ export function GenericToolCallPart({
   const uiResourceUri = getUIResourceUri(meta);
 
   const hasMCPApp = !!uiResourceUri && part.state === "output-available";
+  const canRenderMCPApp = hasMCPApp && canRenderInteractiveThreadApp(task);
   const sourceId = connectionId ? `${connectionId}:${rawToolName}` : null;
   const isDestructive = !!annotations?.destructiveHint;
   const canOpenInPanel =
-    hasMCPApp && !!connectionId && !isDestructive && !!taskId;
+    canRenderMCPApp && !!connectionId && !isDestructive && !!taskId;
 
   const handleOpenInPanel = () => {
     if (!connectionId) return;
@@ -393,7 +396,7 @@ export function GenericToolCallPart({
   if (part.state === "output-error") {
     if (detail) detail += "\n\n";
     detail += "# Error\n" + (errorText ?? "");
-  } else if (part.output !== undefined && !hasMCPApp) {
+  } else if (part.output !== undefined && !canRenderMCPApp) {
     if (detail) detail += "\n\n";
     detail += "# Output\n" + safeStringifyFormatted(part.output);
   }
@@ -434,7 +437,7 @@ export function GenericToolCallPart({
           </button>
         </div>
       )}
-      {hasMCPApp && uiResourceUri && connectionId && org?.id && (
+      {canRenderMCPApp && uiResourceUri && connectionId && org?.id && (
         <>
           <ErrorBoundary
             fallback={({ resetError }) => (

--- a/apps/web/src/components/chat/message/parts/tool-call-part/subtask.tsx
+++ b/apps/web/src/components/chat/message/parts/tool-call-part/subtask.tsx
@@ -148,10 +148,13 @@ function isFlippable(part: SubtaskToolPart): boolean {
 /** Returns a callback that flips the given (still-running) subtask call to the
  *  background, freeing the thread so the user can keep chatting. The server
  *  fans the request out to the pod running the turn. */
-function useFlipToBackground(toolCallId: string): () => Promise<void> {
-  const { taskId: threadId } = useChatTask();
+function useFlipToBackground(
+  toolCallId: string,
+): (() => Promise<void>) | undefined {
+  const { taskId: threadId, canMutateThread } = useChatTask();
   const { org } = useProjectContext();
-  return async () => {
+  const flip = async () => {
+    if (!canMutateThread) return;
     const res = await fetch(
       `/api/${encodeURIComponent(org.slug)}/decopilot/flip/${encodeURIComponent(threadId)}`,
       {
@@ -165,6 +168,7 @@ function useFlipToBackground(toolCallId: string): () => Promise<void> {
     // button resets instead of sitting on "Moving to background…" forever.
     if (!res.ok) throw new Error(`flip failed: ${res.status}`);
   };
+  return canMutateThread ? flip : undefined;
 }
 
 /** A subtle "run in background" pill shown on a still-running foreground
@@ -528,7 +532,7 @@ export function SubtaskPartFallback(props: SubtaskPartProps) {
       state={state}
       usage={usage}
       latency={props.latency}
-      onFlip={isFlippable(props.part) ? onFlip : undefined}
+      onFlip={onFlip && isFlippable(props.part) ? onFlip : undefined}
     >
       <SubtaskResultBody part={props.part} />
     </SubtaskCard>
@@ -568,7 +572,7 @@ export function SubtaskPart(props: SubtaskPartProps) {
       state={state}
       usage={usage}
       latency={props.latency}
-      onFlip={isFlippable(props.part) ? onFlip : undefined}
+      onFlip={onFlip && isFlippable(props.part) ? onFlip : undefined}
     >
       <SubtaskResultBody part={props.part} />
     </SubtaskCard>

--- a/apps/web/src/components/chat/message/thinking-indicator.tsx
+++ b/apps/web/src/components/chat/message/thinking-indicator.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { ToolCallShell } from "./parts/tool-call-part/common.tsx";
 import type { ChatMessage } from "../types.ts";
 import { getRunStatusCopy } from "../run-status.ts";
-import { useOptionalChatStream } from "../context.tsx";
+import { useOptionalChatStream, useOptionalChatTask } from "../context.tsx";
 import { LiveTimer } from "../../live-timer.tsx";
 import { GridLoader } from "../../grid-loader.tsx";
 import { formatDuration } from "../../../lib/format-time.ts";
@@ -153,18 +153,23 @@ export function ThinkingState({ startedAt }: { startedAt: number | null }) {
   const t = useT();
   useClockTick(1000);
   const stream = useOptionalChatStream();
+  const canMutateThread = useOptionalChatTask()?.canMutateThread === true;
   const elapsedMs = startedAt !== null ? Date.now() - startedAt : 0;
   const isSlow = elapsedMs >= SLOW_AFTER_MS;
+  const cancel = () => {
+    if (!canMutateThread) return;
+    stream?.stop();
+  };
 
   return (
     <div className="flex flex-col gap-0.5">
       <RunStatusIndicator startedAt={startedAt} />
-      {isSlow && stream?.stop && (
+      {isSlow && canMutateThread && stream?.stop && (
         <div className="flex items-center gap-2 pb-1 text-[13px] text-muted-foreground/60">
           <span>{t("chat.thinkingIndicator.takingLonger")}</span>
           <button
             type="button"
-            onClick={() => stream.stop()}
+            onClick={cancel}
             className="text-muted-foreground hover:text-foreground underline underline-offset-2"
           >
             {t("chat.thinkingIndicator.cancel")}

--- a/apps/web/src/components/chat/pills/chat-mode-row.tsx
+++ b/apps/web/src/components/chat/pills/chat-mode-row.tsx
@@ -42,8 +42,11 @@ interface SmartProps {
 export function ChatModeRow({ virtualMcp, currentBranch }: SmartProps) {
   const stream = useOptionalChatStream();
   const taskCtx = useOptionalChatTask();
+  const canMutateThread = taskCtx?.canMutateThread ?? true;
   const locked =
-    (stream?.messages ?? []).length > 0 || (taskCtx?.isThreadLocked ?? false);
+    !canMutateThread ||
+    (stream?.messages ?? []).length > 0 ||
+    (taskCtx?.isThreadLocked ?? false);
   const setCurrentTaskBranch = taskCtx?.setCurrentTaskBranch;
 
   const githubRepo = getActiveGithubRepo(virtualMcp);
@@ -71,6 +74,7 @@ export function ChatModeRow({ virtualMcp, currentBranch }: SmartProps) {
         sandboxMap={virtualMcp?.metadata?.sandboxMap}
         value={currentBranch}
         onChange={(next) => {
+          if (!canMutateThread) return;
           if (setCurrentTaskBranch) void setCurrentTaskBranch(next);
         }}
         locked={locked}

--- a/apps/web/src/components/chat/queue-items.ts
+++ b/apps/web/src/components/chat/queue-items.ts
@@ -10,8 +10,6 @@ export interface QueueItemDTO {
   enqueuedAt: number;
   /** The queued turn's text, for tray rendering. */
   text: string;
-  /** Whether the queued turn has non-text parts (attachments/files). */
-  hasAttachments?: boolean;
   /** True for a locally-queued item not yet confirmed by the server list. */
   optimistic?: boolean;
 }

--- a/apps/web/src/components/chat/queue-tray.tsx
+++ b/apps/web/src/components/chat/queue-tray.tsx
@@ -24,8 +24,7 @@
  * No edit action, by product decision: DBOS workflow ids are once-ever, so
  * an "edit" can only be cancel + re-POST — which re-enqueues at the TAIL,
  * not in place. That surprises users who expect the message to keep its
- * position, so the affordance was removed until an in-place design exists
- * (`editQueuedMessage` in chat-context still implements the composition).
+ * position, so the affordance remains absent until an in-place design exists.
  */
 import { Button } from "@deco/ui/components/button.tsx";
 import {
@@ -35,7 +34,7 @@ import {
 } from "@deco/ui/components/tooltip.tsx";
 import { ArrowUp, XClose } from "@untitledui/icons";
 import { useT } from "@/i18n/use-t.ts";
-import { useChatStream } from "./context";
+import { useChatStream, useChatTask } from "./context";
 import { dropPendingBody } from "./message-queue-store";
 import { selectQueuedItems } from "./queue-items";
 import { useMessageQueue, useMessageQueueActions } from "./use-message-queue";
@@ -46,6 +45,25 @@ export function QueueTray({ taskId }: { taskId: string }) {
   const queued = selectQueuedItems(items);
   const actions = useMessageQueueActions();
   const { stop, removeLocalMessage } = useChatStream();
+  const { canMutateThread } = useChatTask();
+
+  const sendNext = () => {
+    if (!canMutateThread) return;
+    void stop();
+  };
+
+  const removeFromQueue = (messageId: string) => {
+    if (!canMutateThread) return;
+    void actions.cancel(taskId, messageId).then((ok) => {
+      if (!ok) return;
+      dropPendingBody(taskId, messageId);
+      // A reload/refetch may have preloaded this queued message's persisted
+      // row into the local body store (render-hidden only while queued) — drop
+      // it too or the cancel unhides it as a stale, forever-unanswered bubble.
+      // No-op when the row was never loaded.
+      removeLocalMessage(messageId);
+    });
+  };
 
   if (queued.length === 0) return null;
 
@@ -60,22 +78,24 @@ export function QueueTray({ taskId }: { taskId: string }) {
             { count: queued.length },
           )}
         </span>
-        <Tooltip delayDuration={400}>
-          <TooltipTrigger asChild>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              aria-label={t("chat.queueTray.sendNow")}
-              onClick={() => void stop()}
-            >
-              <ArrowUp size={14} />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="top">
-            <p className="text-xs">{t("chat.queueTray.sendNow")}</p>
-          </TooltipContent>
-        </Tooltip>
+        {canMutateThread && (
+          <Tooltip delayDuration={400}>
+            <TooltipTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label={t("chat.queueTray.sendNow")}
+                onClick={sendNext}
+              >
+                <ArrowUp size={14} />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side="top">
+              <p className="text-xs">{t("chat.queueTray.sendNow")}</p>
+            </TooltipContent>
+          </Tooltip>
+        )}
       </div>
       {queued.map((item, index) => (
         <div
@@ -91,30 +111,20 @@ export function QueueTray({ taskId }: { taskId: string }) {
           <span className="min-w-0 flex-1 truncate text-sm text-foreground">
             {item.text}
           </span>
-          <div className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover/queuerow:opacity-100">
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-sm"
-              title={t("chat.queueTray.removeFromQueue")}
-              aria-label={t("chat.queueTray.removeFromQueue")}
-              onClick={() =>
-                void actions.cancel(taskId, item.messageId).then((ok) => {
-                  if (ok) {
-                    dropPendingBody(taskId, item.messageId);
-                    // A reload/refetch may have preloaded this queued
-                    // message's persisted row into the local body store
-                    // (render-hidden only while queued) — drop it too or
-                    // the cancel unhides it as a stale, forever-unanswered
-                    // bubble. No-op when the row was never loaded.
-                    removeLocalMessage(item.messageId);
-                  }
-                })
-              }
-            >
-              <XClose className="size-3.5" />
-            </Button>
-          </div>
+          {canMutateThread && (
+            <div className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover/queuerow:opacity-100">
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                title={t("chat.queueTray.removeFromQueue")}
+                aria-label={t("chat.queueTray.removeFromQueue")}
+                onClick={() => removeFromQueue(item.messageId)}
+              >
+                <XClose className="size-3.5" />
+              </Button>
+            </div>
+          )}
         </div>
       ))}
     </div>

--- a/apps/web/src/components/chat/thread-authority.test.ts
+++ b/apps/web/src/components/chat/thread-authority.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  canMutateThread,
+  canRenderInteractiveThreadApp,
   isHostedFirstSubmit,
+  resolveThreadMutationAuthority,
   resolveThreadVirtualMcpId,
 } from "./thread-authority";
 
@@ -23,6 +26,70 @@ describe("resolveThreadVirtualMcpId", () => {
 
   test("does not borrow the URL identity for a malformed existing row", () => {
     expect(resolveThreadVirtualMcpId({}, "stale-query-agent")).toBe("");
+  });
+});
+
+describe("canMutateThread", () => {
+  test("allows only an explicit authenticated new-thread state", () => {
+    const authority = resolveThreadMutationAuthority(null, null);
+    expect(authority).toEqual({ kind: "new" });
+    expect(canMutateThread(authority, "viewer")).toBe(true);
+    expect(canMutateThread(authority, null)).toBe(false);
+  });
+
+  test("allows an existing thread only for its creator", () => {
+    const owned = resolveThreadMutationAuthority("thread", {
+      id: "thread",
+      created_by: "viewer",
+    });
+    const foreign = resolveThreadMutationAuthority("thread", {
+      id: "thread",
+      created_by: "owner",
+    });
+    expect(canMutateThread(owned, "viewer")).toBe(true);
+    expect(canMutateThread(foreign, "viewer")).toBe(false);
+  });
+
+  test("fails closed while the requested row is missing or mismatched", () => {
+    const missing = resolveThreadMutationAuthority("requested", null);
+    const stale = resolveThreadMutationAuthority("requested", {
+      id: "previous",
+      created_by: "viewer",
+    });
+    expect(missing).toEqual({ kind: "unresolved" });
+    expect(stale).toEqual({ kind: "unresolved" });
+    expect(canMutateThread(missing, "viewer")).toBe(false);
+    expect(canMutateThread(stale, "viewer")).toBe(false);
+  });
+
+  test("fails closed for missing identities on an existing row", () => {
+    const missingCreator = resolveThreadMutationAuthority("thread", {
+      id: "thread",
+    });
+    const nullCreator = resolveThreadMutationAuthority("thread", {
+      id: "thread",
+      created_by: null,
+    });
+    const owned = resolveThreadMutationAuthority("thread", {
+      id: "thread",
+      created_by: "owner",
+    });
+    expect(canMutateThread(missingCreator, "viewer")).toBe(false);
+    expect(canMutateThread(nullCreator, "viewer")).toBe(false);
+    expect(canMutateThread(owned, null)).toBe(false);
+    expect(canMutateThread(owned, "")).toBe(false);
+  });
+});
+
+describe("canRenderInteractiveThreadApp", () => {
+  test("requires an explicit mutation grant", () => {
+    expect(canRenderInteractiveThreadApp({ canMutateThread: true })).toBe(true);
+    expect(canRenderInteractiveThreadApp({ canMutateThread: false })).toBe(
+      false,
+    );
+    expect(canRenderInteractiveThreadApp({})).toBe(false);
+    expect(canRenderInteractiveThreadApp(null)).toBe(false);
+    expect(canRenderInteractiveThreadApp(undefined)).toBe(false);
   });
 });
 

--- a/apps/web/src/components/chat/thread-authority.ts
+++ b/apps/web/src/components/chat/thread-authority.ts
@@ -11,6 +11,51 @@ export function resolveThreadVirtualMcpId(
   return thread ? (thread.virtual_mcp_id ?? "") : creationHintVirtualMcpId;
 }
 
+export type ThreadMutationAuthority =
+  | { kind: "new" }
+  | { kind: "existing"; createdBy: string | null | undefined }
+  | { kind: "unresolved" };
+
+/**
+ * Resolve the authority subject independently from the viewer. A missing URL
+ * id is the explicit new-thread creation state. Once an id was requested, a
+ * missing or mismatched row is unresolved and must not inherit creation
+ * authority while route data catches up.
+ */
+export function resolveThreadMutationAuthority(
+  requestedThreadId: string | null | undefined,
+  thread: { id?: string | null; created_by?: string | null } | null | undefined,
+): ThreadMutationAuthority {
+  if (!requestedThreadId) {
+    return thread ? { kind: "unresolved" } : { kind: "new" };
+  }
+  if (!thread || thread.id !== requestedThreadId) {
+    return { kind: "unresolved" };
+  }
+  return { kind: "existing", createdBy: thread.created_by };
+}
+
+/** Whether the current viewer may mutate the resolved thread workspace. */
+export function canMutateThread(
+  authority: ThreadMutationAuthority,
+  userId: string | null | undefined,
+): boolean {
+  if (!userId || authority.kind === "unresolved") return false;
+  if (authority.kind === "new") return true;
+  return !!authority.createdBy && authority.createdBy === userId;
+}
+
+/**
+ * Interactive MCP apps receive a live client that can call tools. Require an
+ * explicit thread-mutation grant so provider-less read-only renderers (for
+ * example Monitor) keep showing serialized output without mounting the app.
+ */
+export function canRenderInteractiveThreadApp(
+  task: { canMutateThread?: boolean } | null | undefined,
+): boolean {
+  return task?.canMutateThread === true;
+}
+
 /** A hosted thread captures its runtime on the first accepted submit. */
 export function isHostedFirstSubmit(
   thread: { harness_id?: string | null } | null | undefined,

--- a/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx
+++ b/apps/web/src/components/sandbox/hooks/sandbox-lifecycle-context.tsx
@@ -396,11 +396,12 @@ export function SandboxLifecycleProvider({
   children: ReactNode;
 }) {
   const { org } = useProjectContext();
-  const { setCurrentTaskBranch } = useChatTask();
+  const { canMutateThread, setCurrentTaskBranch } = useChatTask();
   const manager = useOptionalThreadManager();
   const events = useSandboxEvents();
   const queryClient = useQueryClient();
   const surfaceKind = sandboxSurfaceKind(useIsDesktopApp());
+  const mutationsEnabled = executionEnabled && canMutateThread;
 
   const mcpClient = useMCPClient({
     connectionId: SELF_MCP_ALIAS_ID,
@@ -491,7 +492,7 @@ export function SandboxLifecycleProvider({
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- read-only dedup probe; mutation happens inside effect after add()
     autoStartAttemptedForBranchRef.current.has(autoStartDedupKey);
   const autoStartEligible = shouldAutoStart({
-    executionEnabled,
+    executionEnabled: mutationsEnabled,
     hasActiveGithubRepo,
     userId,
     branch,
@@ -526,7 +527,7 @@ export function SandboxLifecycleProvider({
   // dead handle so we don't loop on repeat 404s; a new dead handle is fine.
   const deadVmId = events.notFound ? (vmEntry?.sandboxHandle ?? null) : null;
   const selfHealEligible = shouldSelfHeal({
-    executionEnabled,
+    executionEnabled: mutationsEnabled,
     notFound: events.notFound,
     deadVmId,
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- read-only dedup probe; recorded inside effect after firing
@@ -562,7 +563,7 @@ export function SandboxLifecycleProvider({
   // a bounded number of times before falling through to the errored card, so
   // the common transient-infra failure self-heals without a user click.
   const claimRetryEligible = shouldAutoRetryClaim({
-    executionEnabled,
+    executionEnabled: mutationsEnabled,
     failedReason: failedPhase?.reason ?? null,
     attempts: claimRetryEpisode.count,
     isPending: startVm.isPending,
@@ -608,7 +609,7 @@ export function SandboxLifecycleProvider({
 
   // User-driven actions.
   const start = () => {
-    if (!executionEnabled || !virtualMcpId) return;
+    if (!mutationsEnabled || !virtualMcpId) return;
     const args = buildSandboxStartArgs(virtualMcpId, branch);
     startVmMutate(args, {
       onSuccess: (data) => {
@@ -621,7 +622,7 @@ export function SandboxLifecycleProvider({
   };
 
   const stop = async () => {
-    if (!executionEnabled || !virtualMcpId || !branch) return;
+    if (!mutationsEnabled || !virtualMcpId || !branch) return;
     sandboxUserStop.mark(virtualMcpId, branch);
     try {
       await mcpClient.callTool({
@@ -638,6 +639,7 @@ export function SandboxLifecycleProvider({
   };
 
   const restart = async () => {
+    if (!mutationsEnabled) return;
     await stop();
     start();
   };
@@ -646,6 +648,7 @@ export function SandboxLifecycleProvider({
   // calls onRetry for `errored` and onResume for `suspended`; both reduce
   // to the same operation in the provider.
   const retry = () => {
+    if (!mutationsEnabled) return;
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- reset dedup so a fresh start can fire
     autoStartAttemptedForBranchRef.current = new Set();
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- reset dedup so self-heal can fire on next gone

--- a/apps/web/src/components/sandbox/preview/drawer/drawer.tsx
+++ b/apps/web/src/components/sandbox/preview/drawer/drawer.tsx
@@ -14,6 +14,7 @@ export interface PreviewDrawerProps {
   branch: string | null;
   status: DrawerStatus;
   scripts: string[];
+  readOnly: boolean;
   open: boolean;
   onOpenChange: (next: boolean) => void;
   onStart: () => void;
@@ -79,7 +80,9 @@ export function PreviewDrawer(props: PreviewDrawerProps) {
   // compute the per-user claim handle. Without them the request 400s
   // before reaching the daemon.
   const execScript = (name: string) => {
-    if (!props.virtualMcpId || !props.branch) return Promise.resolve(null);
+    if (props.readOnly || !props.virtualMcpId || !props.branch) {
+      return Promise.resolve(null);
+    }
     return fetch(
       `/api/${encodeURIComponent(props.orgSlug)}/sandbox/${encodeURIComponent(props.virtualMcpId)}/${encodeURIComponent(props.branch)}/exec/${encodeURIComponent(name)}`,
       { method: "POST" },
@@ -87,7 +90,9 @@ export function PreviewDrawer(props: PreviewDrawerProps) {
   };
 
   const killScript = (name: string) => {
-    if (!props.virtualMcpId || !props.branch) return Promise.resolve(null);
+    if (props.readOnly || !props.virtualMcpId || !props.branch) {
+      return Promise.resolve(null);
+    }
     return fetch(
       `/api/${encodeURIComponent(props.orgSlug)}/sandbox/${encodeURIComponent(props.virtualMcpId)}/${encodeURIComponent(props.branch)}/exec/${encodeURIComponent(name)}/kill`,
       { method: "POST" },
@@ -107,6 +112,7 @@ export function PreviewDrawer(props: PreviewDrawerProps) {
   };
 
   const handleAddScript = async (name: string) => {
+    if (props.readOnly) return;
     setScriptTabs((prev) => (prev.includes(name) ? prev : [...prev, name]));
     setActive(name);
     props.onOpenChange(true);
@@ -116,6 +122,7 @@ export function PreviewDrawer(props: PreviewDrawerProps) {
   // × on a script tab: kill the process AND drop the tab. Active tab
   // falls back to setup.
   const handleCloseScript = async (name: string) => {
+    if (props.readOnly) return;
     await killScript(name);
     setScriptTabs((prev) => prev.filter((t) => t !== name));
     if (active === name) setActive(DEFAULT_TAB);
@@ -125,6 +132,7 @@ export function PreviewDrawer(props: PreviewDrawerProps) {
   // tab; just (re)starts the process. Restart is the same call as Run; the
   // daemon's task-manager replaces the existing task with the same logName.
   const handleRunActive = async () => {
+    if (props.readOnly) return;
     const wasRunning = vmEvents.activeProcesses.includes(active);
     const failureMessage = wasRunning
       ? t("sandbox.drawer.failedToRestart", { name: active })
@@ -135,6 +143,7 @@ export function PreviewDrawer(props: PreviewDrawerProps) {
   // Per-script Stop on the active tab. Marks the script as killing so the
   // toolbar shows "Stopping…"; the prune above clears it once SSE confirms.
   const handleStopActive = async () => {
+    if (props.readOnly) return;
     if (killingScripts.has(active)) return;
     setKillingScripts((prev) => new Set(prev).add(active));
     try {
@@ -173,16 +182,32 @@ export function PreviewDrawer(props: PreviewDrawerProps) {
       <DrawerToolbar
         status={props.status}
         open={props.open}
+        readOnly={props.readOnly}
         onToggle={handleToggle}
-        onStart={props.status === "idle" ? props.onStart : undefined}
+        onStart={
+          !props.readOnly && props.status === "idle" ? props.onStart : undefined
+        }
         onStop={
-          props.status === "running" || props.status === "starting"
+          !props.readOnly &&
+          (props.status === "running" || props.status === "starting")
             ? props.onStop
             : undefined
         }
-        onRestart={props.status === "running" ? props.onRestart : undefined}
-        onResume={props.status === "suspended" ? props.onResume : undefined}
-        onRetry={props.status === "errored" ? props.onRetry : undefined}
+        onRestart={
+          !props.readOnly && props.status === "running"
+            ? props.onRestart
+            : undefined
+        }
+        onResume={
+          !props.readOnly && props.status === "suspended"
+            ? props.onResume
+            : undefined
+        }
+        onRetry={
+          !props.readOnly && props.status === "errored"
+            ? props.onRetry
+            : undefined
+        }
         scripts={props.scripts}
         active={active}
         scriptTabs={scriptTabs}
@@ -201,7 +226,7 @@ export function PreviewDrawer(props: PreviewDrawerProps) {
             vmId={props.vmId}
             active={active}
             hasData={vmEvents.hasData(active)}
-            onRunActive={handleRunActive}
+            onRunActive={props.readOnly ? undefined : handleRunActive}
           />
         </div>
       )}
@@ -231,7 +256,7 @@ function DrawerBody({
   vmId: string | null;
   active: string;
   hasData: boolean;
-  onRunActive: () => void;
+  onRunActive?: () => void;
 }) {
   const t = useT();
   // When the sandbox isn't running, the preview area shows a starting card
@@ -244,13 +269,15 @@ function DrawerBody({
   return (
     <div className="flex h-full flex-col items-center justify-center gap-3 text-sm text-muted-foreground">
       <p>{t("sandbox.drawer.scriptNotRunning", { name: active })}</p>
-      <button
-        type="button"
-        onClick={onRunActive}
-        className="flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-accent"
-      >
-        <Play className="size-3.5" /> {t("sandbox.drawer.run")}
-      </button>
+      {onRunActive && (
+        <button
+          type="button"
+          onClick={onRunActive}
+          className="flex items-center gap-1.5 rounded-md border border-border px-3 py-1.5 text-xs text-foreground hover:bg-accent"
+        >
+          <Play className="size-3.5" /> {t("sandbox.drawer.run")}
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/sandbox/preview/drawer/toolbar.tsx
+++ b/apps/web/src/components/sandbox/preview/drawer/toolbar.tsx
@@ -38,6 +38,7 @@ export type { DrawerStatus } from "./status-pill";
 export interface DrawerToolbarProps {
   status: DrawerStatus;
   open: boolean;
+  readOnly: boolean;
   onToggle: () => void;
   // VM lifecycle actions surfaced via the setup tab's split-button menu.
   onStart?: () => void;
@@ -119,15 +120,19 @@ export function DrawerToolbar(props: DrawerToolbarProps) {
               if (props.active === tabName) props.onToggle();
               else props.onSelectTab(tabName);
             }}
-            onClose={() => props.onCloseScript(tabName)}
+            onClose={
+              props.readOnly ? undefined : () => props.onCloseScript(tabName)
+            }
             t={t}
           >
             {tabName}
           </TabButton>
         ))}
-        <AddScriptButton scripts={addableScripts} onRun={props.onAddScript} />
+        {!props.readOnly && (
+          <AddScriptButton scripts={addableScripts} onRun={props.onAddScript} />
+        )}
       </div>
-      {props.showScriptControls ? (
+      {!props.readOnly && props.showScriptControls ? (
         <ScriptControls
           isRunning={props.scriptIsRunning}
           isKilling={props.scriptIsKilling}
@@ -135,17 +140,17 @@ export function DrawerToolbar(props: DrawerToolbarProps) {
           onStop={props.onStopActiveScript}
           t={t}
         />
-      ) : (
+      ) : !props.showScriptControls ? (
         <SandboxActionControls
           status={props.status}
-          onStart={props.onStart}
-          onStop={props.onStop}
-          onRestart={props.onRestart}
-          onResume={props.onResume}
-          onRetry={props.onRetry}
+          onStart={props.readOnly ? undefined : props.onStart}
+          onStop={props.readOnly ? undefined : props.onStop}
+          onRestart={props.readOnly ? undefined : props.onRestart}
+          onResume={props.readOnly ? undefined : props.onResume}
+          onRetry={props.readOnly ? undefined : props.onRetry}
           t={t}
         />
-      )}
+      ) : null}
     </div>
   );
 }
@@ -234,7 +239,7 @@ function SandboxActionControls({
       </Button>
     );
   }
-  if (status === "starting" || status === "running") {
+  if ((status === "starting" || status === "running") && onStop) {
     const showRestart = status === "running" && !!onRestart;
     return (
       <div className="flex items-center">

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -224,7 +224,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   // Mobile / standalone (no header slot): render the toolbar inline below.
   const headerSlot = useMainPanelHeaderSlot();
   const navigate = useNavigate();
-  const { currentBranch: branch } = useChatTask();
+  const { currentBranch: branch, canMutateThread } = useChatTask();
   const workspace = useBlocksPreviewWorkspace();
   // Toggles the bottom terminal drawer (null on surfaces without the provider).
   const terminal = useTerminalVisibility();
@@ -313,12 +313,17 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     orgSlug: org.slug,
     virtualMcpId: virtualMcpId ?? "",
     branch: branch ?? "",
-    enabled: isDesktopSandbox && devServerReady && !!virtualMcpId && !!branch,
+    enabled:
+      canMutateThread &&
+      isDesktopSandbox &&
+      devServerReady &&
+      !!virtualMcpId &&
+      !!branch,
   });
   // Guard the value, not just the query: React Query's staleTime=Infinity cache
   // can retain a stale repoDir after the provider kind changes from desktop to
   // agent-sandbox, whose daemon reports a container-internal path ("/app/repo").
-  const repoDir = isDesktopSandbox ? rawRepoDir : null;
+  const repoDir = canMutateThread && isDesktopSandbox ? rawRepoDir : null;
 
   // Decofile pages/global sections for the URL bar dropdown. Not gated on the
   // dev server: when it's down we read the committed `.deco/*.gen.json` snapshot
@@ -326,7 +331,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   // (The inline CMS overlay still needs the dev server — it edits the page
   // rendered inside the iframe, which the dev server serves.)
   const decofileParams =
-    virtualMcpId && branch
+    canMutateThread && virtualMcpId && branch
       ? { orgSlug: org.slug, virtualMcpId, branch, previewUrl }
       : null;
   const decofileQuery = useDecofile(decofileParams, {
@@ -348,7 +353,9 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
       hasEditableContent: hasEditableDecoContent(decofile, meta),
     }).kind === "content";
   const createPageParams =
-    virtualMcpId && branch ? { orgSlug: org.slug, virtualMcpId, branch } : null;
+    canMutateThread && virtualMcpId && branch
+      ? { orgSlug: org.slug, virtualMcpId, branch }
+      : null;
   const createPage = useCreatePage(createPageParams);
   const pages = decofile
     ? extractPages(decofile).sort((a, b) => a.name.localeCompare(b.name))
@@ -393,7 +400,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   // whatever product-search / category loader the running site actually ships.
   // A param with no resolvable source keeps the plain inline input.
   const pathParamSources: Record<string, OptionSource[]> = {};
-  if (devServerReady && previewUrl && meta && decofile) {
+  if (canMutateThread && devServerReady && previewUrl && meta && decofile) {
     const manifestLoaders = manifestLoaderResolveTypes(meta, "loaders");
     const pageBlock = currentPageKey ? decofile[currentPageKey] : undefined;
     const pageLoaders = collectPageLoaderResolveTypes(
@@ -412,7 +419,9 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     }
   }
   const pickerSandboxRef =
-    virtualMcpId && branch ? { orgSlug: org.slug, virtualMcpId, branch } : null;
+    canMutateThread && virtualMcpId && branch
+      ? { orgSlug: org.slug, virtualMcpId, branch }
+      : null;
 
   // Per-section metadata for the CMS hover overlay, aligned by index with the
   // iframe's top-level section list. `label`: ONLY global (saved block)
@@ -662,7 +671,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   // sandbox restarts (or wakes) so its loading/error state remains actionable
   // and the panel keeps reading the committed snapshot.
   const effectiveEditingMode: PreviewEditingMode =
-    display.mode !== "sandbox" && editingMode === "visual"
+    !canMutateThread || (display.mode !== "sandbox" && editingMode === "visual")
       ? "preview"
       : editingMode;
 
@@ -749,6 +758,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   };
 
   const activateEditingMode = (mode: PreviewEditingMode) => {
+    if (!canMutateThread) return;
     const previousMode = editingMode;
     if (!isMobile && mode !== previousMode) {
       if (mode === "blocks") blocksPanelRef.current?.resize("30%");
@@ -764,6 +774,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   };
 
   const toggleEditingMode = (mode: PreviewEditorMode) => {
+    if (!canMutateThread) return;
     // The user is driving the editing mode now — stop the one-shot CMS
     // auto-open from ever kicking in behind them. This is the ONLY path back to
     // `editingMode === "preview"` (the direct `activateEditingMode("blocks")`
@@ -778,12 +789,14 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   // card. Gated by the per-agent "Open CMS" Layout setting. Handled by the
   // headless `<CmsAutoOpen>` below, mounted only while `shouldAutoOpenCms`
   // holds; `onOpen` latches so it fires exactly once.
-  const autoOpenCms = shouldAutoOpenCms({
-    cmsDefaultOpen,
-    blocksReady,
-    autoOpenResolved: blocksAutoOpenResolved,
-    editingMode,
-  });
+  const autoOpenCms =
+    canMutateThread &&
+    shouldAutoOpenCms({
+      cmsDefaultOpen,
+      blocksReady,
+      autoOpenResolved: blocksAutoOpenResolved,
+      editingMode,
+    });
   const handleCmsAutoOpen = () => {
     setBlocksAutoOpenResolved(true);
     activateEditingMode("blocks");
@@ -948,7 +961,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     path: string;
     templateKey: string | null;
   }) => {
-    if (!virtualMcpId || !branch) return;
+    if (!canMutateThread || !virtualMcpId || !branch) return;
     const pathError = validatePagePath(path);
     if (pathError) {
       setCreatePageError(pathError);
@@ -1006,7 +1019,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   // its editor opens on the LEFT. So its toggle lives in the floating preview
   // pill next to the visual-editor / device controls (see below), grouped with
   // the other edit-mode affordances rather than in the header's nav-tab row.
-  const blocksActive = editingMode === "blocks";
+  const blocksActive = effectiveEditingMode === "blocks";
 
   // Refresh + page selector + open-in-new-tab — the URL group. Sized to content
   // (capped) rather than stretching, so it doesn't dominate the top bar.
@@ -1015,25 +1028,26 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   // it reads as a distinct action rather than being wedged inside the URL
   // controls. On mobile it anchors the left edge on its own (see below).
   // Filled when the Blocks editor is open; click again for plain preview.
-  const cmsToggle = showPreviewToolbar ? (
-    <HeaderTabButton
-      title={t("sandbox.preview.cms")}
-      tooltip={
-        blocksActive
-          ? t("sandbox.preview.exitEditor")
-          : t("sandbox.preview.editContent")
-      }
-      // Distinctive icon — sheds its label with the system tabs at 768px,
-      // well before this group hides at 384px, so the group stays narrow
-      // through the widths where it is most cramped.
-      labelCollapse="sooner"
-      icon={{ kind: "component", Component: PuzzlePiece01 }}
-      active={blocksActive}
-      onClick={() => toggleEditingMode("blocks")}
-      testId="preview-blocks-toggle"
-      dataTour={TOUR_ANCHORS.edit}
-    />
-  ) : null;
+  const cmsToggle =
+    showPreviewToolbar && canMutateThread ? (
+      <HeaderTabButton
+        title={t("sandbox.preview.cms")}
+        tooltip={
+          blocksActive
+            ? t("sandbox.preview.exitEditor")
+            : t("sandbox.preview.editContent")
+        }
+        // Distinctive icon — sheds its label with the system tabs at 768px,
+        // well before this group hides at 384px, so the group stays narrow
+        // through the widths where it is most cramped.
+        labelCollapse="sooner"
+        icon={{ kind: "component", Component: PuzzlePiece01 }}
+        active={blocksActive}
+        onClick={() => toggleEditingMode("blocks")}
+        testId="preview-blocks-toggle"
+        dataTour={TOUR_ANCHORS.edit}
+      />
+    ) : null;
 
   // The view controls proper: refresh · page selector · open-in-new. Kept as a
   // unit so both layouts can place it as one block — inline after the Edit
@@ -1180,24 +1194,26 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                 autoFocus
               />
             </div>
-            <div className="p-1.5 border-b">
-              <button
-                type="button"
-                className="flex w-full items-center gap-2.5 rounded-md px-3 py-2.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
-                onMouseDown={(e) => {
-                  e.preventDefault();
-                  setPagesOpen(false);
-                  setPagesSearch("");
-                  setCreatePageError(undefined);
-                  setCreatePageDialogOpen(true);
-                }}
-              >
-                <Plus size={16} className="shrink-0 text-muted-foreground" />
-                <span className="flex-1 font-medium">
-                  {t("sandbox.preview.createNewPage")}
-                </span>
-              </button>
-            </div>
+            {canMutateThread && (
+              <div className="p-1.5 border-b">
+                <button
+                  type="button"
+                  className="flex w-full items-center gap-2.5 rounded-md px-3 py-2.5 text-left text-sm hover:bg-accent hover:text-accent-foreground"
+                  onMouseDown={(e) => {
+                    e.preventDefault();
+                    setPagesOpen(false);
+                    setPagesSearch("");
+                    setCreatePageError(undefined);
+                    setCreatePageDialogOpen(true);
+                  }}
+                >
+                  <Plus size={16} className="shrink-0 text-muted-foreground" />
+                  <span className="flex-1 font-medium">
+                    {t("sandbox.preview.createNewPage")}
+                  </span>
+                </button>
+              </div>
+            )}
             {filteredPages.length === 0 &&
             filteredGlobalSections.length === 0 ? (
               <div className="px-4 py-5 text-center text-xs text-muted-foreground">
@@ -1298,7 +1314,9 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   const urlControls = showPreviewToolbar ? (
     <div className="flex min-w-0 items-center gap-0.5">
       {cmsToggle}
-      <div className="mx-0.5 h-5 w-px shrink-0 bg-border" />
+      {canMutateThread && (
+        <div className="mx-0.5 h-5 w-px shrink-0 bg-border" />
+      )}
       {urlGroup}
     </div>
   ) : null;
@@ -1340,45 +1358,39 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                 </DropdownMenuItem>
               </>
             )}
-            {decofile && meta && (
+            {canMutateThread && decofile && meta && currentPageKey && (
               <>
                 <DropdownMenuSeparator />
-                {currentPageKey && (
-                  <DropdownMenuItem
-                    onClick={() => {
-                      workspace.editSeo({
-                        kind: "page",
-                        key: currentPageKey,
-                        path: currentPath,
-                      });
-                      activateEditingMode("blocks");
-                    }}
-                  >
-                    <CreditCardSearch size={14} />
-                    {t("sandbox.preview.editSeo")}
-                  </DropdownMenuItem>
-                )}
-                {currentPageKey && (
-                  <DropdownMenuItem
-                    onClick={() => {
-                      try {
-                        goToTab(
-                          formatCodeTabId(
-                            decoBlockFileViewPath(currentPageKey),
-                          ),
-                        );
-                      } catch {
-                        toast.error(t("sandbox.preview.invalidPageBlockKey"));
-                      }
-                    }}
-                  >
-                    <Code01 size={14} />
-                    {t("sandbox.preview.viewJson")}
-                  </DropdownMenuItem>
-                )}
+                <DropdownMenuItem
+                  onClick={() => {
+                    workspace.editSeo({
+                      kind: "page",
+                      key: currentPageKey,
+                      path: currentPath,
+                    });
+                    activateEditingMode("blocks");
+                  }}
+                >
+                  <CreditCardSearch size={14} />
+                  {t("sandbox.preview.editSeo")}
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => {
+                    try {
+                      goToTab(
+                        formatCodeTabId(decoBlockFileViewPath(currentPageKey)),
+                      );
+                    } catch {
+                      toast.error(t("sandbox.preview.invalidPageBlockKey"));
+                    }
+                  }}
+                >
+                  <Code01 size={14} />
+                  {t("sandbox.preview.viewJson")}
+                </DropdownMenuItem>
               </>
             )}
-            {repoDir && (
+            {canMutateThread && repoDir && (
               <>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem
@@ -1405,45 +1417,52 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                 </DropdownMenuItem>
               </>
             )}
-            <DropdownMenuSeparator />
-            <DropdownMenuItem onClick={() => startCmsTour(t)}>
-              <Compass01 size={14} />
-              {t("cmsTour.menuItem")}
-            </DropdownMenuItem>
+            {canMutateThread && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => startCmsTour(t)}>
+                  <Compass01 size={14} />
+                  {t("cmsTour.menuItem")}
+                </DropdownMenuItem>
+              </>
+            )}
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
     ) : null;
 
-  const canVisualEdit = display.mode === "sandbox";
-  const floatingPreviewControls = canVisualEdit ? (
+  const showFloatingPreviewControls = display.mode === "sandbox";
+  const canVisualEdit = canMutateThread && showFloatingPreviewControls;
+  const floatingPreviewControls = showFloatingPreviewControls ? (
     <div className="absolute bottom-4 left-1/2 z-20 -translate-x-1/2 scale-125">
       <div className="flex items-center gap-0.5 rounded-full border bg-background/60 p-1 shadow-lg backdrop-blur-md">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <ToolbarIconButton
-              onClick={() => toggleEditingMode("visual")}
-              aria-pressed={editingMode === "visual"}
-              aria-label={t("sandbox.preview.visualEditor")}
-              active={editingMode === "visual"}
-              disabled={!canVisualEdit}
-              className="rounded-full"
-              data-tour={TOUR_ANCHORS.visualEditor}
-            >
-              <CursorClick01 size={16} />
-            </ToolbarIconButton>
-          </TooltipTrigger>
-          <TooltipContent side="top">
-            {t("sandbox.preview.visualEditor")}
-          </TooltipContent>
-        </Tooltip>
-        <div className="mx-0.5 h-5 w-px bg-border" />
+        {canVisualEdit && (
+          <>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <ToolbarIconButton
+                  onClick={() => toggleEditingMode("visual")}
+                  aria-pressed={editingMode === "visual"}
+                  aria-label={t("sandbox.preview.visualEditor")}
+                  active={editingMode === "visual"}
+                  className="rounded-full"
+                  data-tour={TOUR_ANCHORS.visualEditor}
+                >
+                  <CursorClick01 size={16} />
+                </ToolbarIconButton>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                {t("sandbox.preview.visualEditor")}
+              </TooltipContent>
+            </Tooltip>
+            <div className="mx-0.5 h-5 w-px bg-border" />
+          </>
+        )}
         <Tooltip>
           <TooltipTrigger asChild>
             <ToolbarIconButton
               onClick={handleDeviceToggle}
               aria-label={t(DEVICE_LABEL_KEYS[previewDeviceSize])}
-              disabled={!canVisualEdit}
               className="rounded-full"
               data-tour={TOUR_ANCHORS.device}
             >
@@ -1599,7 +1618,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                   <div className="absolute inset-0 z-30">
                     <SandboxStateCard
                       kind="suspended"
-                      onResume={lifecycle.resume}
+                      onResume={canMutateThread ? lifecycle.resume : undefined}
                     />
                   </div>
                 )}
@@ -1609,8 +1628,12 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                     <SandboxStateCard
                       kind="errored"
                       error={previewState.error}
-                      onRetry={lifecycle.retry}
-                      connectionsHref={`/${org.slug}/settings/connections`}
+                      onRetry={canMutateThread ? lifecycle.retry : undefined}
+                      connectionsHref={
+                        canMutateThread
+                          ? `/${org.slug}/settings/connections`
+                          : undefined
+                      }
                     />
                   </div>
                 )}
@@ -1685,7 +1708,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                         // This is the VM dev-server preview (sandboxed running app),
                         // NOT an MCP app. MCP apps render via <MCPAppRenderer/>.
                         track("vm_preview_loaded", {
-                          view_mode: editingMode,
+                          view_mode: effectiveEditingMode,
                           vm_id: vmEntry?.sandboxHandle ?? null,
                           // Intentionally excluding the full previewUrl — it can contain
                           // ephemeral tokens / user data in the query string.
@@ -1725,8 +1748,10 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                             // Cross-origin — can't read, keep current value
                           }
                         }
-                        if (editingMode === "visual") injectVisualEditor();
-                        if (editingMode === "blocks") injectCmsEditor();
+                        if (effectiveEditingMode === "visual")
+                          injectVisualEditor();
+                        if (effectiveEditingMode === "blocks")
+                          injectCmsEditor();
                       }}
                     />
                   </div>
@@ -1736,14 +1761,16 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
           </ResizablePanelGroup>
         )}
       </div>
-      <CreatePageModal
-        open={createPageDialogOpen}
-        onOpenChange={setCreatePageDialogOpen}
-        isPending={createPage.isPending}
-        error={createPageError}
-        templates={pages}
-        onSubmit={handleCreatePage}
-      />
+      {canMutateThread && (
+        <CreatePageModal
+          open={createPageDialogOpen}
+          onOpenChange={setCreatePageDialogOpen}
+          isPending={createPage.isPending}
+          error={createPageError}
+          templates={pages}
+          onSubmit={handleCreatePage}
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/sandbox/preview/state-card.tsx
+++ b/apps/web/src/components/sandbox/preview/state-card.tsx
@@ -19,11 +19,11 @@ export type SandboxStateCardProps =
       progress: PhaseProgress;
       claimPhase: ClaimPhase | null;
     }
-  | { kind: "suspended"; onResume: () => void }
+  | { kind: "suspended"; onResume?: () => void }
   | {
       kind: "errored";
       error: SandboxStartError;
-      onRetry: () => void;
+      onRetry?: () => void;
       /** Link to the org's Connections page, for the GitHub-auth case. */
       connectionsHref?: string;
     };
@@ -55,18 +55,23 @@ export function SandboxStateCard(props: SandboxStateCardProps) {
               ? t("sandbox.stateCard.githubNotAuthenticatedMessage")
               : props.error.message}
           </p>
-          <div className="mt-2 flex items-center gap-2">
-            {needsGithubAuth && props.connectionsHref && (
-              <Button asChild>
-                <a href={props.connectionsHref}>
-                  {t("sandbox.stateCard.reconnectGithub")}
-                </a>
-              </Button>
-            )}
-            <Button variant="outline" onClick={props.onRetry}>
-              <RefreshCw01 className="size-4" /> {t("sandbox.stateCard.retry")}
-            </Button>
-          </div>
+          {(props.onRetry || (needsGithubAuth && props.connectionsHref)) && (
+            <div className="mt-2 flex items-center gap-2">
+              {needsGithubAuth && props.connectionsHref && (
+                <Button asChild>
+                  <a href={props.connectionsHref}>
+                    {t("sandbox.stateCard.reconnectGithub")}
+                  </a>
+                </Button>
+              )}
+              {props.onRetry && (
+                <Button variant="outline" onClick={props.onRetry}>
+                  <RefreshCw01 className="size-4" />
+                  {t("sandbox.stateCard.retry")}
+                </Button>
+              )}
+            </div>
+          )}
         </div>
       </div>
     );
@@ -80,9 +85,11 @@ export function SandboxStateCard(props: SandboxStateCardProps) {
         <p className="max-w-sm text-sm text-muted-foreground">
           {t("sandbox.stateCard.resumeToContinue")}
         </p>
-        <Button onClick={props.onResume} className="mt-2">
-          <Play className="size-4" /> {t("sandbox.stateCard.resume")}
-        </Button>
+        {props.onResume && (
+          <Button onClick={props.onResume} className="mt-2">
+            <Play className="size-4" /> {t("sandbox.stateCard.resume")}
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/components/thread/github/checks-tab.tsx
+++ b/apps/web/src/components/thread/github/checks-tab.tsx
@@ -6,7 +6,7 @@ import { ChevronRight, LinkExternal01 } from "@untitledui/icons";
 import { useState } from "react";
 import { useT } from "@/i18n/use-t.ts";
 import { joinCheckOutput } from "./check-run-output.ts";
-import { useChatStream } from "../../chat/chat-context.tsx";
+import { useChatStream, useChatTask } from "../../chat/chat-context.tsx";
 import * as tpl from "./message-templates.ts";
 import {
   useCheckRunDetail,
@@ -32,6 +32,7 @@ interface Props {
 export function ChecksTab({ pr, connectionId, owner, repo }: Props) {
   const { org } = useProjectContext();
   const chat = useChatStream();
+  const { canMutateThread } = useChatTask();
   const t = useT();
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
@@ -44,8 +45,9 @@ export function ChecksTab({ pr, connectionId, owner, repo }: Props) {
     prNumber: pr.number,
   });
 
-  const rerun = (name: string) =>
-    chat.sendMessage({
+  const rerun = (name: string) => {
+    if (!canMutateThread) return;
+    return chat.sendMessage({
       parts: [
         {
           type: "text",
@@ -53,6 +55,7 @@ export function ChecksTab({ pr, connectionId, owner, repo }: Props) {
         },
       ],
     });
+  };
 
   const toggle = (id: string) =>
     setExpanded((prev) => {
@@ -133,7 +136,7 @@ export function ChecksTab({ pr, connectionId, owner, repo }: Props) {
                     <LinkExternal01 className="h-3.5 w-3.5" />
                   </a>
                 )}
-                {c.conclusion === "failure" && (
+                {canMutateThread && c.conclusion === "failure" && (
                   <Button
                     size="sm"
                     variant="ghost"

--- a/apps/web/src/components/thread/github/header-actions.tsx
+++ b/apps/web/src/components/thread/github/header-actions.tsx
@@ -108,7 +108,11 @@ export function HeaderActions({ virtualMcpId }: Props) {
   const { org } = useProjectContext();
   const { data: session } = authClient.useSession();
   const vm = useVirtualMCP(virtualMcpId);
-  const { currentBranch: branch, setCurrentTaskBranch } = useChatTask();
+  const {
+    currentBranch: branch,
+    setCurrentTaskBranch,
+    canMutateThread,
+  } = useChatTask();
   const chat = useChatStream();
   const { openSidePanel } = usePanelActions();
   const [publishOpen, setPublishOpen] = useState(false);
@@ -192,6 +196,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
   const publishGateBase =
     effectiveBranchMeta.kind === "ready" ? effectiveBranchMeta.base : "main";
   const publishGateEnabled =
+    canMutateThread &&
     effectiveBranchMeta.kind === "ready" &&
     Boolean(sandboxRouteBranch) &&
     (effectiveBranchMeta.workingTreeDirty ||
@@ -288,6 +293,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
   }
 
   const send = (text: string) => {
+    if (!canMutateThread) return;
     // Header actions can fire while the chat side panel is closed (e.g. from the
     // GitHub tab), so surface the chat so the user sees the message we just sent.
     openSidePanel("chat");
@@ -308,12 +314,14 @@ export function HeaderActions({ virtualMcpId }: Props) {
   };
 
   const switchToFreshBranch = async () => {
+    if (!canMutateThread) return;
     const nextBranch = generateBranchName(branchUserLabel(session?.user));
     await setCurrentTaskBranch(nextBranch);
   };
 
   const handleSquashMerge = async (pullNumber: number) => {
-    if (!githubRepo?.connectionId || githubActionPending) return;
+    if (!canMutateThread || !githubRepo?.connectionId || githubActionPending)
+      return;
     setGithubActionPending(true);
     try {
       const coAuthor = coAuthorFromSessionUser(session?.user);
@@ -340,7 +348,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
   };
 
   const onActivate = (action: HeaderButton["action"]) => {
-    if (!action || !githubHeadBranch) return;
+    if (!canMutateThread || !action || !githubHeadBranch) return;
     switch (action) {
       case "create-pr":
         setPublishDialogIntent("open-pr");
@@ -378,6 +386,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
   };
 
   const onPublishSide = () => {
+    if (!canMutateThread) return;
     setPublishDialogIntent("publish-only");
     setPublishOpen(true);
   };
@@ -386,7 +395,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
   // button gated by isDecoOnlyDiff so code changes still require review) is
   // owned by the panel-state descriptor — set on states with local work not
   // yet merged, and never on merge-split (where the primary button IS publish).
-  const showPublishSide = button.showPublishSide ?? false;
+  const showPublishSide = canMutateThread && (button.showPublishSide ?? false);
 
   const actionBusy = githubActionPending || isStreaming;
 
@@ -395,6 +404,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
       <HeaderButtonRenderer
         t={t}
         button={button}
+        canMutate={canMutateThread}
         actionBusy={actionBusy}
         githubActionPending={githubActionPending}
         onActivate={onActivate}
@@ -407,13 +417,13 @@ export function HeaderActions({ virtualMcpId }: Props) {
         onReview={
           pr
             ? () => {
-                if (isStreaming) return;
+                if (!canMutateThread || isStreaming) return;
                 void send(tpl.reviewPr({ prNumber: pr.number }));
               }
             : undefined
         }
       />
-      {sandboxRouteBranch && (
+      {canMutateThread && sandboxRouteBranch && (
         <PublishDialog
           open={publishOpen}
           onOpenChange={setPublishOpen}
@@ -451,6 +461,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
 function HeaderButtonRenderer(props: {
   t: TFunction;
   button: HeaderButton;
+  canMutate: boolean;
   actionBusy: boolean;
   githubActionPending: boolean;
   onActivate: (action: HeaderButton["action"]) => void;
@@ -462,21 +473,24 @@ function HeaderButtonRenderer(props: {
   onSquashMerge: (pullNumber: number) => void | Promise<void>;
   onReview?: () => void;
 }) {
-  const { t, button, actionBusy, githubActionPending } = props;
+  const { t, button, canMutate, actionBusy, githubActionPending } = props;
   const chatBlocksAction =
     actionBusy &&
     button.action !== "create-pr" &&
     button.action !== "merge-split";
   const disabled =
+    !canMutate ||
     Boolean(button.disabled) ||
     chatBlocksAction ||
     (githubActionPending && button.action === "merge-split");
   const loading =
     Boolean(button.loading) ||
     (githubActionPending && button.action === "merge-split");
-  const tooltipLabel = chatBlocksAction
-    ? t("thread.headerActions.chatIsRunning")
-    : (button.tooltip ?? null);
+  const tooltipLabel = !canMutate
+    ? t("chat.input.readOnlyOthersChat")
+    : chatBlocksAction
+      ? t("thread.headerActions.chatIsRunning")
+      : (button.tooltip ?? null);
 
   if (
     button.action === "merge-split" &&
@@ -514,10 +528,12 @@ function HeaderButtonRenderer(props: {
           // is disabled and has no action) the step would point at an unrelated
           // button; leaving the anchor off lets the tour skip the step.
           data-tour={
-            button.action === "create-pr" ? TOUR_ANCHORS.submit : undefined
+            canMutate && button.action === "create-pr"
+              ? TOUR_ANCHORS.submit
+              : undefined
           }
           onClick={() => {
-            if (button.action) props.onActivate(button.action);
+            if (canMutate && button.action) props.onActivate(button.action);
           }}
         >
           {loading ? (
@@ -530,7 +546,7 @@ function HeaderButtonRenderer(props: {
           </span>
         </Button>
       </WithTooltip>
-      {props.showPublishSide ? (
+      {canMutate && props.showPublishSide ? (
         <WithTooltip
           label={
             props.publishGate.pending
@@ -544,9 +560,11 @@ function HeaderButtonRenderer(props: {
           <Button
             size="sm"
             variant="success"
-            data-tour={TOUR_ANCHORS.publish}
+            data-tour={canMutate ? TOUR_ANCHORS.publish : undefined}
             disabled={props.githubActionPending || !props.publishGate.allowed}
-            onClick={props.onPublishSide}
+            onClick={() => {
+              if (canMutate) props.onPublishSide();
+            }}
           >
             {props.publishGate.pending ? (
               <Spinner size="xs" variant="default" />

--- a/apps/web/src/desktop/agent-terminal/active-task-provider.tsx
+++ b/apps/web/src/desktop/agent-terminal/active-task-provider.tsx
@@ -27,7 +27,6 @@ import {
   restoreStoredAutosend,
 } from "@/lib/autosend";
 import { useProjectContext } from "@/sdk";
-import { authClient } from "@/lib/auth-client";
 import {
   appendAppContexts,
   promptContentFromParts,
@@ -90,7 +89,6 @@ export function NativeAgentTerminalProvider({
   const task = useChatTask();
   const prefs = useChatPrefs();
   const manager = useThreadManager();
-  const { data: session } = authClient.useSession();
   const search = useSearch({ strict: false }) as { autosend?: string };
   const controller = getOrCreateTerminalController(org.slug, taskId);
   const snapshot = useSyncExternalStore(
@@ -100,9 +98,7 @@ export function NativeAgentTerminalProvider({
   );
   const lockedHarness = toTerminalHarnessId(task.lockedHarness);
   const pendingHarness = toTerminalHarnessId(prefs.pendingHarnessId);
-  const isReadOnly =
-    !task.activeTask?.created_by ||
-    task.activeTask.created_by !== session?.user?.id;
+  const isReadOnly = !task.canMutateThread;
   const shouldAutosend = search.autosend === AUTOSEND_QUERY_VALUE;
   const unsupportedHarnessMessage = t("chat.nativeTerminal.unsupportedHarness");
 
@@ -314,7 +310,6 @@ export function NativeAgentTerminalProvider({
     messages: EMPTY_MESSAGES,
     status: streamStatus(snapshot),
     sendMessage,
-    editQueuedMessage: async () => false,
     stop: () => {
       if (!isReadOnly) controller.interrupt();
     },

--- a/apps/web/src/i18n/en/chat.ts
+++ b/apps/web/src/i18n/en/chat.ts
@@ -69,13 +69,8 @@ export const chat = {
   "chat.chatContext.activeTaskProviderMissingContext":
     "ActiveTaskProvider must be used within ChatContextProvider",
   "chat.chatContext.cancelFailedStatus": "Cancel failed: {status}",
-  "chat.chatContext.couldNotRemoveOriginalMessage":
-    "Couldn't remove the original message",
   "chat.chatContext.failedToCancel": "Failed to cancel",
   "chat.chatContext.failedToQueueMessage": "Failed to queue message",
-  "chat.chatContext.failedToSendEditedMessage": "Failed to send edited message",
-  "chat.chatContext.stillSendingPreviousMessage":
-    "Still sending your previous message — try again in a moment",
   "chat.chatContext.useChatPrefsMissingContext":
     "useChatPrefs must be used within ChatContextProvider",
   "chat.chatContext.useChatStreamMissingContext":

--- a/apps/web/src/i18n/pt-br/chat.ts
+++ b/apps/web/src/i18n/pt-br/chat.ts
@@ -73,14 +73,8 @@ export const chat = {
   "chat.chatContext.activeTaskProviderMissingContext":
     "ActiveTaskProvider deve ser usado dentro de ChatContextProvider",
   "chat.chatContext.cancelFailedStatus": "Falha ao cancelar: {status}",
-  "chat.chatContext.couldNotRemoveOriginalMessage":
-    "Não foi possível remover a mensagem original",
   "chat.chatContext.failedToCancel": "Falha ao cancelar",
   "chat.chatContext.failedToQueueMessage": "Falha ao enfileirar mensagem",
-  "chat.chatContext.failedToSendEditedMessage":
-    "Falha ao enviar mensagem editada",
-  "chat.chatContext.stillSendingPreviousMessage":
-    "Ainda enviando sua mensagem anterior — tente novamente em alguns momentos",
   "chat.chatContext.useChatPrefsMissingContext":
     "useChatPrefs deve ser usado dentro de ChatContextProvider",
   "chat.chatContext.useChatStreamMissingContext":

--- a/apps/web/src/layouts/agent-shell-layout/index.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/index.tsx
@@ -197,7 +197,8 @@ function VmEventsBridge({
   children: ReactNode;
 }) {
   const t = useT();
-  const { currentBranch, activeTask, setCurrentTaskBranch } = useChatTask();
+  const { currentBranch, activeTask, canMutateThread, setCurrentTaskBranch } =
+    useChatTask();
   const isDesktopApp = useIsDesktopApp();
   const surfaceKind = sandboxSurfaceKind(isDesktopApp);
   const { data: session } = authClient.useSession();
@@ -234,9 +235,10 @@ function VmEventsBridge({
   const adoptedBranchForThreadRef = useRef<string | null>(null);
   const adoptBranchEligible =
     executionEnabled &&
+    canMutateThread &&
     shouldAdoptBranch({
       threadLoaded: !!activeTask,
-      isOwner: !!userId && activeTask?.created_by === userId,
+      isOwner: canMutateThread,
       hasActiveGithubRepo: effectiveHasGithubRepo,
       branch: currentBranch ?? null,
       // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- read-only dedup probe; recorded inside the effect after firing
@@ -599,6 +601,7 @@ function AgentInsetProvider() {
             virtualMcpId={chatVirtualMcpId}
             task={ensureState.status === "ready" ? ensureState.task : null}
           >
+            <OrgFilePreviewMount />
             <VmEventsBridge
               virtualMcpId={virtualMcpId}
               hasActiveGithubRepo={hasActiveGithubRepo}
@@ -676,7 +679,6 @@ export default function AgentShellLayout() {
     <Suspense fallback={<ShellRouteLoading />}>
       <OrgFileOpenProvider>
         <AgentInsetProvider />
-        <OrgFilePreviewMount />
       </OrgFileOpenProvider>
     </Suspense>
   );

--- a/apps/web/src/layouts/agent-shell-layout/org-file-preview.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/org-file-preview.tsx
@@ -10,11 +10,13 @@
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useIsMobile } from "@deco/ui/hooks/use-mobile.ts";
 import { LibraryPreviewDialog } from "@/layouts/library/preview-dialog";
+import { useChatTask } from "@/components/chat/context";
 
 export function OrgFilePreviewMount() {
   const isMobile = useIsMobile();
   const navigate = useNavigate();
   const { preview } = useSearch({ strict: false }) as { preview?: string };
+  const { canMutateThread } = useChatTask();
 
   if (!isMobile || !preview) return null;
 
@@ -31,6 +33,7 @@ export function OrgFilePreviewMount() {
         })
       }
       showSeeInLibrary
+      readOnly={!canMutateThread}
     />
   );
 }

--- a/apps/web/src/layouts/library/preview-capabilities.test.ts
+++ b/apps/web/src/layouts/library/preview-capabilities.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveLibraryPreviewCapabilities } from "./preview-capabilities";
+
+describe("resolveLibraryPreviewCapabilities", () => {
+  test("removes edit and share mutations from a read-only thread preview", () => {
+    expect(resolveLibraryPreviewCapabilities(true, "home")).toEqual({
+      canEditHtml: false,
+      canShare: false,
+    });
+  });
+
+  test("preserves the Library's existing mutation capabilities", () => {
+    expect(resolveLibraryPreviewCapabilities(false, "home")).toEqual({
+      canEditHtml: true,
+      canShare: true,
+    });
+    expect(resolveLibraryPreviewCapabilities(false, "public")).toEqual({
+      canEditHtml: false,
+      canShare: true,
+    });
+  });
+});

--- a/apps/web/src/layouts/library/preview-capabilities.ts
+++ b/apps/web/src/layouts/library/preview-capabilities.ts
@@ -1,0 +1,15 @@
+export interface LibraryPreviewCapabilities {
+  canEditHtml: boolean;
+  canShare: boolean;
+}
+
+/** Keep the shared Library preview read-only when it is embedded in a thread. */
+export function resolveLibraryPreviewCapabilities(
+  readOnly: boolean,
+  volume: string | null,
+): LibraryPreviewCapabilities {
+  return {
+    canEditHtml: !readOnly && volume === "home",
+    canShare: !readOnly,
+  };
+}

--- a/apps/web/src/layouts/library/preview-content.tsx
+++ b/apps/web/src/layouts/library/preview-content.tsx
@@ -36,6 +36,7 @@ import {
 } from "@/hooks/use-org-fs";
 import { FileShareButton } from "./file-share-button";
 import { basename, parseLibraryPath } from "./location";
+import { resolveLibraryPreviewCapabilities } from "./preview-capabilities";
 
 const isHtml = (name: string) => /\.html?$/i.test(name);
 
@@ -47,6 +48,8 @@ export interface LibraryPreviewProps {
   onClose: () => void;
   /** Render a "See in library" link (set when previewing outside the Library). */
   showSeeInLibrary?: boolean;
+  /** Omit inline editing and share controls when embedded in a read-only thread. */
+  readOnly?: boolean;
 }
 
 function CloseButton({ onClose }: { onClose: () => void }) {
@@ -69,6 +72,7 @@ export function LibraryFilePreview({
   previewPath,
   onClose,
   showSeeInLibrary = false,
+  readOnly = false,
   variant,
 }: LibraryPreviewProps & { variant: LibraryPreviewVariant }) {
   const t = useT();
@@ -78,6 +82,10 @@ export function LibraryFilePreview({
   const downloadUrl = useOrgFsDownloadUrl(volume ?? "");
   const filename = basename(filePath);
   const isDialog = variant === "dialog";
+  const { canEditHtml, canShare } = resolveLibraryPreviewCapabilities(
+    readOnly,
+    volume,
+  );
 
   const seeInLibrary = showSeeInLibrary ? (
     <SeeInLibraryLink previewPath={previewPath} />
@@ -107,16 +115,18 @@ export function LibraryFilePreview({
           readUrl={file.downloadUrl}
           marker={entryMarker(entry)}
           title={filename}
-          savePath={volume === "home" ? filePath : undefined}
+          savePath={canEditHtml ? filePath : undefined}
           trailing={
             <>
-              <FileShareButton
-                volume={volume ?? ""}
-                path={filePath}
-                shareMode={entry.shareMode ?? "private"}
-                effectivePublic={entry.effectivePublic ?? false}
-                url={window.location.origin + file.downloadUrl}
-              />
+              {canShare && (
+                <FileShareButton
+                  volume={volume ?? ""}
+                  path={filePath}
+                  shareMode={entry.shareMode ?? "private"}
+                  effectivePublic={entry.effectivePublic ?? false}
+                  url={window.location.origin + file.downloadUrl}
+                />
+              )}
               {seeInLibrary}
               {isDialog ? (
                 <div className="w-8 shrink-0" />
@@ -158,13 +168,15 @@ export function LibraryFilePreview({
         </div>
         {file && (
           <>
-            <FileShareButton
-              volume={volume ?? ""}
-              path={filePath}
-              shareMode={entry?.shareMode ?? "private"}
-              effectivePublic={entry?.effectivePublic ?? false}
-              url={window.location.origin + file.downloadUrl}
-            />
+            {canShare && (
+              <FileShareButton
+                volume={volume ?? ""}
+                path={filePath}
+                shareMode={entry?.shareMode ?? "private"}
+                effectivePublic={entry?.effectivePublic ?? false}
+                url={window.location.origin + file.downloadUrl}
+              />
+            )}
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button variant="ghost" size="icon" asChild>

--- a/apps/web/src/layouts/library/preview-dialog.tsx
+++ b/apps/web/src/layouts/library/preview-dialog.tsx
@@ -15,6 +15,7 @@ export function LibraryPreviewDialog({
   previewPath,
   onClose,
   showSeeInLibrary = false,
+  readOnly = false,
 }: LibraryPreviewProps) {
   return (
     <Dialog
@@ -28,6 +29,7 @@ export function LibraryPreviewDialog({
           previewPath={previewPath}
           onClose={onClose}
           showSeeInLibrary={showSeeInLibrary}
+          readOnly={readOnly}
           variant="dialog"
         />
       </DialogContent>

--- a/apps/web/src/layouts/library/preview-panel.tsx
+++ b/apps/web/src/layouts/library/preview-panel.tsx
@@ -19,6 +19,7 @@ export function LibraryPreviewPanel({
   previewPath,
   onClose,
   showSeeInLibrary = false,
+  readOnly = false,
 }: LibraryPreviewProps) {
   return (
     <div className="flex h-full w-full flex-col bg-background">
@@ -26,6 +27,7 @@ export function LibraryPreviewPanel({
         previewPath={previewPath}
         onClose={onClose}
         showSeeInLibrary={showSeeInLibrary}
+        readOnly={readOnly}
         variant="panel"
       />
     </div>

--- a/apps/web/src/layouts/main-panel-tabs/deck-tab.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/deck-tab.tsx
@@ -22,6 +22,7 @@ import {
   useOrgFsStat,
 } from "@/hooks/use-org-fs";
 import { FileShareButton } from "@/layouts/library/file-share-button";
+import { useChatTask } from "@/components/chat/context";
 
 const HOME_VOLUME = "home";
 
@@ -35,6 +36,7 @@ function DeckShimmer({ label }: { label?: string }) {
 }
 
 export function DeckTab({ path }: { path: string }) {
+  const { canMutateThread } = useChatTask();
   const stat = useOrgFsStat(HOME_VOLUME, path, {
     refetchIntervalWhenAbsent: 2000,
   });
@@ -57,15 +59,17 @@ export function DeckTab({ path }: { path: string }) {
       readUrl={readUrl}
       marker={entryMarker(stat.data)}
       title={path}
-      savePath={path}
+      savePath={canMutateThread ? path : undefined}
       trailing={
-        <FileShareButton
-          volume={HOME_VOLUME}
-          path={path}
-          shareMode={stat.data.shareMode ?? "private"}
-          effectivePublic={stat.data.effectivePublic ?? false}
-          url={window.location.origin + readUrl}
-        />
+        canMutateThread ? (
+          <FileShareButton
+            volume={HOME_VOLUME}
+            path={path}
+            shareMode={stat.data.shareMode ?? "private"}
+            effectivePublic={stat.data.effectivePublic ?? false}
+            url={window.location.origin + readUrl}
+          />
+        ) : undefined
       }
     />
   );

--- a/apps/web/src/layouts/main-panel-tabs/index.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/index.tsx
@@ -33,6 +33,7 @@ import {
   parsePinnedViewTabId,
 } from "./tab-id";
 import { ErrorBoundary } from "@/components/error-boundary";
+import { useChatTask } from "@/components/chat/context";
 
 const AppViewContent = lazy(() =>
   import("@/routes/project-app-view").then((m) => ({
@@ -57,6 +58,8 @@ function TabBody({
     typeof useMainPanelTabs
   >["automationTabParsed"];
 }) {
+  const { canMutateThread } = useChatTask();
+
   // Test hook: e2e tests set window.__forceTabError = <activeTab> to deliberately
   // crash the active tab and exercise the ErrorBoundary recovery flow.
   // Dead-stripped from real production builds; alive in dev and in the e2e
@@ -98,9 +101,15 @@ function TabBody({
   }
   const codeTab = parseCodeTabId(activeTab);
   if (codeTab) {
+    if (!canMutateThread) {
+      return <PreviewTab virtualMcpId={virtualMcpId} />;
+    }
     return <CodeTab openPath={codeTab.path} />;
   }
   if (activeTab === "content") {
+    if (!canMutateThread) {
+      return <PreviewTab virtualMcpId={virtualMcpId} />;
+    }
     return <ContentTab virtualMcpId={virtualMcpId} />;
   }
   if (activeTab === "files") {
@@ -123,12 +132,19 @@ function TabBody({
   const libraryFileTab = parseLibraryFileTabId(activeTab);
   if (libraryFileTab) {
     return (
-      <LibraryFileTab key={libraryFileTab.path} path={libraryFileTab.path} />
+      <LibraryFileTab
+        key={libraryFileTab.path}
+        path={libraryFileTab.path}
+        readOnly={!canMutateThread}
+      />
     );
   }
 
   const pinnedView = parsePinnedViewTabId(activeTab);
   if (pinnedView) {
+    if (!canMutateThread) {
+      return <PreviewTab virtualMcpId={virtualMcpId} />;
+    }
     const expandedTool = expandedTools.find(
       (t) =>
         t.appId === pinnedView.connectionId &&
@@ -148,6 +164,9 @@ function TabBody({
 
   const agentTab = layoutTabs.find((t) => t.id === activeTab);
   if (agentTab) {
+    if (!canMutateThread) {
+      return <PreviewTab virtualMcpId={virtualMcpId} />;
+    }
     return (
       <Suspense fallback={<MainPanelLoading />}>
         <AppViewContent

--- a/apps/web/src/layouts/main-panel-tabs/library-file-tab.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/library-file-tab.tsx
@@ -11,7 +11,13 @@
 import { useNavigate } from "@tanstack/react-router";
 import { LibraryPreviewPanel } from "@/layouts/library/preview-panel";
 
-export function LibraryFileTab({ path }: { path: string }) {
+export function LibraryFileTab({
+  path,
+  readOnly,
+}: {
+  path: string;
+  readOnly: boolean;
+}) {
   const navigate = useNavigate();
   const onClose = () =>
     navigate({
@@ -27,6 +33,7 @@ export function LibraryFileTab({ path }: { path: string }) {
       previewPath={path}
       onClose={onClose}
       showSeeInLibrary
+      readOnly={readOnly}
     />
   );
 }

--- a/apps/web/src/layouts/main-panel-tabs/preview-drawer-host.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/preview-drawer-host.tsx
@@ -17,6 +17,7 @@ import {
   useSandboxEvents,
 } from "@/components/sandbox/hooks/use-sandbox-events";
 import { PreviewDrawer } from "@/components/sandbox/preview/drawer/drawer";
+import { useChatTask } from "@/components/chat/context";
 
 const STORAGE_KEY = (id: string) => `preview-drawer:${id}`;
 
@@ -49,6 +50,7 @@ export function PreviewDrawerHost() {
   const inset = useInsetContext();
   const { org } = useProjectContext();
   const virtualMcpId = inset?.virtualMcpId ?? null;
+  const { canMutateThread } = useChatTask();
   const lifecycle = useSandboxLifecycle();
   const events = useSandboxEvents();
 
@@ -59,7 +61,7 @@ export function PreviewDrawerHost() {
   // that's permanently revoked.
   const autoRestartedVmcpRef = useRef<string | null>(null);
   useSandboxChunkHandler((source) => {
-    if (source !== "setup" || !virtualMcpId) return;
+    if (!canMutateThread || source !== "setup" || !virtualMcpId) return;
     if (autoRestartedVmcpRef.current === virtualMcpId) return;
     if (!GIT_AUTH_FAILURE_RE.test(events.getBuffer("setup"))) return;
     autoRestartedVmcpRef.current = virtualMcpId;
@@ -100,6 +102,7 @@ export function PreviewDrawerHost() {
       branch={lifecycle.branch}
       status={lifecycle.status}
       scripts={events.scripts}
+      readOnly={!canMutateThread}
       open={open}
       onOpenChange={handleOpenChange}
       onStart={lifecycle.start}

--- a/apps/web/src/layouts/main-panel-tabs/preview-tab.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/preview-tab.tsx
@@ -12,7 +12,7 @@ import { useT } from "@/i18n/use-t.ts";
 export function PreviewTab({ virtualMcpId }: { virtualMcpId: string }) {
   const t = useT();
   const entity = useVirtualMCP(virtualMcpId);
-  const { activeTask } = useChatTask();
+  const { activeTask, canMutateThread } = useChatTask();
   const [pickerOpen, setPickerOpen] = useState(false);
   // A thread-scoped repo (bound by `load_repo`) is previewable even when the
   // agent itself has no clonable source (e.g. the ephemeral Decopilot agent).
@@ -33,17 +33,21 @@ export function PreviewTab({ virtualMcpId }: { virtualMcpId: string }) {
           title={t("mainPanelTabs.previewTab.noSourceToPreview")}
           description={t("mainPanelTabs.previewTab.connectGithubDescription")}
           actions={
-            <Button onClick={() => setPickerOpen(true)}>
-              <GitHubIcon className="size-4" />
-              {t("mainPanelTabs.previewTab.connectGithub")}
-            </Button>
+            canMutateThread ? (
+              <Button onClick={() => setPickerOpen(true)}>
+                <GitHubIcon className="size-4" />
+                {t("mainPanelTabs.previewTab.connectGithub")}
+              </Button>
+            ) : undefined
           }
         />
-        <GitHubRepoPicker
-          open={pickerOpen}
-          onOpenChange={setPickerOpen}
-          mode="agent"
-        />
+        {canMutateThread && (
+          <GitHubRepoPicker
+            open={pickerOpen}
+            onOpenChange={setPickerOpen}
+            mode="agent"
+          />
+        )}
       </>
     );
   }

--- a/apps/web/src/layouts/main-panel-tabs/source-system-tabs.test.ts
+++ b/apps/web/src/layouts/main-panel-tabs/source-system-tabs.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 import {
   getSourceSystemTabs,
+  getViewerSafeFallbackTab,
+  resolveViewerActiveTab,
   shouldDeepLinkSourceTab,
 } from "./source-system-tabs";
 
@@ -14,6 +16,59 @@ describe("getSourceSystemTabs", () => {
 
   test("returns no source tabs without clonable source", () => {
     expect(getSourceSystemTabs(false)).toEqual([]);
+  });
+
+  test("keeps Preview but hides owner-only Code for a teammate", () => {
+    expect(getSourceSystemTabs(true, false)).toEqual([
+      { id: "preview", title: "Preview" },
+    ]);
+  });
+});
+
+describe("getViewerSafeFallbackTab", () => {
+  test("uses Preview when a read-only source is available", () => {
+    expect(getViewerSafeFallbackTab(true)).toBe("preview");
+  });
+
+  test("uses Settings instead of an owner-only configured default without source", () => {
+    expect(getViewerSafeFallbackTab(false)).toBe("settings");
+  });
+});
+
+describe("resolveViewerActiveTab", () => {
+  const base = {
+    hasClonableSource: false,
+    configuredLayoutTabIds: [] as string[],
+    gitTabVisible: false,
+    gitQueryPending: false,
+  };
+
+  test("replaces a configured Code default with a safe viewer tab", () => {
+    expect(resolveViewerActiveTab({ ...base, rawActiveTab: "code" })).toBe(
+      "settings",
+    );
+  });
+
+  test("falls back to read-only Preview when source is available", () => {
+    expect(
+      resolveViewerActiveTab({
+        ...base,
+        rawActiveTab: "code:src%2Findex.ts",
+        hasClonableSource: true,
+      }),
+    ).toBe("preview");
+  });
+
+  test("rejects app, content, and configured layout tabs", () => {
+    for (const rawActiveTab of ["app:conn:tool", "content", "custom-view"]) {
+      expect(
+        resolveViewerActiveTab({
+          ...base,
+          rawActiveTab,
+          configuredLayoutTabIds: ["custom-view"],
+        }),
+      ).toBe("settings");
+    }
   });
 });
 

--- a/apps/web/src/layouts/main-panel-tabs/source-system-tabs.ts
+++ b/apps/web/src/layouts/main-panel-tabs/source-system-tabs.ts
@@ -1,3 +1,5 @@
+import { parseCodeTabId, parsePinnedViewTabId } from "./tab-id";
+
 export interface SourceSystemTab {
   id: "preview" | "code";
   title: string;
@@ -10,8 +12,49 @@ const SOURCE_SYSTEM_TABS: readonly SourceSystemTab[] = [
 
 export function getSourceSystemTabs(
   hasClonableSource: boolean,
+  canMutateThread = true,
 ): SourceSystemTab[] {
-  return hasClonableSource ? [...SOURCE_SYSTEM_TABS] : [];
+  if (!hasClonableSource) return [];
+  return canMutateThread
+    ? [...SOURCE_SYSTEM_TABS]
+    : SOURCE_SYSTEM_TABS.filter((tab) => tab.id === "preview");
+}
+
+/**
+ * A read-only viewer must never fall through to an owner-only configured tab.
+ * Preview is safe when source exists; otherwise use the non-runtime Settings
+ * view.
+ */
+export function getViewerSafeFallbackTab(
+  hasClonableSource: boolean,
+): "preview" | "settings" {
+  return hasClonableSource ? "preview" : "settings";
+}
+
+export function resolveViewerActiveTab(opts: {
+  rawActiveTab: string;
+  hasClonableSource: boolean;
+  configuredLayoutTabIds: readonly string[];
+  gitTabVisible: boolean;
+  gitQueryPending: boolean;
+}): string {
+  const fallback = getViewerSafeFallbackTab(opts.hasClonableSource);
+  if (
+    parseCodeTabId(opts.rawActiveTab) ||
+    parsePinnedViewTabId(opts.rawActiveTab) ||
+    opts.rawActiveTab === "content" ||
+    opts.configuredLayoutTabIds.includes(opts.rawActiveTab)
+  ) {
+    return fallback;
+  }
+  if (
+    opts.rawActiveTab === "git" &&
+    !opts.gitTabVisible &&
+    !opts.gitQueryPending
+  ) {
+    return fallback;
+  }
+  return opts.rawActiveTab;
 }
 
 /**

--- a/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -63,6 +63,7 @@ import {
 import { resolveTabIcon, type TabIcon, type TabKind } from "./resolve-tab-icon";
 import {
   getSourceSystemTabs,
+  resolveViewerActiveTab,
   shouldDeepLinkSourceTab,
 } from "./source-system-tabs";
 import { useCapability } from "@/hooks/use-capability";
@@ -158,7 +159,7 @@ export function useMainPanelTabs(ctx: {
   const entity = useVirtualMCP(ctx.virtualMcpId);
   const metadata = useTaskMetadata(ctx.taskId);
   const { org } = useProjectContext();
-  const { currentBranch } = useChatTask();
+  const { currentBranch, canMutateThread } = useChatTask();
 
   const githubRepo = getActiveGithubRepo(entity);
   const prQuery = usePrByBranch({
@@ -194,13 +195,17 @@ export function useMainPanelTabs(ctx: {
     )?.ui ?? null;
 
   const entityLayout = entityUI?.layout ?? null;
-  const layoutTabs = (entityLayout?.tabs ?? []) as AgentTabDef[];
+  const configuredLayoutTabs = (entityLayout?.tabs ?? []) as AgentTabDef[];
 
   // The ephemeral dev connection (`dev_<id>`) the agent's sandbox dev server is
   // served through. Its views are auto-detected from the dev server's own MCP
   // app below — no pairing / live-partner config involved.
-  const devConnId = entity?.id ? getDevConnectionId(entity.id) : null;
-  const expandedTools: ThreadExpandedTool[] = metadata?.expanded_tools ?? [];
+  const rawDevConnId = entity?.id ? getDevConnectionId(entity.id) : null;
+  const devConnId = canMutateThread ? rawDevConnId : null;
+  const layoutTabs = canMutateThread ? configuredLayoutTabs : [];
+  const expandedTools: ThreadExpandedTool[] = canMutateThread
+    ? (metadata?.expanded_tools ?? [])
+    : [];
   const hasActiveGithubRepo = agentHasConnectedGithub(entity);
   // A thread-scoped repo (bound by `load_repo`) makes the source tabs
   // (Preview, Code) available even when the agent itself has no repo — e.g.
@@ -245,7 +250,7 @@ export function useMainPanelTabs(ctx: {
   });
   const { data: devToolsResult } = useMCPToolsListQuery({
     client: devClient as NonNullable<typeof devClient>,
-    enabled: !!devClient && devServerReady,
+    enabled: canMutateThread && !!devClient && devServerReady,
   });
   const devViews =
     devConnId && devServerReady
@@ -259,13 +264,22 @@ export function useMainPanelTabs(ctx: {
           }))
       : [];
   const firstDevView = devViews[0];
-  const pinnedViews = firstDevView ? devViews : (entityUI?.pinnedViews ?? []);
+  const configuredPinnedViews = canMutateThread
+    ? (entityUI?.pinnedViews ?? [])
+    : [];
+  const pinnedViews = firstDevView ? devViews : configuredPinnedViews;
+  const configuredDefaultMainView = entityLayout?.defaultMainView ?? null;
   const effectiveDefaultMainView =
     firstDevView && devConnId
       ? { type: "ext-apps", id: devConnId, toolName: firstDevView.toolName }
-      : (entityLayout?.defaultMainView ?? null);
+      : !canMutateThread &&
+          (configuredDefaultMainView?.type === "ext-app" ||
+            configuredDefaultMainView?.type === "ext-apps" ||
+            configuredDefaultMainView?.type === "content")
+        ? null
+        : configuredDefaultMainView;
   const decofileFetchParams =
-    hasClonableSource && entity?.id && currentBranch
+    canMutateThread && hasClonableSource && entity?.id && currentBranch
       ? {
           orgSlug: org.slug,
           virtualMcpId: entity.id,
@@ -283,7 +297,8 @@ export function useMainPanelTabs(ctx: {
   const { data: meta } = useLiveMeta(decofileFetchParams, {
     fetchEnabled: devServerReady,
   });
-  const showContentTab = hasEditableDecoContent(decofile, meta);
+  const showContentTab =
+    canMutateThread && hasEditableDecoContent(decofile, meta);
 
   const { activeTab: rawActiveTab, mainOpen: rawMainOpen } =
     resolveActiveTabAndOpen({
@@ -307,8 +322,15 @@ export function useMainPanelTabs(ctx: {
           tabs: layoutTabs.map((t) => ({ id: t.id })),
         }
       : null;
-  const activeTab =
-    rawActiveTab === "git" && !gitTabVisible && !prQuery.isPending
+  const activeTab = !canMutateThread
+    ? resolveViewerActiveTab({
+        rawActiveTab,
+        hasClonableSource,
+        configuredLayoutTabIds: configuredLayoutTabs.map((tab) => tab.id),
+        gitTabVisible,
+        gitQueryPending: prQuery.isPending,
+      })
+    : rawActiveTab === "git" && !gitTabVisible && !prQuery.isPending
       ? resolveDefaultTabId(layoutForDefault)
       : rawActiveTab === "content" && !showContentTab
         ? resolveDefaultTabId(layoutForDefault)
@@ -349,7 +371,10 @@ export function useMainPanelTabs(ctx: {
   // have a mirrored `githubRepo`. Clicking from off the Report Agent deep-links
   // into it (see setActiveTab).
   leadingSystemTabs.push(
-    ...getSourceSystemTabs(hasClonableSource || reportsOnly).map((tab) => ({
+    ...getSourceSystemTabs(
+      hasClonableSource || reportsOnly,
+      canMutateThread,
+    ).map((tab) => ({
       id: tab.id,
       title:
         tab.id === "preview"
@@ -364,7 +389,8 @@ export function useMainPanelTabs(ctx: {
   // A tab configured as the default main view stays pinned in the bar even
   // before its runtime data is ready (e.g. Content while the repo is still
   // cloning) — otherwise the bar would drop the tab the user chose to land on.
-  const contentIsDefaultMain = effectiveDefaultMainView?.type === "content";
+  const contentIsDefaultMain =
+    canMutateThread && effectiveDefaultMainView?.type === "content";
   if (hasClonableSource && (showContentTab || contentIsDefaultMain)) {
     systemTabs.push({
       id: "content",
@@ -432,7 +458,7 @@ export function useMainPanelTabs(ctx: {
   // current agent (and no agent switch) is needed. On the Report Agent itself
   // the loop above already added it with its configured label/icon, so this is
   // a no-op there (dedup by tab id).
-  if (reportsOnly) {
+  if (reportsOnly && canMutateThread) {
     const reportConnectionId = WellKnownOrgMCPId.COMMERCE_DISCOVERY(org.id);
     const reportTabId = formatPinnedViewTabId(
       reportConnectionId,

--- a/apps/web/src/views/automations/automation-detail.tsx
+++ b/apps/web/src/views/automations/automation-detail.tsx
@@ -142,7 +142,7 @@ export function SettingsTab({
   const connectionNameMap = new Map(allConnections.map((c) => [c.id, c.title]));
 
   // Chat hooks for running the automation
-  const { openTask } = useChatTask();
+  const { canMutateThread, openTask } = useChatTask();
   const { openSidePanel } = usePanelActions();
   const { sendMessage } = useChatStream();
   const initialTiptapDoc =
@@ -170,7 +170,7 @@ export function SettingsTab({
   const [tiptapDirty, setTiptapDirty] = useState(false);
 
   const handleImprovePrompt = async () => {
-    if (isImproving) return;
+    if (!canMutateThread || isImproving) return;
     const parts = derivePartsFromTiptapDoc(tiptapDoc);
     const instructionsText = parts
       .filter((p): p is { type: "text"; text: string } => p.type === "text")
@@ -610,16 +610,18 @@ export function SettingsTab({
             <span className="text-xs font-semibold text-muted-foreground/60">
               {t("automations.automationDetail.instructions")}
             </span>
-            <Button
-              variant="outline"
-              size="sm"
-              className="h-7 gap-1.5 px-2 text-xs"
-              disabled={isImproving || !tiptapDoc}
-              onClick={handleImprovePrompt}
-            >
-              <Stars01 size={13} />
-              {t("automations.automationDetail.improve")}
-            </Button>
+            {canMutateThread && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-7 gap-1.5 px-2 text-xs"
+                disabled={isImproving || !tiptapDoc}
+                onClick={handleImprovePrompt}
+              >
+                <Stars01 size={13} />
+                {t("automations.automationDetail.improve")}
+              </Button>
+            )}
           </div>
           <TiptapProvider
             tiptapDoc={tiptapDoc}

--- a/apps/web/src/views/virtual-mcp/header-info.tsx
+++ b/apps/web/src/views/virtual-mcp/header-info.tsx
@@ -1,4 +1,5 @@
 import type { VirtualMCPEntity } from "@decocms/shared/sdk/types";
+import { useChatTask } from "@/components/chat/context";
 import { agentShowsGithubHeaderActions } from "@/lib/agent-capabilities";
 import { HeaderActions } from "../../components/thread/github/header-actions.tsx";
 import { DevAgentControl } from "../../components/dev-agent/dev-agent-control.tsx";
@@ -13,11 +14,13 @@ export function VirtualMcpHeaderInfo({
 }: {
   virtualMcp: VirtualMCPEntity;
 }) {
+  const { canMutateThread } = useChatTask();
+
   return (
     <div className="flex items-center gap-2">
       <OpenInBoardButton />
       <DevAgentControl virtualMcp={virtualMcp} />
-      {agentShowsGithubHeaderActions(virtualMcp) ? (
+      {canMutateThread && agentShowsGithubHeaderActions(virtualMcp) ? (
         <HeaderActions virtualMcpId={virtualMcp.id} />
       ) : null}
     </div>

--- a/apps/web/src/views/virtual-mcp/index.tsx
+++ b/apps/web/src/views/virtual-mcp/index.tsx
@@ -2,7 +2,7 @@ import { formatDistanceToNow } from "date-fns";
 import { ptBR as ptBRLocale } from "date-fns/locale/pt-BR";
 import { generatePrefixedId } from "@decocms/shared/utils/generate-id";
 import type { VirtualMCPEntity } from "@decocms/shared/sdk/types";
-import { useChatStream } from "@/components/chat/context";
+import { useChatStream, useChatTask } from "@/components/chat/context";
 import { buildImprovePromptDoc } from "@/components/chat/tiptap/build-improve-prompt-doc";
 import { EmptyState } from "@/components/empty-state.tsx";
 import { ErrorBoundary } from "@/components/error-boundary";
@@ -343,9 +343,10 @@ function VirtualMcpDetailViewWithData({
   const [isImproving, setIsImproving] = useState(false);
   const { createNewTask, openSidePanel } = usePanelActions();
   const { sendMessage } = useChatStream();
+  const { canMutateThread } = useChatTask();
 
   const handleImprovePrompt = async () => {
-    if (isImproving) return;
+    if (!canMutateThread || isImproving) return;
     const currentInstructions = form.getValues("metadata.instructions");
     if (!currentInstructions?.trim()) return;
 
@@ -964,18 +965,20 @@ function VirtualMcpDetailViewWithData({
                       {t("virtualMcp.virtualMcp.promptTemplate")}
                     </Button>
                   )}
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    disabled={
-                      isImproving ||
-                      !form.watch("metadata.instructions")?.trim()
-                    }
-                    onClick={handleImprovePrompt}
-                  >
-                    <Stars01 size={13} />
-                    {t("virtualMcp.virtualMcp.improve")}
-                  </Button>
+                  {canMutateThread && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={
+                        isImproving ||
+                        !form.watch("metadata.instructions")?.trim()
+                      }
+                      onClick={handleImprovePrompt}
+                    >
+                      <Stars01 size={13} />
+                      {t("virtualMcp.virtualMcp.improve")}
+                    </Button>
+                  )}
                 </div>
               </div>
               <Controller

--- a/packages/e2e/tests/hosted-runtime-boundary.spec.ts
+++ b/packages/e2e/tests/hosted-runtime-boundary.spec.ts
@@ -1,5 +1,6 @@
 import { retry } from "@decocms/shared/std";
 import type { APIRequestContext } from "@playwright/test";
+import { createServer } from "node:http";
 import { signUpViaApi } from "../fixtures/auth-api";
 import { connectDevDb } from "../fixtures/db";
 import { callSelfMcpTool, createHttpConnection } from "../fixtures/mcp-tools";
@@ -419,20 +420,130 @@ test.describe("hosted runtime boundary", () => {
 
   test("keeps an organization teammate from mutating another owner's thread", async ({
     authedPage,
+    browser,
     playwright,
   }) => {
+    test.setTimeout(60_000);
     const { page, orgSlug, user } = authedPage;
     const ownerApi = page.context().request;
     const memberApi = await newApiContext(playwright);
     const db = await connectDevDb();
+    const previewText = "Viewer-safe teammate sandbox preview";
+    const previewLog = "Viewer-safe teammate dev log";
+    const previewRequests: Array<{
+      method: string;
+      path: string;
+      accept: string | undefined;
+    }> = [];
+    const previewServer = createServer((request, response) => {
+      const path = new URL(request.url ?? "/", "http://127.0.0.1").pathname;
+      previewRequests.push({
+        method: request.method ?? "UNKNOWN",
+        path,
+        accept: request.headers.accept,
+      });
+
+      if (path === "/_sandbox/events") {
+        response.writeHead(200, {
+          "Access-Control-Allow-Origin": "*",
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+          "Content-Type": "text/event-stream",
+        });
+        response.flushHeaders();
+        response.write(
+          [
+            "event: lifecycle",
+            `data: ${JSON.stringify({
+              state: { phase: "running", port: 5173, htmlSupport: true },
+            })}`,
+            "",
+            "event: status",
+            `data: ${JSON.stringify({ state: "running" })}`,
+            "",
+            "event: scripts",
+            `data: ${JSON.stringify({ scripts: ["dev"] })}`,
+            "",
+            "event: tasks",
+            `data: ${JSON.stringify({
+              active: [{ id: "dev", command: "dev", logName: "dev" }],
+            })}`,
+            "",
+            "event: log",
+            `data: ${JSON.stringify({ source: "dev", data: `${previewLog}\n` })}`,
+            "",
+            "",
+          ].join("\n"),
+        );
+        return;
+      }
+
+      response.writeHead(200, { "Content-Type": "text/html; charset=utf-8" });
+      response.end(
+        `<!doctype html><html><body><main>${previewText}</main></body></html>`,
+      );
+    });
     try {
+      await new Promise<void>((resolve) =>
+        previewServer.listen(0, "127.0.0.1", resolve),
+      );
+      const previewAddress = previewServer.address();
+      if (!previewAddress || typeof previewAddress === "string") {
+        throw new Error("Teammate preview server did not bind to a TCP port");
+      }
+      const previewUrl = `http://127.0.0.1:${previewAddress.port}/`;
+
       const organizationId = await organizationIdForSlug(db, orgSlug);
       const agentId = await createAgent(
         ownerApi,
         orgSlug,
         "teammate boundary agent",
       );
+      const githubConnection = await createHttpConnection(ownerApi, orgSlug, {
+        title: "teammate boundary github",
+        url: "http://127.0.0.1:1/unused",
+      });
+      await callSelfMcpTool(
+        ownerApi,
+        orgSlug,
+        "COLLECTION_VIRTUAL_MCP_UPDATE",
+        {
+          id: agentId,
+          data: {
+            connections: [{ connection_id: githubConnection.id }],
+            metadata: {
+              githubRepo: {
+                url: "https://github.com/example/teammate-boundary",
+                owner: "example",
+                name: "teammate-boundary",
+                connectionId: githubConnection.id,
+              },
+            },
+          },
+        },
+      );
       const threadId = await createThread(ownerApi, orgSlug, agentId);
+      const sandboxBranch = `thread:${threadId}`;
+      await callSelfMcpTool(ownerApi, orgSlug, "COLLECTION_THREADS_UPDATE", {
+        id: threadId,
+        data: {
+          branch: sandboxBranch,
+          metadata: {
+            sandboxMap: {
+              [user.userId]: {
+                [sandboxBranch]: {
+                  "agent-sandbox": {
+                    sandboxHandle: `e2e-${threadId}`,
+                    previewUrl,
+                    sandboxProviderKind: "agent-sandbox",
+                    createdAt: Date.now(),
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
       const scope = { threadId, organizationId, userId: user.userId };
       const before = await readThreadAuthorityState(db, scope);
 
@@ -444,7 +555,6 @@ test.describe("hosted runtime boundary", () => {
         member.email,
       );
 
-      const sandboxBranch = `thread:${threadId}`;
       const sandboxBase = `/api/${orgSlug}/sandbox/${agentId}/${encodeURIComponent(
         sandboxBranch,
       )}`;
@@ -490,11 +600,26 @@ test.describe("hosted runtime boundary", () => {
       // suite has no hosted runner, so a request that passed the owner-only gate
       // reaches the normal runner-unavailable response instead of the mutation
       // 403.
-      const statusResponse = await memberApi.get(`${sandboxBase}/git/status`);
-      expect(statusResponse.status()).toBe(503);
-      expect(await statusResponse.json()).toEqual({
-        error: "No sandbox runner configured",
-      });
+      for (const request of [
+        { method: "GET", path: "/git/status" },
+        { method: "POST", path: "/git/status" },
+        { method: "POST", path: "/git/diff" },
+      ] as const) {
+        const response = await memberApi.fetch(
+          `${sandboxBase}${request.path}`,
+          {
+            method: request.method,
+            ...(request.method === "GET" ? {} : { data: {} }),
+          },
+        );
+        expect(
+          response.status(),
+          `${request.method} ${request.path} must remain viewer-safe`,
+        ).toBe(503);
+        expect(await response.json()).toEqual({
+          error: "No sandbox runner configured",
+        });
+      }
 
       const eventsResponse = await memberApi.get(`${sandboxBase}/events`, {
         headers: { Accept: "text/event-stream" },
@@ -529,8 +654,157 @@ test.describe("hosted runtime boundary", () => {
 
       expect(await readThreadAuthorityState(db, scope)).toEqual(before);
       await expectNoQueuedRun(ownerApi, orgSlug, threadId);
+
+      const memberContext = await browser.newContext({
+        storageState: await memberApi.storageState(),
+      });
+      try {
+        const memberPage = await memberContext.newPage();
+        await memberPage.addInitScript(
+          (key) => localStorage.setItem(key, JSON.stringify({ visible: true })),
+          `preview-terminal-visible:${agentId}`,
+        );
+
+        const sandboxEventsUrl = `${getE2EAppOrigin()}${sandboxBase}/events`;
+        let sandboxEventsResponses = 0;
+        await memberPage.route(sandboxEventsUrl, async (route) => {
+          sandboxEventsResponses++;
+          if (sandboxEventsResponses > 1) {
+            await route.fulfill({ status: 204, body: "" });
+            return;
+          }
+          await route.fulfill({
+            status: 200,
+            headers: {
+              "Cache-Control": "no-cache",
+              "Content-Type": "text/event-stream",
+            },
+            body: 'event: phase\ndata: {"kind":"ready"}\n\n',
+          });
+        });
+
+        const viewerSafeSandboxRequests: string[] = [];
+        const forbiddenWorkspaceRequests: string[] = [];
+        memberPage.on("request", (request) => {
+          const method = request.method();
+          const url = request.url();
+
+          const viewerSafeSandboxRequest =
+            (method === "GET" &&
+              (url.includes(`${sandboxBase}/events`) ||
+                url.includes(`${sandboxBase}/git/status`))) ||
+            (method === "POST" &&
+              (url.includes(`${sandboxBase}/git/status`) ||
+                url.includes(`${sandboxBase}/git/diff`)));
+          if (viewerSafeSandboxRequest) {
+            viewerSafeSandboxRequests.push(`${method} ${url}`);
+            return;
+          }
+
+          if (url.includes(`/api/${orgSlug}/sandbox/`)) {
+            forbiddenWorkspaceRequests.push(`${method} ${url}`);
+            return;
+          }
+          if (
+            method === "GET" &&
+            url.includes(`/api/${orgSlug}/decopilot/queue/${threadId}`)
+          ) {
+            forbiddenWorkspaceRequests.push(`${method} ${url}`);
+          }
+          if (method === "GET") return;
+
+          if (
+            url.includes("/tools/SANDBOX_") ||
+            url.includes("/tools/GIT_") ||
+            url.includes("/tools/FS_") ||
+            url.includes("/tools/COLLECTION_THREADS_UPDATE") ||
+            url.includes("/tools/COLLECTION_THREADS_DELETE") ||
+            url.includes(`/decopilot/threads/${threadId}/messages`) ||
+            url.includes(`/decopilot/cancel/${threadId}`) ||
+            url.includes(`/decopilot/flip/${threadId}`)
+          ) {
+            forbiddenWorkspaceRequests.push(`${method} ${url}`);
+          }
+        });
+
+        await memberPage.goto(
+          `/${orgSlug}/${threadId}?virtualmcpid=${agentId}&sidepanel=chat&main=preview`,
+        );
+
+        await expect(
+          memberPage.getByRole("button", { name: "Preview", exact: true }),
+        ).toBeVisible({ timeout: 30_000 });
+        await expect(
+          memberPage.getByRole("button", { name: "Code", exact: true }),
+        ).toHaveCount(0);
+        await expect(
+          memberPage.getByRole("button", { name: "Content", exact: true }),
+        ).toHaveCount(0);
+        await expect(
+          memberPage.getByRole("button", { name: "Publish", exact: true }),
+        ).toHaveCount(0);
+        await expect(
+          memberPage.getByRole("button", { name: /^sandbox$/i }),
+        ).toBeVisible();
+        await expect(
+          memberPage
+            .frameLocator('iframe[title="Dev Server Preview"]')
+            .getByText(previewText, { exact: true }),
+        ).toBeVisible({ timeout: 15_000 });
+        const devLogTab = memberPage.getByRole("button", {
+          name: "dev",
+          exact: true,
+        });
+        await expect(devLogTab).toBeVisible();
+        await devLogTab.click();
+        await expect(memberPage.locator(".xterm-rows")).toContainText(
+          previewLog,
+          { timeout: 15_000 },
+        );
+        for (const action of ["Start", "Stop", "Restart", "Resume", "Retry"]) {
+          await expect(
+            memberPage.getByRole("button", { name: action, exact: true }),
+          ).toHaveCount(0);
+        }
+        await memberPage.waitForTimeout(250);
+        expect(
+          viewerSafeSandboxRequests.some((request) =>
+            request.includes(`${sandboxBase}/events`),
+          ),
+        ).toBe(true);
+        expect(
+          previewRequests.some(
+            (request) =>
+              request.method === "GET" && request.path === "/_sandbox/events",
+          ),
+        ).toBe(true);
+        expect(
+          previewRequests.some(
+            (request) =>
+              request.method === "GET" &&
+              request.path === "/" &&
+              request.accept?.includes("text/html"),
+          ),
+        ).toBe(true);
+        expect(forbiddenWorkspaceRequests).toEqual([]);
+        expect(await readThreadAuthorityState(db, scope)).toEqual(before);
+        await expectNoQueuedRun(ownerApi, orgSlug, threadId);
+      } finally {
+        await memberContext.close();
+      }
     } finally {
-      await Promise.all([db.end(), memberApi.dispose()]);
+      previewServer.closeAllConnections();
+      await Promise.all([
+        db.end(),
+        memberApi.dispose(),
+        previewServer.listening
+          ? new Promise<void>((resolve, reject) =>
+              previewServer.close((error) =>
+                error ? reject(error) : resolve(),
+              ),
+            )
+          : Promise.resolve(),
+      ]);
     }
   });
 


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## How did you verify your code works?
> Name the tests you ran or added and what you observed. "Verified manually" or "existing tests" without specifics doesn't count.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces thread owner authority across the web app: only the thread creator can mutate a thread. Viewers get a safe, read‑only chat, sandbox, and source experience with guarded routing and UI.

- **Refactors**
  - Centralized authority in `thread-authority` with `resolveThreadMutationAuthority`, `canMutateThread`, and `canRenderInteractiveThreadApp`.
  - Source tabs and routing now viewer-safe: `getSourceSystemTabs`, `resolveViewerActiveTab`, and a fallback to Preview/Settings; non‑owners are routed away from Code.
  - Sandbox respects read‑only: lifecycle and VM terminal gated; preview drawer/toolbar block start/exec/kill/add/close; auto‑start and adopt‑branch checks require `canMutateThread`.
  - Chat and GitHub actions guard on `canMutateThread`: input, ice breakers, next action, cancel/stop, tool‑call “flip,” header actions, and rerun checks.

- **New Features**
  - Library previews honor read‑only via `resolveLibraryPreviewCapabilities`; inline HTML edit/share disabled; `LibraryFileTab`, dialogs, and `DeckTab` accept `readOnly`.
  - Main panel routes viewers to Preview instead of Code; Preview tab’s “Connect GitHub” CTA only shown/enabled for owners.
  - Tests added for authority resolution, viewer‑safe tabs/capabilities, and an e2e flow ensuring teammates can’t mutate another owner’s thread while still seeing safe sandbox/preview output.

<sup>Written for commit 20bb8437f58979c55a1b12637b56e0d85f65972d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

