### PR TITLE
fix(sandbox): translate submodule-credentials-field's hardcoded strings

### DIFF
--- a/apps/web/src/components/sandbox/runtime-card/submodule-credentials-field.tsx
+++ b/apps/web/src/components/sandbox/runtime-card/submodule-credentials-field.tsx
@@ -35,6 +35,7 @@ import {
 import { cn } from "@deco/ui/lib/utils.ts";
 import { Plus, Trash01 } from "@untitledui/icons";
 import { SUBMODULE_HOST_RE } from "@/sdk";
+import { useT } from "@/i18n/use-t.ts";
 import { ErrorBoundary } from "@/components/error-boundary";
 import {
   SECRET_NAME_RE,
@@ -67,20 +68,20 @@ export function SubmoduleCredentialsField<T extends FieldValues>({
   control,
   form,
 }: SubmoduleCredentialsFieldProps<T>) {
+  const t = useT();
   return (
     <div className="space-y-2">
       <Label className="font-normal text-foreground">
-        Submodule credentials
+        {t("sandbox.submoduleCredentialsField.title")}
       </Label>
       <p className="text-xs text-muted-foreground">
-        Personal access tokens for cloning private git submodules that live in
-        other repositories. Reference an org/user secret per host; SSH submodule
-        URLs are rewritten to HTTPS so the token applies.
+        {t("sandbox.submoduleCredentialsField.description")}
       </p>
       <ErrorBoundary
         fallback={({ error }) => (
           <div className="rounded-md border border-destructive/40 bg-destructive/5 px-3 py-2 text-xs text-destructive">
-            {error?.message ?? "Failed to load secrets"}
+            {error?.message ??
+              t("sandbox.submoduleCredentialsField.failedToLoadSecrets")}
           </div>
         )}
       >
@@ -101,6 +102,7 @@ function SubmoduleCredentialsEditor<T extends FieldValues>({
   control,
   form,
 }: EditorProps<T>) {
+  const t = useT();
   const fieldPath = "metadata.runtime.submoduleCredentials" as FieldPath<T>;
   const { fields, append, remove } = useFieldArray({
     control,
@@ -143,7 +145,7 @@ function SubmoduleCredentialsEditor<T extends FieldValues>({
         className="w-full"
       >
         <Plus className="size-3.5" />
-        Add submodule credential
+        {t("sandbox.submoduleCredentialsField.addSubmoduleCredential")}
       </Button>
 
       {dialogIndex !== null ? (
@@ -182,6 +184,7 @@ function SubmoduleRow<T extends FieldValues>({
   onCreateNewSecret,
   onRemove,
 }: SubmoduleRowProps<T>) {
+  const t = useT();
   const hostName = `${fieldPath}.${index}.host` as FieldPath<T>;
   const secretIdName = `${fieldPath}.${index}.secretId` as FieldPath<T>;
 
@@ -199,7 +202,9 @@ function SubmoduleRow<T extends FieldValues>({
                 <Input
                   {...field}
                   value={(field.value as string | undefined) ?? ""}
-                  placeholder="github.com"
+                  placeholder={t(
+                    "sandbox.submoduleCredentialsField.hostPlaceholder",
+                  )}
                   spellCheck={false}
                   autoComplete="off"
                   autoCapitalize="off"
@@ -210,7 +215,10 @@ function SubmoduleRow<T extends FieldValues>({
                       "border-destructive focus-visible:ring-destructive",
                   )}
                   aria-invalid={invalid}
-                  aria-label={`Submodule credential ${index + 1} host`}
+                  aria-label={t(
+                    "sandbox.submoduleCredentialsField.hostAriaLabel",
+                    { index: index + 1 },
+                  )}
                   onBlur={(e) => {
                     field.onChange(e.target.value.trim());
                     field.onBlur();
@@ -218,7 +226,7 @@ function SubmoduleRow<T extends FieldValues>({
                 />
                 {invalid ? (
                   <p className="text-[11px] text-destructive">
-                    Bare hostname, e.g. github.com (no scheme or path).
+                    {t("sandbox.submoduleCredentialsField.hostInvalidMessage")}
                   </p>
                 ) : null}
               </div>
@@ -242,14 +250,18 @@ function SubmoduleRow<T extends FieldValues>({
                   !field.value && "text-muted-foreground",
                 )}
               >
-                <SelectValue placeholder="Pick a secret…">
+                <SelectValue
+                  placeholder={t(
+                    "sandbox.submoduleCredentialsField.pickSecretPlaceholder",
+                  )}
+                >
                   <SecretPickerValue field={field} secretById={secretById} />
                 </SelectValue>
               </SelectTrigger>
               <SelectContent>
                 {secrets.length === 0 ? (
                   <div className="px-2 py-2 text-xs text-muted-foreground">
-                    No secrets yet. Use the “+” to create one.
+                    {t("sandbox.submoduleCredentialsField.noSecretsYet")}
                   </div>
                 ) : (
                   secrets.map((s) => (
@@ -271,13 +283,17 @@ function SubmoduleRow<T extends FieldValues>({
               type="button"
               variant="ghost"
               size="icon"
-              aria-label="Create new secret"
+              aria-label={t(
+                "sandbox.submoduleCredentialsField.createNewSecretAriaLabel",
+              )}
               onClick={onCreateNewSecret}
             >
               <Plus className="size-3.5" />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Create new secret</TooltipContent>
+          <TooltipContent>
+            {t("sandbox.submoduleCredentialsField.createNewSecret")}
+          </TooltipContent>
         </Tooltip>
       </div>
 
@@ -288,13 +304,17 @@ function SubmoduleRow<T extends FieldValues>({
               type="button"
               variant="ghost"
               size="icon"
-              aria-label="Remove submodule credential"
+              aria-label={t(
+                "sandbox.submoduleCredentialsField.removeAriaLabel",
+              )}
               onClick={onRemove}
             >
               <Trash01 className="size-3.5" />
             </Button>
           </TooltipTrigger>
-          <TooltipContent>Remove</TooltipContent>
+          <TooltipContent>
+            {t("sandbox.submoduleCredentialsField.remove")}
+          </TooltipContent>
         </Tooltip>
       </div>
     </div>
@@ -307,6 +327,7 @@ interface CreateSecretDialogProps {
 }
 
 function CreateSecretDialog({ onClose, onSaved }: CreateSecretDialogProps) {
+  const t = useT();
   const [name, setName] = useState("");
   const [scope, setScope] = useState<SecretScopeKind>("organization");
   const [value, setValue] = useState("");
@@ -329,10 +350,18 @@ function CreateSecretDialog({ onClose, onSaved }: CreateSecretDialogProps) {
         value,
         description: description.trim() || undefined,
       });
-      toast.success(`Saved secret "${result.name}"`);
+      toast.success(
+        t("sandbox.submoduleCredentialsField.secretSaved", {
+          name: result.name,
+        }),
+      );
       onSaved(result.id);
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Failed to save");
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : t("sandbox.submoduleCredentialsField.failedToSaveSecret"),
+      );
     }
   };
 
@@ -345,16 +374,18 @@ function CreateSecretDialog({ onClose, onSaved }: CreateSecretDialogProps) {
     >
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
-          <DialogTitle>Create new secret</DialogTitle>
+          <DialogTitle>
+            {t("sandbox.submoduleCredentialsField.createNewSecretTitle")}
+          </DialogTitle>
           <DialogDescription>
-            Stored encrypted in the credential vault. The submodule credential
-            will reference the new secret by id — its value never leaves the
-            server.
+            {t("sandbox.submoduleCredentialsField.createNewSecretDescription")}
           </DialogDescription>
         </DialogHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-1.5">
-            <Label htmlFor="submodule-secret-scope">Scope</Label>
+            <Label htmlFor="submodule-secret-scope">
+              {t("sandbox.submoduleCredentialsField.scopeLabel")}
+            </Label>
             <Select
               value={scope}
               onValueChange={(v) => setScope(v as SecretScopeKind)}
@@ -364,52 +395,60 @@ function CreateSecretDialog({ onClose, onSaved }: CreateSecretDialogProps) {
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="organization">
-                  Organization — visible to all members
+                  {t("sandbox.submoduleCredentialsField.scopeOrganization")}
                 </SelectItem>
                 <SelectItem value="user">
-                  Private — only visible to me
+                  {t("sandbox.submoduleCredentialsField.scopePrivate")}
                 </SelectItem>
               </SelectContent>
             </Select>
           </div>
           <div className="space-y-1.5">
-            <Label htmlFor="submodule-secret-name">Name</Label>
+            <Label htmlFor="submodule-secret-name">
+              {t("sandbox.submoduleCredentialsField.nameLabel")}
+            </Label>
             <Input
               id="submodule-secret-name"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              placeholder="GITHUB_SUBMODULE_PAT"
+              placeholder={t(
+                "sandbox.submoduleCredentialsField.namePlaceholder",
+              )}
               autoComplete="off"
               required
             />
             <p className="text-xs text-muted-foreground">
-              Letters, digits, underscore, dot, hyphen.
+              {t("sandbox.submoduleCredentialsField.nameHelperText")}
             </p>
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="submodule-secret-value">
-              Personal access token
+              {t("sandbox.submoduleCredentialsField.tokenLabel")}
             </Label>
             <Input
               id="submodule-secret-value"
               type="password"
               value={value}
               onChange={(e) => setValue(e.target.value)}
-              placeholder="ghp_…"
+              placeholder={t(
+                "sandbox.submoduleCredentialsField.tokenPlaceholder",
+              )}
               autoComplete="new-password"
               required
             />
           </div>
           <div className="space-y-1.5">
             <Label htmlFor="submodule-secret-description">
-              Description (optional)
+              {t("sandbox.submoduleCredentialsField.descriptionLabel")}
             </Label>
             <Textarea
               id="submodule-secret-description"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               rows={2}
-              placeholder="What is this token used for?"
+              placeholder={t(
+                "sandbox.submoduleCredentialsField.descriptionPlaceholder",
+              )}
             />
           </div>
           <DialogFooter>
@@ -419,13 +458,15 @@ function CreateSecretDialog({ onClose, onSaved }: CreateSecretDialogProps) {
               onClick={onClose}
               disabled={createSecret.isPending}
             >
-              Cancel
+              {t("sandbox.submoduleCredentialsField.cancel")}
             </Button>
             <Button
               type="submit"
               disabled={!canSubmit || createSecret.isPending}
             >
-              {createSecret.isPending ? "Saving…" : "Save secret"}
+              {createSecret.isPending
+                ? t("sandbox.submoduleCredentialsField.saving")
+                : t("sandbox.submoduleCredentialsField.saveSecret")}
             </Button>
           </DialogFooter>
         </form>

--- a/apps/web/src/i18n/en/sandbox.ts
+++ b/apps/web/src/i18n/en/sandbox.ts
@@ -604,6 +604,50 @@ export const sandbox = {
   "sandbox.stateCard.resume": "Resume",
   "sandbox.stateCard.resumeToContinue": "Resume to continue.",
   "sandbox.stateCard.retry": "Retry",
+  "sandbox.submoduleCredentialsField.addSubmoduleCredential":
+    "Add submodule credential",
+  "sandbox.submoduleCredentialsField.cancel": "Cancel",
+  "sandbox.submoduleCredentialsField.createNewSecret": "Create new secret",
+  "sandbox.submoduleCredentialsField.createNewSecretAriaLabel":
+    "Create new secret",
+  "sandbox.submoduleCredentialsField.createNewSecretDescription":
+    "Stored encrypted in the credential vault. The submodule credential will reference the new secret by id — its value never leaves the server.",
+  "sandbox.submoduleCredentialsField.createNewSecretTitle": "Create new secret",
+  "sandbox.submoduleCredentialsField.description":
+    "Personal access tokens for cloning private git submodules that live in other repositories. Reference an org/user secret per host; SSH submodule URLs are rewritten to HTTPS so the token applies.",
+  "sandbox.submoduleCredentialsField.descriptionLabel":
+    "Description (optional)",
+  "sandbox.submoduleCredentialsField.descriptionPlaceholder":
+    "What is this token used for?",
+  "sandbox.submoduleCredentialsField.failedToLoadSecrets":
+    "Failed to load secrets",
+  "sandbox.submoduleCredentialsField.failedToSaveSecret": "Failed to save",
+  "sandbox.submoduleCredentialsField.hostAriaLabel":
+    "Submodule credential {index} host",
+  "sandbox.submoduleCredentialsField.hostInvalidMessage":
+    "Bare hostname, e.g. github.com (no scheme or path).",
+  "sandbox.submoduleCredentialsField.hostPlaceholder": "github.com",
+  "sandbox.submoduleCredentialsField.nameLabel": "Name",
+  "sandbox.submoduleCredentialsField.namePlaceholder": "GITHUB_SUBMODULE_PAT",
+  "sandbox.submoduleCredentialsField.nameHelperText":
+    "Letters, digits, underscore, dot, hyphen.",
+  "sandbox.submoduleCredentialsField.noSecretsYet":
+    'No secrets yet. Use the "+" to create one.',
+  "sandbox.submoduleCredentialsField.pickSecretPlaceholder": "Pick a secret…",
+  "sandbox.submoduleCredentialsField.remove": "Remove",
+  "sandbox.submoduleCredentialsField.removeAriaLabel":
+    "Remove submodule credential",
+  "sandbox.submoduleCredentialsField.saveSecret": "Save secret",
+  "sandbox.submoduleCredentialsField.saving": "Saving…",
+  "sandbox.submoduleCredentialsField.scopeLabel": "Scope",
+  "sandbox.submoduleCredentialsField.scopeOrganization":
+    "Organization — visible to all members",
+  "sandbox.submoduleCredentialsField.scopePrivate":
+    "Private — only visible to me",
+  "sandbox.submoduleCredentialsField.secretSaved": 'Saved secret "{name}"',
+  "sandbox.submoduleCredentialsField.title": "Submodule credentials",
+  "sandbox.submoduleCredentialsField.tokenLabel": "Personal access token",
+  "sandbox.submoduleCredentialsField.tokenPlaceholder": "ghp_…",
   "sandbox.toolbar.closeTab": "Close {tab}",
   "sandbox.toolbar.noScriptsFound": "No scripts found",
   "sandbox.toolbar.restart": "Restart",

--- a/apps/web/src/i18n/pt-br/sandbox.ts
+++ b/apps/web/src/i18n/pt-br/sandbox.ts
@@ -631,6 +631,51 @@ export const sandbox = {
   "sandbox.stateCard.resume": "Retomar",
   "sandbox.stateCard.resumeToContinue": "Retome para continuar.",
   "sandbox.stateCard.retry": "Tentar Novamente",
+  "sandbox.submoduleCredentialsField.addSubmoduleCredential":
+    "Adicionar credencial de submódulo",
+  "sandbox.submoduleCredentialsField.cancel": "Cancelar",
+  "sandbox.submoduleCredentialsField.createNewSecret": "Criar novo segredo",
+  "sandbox.submoduleCredentialsField.createNewSecretAriaLabel":
+    "Criar novo segredo",
+  "sandbox.submoduleCredentialsField.createNewSecretDescription":
+    "Armazenado criptografado no cofre de credenciais. A credencial de submódulo fará referência ao novo segredo pelo id — seu valor nunca sai do servidor.",
+  "sandbox.submoduleCredentialsField.createNewSecretTitle":
+    "Criar novo segredo",
+  "sandbox.submoduleCredentialsField.description":
+    "Tokens de acesso pessoal para clonar submódulos git privados hospedados em outros repositórios. Referencie um segredo de org/usuário por host; URLs SSH de submódulo são reescritas para HTTPS para que o token se aplique.",
+  "sandbox.submoduleCredentialsField.descriptionLabel": "Descrição (opcional)",
+  "sandbox.submoduleCredentialsField.descriptionPlaceholder":
+    "Para que este token é usado?",
+  "sandbox.submoduleCredentialsField.failedToLoadSecrets":
+    "Falha ao carregar segredos",
+  "sandbox.submoduleCredentialsField.failedToSaveSecret": "Falha ao salvar",
+  "sandbox.submoduleCredentialsField.hostAriaLabel":
+    "Host da credencial de submódulo {index}",
+  "sandbox.submoduleCredentialsField.hostInvalidMessage":
+    "Nome de host simples, ex.: github.com (sem esquema ou caminho).",
+  "sandbox.submoduleCredentialsField.hostPlaceholder": "github.com",
+  "sandbox.submoduleCredentialsField.nameLabel": "Nome",
+  "sandbox.submoduleCredentialsField.namePlaceholder": "GITHUB_SUBMODULE_PAT",
+  "sandbox.submoduleCredentialsField.nameHelperText":
+    "Letras, dígitos, underscore, ponto, hífen.",
+  "sandbox.submoduleCredentialsField.noSecretsYet":
+    'Nenhum segredo ainda. Use o "+" para criar um.',
+  "sandbox.submoduleCredentialsField.pickSecretPlaceholder":
+    "Escolha um segredo…",
+  "sandbox.submoduleCredentialsField.remove": "Remover",
+  "sandbox.submoduleCredentialsField.removeAriaLabel":
+    "Remover credencial de submódulo",
+  "sandbox.submoduleCredentialsField.saveSecret": "Salvar segredo",
+  "sandbox.submoduleCredentialsField.saving": "Salvando…",
+  "sandbox.submoduleCredentialsField.scopeLabel": "Escopo",
+  "sandbox.submoduleCredentialsField.scopeOrganization":
+    "Organização — visível para todos os membros",
+  "sandbox.submoduleCredentialsField.scopePrivate":
+    "Privado — visível apenas para mim",
+  "sandbox.submoduleCredentialsField.secretSaved": 'Segredo "{name}" salvo',
+  "sandbox.submoduleCredentialsField.title": "Credenciais de submódulo",
+  "sandbox.submoduleCredentialsField.tokenLabel": "Token de acesso pessoal",
+  "sandbox.submoduleCredentialsField.tokenPlaceholder": "ghp_…",
   "sandbox.toolbar.closeTab": "Fechar {tab}",
   "sandbox.toolbar.noScriptsFound": "Nenhum script encontrado",
   "sandbox.toolbar.restart": "Reiniciar",


### PR DESCRIPTION
Its sibling in the same directory, `env-vars-field.tsx`, fully routes every label/placeholder/toast through `useT()`, but `submodule-credentials-field.tsx` (the sandbox runtime card's submodule-PAT editor) hardcodes every user-facing string in English — labels, placeholders, aria-labels, dialog title/description, and toasts. This violates the repo's i18n rule (CLAUDE.md: "Never hardcode user-facing strings in apps/web/src") and leaves this one editor untranslated for pt-br users while the rest of the Sandbox card is fully localized.

Changes:
- Added `sandbox.submoduleCredentialsField.*` keys to `i18n/en/sandbox.ts` and their pt-br translations to `i18n/pt-br/sandbox.ts`, mirroring the existing `sandbox.envVarsField.*` structure for the equivalent create-secret dialog fields.
- Wired `submodule-credentials-field.tsx` to use `useT()` for every previously-hardcoded string (title, description, placeholders, aria-labels, dialog copy, toasts).

No logic changes — this is a pure string-source swap, so behavior is unchanged; the pt-br `satisfies Record<keyof typeof en, string>` constraint in `i18n/pt-br/index.ts` is what makes a missing/extra key a compile error, which is what I verified with the typecheck below.

To confirm: switch language to Português in preferences, open a virtual MCP's Sandbox settings, and check the "Submodule credentials" section renders in pt-br.

Locally verified:
- `bun run fmt`
- `cd apps/web && bunx tsc --noEmit` (green — proves en/pt-br key parity)
- `bunx oxlint` on the 3 touched files (0 warnings/errors)

Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localized the Sandbox runtime card’s Submodule credentials editor by replacing hardcoded English strings with i18n keys for en and pt-br. No logic changes; all UI text now comes from `useT()`.

- **Bug Fixes**
  - Routed all labels, placeholders, aria labels, dialog copy, and toasts in `submodule-credentials-field.tsx` through `useT()`.
  - Added `sandbox.submoduleCredentialsField.*` keys to `i18n/en/sandbox.ts` and `i18n/pt-br/sandbox.ts`, mirroring `sandbox.envVarsField.*`.

<sup>Written for commit 1d9f1776d930e7fa4216b24e6cd985110ad17c3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

