### PR TITLE
fix(sections-editor): associate the enum field's label with its select trigger

### DIFF
--- a/apps/web/src/components/sections-editor/fields/enum-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/enum-field.tsx
@@ -39,7 +39,7 @@ export function EnumField({
         value={selectValue}
         onValueChange={(v) => onChange(selectValueToEnumOption(v, options))}
       >
-        <SelectTrigger className="h-10">
+        <SelectTrigger id={path} className="h-10">
           <SelectValue
             placeholder={t("sectionsEditor.enumField.selectPlaceholder")}
           />


### PR DESCRIPTION
**Source:** bug found while auditing `sections-editor/fields/` field components (this tick's focus area) for validation/tooltip/label consistency.

**Why a maintainer wants it:** `EnumField`'s `FieldLabel` sets `htmlFor={path}`, but the `SelectTrigger` it labels never received a matching `id={path}` — so clicking the field's label text does nothing (no focus, no open), unlike every other Select-based field in the same directory. `InlineUnionField` already wires `SelectTrigger id={path}` to the identical `FieldLabel` pattern, so this is a one-off gap, not a design choice.

**Failure scenario:** open any sandbox config field whose schema is a JSON Schema `enum` (rendered via `EnumField`). Click the field's label text — clicking `<label for="...">` should focus/open its control per standard browser label semantics, but the select is unaffected because no element in the DOM has that `id`. This also silently breaks the implicit label/control association screen readers rely on.

**Fix:** add `id={path}` to `EnumField`'s `SelectTrigger`, matching the working pattern in `inline-union-field.tsx`. Net diff: +1/-1, one line, no behavior change beyond restoring the label association.

**Verify:** open a virtual MCP's sandbox settings with an enum-typed config field, click the field's label — the select should now focus/open.

**Checks run locally:** `bun run fmt` (clean), `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint apps/web/src/components/sections-editor/fields/enum-field.tsx` (0 warnings/errors). No test added — this is a one-line JSX-attribute fix mirroring an existing, already-covered-by-usage pattern, not new logic; full CI runs the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the sections editor enum field label association by setting id={path} on the select trigger. Clicking the label now focuses/opens the select and restores proper screen reader mapping.

<sup>Written for commit 767afbb8e6bcbb42a64beb219609a45fb4d648d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

