### PR TITLE
fix(task-board): count repositories, not connections, when picking a claude-code task repo

### DIFF
--- a/apps/api/src/tools/task-board/claude-code-task-run.test.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   buildClaudeCodeTaskPrompt,
+  pickSoleTaskRepo,
   type TaskRepo,
 } from "./claude-code-task-run";
 
@@ -87,5 +88,81 @@ describe("buildClaudeCodeTaskPrompt", () => {
     const prompt = buildClaudeCodeTaskPrompt(task, repo);
     expect(prompt).not.toContain("gh pr checkout");
     expect(prompt).not.toContain("existing one");
+  });
+});
+
+/** An active repo-scoped `mcp-github` connection, as `connections.list` returns it. */
+const repoConn = (
+  id: string,
+  owner: string,
+  name: string,
+  extra?: Record<string, unknown>,
+) => ({
+  id,
+  status: "active",
+  metadata: {
+    ...extra,
+    repoScope: { installationId: 42, owner, repo: name },
+  },
+});
+
+describe("pickSoleTaskRepo", () => {
+  test("no imported repo is not eligible", () => {
+    expect(pickSoleTaskRepo([])).toBeNull();
+    // The bare org-level connection carries no repoScope.
+    expect(
+      pickSoleTaskRepo([{ id: "conn_0", status: "active", metadata: {} }]),
+    ).toBeNull();
+  });
+
+  test("one repo, one connection", () => {
+    expect(pickSoleTaskRepo([repoConn("conn_1", "acme", "web")])).toEqual({
+      connectionId: "conn_1",
+      owner: "acme",
+      name: "web",
+      installationId: 42,
+      url: "https://github.com/acme/web",
+    });
+  });
+
+  // The regression: importing one repo leaves an org-shared connection AND a
+  // per-agent one behind. Counting connections read that as "ambiguous".
+  test("one repo behind two connections is still one repo, org-shared wins", () => {
+    const picked = pickSoleTaskRepo([
+      repoConn("conn_agent", "acme", "web"),
+      repoConn("conn_shared", "acme", "web", { orgShared: true }),
+    ]);
+    expect(picked?.connectionId).toBe("conn_shared");
+  });
+
+  test("falls back to the per-agent connection when none is org-shared", () => {
+    const picked = pickSoleTaskRepo([repoConn("conn_agent", "acme", "web")]);
+    expect(picked?.connectionId).toBe("conn_agent");
+  });
+
+  test("owner/repo case does not split one repo into two", () => {
+    const picked = pickSoleTaskRepo([
+      repoConn("conn_1", "acme", "web"),
+      repoConn("conn_2", "Acme", "Web"),
+    ]);
+    expect(picked).not.toBeNull();
+  });
+
+  test("two different repos stay ambiguous", () => {
+    expect(
+      pickSoleTaskRepo([
+        repoConn("conn_1", "acme", "web"),
+        repoConn("conn_2", "acme", "api"),
+      ]),
+    ).toBeNull();
+  });
+
+  test("an inactive connection does not count as an imported repo", () => {
+    const picked = pickSoleTaskRepo([
+      repoConn("conn_1", "acme", "web"),
+      { ...repoConn("conn_2", "acme", "api"), status: "inactive" },
+    ]);
+    expect(picked?.owner).toBe("acme");
+    expect(picked?.name).toBe("web");
   });
 });

--- a/apps/api/src/tools/task-board/claude-code-task-run.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.ts
@@ -9,7 +9,8 @@
  * has a checkout.
  *
  * That constraint drives the eligibility rule below: this harness runs a task
- * only when the org has exactly ONE importable repo, so "which repo" has a
+ * only when the org has exactly ONE importable REPOSITORY (which is not the
+ * same as one connection — see `pickSoleTaskRepo`), so "which repo" has a
  * single correct answer. Every other case (no repos, several repos) falls back
  * to Decopilot, which can ask/choose at runtime. A task must never end up in a
  * sandbox with no checkout and a prompt telling it to open a PR.
@@ -17,6 +18,7 @@
 
 import type { StudioContext } from "@/core/studio-context";
 import { selectLoadableRepos } from "@/harnesses/decopilot/built-in-tools/load-repo";
+import { isOrgSharedConnection } from "@decocms/shared/github-repo-scope";
 import type { SuperAgentPromptOpts } from "./enqueue-super-agent";
 
 /** The repo a claude-code task run works in. */
@@ -28,12 +30,70 @@ export interface TaskRepo {
   url: string;
 }
 
