### PR TITLE
refactor(web): make native terminal protocol strict

### DIFF
--- a/apps/web/src/desktop/agent-terminal/protocol.test.ts
+++ b/apps/web/src/desktop/agent-terminal/protocol.test.ts
@@ -14,17 +14,17 @@ import {
 } from "./protocol";
 
 describe("native terminal protocol", () => {
-  test("parses camelCase and snake_case lifecycle frames", () => {
+  test("parses the canonical camelCase lifecycle frames", () => {
     expect(
       parseTerminalServerFrame(
         JSON.stringify({
           type: "ready",
-          session_id: "session-1",
+          sessionId: "session-1",
           generation: "thread-generation-3",
-          harness_id: "claude-code",
-          physical_state: "running",
-          logical_state: "idle",
-          last_seq: 12,
+          harnessId: "claude-code",
+          physicalState: "running",
+          logicalState: "idle",
+          lastSeq: 12,
         }),
       ),
     ).toEqual({
@@ -71,6 +71,101 @@ describe("native terminal protocol", () => {
       message: "coding agent is busy",
       retryable: false,
       requestId: "request-1",
+    });
+  });
+
+  test("rejects legacy snake_case lifecycle and output fields", () => {
+    expect(
+      parseTerminalServerFrame(
+        JSON.stringify({
+          type: "ready",
+          session_id: "session-1",
+          generation: "thread-generation-3",
+          harness_id: "claude-code",
+          physical_state: "running",
+          logical_state: "idle",
+          last_seq: 12,
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      parseTerminalServerFrame(
+        JSON.stringify({
+          type: "ready",
+          sessionId: "session-1",
+          session_id: "retired-session",
+          generation: "thread-generation-3",
+          harnessId: "codex",
+          physicalState: "running",
+          logicalState: "idle",
+          lastSeq: 12,
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      parseTerminalServerFrame(
+        JSON.stringify({
+          type: "output",
+          seq: 1,
+          data_base64: btoa("legacy"),
+          replay: false,
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      parseTerminalServerFrame(
+        JSON.stringify({
+          type: "output",
+          seq: 1,
+          dataBase64: btoa("canonical"),
+          data_base64: btoa("retired"),
+          replay: false,
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      parseTerminalServerFrame(
+        JSON.stringify({
+          type: "output",
+          seq: 1,
+          data: "legacy plaintext",
+          replay: false,
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      parseTerminalServerFrame(
+        JSON.stringify({
+          type: "prompt_accepted",
+          request_id: "legacy-request",
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  test("rejects the removed claude harness alias while allowing omission", () => {
+    expect(
+      parseTerminalServerFrame(
+        JSON.stringify({
+          type: "state",
+          physicalState: "running",
+          logicalState: "idle",
+          harnessId: "claude",
+        }),
+      ),
+    ).toBeNull();
+    expect(
+      parseTerminalServerFrame(
+        JSON.stringify({
+          type: "state",
+          physicalState: "running",
+          logicalState: "idle",
+        }),
+      ),
+    ).toEqual({
+      type: "state",
+      physicalState: "running",
+      logicalState: "idle",
     });
   });
 
@@ -160,6 +255,7 @@ describe("native terminal protocol", () => {
     expect(toTerminalHarnessId("claude-code")).toBe("claude-code");
     expect(toTerminalHarnessId("codex")).toBe("codex");
     expect(toTerminalHarnessId("opencode")).toBe("opencode");
+    expect(toTerminalHarnessId("claude")).toBeNull();
     expect(toTerminalHarnessId("decopilot")).toBeNull();
     expect(fromTerminalHarnessId("claude-code")).toBe("claude-code");
     expect(fromTerminalHarnessId("opencode")).toBe("opencode");

--- a/apps/web/src/desktop/agent-terminal/protocol.ts
+++ b/apps/web/src/desktop/agent-terminal/protocol.ts
@@ -113,6 +113,14 @@ function record(value: unknown): Record<string, unknown> | null {
   return value as Record<string, unknown>;
 }
 
+function hasOnlyKeys(
+  value: Record<string, unknown>,
+  keys: readonly string[],
+): boolean {
+  const allowed = new Set(keys);
+  return Object.keys(value).every((key) => allowed.has(key));
+}
+
 function safeSequence(value: unknown): number | null {
   return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
     ? value
@@ -206,22 +214,11 @@ export function shouldResetTerminalReplay(
 }
 
 function terminalHarnessId(value: unknown): TerminalHarnessId | undefined {
-  if (value === "claude" || value === "claude-code") return "claude-code";
-  if (value === "codex") return "codex";
-  if (value === "opencode") return "opencode";
-  return undefined;
-}
-
-function field(
-  value: Record<string, unknown>,
-  camelCase: string,
-  snakeCase: string,
-): unknown {
-  return value[camelCase] ?? value[snakeCase];
+  return toTerminalHarnessId(value) ?? undefined;
 }
 
 function outputBytes(value: Record<string, unknown>): Uint8Array | null {
-  const base64 = field(value, "dataBase64", "data_base64");
+  const base64 = value.dataBase64;
   if (typeof base64 === "string") {
     try {
       const binary = atob(base64);
@@ -230,10 +227,7 @@ function outputBytes(value: Record<string, unknown>): Uint8Array | null {
       return null;
     }
   }
-  // Transitional compatibility for early fixtures and local-api builds.
-  return typeof value.data === "string"
-    ? new TextEncoder().encode(value.data)
-    : null;
+  return null;
 }
 
 /** Parse and validate the untrusted control frames received from local-api. */
@@ -253,14 +247,23 @@ export function parseTerminalServerFrame(
 
   switch (value.type) {
     case "ready": {
+      if (
+        !hasOnlyKeys(value, [
+          "type",
+          "sessionId",
+          "generation",
+          "harnessId",
+          "physicalState",
+          "logicalState",
+          "lastSeq",
+        ])
+      ) {
+        return null;
+      }
       const generation = value.generation;
-      const physical = physicalState(
-        field(value, "physicalState", "physical_state"),
-      );
-      const logical = logicalState(
-        field(value, "logicalState", "logical_state"),
-      );
-      const lastSeq = safeSequence(field(value, "lastSeq", "last_seq"));
+      const physical = physicalState(value.physicalState);
+      const logical = logicalState(value.logicalState);
+      const lastSeq = safeSequence(value.lastSeq);
       if (
         typeof generation !== "string" ||
         generation.length === 0 ||
@@ -270,24 +273,23 @@ export function parseTerminalServerFrame(
       ) {
         return null;
       }
-      const sessionId = field(value, "sessionId", "session_id");
+      const sessionId = value.sessionId;
+      const harnessId = terminalHarnessId(value.harnessId);
+      if (value.harnessId !== undefined && !harnessId) return null;
       return {
         type: "ready",
         ...(typeof sessionId === "string" ? { sessionId } : {}),
         generation,
-        ...(terminalHarnessId(field(value, "harnessId", "harness_id"))
-          ? {
-              harnessId: terminalHarnessId(
-                field(value, "harnessId", "harness_id"),
-              ),
-            }
-          : {}),
+        ...(harnessId ? { harnessId } : {}),
         physicalState: physical,
         logicalState: logical,
         lastSeq,
       };
     }
     case "output": {
+      if (!hasOnlyKeys(value, ["type", "seq", "dataBase64", "replay"])) {
+        return null;
+      }
       const seq = safeSequence(value.seq);
       const data = outputBytes(value);
       if (seq === null || !data) return null;
@@ -299,28 +301,35 @@ export function parseTerminalServerFrame(
       };
     }
     case "reset": {
+      if (!hasOnlyKeys(value, ["type", "seq", "dataBase64"])) return null;
       const seq = safeSequence(value.seq);
       const data = outputBytes(value);
       if (seq === null || !data) return null;
       return { type: "reset", seq, data };
     }
     case "state": {
-      const physical = physicalState(
-        field(value, "physicalState", "physical_state"),
-      );
-      const logical = logicalState(
-        field(value, "logicalState", "logical_state"),
-      );
+      if (
+        !hasOnlyKeys(value, [
+          "type",
+          "physicalState",
+          "logicalState",
+          "threadStatus",
+          "harnessId",
+        ])
+      ) {
+        return null;
+      }
+      const physical = physicalState(value.physicalState);
+      const logical = logicalState(value.logicalState);
       if (!physical || !logical) return null;
-      const rawThreadStatus = field(value, "threadStatus", "thread_status");
+      const rawThreadStatus = value.threadStatus;
       const threadStatus =
         typeof rawThreadStatus === "string" &&
         THREAD_STATUSES.has(rawThreadStatus as ThreadDisplayStatus)
           ? (rawThreadStatus as ThreadDisplayStatus)
           : undefined;
-      const harnessId = terminalHarnessId(
-        field(value, "harnessId", "harness_id"),
-      );
+      const harnessId = terminalHarnessId(value.harnessId);
+      if (value.harnessId !== undefined && !harnessId) return null;
       return {
         type: "state",
         physicalState: physical,
@@ -330,12 +339,16 @@ export function parseTerminalServerFrame(
       };
     }
     case "prompt_accepted": {
-      const requestId = field(value, "requestId", "request_id");
+      if (!hasOnlyKeys(value, ["type", "requestId"])) return null;
+      const requestId = value.requestId;
       return typeof requestId === "string" && requestId
         ? { type: "prompt_accepted", requestId }
         : null;
     }
     case "exit": {
+      if (!hasOnlyKeys(value, ["type", "code", "signal", "expected"])) {
+        return null;
+      }
       const code = value.code;
       const signal = value.signal;
       return {
@@ -346,10 +359,21 @@ export function parseTerminalServerFrame(
       };
     }
     case "error": {
+      if (
+        !hasOnlyKeys(value, [
+          "type",
+          "code",
+          "message",
+          "retryable",
+          "requestId",
+        ])
+      ) {
+        return null;
+      }
       if (typeof value.code !== "string" || typeof value.message !== "string") {
         return null;
       }
-      const requestId = field(value, "requestId", "request_id");
+      const requestId = value.requestId;
       return {
         type: "error",
         code: value.code,

--- a/apps/web/src/desktop/agent-terminal/terminal-controller.test.ts
+++ b/apps/web/src/desktop/agent-terminal/terminal-controller.test.ts
@@ -67,6 +67,15 @@ function runningReady(harnessId: "claude-code" | "codex") {
   };
 }
 
+function outputFrame(seq: number, data: string, replay: boolean) {
+  return {
+    type: "output",
+    seq,
+    dataBase64: btoa(data),
+    replay,
+  };
+}
+
 beforeEach(() => {
   TestWebSocket.instances = [];
   Object.defineProperty(globalThis, "window", {
@@ -246,7 +255,7 @@ describe("native terminal capability reply authority", () => {
     const socket = TestWebSocket.instances[0]!;
     socket.open();
     socket.receive(runningReady("codex"));
-    socket.receive({ type: "output", seq: 5, data: "\x1b[", replay: false });
+    socket.receive(outputFrame(5, "\x1b[", false));
     unsubscribeInitial();
 
     const remountAuthority = createTerminalParserCapabilityQueryAuthority();
@@ -274,12 +283,7 @@ describe("native terminal capability reply authority", () => {
     const replacement = TestWebSocket.instances[1]!;
     replacement.open();
     replacement.receive({ ...runningReady("codex"), lastSeq: 5 });
-    replacement.receive({
-      type: "output",
-      seq: 10,
-      data: "c",
-      replay: false,
-    });
+    replacement.receive(outputFrame(10, "c", false));
     expect(remountAuthority.takeReplyAuthority({ kind: "da1" })).toBeTrue();
     unsubscribeRemount();
 
@@ -312,8 +316,8 @@ describe("native terminal capability reply authority", () => {
     const socket = TestWebSocket.instances[0]!;
     socket.open();
     socket.receive(runningReady("codex"));
-    socket.receive({ type: "output", seq: 5, data: "\x1b[", replay: false });
-    socket.receive({ type: "output", seq: 10, data: "0", replay: false });
+    socket.receive(outputFrame(5, "\x1b[", false));
+    socket.receive(outputFrame(10, "0", false));
     unsubscribeInitial();
 
     const remountAuthority = createTerminalParserCapabilityQueryAuthority();
@@ -331,7 +335,7 @@ describe("native terminal capability reply authority", () => {
     const replacement = TestWebSocket.instances[1]!;
     replacement.open();
     replacement.receive({ ...runningReady("codex"), lastSeq: 10 });
-    replacement.receive({ type: "output", seq: 15, data: "c", replay: false });
+    replacement.receive(outputFrame(15, "c", false));
     expect(remountAuthority.takeReplyAuthority({ kind: "da1" })).toBeTrue();
     expect(remountAuthority.takeReplyAuthority({ kind: "da1" })).toBeFalse();
 
@@ -349,12 +353,7 @@ describe("native terminal capability reply authority", () => {
     const socket = TestWebSocket.instances[0]!;
     socket.open();
     socket.receive(runningReady("codex"));
-    socket.receive({
-      type: "output",
-      seq: 5,
-      data: "\x1b[c",
-      replay: false,
-    });
+    socket.receive(outputFrame(5, "\x1b[c", false));
 
     let staleAcknowledge = () => {};
     let firstAllowed = false;
@@ -406,12 +405,7 @@ describe("native terminal capability reply authority", () => {
     const socket = TestWebSocket.instances[0]!;
     socket.open();
     socket.receive(runningReady("codex"));
-    socket.receive({
-      type: "output",
-      seq: 5,
-      data: "\x1b]10;?\x1b\\",
-      replay: true,
-    });
+    socket.receive(outputFrame(5, "\x1b]10;?\x1b\\", true));
 
     const firstFrames: Array<{
       seq: number;
@@ -444,12 +438,7 @@ describe("native terminal capability reply authority", () => {
       { seq: 5, allowCapabilityReplies: false },
     ]);
 
-    socket.receive({
-      type: "output",
-      seq: 10,
-      data: "\x1b[14t",
-      replay: false,
-    });
+    socket.receive(outputFrame(10, "\x1b[14t", false));
     expect(firstFrames.at(-1)).toEqual({
       seq: 10,
       allowCapabilityReplies: true,
@@ -488,8 +477,8 @@ describe("native terminal capability reply authority", () => {
     const first = TestWebSocket.instances[0]!;
     first.open();
     first.receive(runningReady("codex"));
-    first.receive({ type: "output", seq: 5, data: "history", replay: true });
-    first.receive({ type: "output", seq: 10, data: "live", replay: false });
+    first.receive(outputFrame(5, "history", true));
+    first.receive(outputFrame(10, "live", false));
     expect(received).toEqual([
       { seq: 5, allowCapabilityReplies: false },
       { seq: 10, allowCapabilityReplies: true },
@@ -500,18 +489,8 @@ describe("native terminal capability reply authority", () => {
     const replacement = TestWebSocket.instances[1]!;
     replacement.open();
     replacement.receive({ ...runningReady("codex"), lastSeq: 15 });
-    replacement.receive({
-      type: "output",
-      seq: 10,
-      data: "duplicate",
-      replay: true,
-    });
-    replacement.receive({
-      type: "output",
-      seq: 15,
-      data: "missed while disconnected",
-      replay: true,
-    });
+    replacement.receive(outputFrame(10, "duplicate", true));
+    replacement.receive(outputFrame(15, "missed while disconnected", true));
     expect(received).toEqual([
       { seq: 5, allowCapabilityReplies: false },
       { seq: 10, allowCapabilityReplies: true },


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## How did you verify your code works?
> Name the tests you ran or added and what you observed. "Verified manually" or "existing tests" without specifics doesn't count.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces a strict native terminal protocol: only canonical camelCase fields and allowed keys per frame are accepted; output bytes must use base64; legacy snake_case, plaintext output, and the `claude` harness alias are rejected.

- **Refactors**
  - Enforces per-frame allowed keys for `ready`, `output`, `reset`, `state`, `prompt_accepted`, `exit`, and `error`.
  - Removes all snake_case/mixed-case fallbacks; camelCase only.
  - Requires `dataBase64` for `output`/`reset`; rejects `data` and `data_base64`.
  - Validates `harnessId` (`claude-code`, `codex`, `opencode`); rejects `claude`; omission allowed.
  - Updates tests for strict parsing and converts terminal-controller tests to base64 frames.

- **Migration**
  - Send camelCase fields only and include no extra keys.
  - Use `dataBase64` for all output bytes.
  - Use allowed `harnessId` values or omit it; stop sending `claude`.

<sup>Written for commit cc3f51a01171023510a53d3db75da509f955b28d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

