### PR TITLE
feat(threads): add selector-free routing authority

### DIFF
--- a/apps/api/migrations/158-thread-routing-lock.integration.test.ts
+++ b/apps/api/migrations/158-thread-routing-lock.integration.test.ts
@@ -1,0 +1,278 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { type Kysely, sql } from "kysely";
+import type { StudioDatabase } from "../src/database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+  seedCommonTestPgFixtures,
+} from "../src/database/test-db-pg";
+import { SqlThreadStorage } from "../src/storage/threads";
+import { down, up } from "./158-thread-routing-lock";
+
+const ROUTING_COLUMNS = [
+  "routing_locked_at",
+  "hosted_execution_disabled_at",
+] as const;
+
+async function routingColumns(database: StudioDatabase) {
+  const result = await sql<{
+    column_name: string;
+    data_type: string;
+    is_nullable: string;
+  }>`
+    SELECT column_name, data_type, is_nullable
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'threads'
+      AND column_name IN (
+        'routing_locked_at',
+        'hosted_execution_disabled_at'
+      )
+    ORDER BY column_name
+  `.execute(database.db);
+  return result.rows;
+}
+
+describe("migration 158: thread routing lock", () => {
+  let database: StudioDatabase;
+  let migrationDb: Kysely<unknown>;
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    await seedCommonTestPgFixtures(database);
+    migrationDb = database.db as unknown as Kysely<unknown>;
+
+    // Recover cleanly if an interrupted local run stopped after `down`.
+    if ((await routingColumns(database)).length === 0) {
+      await up(migrationDb);
+    }
+  });
+
+  afterAll(async () => {
+    if (database) {
+      if ((await routingColumns(database)).length === 0) {
+        await up(migrationDb);
+      }
+      await closeTestPgDatabase(database);
+    }
+  });
+
+  it("backfills authority and fails closed without locking pristine drafts", async () => {
+    const storage = new SqlThreadStorage(database.db);
+    const create = async (
+      id: string,
+      data: {
+        status?: "completed" | "in_progress" | "requires_action" | "failed";
+        harness_id?: string | null;
+        sandbox_provider_kind?: string | null;
+      } = {},
+    ) =>
+      storage.create({
+        id,
+        organization_id: "org_1",
+        created_by: "user_1",
+        title: id,
+        ...data,
+      });
+
+    await create("thrd_158_pristine");
+    await create("thrd_158_canonical", {
+      harness_id: "decopilot",
+      sandbox_provider_kind: "agent-sandbox",
+    });
+    await create("thrd_158_claimable_partial", {
+      sandbox_provider_kind: "agent-sandbox",
+    });
+    await create("thrd_158_native", {
+      harness_id: "codex",
+      sandbox_provider_kind: "user-desktop",
+    });
+    await create("thrd_158_incomplete", { harness_id: "decopilot" });
+    await create("thrd_158_unknown_provider", {
+      sandbox_provider_kind: "cluster",
+    });
+    await create("thrd_158_message_history");
+    await create("thrd_158_part_history");
+    await create("thrd_158_in_progress", { status: "in_progress" });
+    await create("thrd_158_requires_action", { status: "requires_action" });
+    await create("thrd_158_failed", { status: "failed" });
+    await create("thrd_158_run_evidence");
+    await storage.update("thrd_158_run_evidence", "org_1", {
+      run_started_at: "2026-08-01T12:00:00.000Z",
+    });
+
+    const now = new Date().toISOString();
+    await sql`
+      INSERT INTO thread_messages (
+        id, thread_id, metadata, parts, role, created_at, updated_at
+      ) VALUES (
+        'msg_158_history',
+        'thrd_158_message_history',
+        NULL,
+        '[]',
+        'user',
+        ${now},
+        ${now}
+      )
+    `.execute(database.db);
+    await sql`
+      INSERT INTO thread_message_parts (
+        id, seq, org_id, thread_id, run_id, message_id, role, kind,
+        payload, payload_ref, metadata, created_at
+      ) VALUES (
+        'part_158_history',
+        1,
+        'org_1',
+        'thrd_158_part_history',
+        'run_158_history',
+        'msg_158_part_history',
+        'user',
+        'text',
+        ${JSON.stringify({ type: "text", text: "started" })}::jsonb,
+        NULL,
+        NULL,
+        ${now}
+      )
+    `.execute(database.db);
+
+    // Re-run the migration over the seeded pre-158 state.
+    await down(migrationDb);
+    expect(await routingColumns(database)).toEqual([]);
+    await up(migrationDb);
+
+    expect(await routingColumns(database)).toEqual([
+      {
+        column_name: "hosted_execution_disabled_at",
+        data_type: "timestamp with time zone",
+        is_nullable: "YES",
+      },
+      {
+        column_name: "routing_locked_at",
+        data_type: "timestamp with time zone",
+        is_nullable: "YES",
+      },
+    ]);
+
+    const result = await sql<{
+      id: string;
+      harness_id: string | null;
+      sandbox_provider_kind: string | null;
+      routing_locked: boolean;
+      hosted_disabled: boolean;
+    }>`
+      SELECT
+        id,
+        harness_id,
+        sandbox_provider_kind,
+        routing_locked_at IS NOT NULL AS routing_locked,
+        hosted_execution_disabled_at IS NOT NULL AS hosted_disabled
+      FROM threads
+      WHERE id LIKE 'thrd_158_%'
+      ORDER BY id COLLATE "C"
+    `.execute(database.db);
+
+    expect(result.rows).toEqual([
+      {
+        id: "thrd_158_canonical",
+        harness_id: "decopilot",
+        sandbox_provider_kind: "agent-sandbox",
+        routing_locked: true,
+        hosted_disabled: false,
+      },
+      {
+        id: "thrd_158_claimable_partial",
+        harness_id: "decopilot",
+        sandbox_provider_kind: "agent-sandbox",
+        routing_locked: true,
+        hosted_disabled: false,
+      },
+      {
+        id: "thrd_158_failed",
+        harness_id: "decopilot",
+        sandbox_provider_kind: "agent-sandbox",
+        routing_locked: true,
+        hosted_disabled: false,
+      },
+      {
+        id: "thrd_158_in_progress",
+        harness_id: "decopilot",
+        sandbox_provider_kind: "agent-sandbox",
+        routing_locked: true,
+        hosted_disabled: false,
+      },
+      {
+        id: "thrd_158_incomplete",
+        harness_id: "decopilot",
+        sandbox_provider_kind: null,
+        routing_locked: true,
+        hosted_disabled: true,
+      },
+      {
+        id: "thrd_158_message_history",
+        harness_id: "decopilot",
+        sandbox_provider_kind: "agent-sandbox",
+        routing_locked: true,
+        hosted_disabled: false,
+      },
+      {
+        id: "thrd_158_native",
+        harness_id: "codex",
+        sandbox_provider_kind: "user-desktop",
+        routing_locked: true,
+        hosted_disabled: true,
+      },
+      {
+        id: "thrd_158_part_history",
+        harness_id: "decopilot",
+        sandbox_provider_kind: "agent-sandbox",
+        routing_locked: true,
+        hosted_disabled: false,
+      },
+      {
+        id: "thrd_158_pristine",
+        harness_id: null,
+        sandbox_provider_kind: null,
+        routing_locked: false,
+        hosted_disabled: false,
+      },
+      {
+        id: "thrd_158_requires_action",
+        harness_id: "decopilot",
+        sandbox_provider_kind: "agent-sandbox",
+        routing_locked: true,
+        hosted_disabled: false,
+      },
+      {
+        id: "thrd_158_run_evidence",
+        harness_id: "decopilot",
+        sandbox_provider_kind: "agent-sandbox",
+        routing_locked: true,
+        hosted_disabled: false,
+      },
+      {
+        id: "thrd_158_unknown_provider",
+        harness_id: null,
+        sandbox_provider_kind: "cluster",
+        routing_locked: true,
+        hosted_disabled: true,
+      },
+    ]);
+
+    // The migration changes authority metadata only; adjacent history remains.
+    const history = await sql<{ count: number }>`
+      SELECT count(*)::integer AS count
+      FROM thread_messages
+      WHERE thread_id = 'thrd_158_message_history'
+    `.execute(database.db);
+    expect(history.rows).toEqual([{ count: 1 }]);
+
+    await down(migrationDb);
+    expect(await routingColumns(database)).toEqual([]);
+    await up(migrationDb);
+    expect(
+      (await routingColumns(database)).map((row) => row.column_name),
+    ).toEqual([...ROUTING_COLUMNS].sort());
+  });
+});

