### PR TITLE
feat(settings): toggle the claude-code sandbox harness from org settings

### DIFF
--- a/apps/web/src/components/settings/agent-runtime-settings.tsx
+++ b/apps/web/src/components/settings/agent-runtime-settings.tsx
@@ -1,0 +1,32 @@
+import { Terminal } from "@untitledui/icons";
+import {
+  SettingsCard,
+  SettingsSection,
+} from "@/components/settings/settings-section";
+import { FlagToggle } from "@/components/settings/review-settings";
+import { useT } from "@/i18n/use-t.ts";
+
+/**
+ * Which harness runs the org's agent tasks. Off by default: the claude-code
+ * harness dispatches through the sandbox rather than in-process, and needs an
+ * Anthropic or OpenRouter model credential — hence the toggle rather than a
+ * silent rollout.
+ */
+export function AgentRuntimeSettings() {
+  const t = useT();
+  return (
+    <SettingsSection
+      title={t("settings.agentRuntime.title")}
+      description={t("settings.agentRuntime.description")}
+    >
+      <SettingsCard>
+        <FlagToggle
+          flag="claude_code_sandbox_enabled"
+          icon={<Terminal size={16} />}
+          titleKey="settings.agentRuntime.claudeCodeTitle"
+          descriptionKey="settings.agentRuntime.claudeCodeDescription"
+        />
+      </SettingsCard>
+    </SettingsSection>
+  );
+}

--- a/apps/web/src/components/settings/review-settings.tsx
+++ b/apps/web/src/components/settings/review-settings.tsx
@@ -47,7 +47,8 @@ export function ReviewSettings() {
   );
 }
 
-function FlagToggle({
+/** One org flag as a switch. Shared with the other org-settings sections. */
+export function FlagToggle({
   flag,
   icon,
   titleKey,

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -383,7 +383,13 @@ export const settings = {
   "settings.review.autoMergeTitle": "Enable Auto-merge",
   "settings.review.autoMergeDescription":
     "When every enabled reviewer approves, merge the pull request automatically instead of waiting for a human. If a conflict blocks the merge, the Super Agent resolves it first.",
-  "settings.review.updateError": "Couldn't update the review setting",
+  "settings.review.updateError": "Couldn't update the setting",
+  "settings.agentRuntime.title": "Agent runtime",
+  "settings.agentRuntime.description":
+    "Which harness runs this organization's agent tasks.",
+  "settings.agentRuntime.claudeCodeTitle": "Run tasks with Claude Code",
+  "settings.agentRuntime.claudeCodeDescription":
+    "Super Agent tasks run the Claude Code harness next to the checkout in the managed sandbox instead of Decopilot. Needs an Anthropic or OpenRouter model credential, and a single connected repository.",
   "settings.orgRoleDetail.addMember": "Add Member",
   "settings.orgRoleDetail.addMembersToGrantPermissions":
     "Add members to grant them the configured permissions.",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -400,7 +400,13 @@ export const settings = {
   "settings.review.autoMergeDescription":
     "Quando todos os revisores habilitados aprovam, mescla o pull request automaticamente em vez de esperar por uma pessoa. Se um conflito bloquear o merge, o Super Agent resolve antes.",
   "settings.review.updateError":
-    "N\u00e3o foi poss\u00edvel atualizar a configura\u00e7\u00e3o de revis\u00e3o",
+    "N\u00e3o foi poss\u00edvel atualizar a configura\u00e7\u00e3o",
+  "settings.agentRuntime.title": "Runtime do agente",
+  "settings.agentRuntime.description":
+    "Qual harness executa as tarefas de agente desta organiza\u00e7\u00e3o.",
+  "settings.agentRuntime.claudeCodeTitle": "Executar tarefas com Claude Code",
+  "settings.agentRuntime.claudeCodeDescription":
+    "As tarefas do Super Agent rodam o harness do Claude Code junto ao checkout no sandbox gerenciado, em vez do Decopilot. Requer uma credencial de modelo Anthropic ou OpenRouter e um \u00fanico reposit\u00f3rio conectado.",
   "settings.orgRoleDetail.addMember": "Adicionar Membro",
   "settings.orgRoleDetail.addMembersToGrantPermissions":
     "Adicione membros para conceder as permiss\u00f5es configuradas.",

--- a/apps/web/src/views/settings/org-general.tsx
+++ b/apps/web/src/views/settings/org-general.tsx
@@ -3,6 +3,7 @@ import { ConnectBanner } from "@/components/connect/connect-banner";
 import { OrganizationForm } from "@/components/settings/organization-form";
 import { MainAgentSettings } from "@/components/settings/main-agent-settings";
 import { ReviewSettings } from "@/components/settings/review-settings";
+import { AgentRuntimeSettings } from "@/components/settings/agent-runtime-settings";
 import { DomainSettings } from "@/components/settings/domain-settings";
 import { DeleteOrganizationSection } from "@/components/settings/delete-organization-section";
 import { SettingsPage } from "@/components/settings/settings-section";
@@ -19,6 +20,7 @@ export function OrgGeneralPage() {
             <ConnectBanner />
             <OrganizationForm />
             <MainAgentSettings />
+            <AgentRuntimeSettings />
             <ReviewSettings />
             <DomainSettings />
             <DeleteOrganizationSection />


### PR DESCRIPTION
## Summary

`claude_code_sandbox_enabled` (added in #5604) is off by default and was only flippable through `ORGANIZATION_SETTINGS_UPDATE`. This puts it in the UI.

Adds an **Agent runtime** section to org general settings with one switch, reusing the `FlagToggle` already in `review-settings.tsx` (now exported) — the flag write path (`useSetOrgFlag` → shallow-merged `flags` bag) is unchanged.

The description names the two prerequisites the gate itself doesn't check for you, so the failure isn't discovered as an opaque model error at dispatch: an Anthropic or OpenRouter credential (`claudeCodeEnvFromCredential` rejects anything else) and a single connected repository (`resolveSoleTaskRepo` returns `null` on 0 or 2+, silently falling back to Decopilot).

Also generalizes the `settings.review.updateError` copy from "Couldn't update the review setting" to "Couldn't update the setting" — the same toast now backs both sections. Key unchanged.

## Testing

- `bun run lint` — 0 errors
- `bun run fmt`
- `bun run --cwd=apps/web check` — no new errors (the pre-existing `@xterm/addon-webgl` resolution error is a stale local install, untouched here)
- pt-br dictionary mirrors en, so `check` proves translation completeness

No test added: this is a declarative section wiring an existing, already-tested hook to an existing, already-tested toggle component.

## Screenshots

Org → Settings → General, between "Main agent" and "Reviewers & merge". _(to add)_


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Agent runtime section in org settings so admins can toggle the Claude Code sandbox harness. This exposes `claude_code_sandbox_enabled` in the UI and explains prerequisites to avoid opaque failures.

- **New Features**
  - New Agent runtime section in Org → Settings → General with a switch to run tasks with Claude Code in the managed sandbox.
  - Reuses the `FlagToggle` to control `claude_code_sandbox_enabled`; flag write path stays the same.
  - UI copy calls out prerequisites: an Anthropic or OpenRouter credential and exactly one connected repository.

- **Refactors**
  - Exported `FlagToggle` for reuse across settings sections.
  - Generalized toast copy to "Couldn't update the setting" (same key).
  - Added i18n strings (en, pt-br) and wired `AgentRuntimeSettings` into the org general settings page.

<sup>Written for commit f0eec188c192238b3d70cabc38f048de5ec0cd6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

