### PR TITLE
fix(settings): stop the org settings page from letting the slug be renamed

### DIFF
--- a/apps/web/src/components/settings/organization-form.tsx
+++ b/apps/web/src/components/settings/organization-form.tsx
@@ -7,7 +7,6 @@ import { Avatar } from "@deco/ui/components/avatar.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useNavigate } from "@tanstack/react-router";
 import {
   SettingsCard,
   SettingsCardItem,
@@ -18,23 +17,10 @@ import { Controller, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 import { track } from "@/lib/posthog-client";
-import { isReservedOrganizationSlug } from "@decocms/shared/organization-slugs";
 
 // TODO(i18n): validation messages at module scope, move schema into component if needed
 const organizationSettingsSchema = z.object({
   name: z.string().min(1, "Name is required").max(255, "Name is too long"),
-  slug: z
-    .string()
-    .min(1, "Slug is required")
-    .max(50, "Slug is too long")
-    .regex(
-      /^[a-z0-9-]+$/,
-      "Slug must contain only lowercase letters, numbers, and hyphens",
-    )
-    .refine(
-      (slug) => !isReservedOrganizationSlug(slug),
-      "This organization URL is reserved by Studio",
-    ),
   logo: z.string().optional(),
 });
 
@@ -103,7 +89,6 @@ function CompactLogoUpload({
 
 export function OrganizationForm() {
   const t = useT();
-  const navigate = useNavigate();
   const { org } = useProjectContext();
   const orgAuth = useOrgAuthClient();
   const queryClient = useQueryClient();
@@ -112,7 +97,6 @@ export function OrganizationForm() {
     resolver: zodResolver(organizationSettingsSchema),
     values: {
       name: org.name ?? "",
-      slug: org.slug ?? "",
       logo: org.logo ?? "",
     },
   });
@@ -121,7 +105,6 @@ export function OrganizationForm() {
     mutationFn: async (data: OrganizationSettingsFormValues) => {
       const updateData: Record<string, unknown> = {
         name: data.name,
-        slug: data.slug,
       };
 
       if (data.logo) {
@@ -141,7 +124,7 @@ export function OrganizationForm() {
 
       return result;
     },
-    onSuccess: (data, variables) => {
+    onSuccess: (_data, variables) => {
       track("organization_settings_updated", {
         organization_id: org.id,
         fields: Object.keys(variables),
@@ -151,13 +134,6 @@ export function OrganizationForm() {
         queryKey: KEYS.activeOrganization(org.slug),
       });
       toast.success(t("settings.organizationForm.updateSuccess"));
-
-      if (data?.data?.slug && data.data.slug !== org.slug) {
-        navigate({
-          to: "/$org/settings/general",
-          params: { org: data.data.slug },
-        });
-      }
     },
     onError: (error, variables) => {
       track("organization_settings_update_failed", {
@@ -252,52 +228,29 @@ export function OrganizationForm() {
         />
         <SettingsCardItem
           title={t("settings.organizationForm.urlTitle")}
+          description={t("settings.organizationForm.urlDescription")}
           action={
-            <div className="flex items-center w-[280px] rounded-md border border-input bg-input/30 focus-within:ring-2 focus-within:ring-ring/50 overflow-hidden">
+            // Read-only: the slug anchors org URLs (/api/:org/..., /$org/...);
+            // renaming it would silently break every saved link and API
+            // integration, so it can't be edited from here (see
+            // ORGANIZATION_UPDATE, which rejects slug changes for the same
+            // reason).
+            <div className="flex items-center w-[280px] rounded-md border border-input bg-muted/40 overflow-hidden">
               {urlOrigin && (
                 <span className="pl-3 text-sm text-muted-foreground select-none">
                   {urlOrigin}
                 </span>
               )}
-              <Controller
-                control={form.control}
-                name="slug"
-                render={({ field }) => (
-                  <input
-                    id="org-slug"
-                    value={field.value ?? ""}
-                    name={field.name}
-                    ref={field.ref}
-                    placeholder={t("settings.organizationForm.slugPlaceholder")}
-                    className="flex-1 min-w-0 bg-transparent px-2 py-1.5 text-sm text-foreground placeholder:text-muted-foreground/60 outline-none"
-                    onChange={(e) => {
-                      const sanitized = e.target.value
-                        .toLowerCase()
-                        .replace(/[^a-z0-9-]/g, "");
-                      form.setValue("slug", sanitized, {
-                        shouldDirty: true,
-                        shouldTouch: true,
-                        shouldValidate: true,
-                      });
-                      scheduleSave();
-                    }}
-                    onBlur={() => {
-                      field.onBlur();
-                      flushAndSave();
-                    }}
-                  />
-                )}
-              />
+              <span className="flex-1 min-w-0 px-2 py-1.5 text-sm text-foreground truncate">
+                {org.slug}
+              </span>
             </div>
           }
         />
-        {(errors.name || errors.slug || errors.logo) && (
+        {(errors.name || errors.logo) && (
           <div className="px-5 pb-3 flex flex-col gap-1">
             {errors.name && (
               <p className="text-xs text-destructive">{errors.name.message}</p>
-            )}
-            {errors.slug && (
-              <p className="text-xs text-destructive">{errors.slug.message}</p>
             )}
             {errors.logo && (
               <p className="text-xs text-destructive">{errors.logo.message}</p>

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -535,10 +535,11 @@ export const settings = {
   "settings.organizationForm.logoTitle": "Logo",
   "settings.organizationForm.namePlaceholder": "Organization name",
   "settings.organizationForm.nameTitle": "Name",
-  "settings.organizationForm.slugPlaceholder": "my-organization",
   "settings.organizationForm.updateSuccess":
     "Organization updated successfully",
   "settings.organizationForm.uploadLogoLabel": "Upload organization logo",
+  "settings.organizationForm.urlDescription":
+    "Can't be changed — it's used in URLs and API integrations.",
   "settings.organizationForm.urlTitle": "URL",
   "settings.providerKeyRow.addedTimeAgo": "{label} · added {time} ago",
   "settings.providerKeyRow.cancel": "Cancel",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -566,11 +566,12 @@ export const settings = {
   "settings.organizationForm.logoTitle": "Logo",
   "settings.organizationForm.namePlaceholder": "Nome da organiza\u00e7\u00e3o",
   "settings.organizationForm.nameTitle": "Nome",
-  "settings.organizationForm.slugPlaceholder": "minha-organizacao",
   "settings.organizationForm.updateSuccess":
     "Organiza\u00e7\u00e3o atualizada com sucesso",
   "settings.organizationForm.uploadLogoLabel":
     "Enviar logo da organiza\u00e7\u00e3o",
+  "settings.organizationForm.urlDescription":
+    "N\u00e3o pode ser alterada \u2014 \u00e9 usada em URLs e integra\u00e7\u00f5es de API.",
   "settings.organizationForm.urlTitle": "URL",
   "settings.providerKeyRow.addedTimeAgo": "{label} · adicionada há {time}",
   "settings.providerKeyRow.cancel": "Cancelar",


### PR DESCRIPTION
## Source

A bug found while auditing the org-settings/config-resolution area: `apps/web/src/components/settings/organization-form.tsx`'s org URL/slug field was a live, editable input.

## Why a maintainer wants this

When the org-scoped `/api/:org/...` route migration shipped (#3272), `ORGANIZATION_UPDATE` (`apps/api/src/tools/organization/update.ts`) was deliberately changed to reject slug updates, with the comment: "Slug is intentionally NOT updatable: it anchors org URLs (`/api/:org/...`) and renaming would silently invalidate every saved URL." This is also documented as a repo-wide invariant in `CLAUDE.md`'s API Path Convention section ("Org slugs are immutable ... so URLs remain stable").

But the actual Settings → General page never went through that tool — it calls Better Auth's own `organization.update` endpoint directly via `useOrgAuthClient()`, and that endpoint (in the vendored `@decocms/better-auth` package) happily accepts and persists a `slug` change (only checking uniqueness). So any org admin could rename the org's slug from Settings, silently invalidating every bookmarked `/$org/...` link, saved `/api/:org/...` API integration, and webhook built against the old slug — the exact failure the tool-side fix was meant to prevent.

## The fix

Made the URL/slug field in `OrganizationForm` read-only (plain text, not a form input), removed `slug` from the form schema and the `Better Auth` update payload, and dropped the now-dead "navigate to new slug on rename" logic. Added an i18n description explaining why (en + pt-br). Net diff: -61/+16, mostly deletions (dead validation, dead navigate-on-rename branch, an unused i18n placeholder key).

## How to verify

- Open Settings → General for an org: the URL field now renders the slug as static text, not an editable input.
- `rg -n 'slug' apps/web/src/components/settings/organization-form.tsx` — only the two read-only display sites remain (`org.slug` and the query-key cache invalidation).

## Checks run locally

- `bun run fmt` — clean
- `cd apps/web && bunx tsc --noEmit` — clean
- `bunx oxlint` on the 3 changed files — 0 warnings, 0 errors

Full CI (lint, full typecheck, test suite) validates the rest.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the organization slug on Settings → General read-only to prevent breaking `/api/:org/...` URLs and integrations. Removes slug update paths so the UI matches the invariant that org slugs are immutable.

- **Bug Fixes**
  - Render the org slug as static text with a brief explanation (en, pt-br).
  - Remove `slug` from the form schema and the update payload sent to `@decocms/better-auth`.
  - Delete slug validation and navigate-on-rename logic; keep cache invalidation only.

<sup>Written for commit 6a1ac71b078e4f51ed1c0ad62dcbdf6517287840. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

