### PR TITLE
fix(task-board): stop a request_changes dispatch failure from failing the review decision

### DIFF
--- a/apps/api/src/tools/task-board/review-decision.ts
+++ b/apps/api/src/tools/task-board/review-decision.ts
@@ -148,9 +148,16 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
         organizationId,
       );
       const pr = prs[0];
+      // Best-effort, like the auto-merge conflict path below — a dispatch
+      // failure (no model configured, queue error) must never fail this
+      // decision: the bounce-to-in_progress + activity write already
+      // committed, so surfacing an error here would report failure on an
+      // otherwise-successful reviewer decision.
       await enqueueSuperAgentForTask(ctx, updated, {
         feedback: `${REVIEWER_LABEL[reviewer]}: ${notes}`,
         pr: pr ? { number: pr.number, url: pr.url } : undefined,
+      }).catch((err) => {
+        console.error("[task-board] request_changes re-enqueue failed", err);
       });
       return { status: updated.status, merged: false };
     }


### PR DESCRIPTION
PR #5633 (merged today) hardened the `approve` + auto-merge-conflict path in `TASK_BOARD_REVIEW_DECISION` so a Super Agent dispatch failure (no model configured, queue error) never fails the tool call, since by that point the task was already bounced to `in_progress` and the activity was already recorded — surfacing the error would report failure on an otherwise-successful reviewer decision. The sibling `request_changes` branch in the same function does the exact same bounce-to-`in_progress` + activity-write + re-enqueue sequence but was missed — it still lets `enqueueSuperAgentForTask` throw straight out of the tool handler.

**Failure scenario:** a reviewer (QA Agent / Code Reviewer) calls `TASK_BOARD_REVIEW_DECISION` with `decision: "request_changes"`. The task is bounced to `in_progress` and the `review_changes_requested` activity is recorded (both committed), then `enqueueSuperAgentForTask` throws (e.g. no model configured for the org, or a transient queue error). Today that exception propagates out of the tool handler, so the reviewer's otherwise-successful decision comes back as a tool error even though the DB state already changed — and the task is left `in_progress` with no run actually enqueued.

**Fix:** wrap the `enqueueSuperAgentForTask` call in the same `.catch()` + `console.error` pattern #5633 just added to the `approve` path directly below it in this file, so a dispatch failure logs and the decision still returns success.

No test added: `review-decision.ts` has no existing unit-test file — its logic runs entirely through `StudioContext`/`ctx.storage`, and per this repo's testing tiers (see TESTING.md) that requires a real-Postgres integration/e2e test, not a mock. This laptop has no Postgres/NATS to run one, so this mirrors the already-reviewed, already-merged sibling fix's pattern exactly rather than adding new coverage.

**To confirm:** read `apps/api/src/tools/task-board/review-decision.ts`'s `request_changes` branch alongside the `approve`+conflict branch below it (added by #5633) — they now follow the identical best-effort-enqueue shape.

**Verified locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/api workspace, clean), `bunx oxlint apps/api/src/tools/task-board/review-decision.ts` (0 warnings/errors). Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a `request_changes` review decision from failing when Super Agent dispatch fails. The decision now returns success and logs the error, matching the `approve` path behavior.

- **Bug Fixes**
  - Wrap `enqueueSuperAgentForTask` in `.catch(...)` for the `request_changes` path and log failures, so the already-committed bounce to `in_progress` and activity write don’t surface as a tool error.

<sup>Written for commit c30f3a065f1722984c3a398c946004df373ddcc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