+/** The connection shape the repo pick needs (mirrors `selectLoadableRepos`). */
+type RepoConnection = {
+  id: string;
+  status: string;
+  metadata: Record<string, unknown> | null;
+};
+
+/** GitHub treats owner/repo case-insensitively; the identity key must too. */
+const repoKey = (owner: string, repo: string) =>
+  `${owner}/${repo}`.toLowerCase();
+
 /**
  * The org's single importable repo, or null when the answer is ambiguous.
  *
+ * "Single" counts REPOSITORIES, not connections. Importing one repo routinely
+ * leaves TWO loadable `mcp-github` children behind — the org-shared one and a
+ * per-agent import — both pointing at the same repository. Counting connections
+ * made a genuinely one-repo org look ambiguous and silently dropped every task
+ * to Decopilot.
+ *
+ * When one repository is backed by several connections, the org-shared one
+ * wins: the per-agent child is disposable (torn down with its agent), and the
+ * clone only needs one of the two equivalent tokens.
+ *
+ * Pure, so the counting rule is unit-tested without a StudioContext.
+ */
+export function pickSoleTaskRepo(
+  connections: RepoConnection[],
+): TaskRepo | null {
+  const byId = new Map(connections.map((c) => [c.id, c]));
+  const byRepo = new Map<
+    string,
+    ReturnType<typeof selectLoadableRepos>[number][]
+  >();
+  for (const repo of selectLoadableRepos(connections)) {
+    const key = repoKey(repo.owner, repo.repo);
+    byRepo.set(key, [...(byRepo.get(key) ?? []), repo]);
+  }
+  if (byRepo.size !== 1) return null;
+
+  const candidates = [...byRepo.values()][0]!;
+  const chosen =
+    candidates.find((c) => {
+      const conn = byId.get(c.connectionId);
+      return conn ? isOrgSharedConnection(conn) : false;
+    }) ?? candidates[0]!;
+
+  return {
+    connectionId: chosen.connectionId,
+    owner: chosen.owner,
+    name: chosen.repo,
+    installationId: chosen.installationId,
+    url: `https://github.com/${chosen.owner}/${chosen.repo}`,
+  };
+}
+
+/**
+ * `pickSoleTaskRepo` over the org's `mcp-github` connections.
+ *
  * Null means "not eligible for claude-code" — see the module doc. Never throws:
  * a lookup failure degrades to the Decopilot path rather than failing the
- * delegation that already persisted.
+ * delegation that already persisted. The null cases are logged: the fallback is
+ * otherwise invisible, and "why did this task run Decopilot?" is exactly the
+ * question an operator has.
  */
 export async function resolveSoleTaskRepo(
   ctx: StudioContext,
@@ -43,16 +103,16 @@ export async function resolveSoleTaskRepo(
     const { items } = await ctx.storage.connections.list(organizationId, {
       slug: "mcp-github",
     });
-    const repos = selectLoadableRepos(items);
-    if (repos.length !== 1) return null;
-    const repo = repos[0]!;
-    return {
-      connectionId: repo.connectionId,
-      owner: repo.owner,
-      name: repo.repo,
-      installationId: repo.installationId,
-      url: `https://github.com/${repo.owner}/${repo.repo}`,
-    };
+    const repo = pickSoleTaskRepo(items);
+    if (!repo) {
+      const repos = selectLoadableRepos(items);
+      const distinct = new Set(repos.map((r) => repoKey(r.owner, r.repo)));
+      console.warn(
+        `[task-board] claude-code skipped for org ${organizationId}: ` +
+          `${distinct.size} importable repos (needs exactly 1) — running Decopilot`,
+      );
+    }
+    return repo;
   } catch (err) {
     console.warn("[task-board] repo lookup for claude-code failed", err);
     return null;


### PR DESCRIPTION
## Summary

On staging, a Super Agent task in an org with `claude_code_sandbox_enabled` on and exactly **one** imported repo still ran Decopilot. Root cause: `resolveSoleTaskRepo` counts **connections**, not **repositories**.

Importing a repo through the UI leaves two loadable `mcp-github` children behind — the org-shared one (`metadata.orgShared`) and a per-agent import — both carrying a `repoScope` for the *same* repository. `selectLoadableRepos` returns both, `repos.length !== 1` is true, and the task drops to Decopilot. Observed in `teste-franca` (org `7Q8Ji8mMbaAJB5MiYlvxqF2sHwwxixp1`), where `conn_h2Wlxn2sDsPV3__8ULqGu` and `conn_SsbCkcdExkAszmmxeimll` both point at `deco-sites/decocms-tanstack`.

So the harness was effectively unreachable from the task board: a one-repo org fails the count, and a multi-repo org is ambiguous by design.

## What changed

- New pure `pickSoleTaskRepo(connections)`: groups loadable repos by `owner/repo` (lowercased — GitHub is case-insensitive there) and requires exactly one *repository*.
- When several connections back that one repository, the **org-shared** one wins (`isOrgSharedConnection`): the per-agent child is disposable — it's torn down with its agent — and the clone only needs one of two equivalent tokens.
- `resolveSoleTaskRepo` now logs the Decopilot fallback with the distinct-repo count. Debugging this took a DB session precisely because the fallback was silent; "why did this task run Decopilot?" should be answerable from the logs.

Genuinely multi-repo orgs still fall back to Decopilot — unchanged, and correct: `load_repo` can choose at runtime, this path cannot. Letting an org pin a default task repo is the follow-up if that becomes the common case.

## Testing

- `bun test apps/api/src/tools/task-board/claude-code-task-run.test.ts` — 16 pass. New cases: two connections / one repo (the regression, asserts org-shared wins), per-agent-only fallback, owner/repo casing, two distinct repos stay ambiguous, inactive connections don't count, bare org connection isn't a repo.
- `bun run --cwd=apps/api check`, `bun run lint` (0 errors), `bun run fmt`.

No e2e: the eligibility rule is pure and now covered directly; the dispatch path around it is unchanged.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes repo selection for Claude Code tasks by counting repositories instead of connections, so single-repo orgs stop falling back to Decopilot. Adds clear logging when Claude Code is skipped.

- **Bug Fixes**
  - Added `pickSoleTaskRepo` to group `mcp-github` connections by `owner/repo` (case-insensitive) and require exactly one repository.
  - Prefer the org-shared connection when multiple connections back the same repo (via `@decocms/shared/github-repo-scope`’s `isOrgSharedConnection`).
  - Updated `resolveSoleTaskRepo` to use the new picker and log Decopilot fallback with the distinct repo count.
  - Added unit tests for duplicate connections, casing, inactive connections, and non-repo connections.

<sup>Written for commit 5b3a023ee2df670924aac5015e204e6ea71ad000. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

