### PR TITLE
fix(sections-editor): associate the anyOf field's label with its select trigger

### DIFF
--- a/apps/web/src/components/sections-editor/fields/any-of-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/any-of-field.tsx
@@ -437,7 +437,7 @@ export function AnyOfField({
             virtualMcpId={sandbox?.virtualMcpId}
           />
           <Select value={activeRt || undefined} onValueChange={handleRefChange}>
-            <SelectTrigger>
+            <SelectTrigger id={path}>
               <SelectValue
                 placeholder={t("sectionsEditor.anyOfField.selectPlaceholder")}
               />


### PR DESCRIPTION
Follows #5662, which fixed the identical bug in enum-field.tsx (SelectTrigger missing the `id` its FieldLabel's `htmlFor` points to). any-of-field.tsx's block-reference Select has the same gap: `FieldLabel htmlFor={path}` at line 434 but a bare `<SelectTrigger>` with no `id`, so clicking/focusing the label never reaches the trigger and screen readers can't associate them.

Fix: add `id={path}` to the `SelectTrigger`, mirroring #5662 and the working pattern already used a few lines below in this same file (the fallback `<input id={path} .../>`) and in inline-union-field.tsx (`<SelectTrigger id={path}>`).

Failure scenario: in a virtual MCP's block editor, any field backed by an `anyOf` schema with multiple `$ref` options (e.g. picking a loader/module variant) renders a label whose `<label for="...">` points to nothing — clicking the label text doesn't focus the select, and assistive tech reads the control as unlabeled.

Reviewer check: open the sections editor on a block with an anyOf-typed prop with 2+ ref options, click the field's label text, confirm the select trigger receives focus (same manual check as #5662).

Verified locally: `bun run fmt`, `bunx oxlint` on the changed file (0 warnings/errors), `bunx tsc --noEmit` in apps/web (clean). No existing test covers this file; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes accessibility in the sections editor by linking the anyOf field’s label to its select trigger, so clicking the label focuses the select and screen readers read the correct label.

- **Bug Fixes**
  - Added `id={path}` to the anyOf field’s `SelectTrigger`, matching the label’s `htmlFor`.
  - Applies to anyOf props with multiple `$ref` options in block editors.

<sup>Written for commit 43614b36b24869409d329fdbad58f10356c546f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

