### PR TITLE
refactor(tools): remove orphaned 'Link tools' comment from registry-metadata

### DIFF
--- a/packages/shared/src/tools/registry-metadata.ts
+++ b/packages/shared/src/tools/registry-metadata.ts
@@ -212,8 +212,6 @@ const ALL_TOOL_NAMES = [
   // GitHub tools (app-only)
   "GITHUB_LIST_USER_ORGS",
 
-  // Link tools
-
   // Search tools
   "GLOBAL_SEARCH",
 


### PR DESCRIPTION
PR #5596 removed the 'Links' ToolCategory and all related tools, but left behind a stray comment block (`// Link tools`) that serves no purpose. This is a cleanup of that orphaned remnant.

## Justification
The comment documents a category that no longer exists and is not referenced anywhere in the codebase (the `getToolsByCategory()` function never had an entry for "Links" after removal). This is a net -2 lines of dead code.

## Verification
- `bun run fmt` — passes
- `bunx tsc --noEmit` in packages/shared — clean, no type errors
- `bun test apps/api/src/tools/registry-metadata.test.ts` — 12/12 tests pass
- `bunx oxlint packages/shared/src/tools/registry-metadata.ts` — no warnings or errors

This is a behavior-preserving deletion: the removed comment was purely documentary, with zero impact on runtime behavior or module exports.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the stray "Link tools" comment from `packages/shared/src/tools/registry-metadata.ts` after the Links category was deleted. No behavior change; this only removes dead documentation.

<sup>Written for commit 8066073fe60a4289eac1e69ddd5121f18f15b84d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

