### PR TITLE
fix(task-board): fence the request_changes bounce against concurrent reviewers

### DIFF
--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -488,6 +488,38 @@ export class TaskBoardStorage {
   }
 
   /**
+   * Atomically claim a task for a reviewer's `request_changes` bounce: move it
+   * from In Review to In Progress ONLY if it's still In Review, returning the
+   * updated item to the single winner and null to everyone else. QA and Code
+   * Reviewer run concurrently, and either can independently decide changes are
+   * needed — without this fence both would bounce the task and each enqueue
+   * its own Super Agent run on the SAME PR, racing to push conflicting commits.
+   * Same atomic-conditional-UPDATE pattern as `claimConflictResolution`.
+   */
+  async claimReviewChangesBounce(
+    id: string,
+    organizationId: string,
+    by: string,
+  ): Promise<TaskBoardItem | null> {
+    const row = await this.db
+      .updateTable("task_board_items")
+      .set({
+        status: "in_progress",
+        updated_by: by,
+        updated_at: new Date().toISOString(),
+      })
+      .where("id", "=", id)
+      .where("organization_id", "=", organizationId)
+      .where("status", "=", "in_review")
+      .returningAll()
+      .executeTakeFirst();
+    if (!row) return null;
+    const item = this.itemFromDbRow(row);
+    await this.attachRefs([item], organizationId);
+    return item;
+  }
+
+  /**
    * Populate each item's `threads` and `tags` — one transaction, so a card
    * can't read its threads from before a concurrent edit and its tags from
    * after.

--- a/apps/api/src/tools/task-board/review-decision.ts
+++ b/apps/api/src/tools/task-board/review-decision.ts
@@ -128,10 +128,17 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
       // Any reviewer requesting changes bounces the task straight back to the
       // Super Agent with the feedback in its re-run prompt — no need to wait on
       // the other reviewer. Pull it back to In Progress and re-enqueue directly.
-      const updated = await ctx.storage.taskBoard.update(
+      //
+      // Atomically claim the bounce — the dispatch fence. QA and Code Reviewer
+      // run concurrently, and either can independently decide changes are
+      // needed; without this fence both would win a plain update and each
+      // enqueue its own Super Agent run on the SAME PR, racing to push
+      // conflicting commits. The decision is still recorded either way (see
+      // below) — only the second reviewer's re-enqueue is skipped, since the
+      // first winner's run already carries the fix forward.
+      const updated = await ctx.storage.taskBoard.claimReviewChangesBounce(
         taskBoardItemId,
         organizationId,
-        { status: "in_progress" },
         item.updatedBy,
       );
       await recordTaskActivity(ctx, {
@@ -140,6 +147,14 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
         actorId: null,
         data: { reviewer, notes, verified },
       });
+      if (!updated) {
+        const current =
+          (await ctx.storage.taskBoard.getById(
+            taskBoardItemId,
+            organizationId,
+          )) ?? item;
+        return { status: current.status, merged: false };
+      }
       emitTaskBoardUpdated(organizationId, updated);
       // Pass the PR under review so the re-run updates it in place (checks out
       // its branch) instead of opening a second PR. Newest linked PR is the one.


### PR DESCRIPTION
**Source:** a concurrency gap found while auditing `TASK_BOARD_REVIEW_DECISION` (adjacent to the already-open #5547 stale-token-cycle fix and the already-merged #5664 dispatch-failure fix — this is a distinct bug, not a duplicate of either).

**Why a maintainer wants it:** QA Agent and Code Reviewer run concurrently (`enqueueEnabledReviewers` dispatches both via `Promise.all`). If both independently decide `request_changes` around the same time (plausible — each reviews the same PR independently and may both find issues), `TASK_BOARD_REVIEW_DECISION`'s request_changes branch had no fence: it called the plain `taskBoard.update()` (no status precondition), so BOTH calls would win, bounce the task to In Progress, and each call `enqueueSuperAgentForTask` — dispatching two Super Agent runs on the SAME PR at the same time, racing to push conflicting commits. This is the exact race class the codebase already fenced once, for merge-conflict auto-resolution (`claimConflictResolution`, see its docstring: "a read-then-write would let both dispatch a Super Agent run on the same PR") — the request_changes bounce just never got the same treatment.

**The fix:** added `claimReviewChangesBounce` to `TaskBoardStorage`, mirroring `claimConflictResolution`'s atomic-conditional-UPDATE pattern (`status in_review -> in_progress` only if the row is still `in_review`). `review-decision.ts`'s request_changes branch now uses it: the winner proceeds exactly as before (bounce, activity record, re-enqueue); the loser still gets its `review_changes_requested` activity entry recorded (so its feedback isn't lost from the timeline) but skips the re-enqueue, since the winner's Super Agent run already carries the fix forward.

**Failure scenario before the fix:** QA and Code Reviewer both call `TASK_BOARD_REVIEW_DECISION` with `decision: "request_changes"` within the same race window -> two Super Agent runs get dispatched on the same task/PR, each checking out the same branch and pushing independently.

**Reviewer command:** `bunx tsc --noEmit` in `apps/api` (clean) and `bun test apps/api/src/storage/task-board.test.ts` (10/10 pass, unaffected pure-logic tests). No new test: this is a DB-level race fence in the same territory as `claimConflictResolution`, which this repo's own `conflict-reaction.test.ts` documents as integration/e2e-only ("the orchestration (claim fence, enqueue, gating against real storage) is integration/e2e") — this environment has no Postgres to write or run one.

**Locally verified:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bun test apps/api/src/storage/task-board.test.ts` (10/10 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate Super Agent runs when QA and Code Reviewer both request changes at the same time by adding an atomic claim around the bounce to In Progress. Only one reviewer re-enqueues; the other still logs activity.

- **Bug Fixes**
  - Added `claimReviewChangesBounce` to atomically flip status `in_review` -> `in_progress` only if still `in_review`.
  - Updated the `request_changes` path in the review decision to use the claim; the non-winner records `review_changes_requested` but skips re-enqueue.
  - Mirrors the existing conflict-resolution fence to remove the race and avoid concurrent runs on the same PR.

<sup>Written for commit 83849c4566ae0aad9029ba9766ec011418402876. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