--- a/apps/api/migrations/158-thread-routing-lock.ts
+++ b/apps/api/migrations/158-thread-routing-lock.ts
@@ -1,0 +1,88 @@
+import { sql, type Kysely } from "kysely";
+
+/**
+ * Introduce selector-independent routing authority for threads.
+ *
+ * This is the expand half of the routing-lock migration: existing selectors
+ * remain in place and continue to drive reads, while every historical thread
+ * with evidence of execution is conservatively locked. Retired or malformed
+ * selector tuples are also marked ineligible for hosted execution so the
+ * later switch cannot accidentally make them claimable.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("threads")
+    .addColumn("routing_locked_at", "timestamptz")
+    .addColumn("hosted_execution_disabled_at", "timestamptz")
+    .execute();
+
+  // The timestamp is an authority marker, not a reconstructed audit event.
+  // Use the database clock rather than casting legacy text timestamps: old
+  // rows only need to stay locked, even if their historical dates are bad.
+  await sql`
+    UPDATE threads AS thread
+    SET routing_locked_at = now()
+    WHERE routing_locked_at IS NULL
+      AND (
+        thread.harness_id IS NOT NULL
+        OR thread.sandbox_provider_kind IS NOT NULL
+        OR thread.status <> 'completed'
+        OR thread.context_start_message_id IS NOT NULL
+        OR thread.run_owner_pod IS NOT NULL
+        OR thread.run_config IS NOT NULL
+        OR thread.run_started_at IS NOT NULL
+        OR thread.last_progress_at IS NOT NULL
+        OR thread.inflight_async_jobs IS NOT NULL
+        OR thread.run_fence_token IS NOT NULL
+        OR thread.cancel_requested_at IS NOT NULL
+        OR thread.failure_reason IS NOT NULL
+        OR thread.failure_kind IS NOT NULL
+        OR thread.run_acked_seq IS NOT NULL
+        OR EXISTS (
+          SELECT 1
+          FROM thread_messages AS message
+          WHERE message.thread_id = thread.id
+        )
+        OR EXISTS (
+          SELECT 1
+          FROM thread_message_parts AS part
+          WHERE part.thread_id = thread.id
+        )
+      )
+  `.execute(db);
+
+  await sql`
+    UPDATE threads
+    SET hosted_execution_disabled_at = now()
+    WHERE hosted_execution_disabled_at IS NULL
+      AND CASE
+        WHEN harness_id IS NULL AND sandbox_provider_kind IS NULL THEN false
+        WHEN harness_id IS NULL
+          AND sandbox_provider_kind = 'agent-sandbox' THEN false
+        WHEN harness_id = 'decopilot'
+          AND sandbox_provider_kind = 'agent-sandbox' THEN false
+        ELSE true
+      END
+  `.execute(db);
+
+  // Keep old and new application pods interoperable during the rolling
+  // switch. The durable lock is the new authority, but expand-version readers
+  // still inspect the selectors. Canonicalize every enabled locked thread only
+  // after incompatible historical tuples have been tombstoned above.
+  await sql`
+    UPDATE threads
+    SET
+      harness_id = 'decopilot',
+      sandbox_provider_kind = 'agent-sandbox'
+    WHERE routing_locked_at IS NOT NULL
+      AND hosted_execution_disabled_at IS NULL
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("threads")
+    .dropColumn("hosted_execution_disabled_at")
+    .dropColumn("routing_locked_at")
+    .execute();
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -156,6 +156,7 @@ import * as migration154taskboardqaactivity from "./154-task-board-qa-activity.t
 import * as migration155taskboardreviewclaims from "./155-task-board-review-claims.ts";
 import * as migration156taskboardconflictactivity from "./156-task-board-conflict-activity.ts";
 import * as migration157dropthreadlinktransport from "./157-drop-thread-link-transport.ts";
+import * as migration158threadroutinglock from "./158-thread-routing-lock.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -338,6 +339,7 @@ const migrations: Record<string, Migration> = {
   "155-task-board-review-claims": migration155taskboardreviewclaims,
   "156-task-board-conflict-activity": migration156taskboardconflictactivity,
   "157-drop-thread-link-transport": migration157dropthreadlinktransport,
+  "158-thread-routing-lock": migration158threadroutinglock,
 };
 
 export default migrations;

--- a/apps/api/src/api/watch.test.ts
+++ b/apps/api/src/api/watch.test.ts
@@ -140,6 +140,9 @@ function makeThread(overrides: Partial<Thread>): Thread {
     branch: overrides.branch ?? null,
     sandbox_provider_kind: overrides.sandbox_provider_kind ?? null,
     harness_id: overrides.harness_id ?? null,
+    routing_locked_at: overrides.routing_locked_at ?? null,
+    hosted_execution_disabled_at:
+      overrides.hosted_execution_disabled_at ?? null,
     metadata: overrides.metadata ?? {},
     created_at: overrides.created_at ?? "2026-01-01T00:00:00.000Z",
     updated_at: overrides.updated_at ?? "2026-01-01T00:00:00.000Z",

--- a/apps/api/src/storage/automations.ts
+++ b/apps/api/src/storage/automations.ts
@@ -598,6 +598,8 @@ class KyselyAutomationsStorage implements AutomationsStorage {
         virtual_mcp_id: automation.virtual_mcp_id,
         harness_id: "decopilot",
         sandbox_provider_kind: "agent-sandbox",
+        routing_locked_at: now,
+        hosted_execution_disabled_at: null,
         hidden: false,
         // Pin v2 (the only write path). Automation runs don't go through the
         // routes.ts first-message site that pins user-message threads v2, so

--- a/apps/api/src/storage/ports.ts
+++ b/apps/api/src/storage/ports.ts
@@ -69,9 +69,10 @@ export interface ThreadStoragePort {
     data: ThreadUpdateData,
   ): Promise<Thread>;
   /**
-   * Apply an update only while no runtime has claimed the thread. Used for
-   * agent/branch mutations so a concurrent hosted/native pin cannot race a
-   * preceding read and move a started chat to another execution context.
+   * Apply an update only while both the durable routing lock and the legacy
+   * harness selector remain unset. The dual predicate is the expand-phase CAS:
+   * new pods honor `routing_locked_at`, while `harness_id IS NULL` keeps them
+   * safe when racing an older pod that has not learned to mint the lock yet.
    */
   updateRoutingIfRuntimeUnlocked(
     id: string,
@@ -81,9 +82,9 @@ export interface ThreadStoragePort {
   /**
    * Atomically pin an unlocked thread to the hosted Decopilot runtime. The
    * runtime identifiers are storage-owned constants; callers supply only the
-   * branch and optional message format. The `harness_id IS NULL` predicate is
-   * the lock, while the provider predicate preserves a concurrent partial
-   * native claim.
+   * branch and optional message format. During the expand phase this also
+   * mints `routing_locked_at`, while the existing selector predicates remain
+   * the concurrency guard until every reader switches to the durable lock.
    */
   pinHostedRuntimeIfUnset(
     id: string,

--- a/apps/api/src/storage/threads.integration.test.ts
+++ b/apps/api/src/storage/threads.integration.test.ts
@@ -193,6 +193,26 @@ describe("SqlThreadStorage", () => {
       expect(thread.harness_id).toBe("decopilot");
       expect(thread.sandbox_provider_kind).toBe("agent-sandbox");
       expect(thread.branch).toBe("main");
+      expect(thread.routing_locked_at).not.toBeNull();
+      expect(thread.hosted_execution_disabled_at).toBeNull();
+    });
+
+    it("keeps pristine drafts unlocked and retires incompatible creates", async () => {
+      const draft = await storage.create({
+        organization_id: "org_1",
+        created_by: "user_1",
+      });
+      expect(draft.routing_locked_at).toBeNull();
+      expect(draft.hosted_execution_disabled_at).toBeNull();
+
+      const retired = await storage.create({
+        organization_id: "org_1",
+        created_by: "user_1",
+        harness_id: "codex",
+        sandbox_provider_kind: "user-desktop",
+      });
+      expect(retired.routing_locked_at).not.toBeNull();
+      expect(retired.hosted_execution_disabled_at).not.toBeNull();
     });
 
     it("does not overwrite a concurrent native runtime claim", async () => {
@@ -211,6 +231,8 @@ describe("SqlThreadStorage", () => {
             harness_id: "codex",
             sandbox_provider_kind: "user-desktop",
             branch: "native",
+            routing_locked_at: sql`coalesce(routing_locked_at, now())`,
+            hosted_execution_disabled_at: sql`coalesce(hosted_execution_disabled_at, now())`,
             updated_at: new Date().toISOString(),
           })
           .where("id", "=", thread.id)
@@ -230,15 +252,40 @@ describe("SqlThreadStorage", () => {
           harness_id: "decopilot",
           sandbox_provider_kind: "agent-sandbox",
           branch: "hosted",
+          routing_locked_at: expect.any(String),
         });
       } else {
         expect(persisted).toMatchObject({
           harness_id: "codex",
           sandbox_provider_kind: "user-desktop",
           branch: "native",
+          routing_locked_at: expect.any(String),
+          hosted_execution_disabled_at: expect.any(String),
         });
       }
       expect(hostedClaim.thread).toEqual(persisted);
+    });
+
+    it("claims the routing lock exactly once with the hosted runtime", async () => {
+      const thread = await storage.create({
+        organization_id: "org_1",
+        created_by: "user_1",
+      });
+      expect(thread.routing_locked_at).toBeNull();
+
+      const first = await storage.pinHostedRuntimeIfUnset(thread.id, "org_1", {
+        branch: "main",
+      });
+      expect(first.claimed).toBe(true);
+      expect(first.thread?.routing_locked_at).not.toBeNull();
+      const lockedAt = first.thread?.routing_locked_at;
+
+      const second = await storage.pinHostedRuntimeIfUnset(thread.id, "org_1", {
+        branch: "other",
+      });
+      expect(second.claimed).toBe(false);
+      expect(second.thread?.routing_locked_at).toBe(lockedAt);
+      expect(second.thread?.hosted_execution_disabled_at).toBeNull();
     });
 
     it("preserves branch state written before the runtime claim", async () => {
@@ -288,6 +335,28 @@ describe("SqlThreadStorage", () => {
         virtual_mcp_id: "agent-after",
         branch: "feature",
         harness_id: null,
+      });
+
+      const selectorFreeLocked = await storage.create({
+        organization_id: "org_1",
+        created_by: "user_1",
+        virtual_mcp_id: "locked-agent",
+        branch: "locked-branch",
+        routing_locked_at: "2026-08-01T00:00:00.000Z",
+      });
+      expect(selectorFreeLocked.harness_id).toBeNull();
+      expect(
+        await storage.updateRoutingIfRuntimeUnlocked(
+          selectorFreeLocked.id,
+          "org_1",
+          { virtual_mcp_id: "too-late", branch: "too-late" },
+        ),
+      ).toBeNull();
+      expect(await storage.get(selectorFreeLocked.id, "org_1")).toMatchObject({
+        virtual_mcp_id: "locked-agent",
+        branch: "locked-branch",
+        harness_id: null,
+        routing_locked_at: "2026-08-01T00:00:00.000Z",
       });
 
       await storage.pinHostedRuntimeIfUnset(unlocked.id, "org_1", {

--- a/apps/api/src/storage/threads.ts
+++ b/apps/api/src/storage/threads.ts
@@ -310,6 +310,22 @@ export class SqlThreadStorage implements ThreadStoragePort {
       data.title = DEFAULT_THREAD_TITLE;
     }
 
+    const hasRoutingAuthorityEvidence =
+      data.harness_id != null ||
+      data.sandbox_provider_kind != null ||
+      (data.status !== undefined && data.status !== "completed") ||
+      data.context_start_message_id != null ||
+      data.run_owner_pod != null ||
+      data.run_config != null ||
+      data.run_started_at != null ||
+      data.last_progress_at != null;
+    const isHostedCompatibleRuntime =
+      (data.harness_id == null && data.sandbox_provider_kind == null) ||
+      (data.harness_id == null &&
+        data.sandbox_provider_kind === "agent-sandbox") ||
+      (data.harness_id === "decopilot" &&
+        data.sandbox_provider_kind === "agent-sandbox");
+
     const row = {
       id,
       organization_id: data.organization_id,
@@ -321,6 +337,11 @@ export class SqlThreadStorage implements ThreadStoragePort {
       branch: data.branch ?? null,
       sandbox_provider_kind: data.sandbox_provider_kind ?? null,
       harness_id: data.harness_id ?? null,
+      routing_locked_at:
+        data.routing_locked_at ?? (hasRoutingAuthorityEvidence ? now : null),
+      hosted_execution_disabled_at:
+        data.hosted_execution_disabled_at ??
+        (isHostedCompatibleRuntime ? null : now),
       created_at: now,
       updated_at: now,
       created_by: data.created_by,
@@ -451,6 +472,13 @@ export class SqlThreadStorage implements ThreadStoragePort {
     if (data.harness_id !== undefined) {
       updateData.harness_id = data.harness_id;
     }
+    if (data.routing_locked_at !== undefined) {
+      updateData.routing_locked_at = data.routing_locked_at;
+    }
+    if (data.hosted_execution_disabled_at !== undefined) {
+      updateData.hosted_execution_disabled_at =
+        data.hosted_execution_disabled_at;
+    }
     if (data.message_storage_version !== undefined) {
       updateData.message_storage_version = data.message_storage_version;
     }
@@ -460,7 +488,9 @@ export class SqlThreadStorage implements ThreadStoragePort {
       .where("id", "=", id)
       .where("organization_id", "=", organizationId);
     if (requireRuntimeUnlocked) {
-      query = query.where("harness_id", "is", null);
+      query = query
+        .where("routing_locked_at", "is", null)
+        .where("harness_id", "is", null);
     }
     const row = await query.returningAll().executeTakeFirst();
     return row ? this.threadFromDbRow(row) : null;
@@ -478,6 +508,9 @@ export class SqlThreadStorage implements ThreadStoragePort {
         sandbox_provider_kind: sql<string | null>`coalesce(${sql.ref(
           "sandbox_provider_kind",
         )}, 'agent-sandbox')`,
+        routing_locked_at: sql<Date>`coalesce(${sql.ref(
+          "routing_locked_at",
+        )}, now())`,
         branch: sql<string | null>`coalesce(${sql.ref("branch")}, ${
           pin.branch
         })`,
@@ -1119,6 +1152,8 @@ export class SqlThreadStorage implements ThreadStoragePort {
     branch?: string | null;
     sandbox_provider_kind?: string | null;
     harness_id?: string | null;
+    routing_locked_at?: Date | string | null;
+    hosted_execution_disabled_at?: Date | string | null;
     metadata?: ThreadMetadata | string | null;
     created_at: Date | string;
     updated_at: Date | string;
@@ -1164,6 +1199,12 @@ export class SqlThreadStorage implements ThreadStoragePort {
       branch: row.branch ?? null,
       sandbox_provider_kind: row.sandbox_provider_kind ?? null,
       harness_id: row.harness_id ?? null,
+      routing_locked_at: row.routing_locked_at
+        ? toIsoString(row.routing_locked_at)
+        : null,
+      hosted_execution_disabled_at: row.hosted_execution_disabled_at
+        ? toIsoString(row.hosted_execution_disabled_at)
+        : null,
       metadata,
       created_at: toIsoString(row.created_at),
       updated_at: toIsoString(row.updated_at),

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -965,6 +965,18 @@ export interface ThreadTable {
   sandbox_provider_kind: string | null;
   /** Harness id pinned on first message (e.g. "claude-code", "codex", "decopilot") */
   harness_id: string | null;
+  /** Durable authority lock; null only while routing may still change. */
+  routing_locked_at: ColumnType<
+    Date | null,
+    Date | string | null,
+    Date | string | null
+  >;
+  /** Fail-closed marker for historical runtimes that hosted Studio must not execute. */
+  hosted_execution_disabled_at: ColumnType<
+    Date | null,
+    Date | string | null,
+    Date | string | null
+  >;
   /** Per-task UI state (e.g., expanded_tools for right-panel tabs) */
   metadata: ColumnType<ThreadMetadata, string | undefined, string>;
   created_at: ColumnType<Date, Date | string, never>;
@@ -1043,6 +1055,10 @@ export interface Thread {
   sandbox_provider_kind: string | null;
   /** Harness id pinned on first message (e.g. "claude-code", "codex", "decopilot") */
   harness_id: string | null;
+  /** Durable authority lock; null only while routing may still change. */
+  routing_locked_at: string | null;
+  /** Fail-closed marker for historical runtimes that hosted Studio must not execute. */
+  hosted_execution_disabled_at: string | null;
   metadata: ThreadMetadata;
   /**
    * Message storage format for this thread's history.

--- a/apps/api/src/tools/thread/helpers.test.ts
+++ b/apps/api/src/tools/thread/helpers.test.ts
@@ -27,6 +27,8 @@ const BASE_THREAD: Thread = {
   branch: null,
   sandbox_provider_kind: null,
   harness_id: null,
+  routing_locked_at: null,
+  hosted_execution_disabled_at: null,
   metadata: {},
   message_storage_version: 1,
 };
@@ -139,5 +141,20 @@ describe("normalizeThreadForResponse", () => {
     expect(result).not.toHaveProperty("context_start_message_id");
     expect(result).not.toHaveProperty("run_owner_pod");
     expect(result).not.toHaveProperty("run_started_at");
+  });
+
+  test("preserves routing authority fields in API responses", () => {
+    const result = normalizeThreadForResponse(
+      {
+        ...BASE_THREAD,
+        routing_locked_at: "2026-08-04T12:00:00.000Z",
+        hosted_execution_disabled_at: "2026-08-04T12:01:00.000Z",
+      },
+      NOW,
+    );
+    expect(result.routing_locked_at).toBe("2026-08-04T12:00:00.000Z");
+    expect(result.hosted_execution_disabled_at).toBe(
+      "2026-08-04T12:01:00.000Z",
+    );
   });
 });

--- a/apps/api/src/tools/thread/helpers.ts
+++ b/apps/api/src/tools/thread/helpers.ts
@@ -86,6 +86,8 @@ export function normalizeThreadForResponse(
     branch: thread.branch,
     sandbox_provider_kind: thread.sandbox_provider_kind,
     harness_id: thread.harness_id,
+    routing_locked_at: thread.routing_locked_at,
+    hosted_execution_disabled_at: thread.hosted_execution_disabled_at,
     metadata:
       thread.metadata && Object.keys(thread.metadata).length > 0
         ? thread.metadata

--- a/apps/native/crates/local-api/src/routes/intercept/thread_tools.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/thread_tools.rs
@@ -1165,6 +1165,7 @@ mod tests {
         assert_eq!(created["item"]["title"], "hello");
         assert_eq!(created["item"]["virtual_mcp_id"], "vmcp-1");
         assert_eq!(created["item"]["hidden"], false);
+        assert!(created["item"]["routing_locked_at"].is_null());
         assert!(!created["item"]
             .as_object()
             .unwrap()

--- a/apps/native/crates/local-api/src/routes/intercept/watch.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/watch.rs
@@ -413,6 +413,7 @@ pub(crate) fn emit_thread_status(
         "trigger_id": thread.trigger_id,
         "title": thread.title,
         "branch": thread.branch,
+        "routing_locked_at": thread.routing_locked_at,
         "created_at": thread.created_at,
         "updated_at": thread.updated_at,
     });
@@ -470,6 +471,7 @@ mod tests {
             branch: Some("feature/native".to_string()),
             sandbox_provider_kind: Some("user-desktop".to_string()),
             harness_id: Some("claude-code".to_string()),
+            routing_locked_at: Some("2026-07-24T11:30:00.000Z".to_string()),
             metadata: Some(json!({"kind": "agent"})),
             run_config: None,
             created_at: "2026-07-24T11:00:00.000Z".to_string(),
@@ -538,6 +540,10 @@ mod tests {
         assert_eq!(parsed["data"]["created_by"], "alice");
         assert_eq!(parsed["data"]["title"], "Local thread");
         assert_eq!(parsed["data"]["branch"], "feature/native");
+        assert_eq!(
+            parsed["data"]["routing_locked_at"],
+            "2026-07-24T11:30:00.000Z"
+        );
         assert_eq!(parsed["data"]["created_at"], "2026-07-24T11:00:00.000Z");
         assert_eq!(parsed["data"]["metadata"]["kind"], "agent");
 

--- a/apps/native/crates/local-api/src/routes/threads/db.rs
+++ b/apps/native/crates/local-api/src/routes/threads/db.rs
@@ -26,7 +26,7 @@ use uuid::Uuid;
 
 /// Native owns this schema independently from Studio's Postgres migrations.
 /// The two stores intentionally share wire entities, not physical tables.
-const CURRENT_SCHEMA_VERSION: u32 = 12;
+const CURRENT_SCHEMA_VERSION: u32 = 13;
 
 const NATIVE_TERMINAL_SESSION_ID_PREFIX: &str = "native-terminal:";
 
@@ -683,6 +683,47 @@ WHERE provider_session_id IS NULL
   AND blocks_prior_provider_resume = 1;
 "#,
     },
+    Migration {
+        version: 13,
+        // A routing lock is the selector-free, public proof that this thread
+        // has claimed a runtime. Native keeps harness_id and
+        // sandbox_provider_kind as local terminal authority, but callers no
+        // longer need to infer immutability from either selector. Historical
+        // selector pins, lifecycle state, transcript rows, and terminal rows
+        // are all conservative evidence that routing must stay locked.
+        sql: r#"
+ALTER TABLE native_scoped_threads
+ADD COLUMN routing_locked_at TEXT
+CHECK (routing_locked_at IS NULL OR trim(routing_locked_at) <> '');
+
+UPDATE native_scoped_threads
+SET routing_locked_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE harness_id IS NOT NULL
+   OR sandbox_provider_kind IS NOT NULL
+   OR status <> 'completed'
+   OR EXISTS (
+       SELECT 1
+       FROM native_scoped_messages
+       WHERE thread_id = native_scoped_threads.id
+   )
+   OR EXISTS (
+       SELECT 1
+       FROM native_terminal_sessions
+       WHERE account_scope = native_scoped_threads.account_scope
+         AND organization_id = native_scoped_threads.organization_id
+         AND thread_id = native_scoped_threads.id
+         AND thread_generation = native_scoped_threads.generation
+   );
+
+CREATE TRIGGER native_scoped_threads_routing_lock_immutable
+BEFORE UPDATE OF routing_locked_at ON native_scoped_threads
+WHEN OLD.routing_locked_at IS NOT NULL
+ AND NEW.routing_locked_at IS NOT OLD.routing_locked_at
+BEGIN
+    SELECT RAISE(ABORT, 'native_scoped_threads.routing_locked_at is immutable');
+END;
+"#,
+    },
 ];
 
 #[derive(Debug)]
@@ -829,6 +870,7 @@ pub struct RtThread {
     pub branch: Option<String>,
     pub sandbox_provider_kind: Option<String>,
     pub harness_id: Option<String>,
+    pub routing_locked_at: Option<String>,
     #[serde(skip_serializing_if = "thread_metadata_is_absent")]
     pub metadata: Option<Value>,
     pub run_config: Option<Value>,
@@ -1514,8 +1556,8 @@ impl ThreadsDb {
             params![account_scope, organization_id, id],
             |row| {
                 let thread = row_to_rt_thread(row)?;
-                let generation = row.get(18)?;
-                let delete_pending = row.get(19)?;
+                let generation = row.get(19)?;
+                let delete_pending = row.get(20)?;
                 Ok((
                     thread,
                     RtThreadFence {
@@ -1716,11 +1758,11 @@ impl ThreadsDb {
     }
 
     /// Preflights a workspace-identity patch while a caller holds the
-    /// process-local terminal start lock. Archiving must stop a live terminal
-    /// before it writes `hidden`; this check prevents that stop from erasing
-    /// the very `starting`/`running` evidence that should reject a combined
-    /// branch or virtual-MCP change. The update transaction repeats the gate
-    /// as the storage-level authority fence.
+    /// process-local terminal start lock. The durable routing timestamp stays
+    /// set after a terminal exits, so stopping a live terminal before archive
+    /// cannot make a combined branch or virtual-MCP change mutable again. The
+    /// update transaction repeats the gate as the storage-level authority
+    /// fence.
     pub fn rt_validate_workspace_identity_patch_fenced(
         &self,
         fence: &RtThreadFence,
@@ -1731,12 +1773,7 @@ impl ThreadsDb {
         let gate: Option<(bool, Option<String>, String, bool)> = tx
             .query_row(
                 "SELECT delete_pending, branch, virtual_mcp_id, \
-                     harness_id IS NOT NULL OR EXISTS(\
-                         SELECT 1 FROM native_terminal_sessions \
-                         WHERE account_scope = ?1 AND organization_id = ?2 AND thread_id = ?3 \
-                           AND thread_generation = ?4 \
-                           AND physical_state IN ('starting', 'running')\
-                     ) \
+                     routing_locked_at IS NOT NULL \
                  FROM native_scoped_threads \
                  WHERE account_scope = ?1 AND organization_id = ?2 AND id = ?3 \
                    AND generation = ?4",
@@ -1881,12 +1918,7 @@ impl ThreadsDb {
                 .is_some_and(|virtual_mcp_id| virtual_mcp_id != &current_virtual_mcp_id);
         if changes_workspace_identity {
             let workspace_locked: bool = tx.query_row(
-                "SELECT harness_id IS NOT NULL OR EXISTS(\
-                     SELECT 1 FROM native_terminal_sessions \
-                     WHERE account_scope = ?1 AND organization_id = ?2 AND thread_id = ?3 \
-                       AND thread_generation = native_scoped_threads.generation \
-                       AND physical_state IN ('starting', 'running')\
-                 ) FROM native_scoped_threads \
+                "SELECT routing_locked_at IS NOT NULL FROM native_scoped_threads \
                  WHERE account_scope = ?1 AND organization_id = ?2 AND id = ?3",
                 params![account_scope, organization_id, id],
                 |row| row.get(0),
@@ -2062,8 +2094,9 @@ impl ThreadsDb {
 
     /// First-terminal thread-lock pin:
     /// sets `harness_id`/`sandbox_provider_kind`/`branch` ONLY when each is
-    /// currently `NULL` — a later launch on the same thread leaves them
-    /// untouched even if it names a different harness.
+    /// currently `NULL` and permanently records the first routing claim — a
+    /// later launch on the same thread leaves them untouched even if it names
+    /// a different harness.
     #[cfg(test)]
     pub fn rt_pin_harness_if_unset_in_org(
         &self,
@@ -2073,17 +2106,20 @@ impl ThreadsDb {
         sandbox_provider_kind: Option<&str>,
         branch: Option<&str>,
     ) -> DbResult<()> {
+        let ts = now_rfc3339();
         let conn = self.lock();
         conn.execute(
             "UPDATE native_scoped_threads SET \
              harness_id = COALESCE(harness_id, ?1), \
              sandbox_provider_kind = COALESCE(sandbox_provider_kind, ?2), \
-             branch = COALESCE(branch, ?3) \
-             WHERE id = ?4 AND organization_id = ?5",
+             branch = COALESCE(branch, ?3), \
+             routing_locked_at = COALESCE(routing_locked_at, ?4) \
+             WHERE id = ?5 AND organization_id = ?6",
             params![
                 harness_id,
                 sandbox_provider_kind,
                 branch,
+                ts,
                 id,
                 organization_id
             ],
@@ -2098,18 +2134,21 @@ impl ThreadsDb {
         sandbox_provider_kind: Option<&str>,
         branch: Option<&str>,
     ) -> DbResult<bool> {
+        let ts = now_rfc3339();
         let conn = self.lock();
         Ok(conn.execute(
             "UPDATE native_scoped_threads SET \
              harness_id = COALESCE(harness_id, ?1), \
              sandbox_provider_kind = COALESCE(sandbox_provider_kind, ?2), \
-             branch = COALESCE(branch, ?3) \
-             WHERE id = ?4 AND organization_id = ?5 AND generation = ?6 \
-               AND account_scope = ?7 AND delete_pending = 0 AND hidden = 0",
+             branch = COALESCE(branch, ?3), \
+             routing_locked_at = COALESCE(routing_locked_at, ?4) \
+             WHERE id = ?5 AND organization_id = ?6 AND generation = ?7 \
+               AND account_scope = ?8 AND delete_pending = 0 AND hidden = 0",
             params![
                 harness_id,
                 sandbox_provider_kind,
                 branch,
+                ts,
                 fence.thread_id,
                 fence.organization_id,
                 fence.generation,
@@ -2234,7 +2273,8 @@ impl ThreadsDb {
         }
         let thread_changed = tx.execute(
             "UPDATE native_scoped_threads SET \
-                 status = ?1, updated_at = ?2 \
+                 status = ?1, updated_at = ?2, \
+                 routing_locked_at = COALESCE(routing_locked_at, ?2) \
              WHERE account_scope = ?3 AND organization_id = ?4 AND id = ?5 \
                AND generation = ?6 AND delete_pending = 0",
             params![
@@ -3151,7 +3191,8 @@ impl ThreadsDb {
 
 const RT_THREAD_COLUMNS: &str = "id, organization_id, title, description, hidden, status, \
      created_by, updated_by, virtual_mcp_id, trigger_id, branch, sandbox_provider_kind, \
-     harness_id, metadata, run_config, created_at, updated_at, updated_by_explicit";
+     harness_id, metadata, run_config, created_at, updated_at, routing_locked_at, \
+     updated_by_explicit";
 
 fn parse_stored_json(raw: String, column: usize) -> rusqlite::Result<Value> {
     serde_json::from_str(&raw).map_err(|error| {
@@ -3174,7 +3215,7 @@ fn row_to_rt_thread(row: &rusqlite::Row) -> rusqlite::Result<RtThread> {
     let metadata_raw: Option<String> = row.get(13)?;
     let run_config_raw: Option<String> = row.get(14)?;
     let updated_by_raw: String = row.get(7)?;
-    let updated_by_explicit = row.get::<_, i64>(17)? != 0;
+    let updated_by_explicit = row.get::<_, i64>(18)? != 0;
     Ok(RtThread {
         id: row.get(0)?,
         organization_id: row.get(1)?,
@@ -3189,6 +3230,7 @@ fn row_to_rt_thread(row: &rusqlite::Row) -> rusqlite::Result<RtThread> {
         branch: row.get(10)?,
         sandbox_provider_kind: row.get(11)?,
         harness_id: row.get(12)?,
+        routing_locked_at: row.get(17)?,
         metadata: parse_optional_stored_json(metadata_raw, 13)?,
         run_config: parse_optional_stored_json(run_config_raw, 14)?,
         created_at: row.get(15)?,
@@ -5255,9 +5297,30 @@ ON rt_turn_queue(state, organization_id, thread_id, thread_generation, fifo_ordi
         assert_eq!(mutable.branch.as_deref(), Some("feature"));
         assert_eq!(mutable.virtual_mcp_id, "vmcp-b");
 
-        created_terminal(
+        let starting = created_terminal(
             db.rt_create_terminal_session_fenced(&starting_fence, "terminal-starting", "codex")
                 .unwrap(),
+        );
+        let first_routing_lock = starting
+            .thread
+            .routing_locked_at
+            .clone()
+            .expect("a durable terminal reservation locks routing");
+        let exited = updated_terminal(
+            db.rt_compare_and_set_terminal_session_state(
+                &starting_fence,
+                "terminal-starting",
+                0,
+                RtTerminalPhysicalState::Exited,
+                RtTerminalLogicalState::Interrupted,
+                None,
+                Some("test exit"),
+            )
+            .unwrap(),
+        );
+        assert_eq!(
+            exited.thread.routing_locked_at.as_deref(),
+            Some(first_routing_lock.as_str())
         );
         let metadata_only = db
             .rt_update_thread_in_scope(
@@ -5309,6 +5372,12 @@ ON rt_turn_queue(state, organization_id, thread_id, thread_generation, fifo_ordi
         assert!(db
             .rt_pin_harness_if_unset_fenced(&pinned_fence, "opencode", None, None)
             .unwrap());
+        assert!(db
+            .rt_thread_fenced(&pinned_fence)
+            .unwrap()
+            .unwrap()
+            .routing_locked_at
+            .is_some());
         assert!(matches!(
             db.rt_update_thread_in_scope(
                 &scope,
@@ -6154,6 +6223,11 @@ ON rt_turn_queue(state, organization_id, thread_id, thread_generation, fifo_ordi
         assert_eq!(created.session.revision, 0);
         assert_eq!(created.thread.status, RT_THREAD_STATUS_COMPLETED);
         assert_eq!(created.thread.harness_id, None);
+        let routing_locked_at = created
+            .thread
+            .routing_locked_at
+            .clone()
+            .expect("terminal reservation must claim routing before harness pin");
         assert!(db
             .rt_pin_harness_if_unset_fenced(&fence, "claude-code", None, None)
             .unwrap());
@@ -6163,6 +6237,14 @@ ON rt_turn_queue(state, organization_id, thread_id, thread_generation, fifo_ordi
                 .flatten()
                 .as_deref(),
             Some("claude-code")
+        );
+        assert_eq!(
+            db.rt_thread_fenced(&fence)
+                .unwrap()
+                .unwrap()
+                .routing_locked_at
+                .as_deref(),
+            Some(routing_locked_at.as_str())
         );
 
         let attached = db
@@ -6867,7 +6949,10 @@ ON rt_turn_queue(state, organization_id, thread_id, thread_generation, fifo_ordi
         }
 
         let db = ThreadsDb::open(dir.path()).unwrap();
-        assert_eq!(schema_version(&local_db_path(dir.path())), 12);
+        assert_eq!(
+            schema_version(&local_db_path(dir.path())),
+            CURRENT_SCHEMA_VERSION
+        );
         let fence = db
             .rt_thread_fence_in_scope(&scope, "v12-org", "v12-thread")
             .unwrap()
@@ -6915,6 +7000,115 @@ ON rt_turn_queue(state, organization_id, thread_id, thread_generation, fifo_ordi
                 .unwrap(),
             RtTerminalResumeDecision::Resume("provider-b".to_string())
         );
+    }
+
+    #[test]
+    fn version_thirteen_backfills_every_durable_routing_signal() {
+        let dir = tempfile::tempdir().unwrap();
+        let scope = RtAccountScope::new("studio.decocms.com", "v13-user").unwrap();
+        create_v7_fixture(dir.path(), &scope, "fixture-org", "fixture-thread");
+        {
+            let conn = Connection::open(local_db_path(dir.path())).unwrap();
+            conn.pragma_update(None, "foreign_keys", 1).unwrap();
+            for migration in MIGRATIONS
+                .iter()
+                .filter(|migration| (8..=12).contains(&migration.version))
+            {
+                conn.execute_batch(migration.sql).unwrap();
+                conn.pragma_update(None, "user_version", migration.version)
+                    .unwrap();
+            }
+            for (id, status, harness_id, sandbox_provider_kind) in [
+                ("unstarted", "completed", None, None),
+                ("selector-pinned", "completed", Some("codex"), None),
+                ("provider-pinned", "completed", None, Some("user-desktop")),
+                ("status-history", "failed", None, None),
+                ("message-history", "completed", None, None),
+                ("terminal-history", "completed", None, None),
+            ] {
+                conn.execute(
+                    "INSERT INTO native_scoped_threads (\
+                         id, organization_id, title, description, hidden, status, created_by, \
+                         updated_by, virtual_mcp_id, trigger_id, branch, sandbox_provider_kind, \
+                         harness_id, metadata, run_config, created_at, updated_at, generation, \
+                         account_scope, updated_by_explicit, delete_pending\
+                     ) VALUES (?1, 'v13-org', ?1, NULL, 0, ?2, 'v13-user', 'v13-user', \
+                         'vmcp', NULL, NULL, ?4, ?3, NULL, NULL, \
+                         '2026-08-04T10:00:00.000Z', '2026-08-04T10:00:00.000Z', \
+                         'generation-' || ?1, ?5, 0, 0)",
+                    params![
+                        id,
+                        status,
+                        harness_id,
+                        sandbox_provider_kind,
+                        scope.storage_key(),
+                    ],
+                )
+                .unwrap();
+            }
+            conn.execute(
+                "INSERT INTO native_scoped_messages (\
+                     id, thread_id, role, parts, metadata, seq, created_at, updated_at\
+                 ) VALUES ('history-message', 'message-history', 'user', '[]', NULL, 1, \
+                     '2026-08-04T10:01:00.000Z', '2026-08-04T10:01:00.000Z')",
+                [],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO native_terminal_sessions (\
+                     id, account_scope, organization_id, thread_id, thread_generation, \
+                     harness_id, physical_state, logical_state, provider_session_id, revision, \
+                     exit_code, last_error, started_at, ended_at, created_at, updated_at, \
+                     blocks_prior_provider_resume, rejected_provider_session_id\
+                 ) VALUES ('history-terminal', ?1, 'v13-org', 'terminal-history', \
+                     'generation-terminal-history', 'claude-code', 'exited', 'completed', \
+                     NULL, 0, 0, NULL, '2026-08-04T10:02:00.000Z', \
+                     '2026-08-04T10:03:00.000Z', '2026-08-04T10:02:00.000Z', \
+                     '2026-08-04T10:03:00.000Z', 0, NULL)",
+                [scope.storage_key()],
+            )
+            .unwrap();
+            conn.pragma_update(None, "user_version", 12).unwrap();
+            validate_foreign_keys(&conn).unwrap();
+        }
+
+        let db = ThreadsDb::open(dir.path()).unwrap();
+        assert_eq!(
+            schema_version(&local_db_path(dir.path())),
+            CURRENT_SCHEMA_VERSION
+        );
+        let unstarted = db
+            .rt_get_thread_in_scope(&scope, "v13-org", "unstarted")
+            .unwrap()
+            .unwrap();
+        assert!(unstarted.routing_locked_at.is_none());
+        for id in [
+            "selector-pinned",
+            "provider-pinned",
+            "status-history",
+            "message-history",
+            "terminal-history",
+        ] {
+            let thread = db
+                .rt_get_thread_in_scope(&scope, "v13-org", id)
+                .unwrap()
+                .unwrap();
+            let routing_locked_at = thread
+                .routing_locked_at
+                .unwrap_or_else(|| panic!("{id} was not routing-locked"));
+            assert!(
+                routing_locked_at.ends_with('Z'),
+                "{id}: {routing_locked_at}"
+            );
+        }
+        assert!(db
+            .lock()
+            .execute(
+                "UPDATE native_scoped_threads SET routing_locked_at = NULL \
+                 WHERE id = 'selector-pinned'",
+                [],
+            )
+            .is_err());
     }
 
     #[test]
@@ -6967,7 +7161,10 @@ ON rt_turn_queue(state, organization_id, thread_id, thread_generation, fifo_ordi
         }
 
         let db = ThreadsDb::open(dir.path()).unwrap();
-        assert_eq!(schema_version(&local_db_path(dir.path())), 12);
+        assert_eq!(
+            schema_version(&local_db_path(dir.path())),
+            CURRENT_SCHEMA_VERSION
+        );
         let fence = db
             .rt_thread_fence_in_scope(&scope, "v10-org", "v10-thread")
             .unwrap()

--- a/apps/native/crates/local-api/src/terminal/launch_context.rs
+++ b/apps/native/crates/local-api/src/terminal/launch_context.rs
@@ -2868,6 +2868,7 @@ mod tests {
             branch: Some(branch.to_string()),
             sandbox_provider_kind: None,
             harness_id: None,
+            routing_locked_at: None,
             metadata: None,
             run_config: None,
             created_at: "2026-01-01T00:00:00Z".to_string(),

--- a/packages/shared/src/entities.ts
+++ b/packages/shared/src/entities.ts
@@ -47,6 +47,8 @@ export interface StudioThread {
   branch: string | null;
   sandbox_provider_kind: string | null;
   harness_id: string | null;
+  routing_locked_at?: string | null;
+  hosted_execution_disabled_at?: string | null;
   metadata: ThreadMetadata;
   message_storage_version: number;
 }

--- a/packages/shared/src/thread/schema.test.ts
+++ b/packages/shared/src/thread/schema.test.ts
@@ -1,5 +1,80 @@
 import { describe, expect, test } from "bun:test";
-import { ThreadUpdateDataSchema } from "./schema.ts";
+import { ThreadEntitySchema, ThreadUpdateDataSchema } from "./schema.ts";
+
+const THREAD_ENTITY = {
+  id: "thread-1",
+  organization_id: "org-1",
+  title: "Thread",
+  description: null,
+  created_at: "2026-08-04T12:00:00.000Z",
+  updated_at: "2026-08-04T12:00:00.000Z",
+  status: "in_progress",
+  created_by: "user-1",
+};
+
+describe("ThreadEntitySchema", () => {
+  test("preserves a routing lock timestamp", () => {
+    const result = ThreadEntitySchema.parse({
+      ...THREAD_ENTITY,
+      routing_locked_at: "2026-08-04T12:01:00.000Z",
+    });
+
+    expect(result.routing_locked_at).toBe("2026-08-04T12:01:00.000Z");
+  });
+
+  test("accepts a null or omitted routing lock timestamp", () => {
+    expect(
+      ThreadEntitySchema.parse({
+        ...THREAD_ENTITY,
+        routing_locked_at: null,
+      }).routing_locked_at,
+    ).toBeNull();
+    expect(ThreadEntitySchema.parse(THREAD_ENTITY).routing_locked_at).toBe(
+      undefined,
+    );
+  });
+
+  test("rejects an invalid routing lock timestamp", () => {
+    const result = ThreadEntitySchema.safeParse({
+      ...THREAD_ENTITY,
+      routing_locked_at: "not-a-timestamp",
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  test("preserves a hosted execution tombstone timestamp", () => {
+    const result = ThreadEntitySchema.parse({
+      ...THREAD_ENTITY,
+      hosted_execution_disabled_at: "2026-08-04T12:02:00.000Z",
+    });
+
+    expect(result.hosted_execution_disabled_at).toBe(
+      "2026-08-04T12:02:00.000Z",
+    );
+  });
+
+  test("accepts a null or omitted hosted execution tombstone", () => {
+    expect(
+      ThreadEntitySchema.parse({
+        ...THREAD_ENTITY,
+        hosted_execution_disabled_at: null,
+      }).hosted_execution_disabled_at,
+    ).toBeNull();
+    expect(
+      ThreadEntitySchema.parse(THREAD_ENTITY).hosted_execution_disabled_at,
+    ).toBe(undefined);
+  });
+
+  test("rejects an invalid hosted execution tombstone timestamp", () => {
+    const result = ThreadEntitySchema.safeParse({
+      ...THREAD_ENTITY,
+      hosted_execution_disabled_at: "not-a-timestamp",
+    });
+
+    expect(result.success).toBe(false);
+  });
+});
 
 describe("ThreadUpdateDataSchema", () => {
   test("rejects an empty-string branch", () => {

--- a/packages/shared/src/thread/schema.ts
+++ b/packages/shared/src/thread/schema.ts
@@ -100,6 +100,22 @@ export const ThreadEntitySchema = z.object({
     .describe(
       "Pinned on first message; selects which harness runs the thread (e.g. 'claude-code', 'codex', 'decopilot').",
     ),
+  routing_locked_at: z
+    .string()
+    .datetime()
+    .nullable()
+    .optional()
+    .describe(
+      "Timestamp when the thread's hosted runtime routing became immutable.",
+    ),
+  hosted_execution_disabled_at: z
+    .string()
+    .datetime()
+    .nullable()
+    .optional()
+    .describe(
+      "Timestamp when hosted execution was disabled for a historical noncanonical runtime.",
+    ),
   metadata: ThreadMetadataSchema.optional().describe(
     "Free-form per-thread UI state (e.g. expanded_tools)",
   ),

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -3461,6 +3461,8 @@ export interface StudioToolIO {
         branch?: string | null | undefined;
         sandbox_provider_kind?: string | null | undefined;
         harness_id?: string | null | undefined;
+        routing_locked_at?: string | null | undefined;
+        hosted_execution_disabled_at?: string | null | undefined;
         metadata?:
           | {
               [x: string]: unknown;
@@ -3527,6 +3529,8 @@ export interface StudioToolIO {
         branch?: string | null | undefined;
         sandbox_provider_kind?: string | null | undefined;
         harness_id?: string | null | undefined;
+        routing_locked_at?: string | null | undefined;
+        hosted_execution_disabled_at?: string | null | undefined;
         metadata?:
           | {
               [x: string]: unknown;
@@ -3570,6 +3574,8 @@ export interface StudioToolIO {
         branch?: string | null | undefined;
         sandbox_provider_kind?: string | null | undefined;
         harness_id?: string | null | undefined;
+        routing_locked_at?: string | null | undefined;
+        hosted_execution_disabled_at?: string | null | undefined;
         metadata?:
           | {
               [x: string]: unknown;
@@ -3639,6 +3645,8 @@ export interface StudioToolIO {
         branch?: string | null | undefined;
         sandbox_provider_kind?: string | null | undefined;
         harness_id?: string | null | undefined;
+        routing_locked_at?: string | null | undefined;
+        hosted_execution_disabled_at?: string | null | undefined;
         metadata?:
           | {
               [x: string]: unknown;
@@ -3680,6 +3688,8 @@ export interface StudioToolIO {
         branch?: string | null | undefined;
         sandbox_provider_kind?: string | null | undefined;
         harness_id?: string | null | undefined;
+        routing_locked_at?: string | null | undefined;
+        hosted_execution_disabled_at?: string | null | undefined;
         metadata?:
           | {
               [x: string]: unknown;


### PR DESCRIPTION
## What is this contribution about?
> Describe your changes and why they're needed.

## How did you verify your code works?
> Name the tests you ran or added and what you observed. "Verified manually" or "existing tests" without specifics doesn't count.

## Screenshots/Demonstration
> Add screenshots or a Loom video if your changes affect the UI.

## How to Test
> Provide step-by-step instructions for reviewers to test your changes:
> 1. Step one
> 2. Step two
> 3. Expected outcome

## Migration Notes
> If this PR requires database migrations, configuration changes, or other setup steps, document them here. Remove this section if not applicable.

## Review Checklist
- [ ] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduce a selector-free routing lock for threads to make runtime authority durable and race-safe, with backfills for historical data and API exposure. Keeps pristine drafts unlocked and fails closed for noncanonical or partial runtime tuples.

- **New Features**
  - Added `routing_locked_at` and `hosted_execution_disabled_at` to thread entities across `apps/api`, `apps/native`, and `packages/shared`.
  - Migration 158 backfills:
    - Locks threads with any execution evidence (selectors, status, messages, parts, run timestamps).
    - Disables hosted execution for noncanonical/unknown tuples; canonicalizes enabled locked threads to `decopilot` + `agent-sandbox`.
  - Storage updates:
    - Create: auto-locks when there’s execution evidence; tombstones incompatible hosted tuples.
    - Conditional updates: now guarded by both `routing_locked_at IS NULL` and `harness_id IS NULL`.
    - Hosted pin: mints `routing_locked_at` exactly once; preserves branch and avoids racing native claims.
    - Automations: threads created via automations are pinned to hosted and locked on insert.
  - Native (local DB): schema v13 adds `routing_locked_at`, backfills from status/history/terminals, and makes the lock immutable; terminal start/status transitions claim the lock; watch events include `routing_locked_at`.
  - API/types: new fields surfaced in responses and validated in `ThreadEntitySchema`; `StudioToolIO` and shared entities updated; tests cover behavior.

- **Migration**
  - Apply migration `158-thread-routing-lock` (Postgres) and open Native DB to auto-migrate to v13.
  - No manual steps required; rolling-safe with old pods still honoring selector predicates during the switch.

<sup>Written for commit 0d297425bf3bab3de424665a2a10102f8cfc390d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

