### PR TITLE
fix(sandbox): translate saved-section-editor breadcrumb nav aria-label

### DIFF
--- a/apps/web/src/components/sandbox/content/saved-section-editor.tsx
+++ b/apps/web/src/components/sandbox/content/saved-section-editor.tsx
@@ -162,7 +162,7 @@ export function SavedSectionEditor({
               aria-hidden
             />
             <nav
-              aria-label="Editing breadcrumb"
+              aria-label={t("sandbox.savedSectionEditor.editingBreadcrumb")}
               className="flex min-w-0 flex-1 items-center gap-1 overflow-hidden text-sm"
             >
               {headerCrumbs.map((crumb, index) => {

--- a/apps/web/src/i18n/en/sandbox.ts
+++ b/apps/web/src/i18n/en/sandbox.ts
@@ -581,6 +581,7 @@ export const sandbox = {
     "Path (relative to repo root) to the directory containing package.json. Leave blank for the repo root.",
   "sandbox.savedSectionEditor.closeJsonEditor": "Close JSON editor",
   "sandbox.savedSectionEditor.editAsJson": "Edit as JSON",
+  "sandbox.savedSectionEditor.editingBreadcrumb": "Editing breadcrumb",
   "sandbox.savedSectionEditor.globalSectionDescription":
     "Global section — changes save automatically and apply everywhere it's used.",
   "sandbox.savedSectionEditor.invalidJsonError":

--- a/apps/web/src/i18n/pt-br/sandbox.ts
+++ b/apps/web/src/i18n/pt-br/sandbox.ts
@@ -607,6 +607,7 @@ export const sandbox = {
     "Caminho (relativo à raiz do repositório) do diretório que contém package.json. Deixe em branco para a raiz do repositório.",
   "sandbox.savedSectionEditor.closeJsonEditor": "Fechar editor JSON",
   "sandbox.savedSectionEditor.editAsJson": "Editar como JSON",
+  "sandbox.savedSectionEditor.editingBreadcrumb": "Trilha de edição",
   "sandbox.savedSectionEditor.globalSectionDescription":
     "Seção global — alterações são salvas automaticamente e aplicadas em todos os locais onde é usada.",
   "sandbox.savedSectionEditor.invalidJsonError":


### PR DESCRIPTION
The `sandbox.savedSectionEditor` i18n area was hunted for gaps this tick: `apps/web/src/i18n/{en,pt-br}/sandbox.ts` are fully in sync (577 keys each, no missing/extra keys — verified by flattening both dictionaries and diffing key sets), but the breadcrumb `<nav>` in `apps/web/src/components/sandbox/content/saved-section-editor.tsx` had a raw hardcoded `aria-label="Editing breadcrumb"` sitting right next to two sibling controls in the same file that already go through `t("sandbox.savedSectionEditor....")` — a screen-reader user gets an English label here even on the pt-br locale.

Added `sandbox.savedSectionEditor.editingBreadcrumb` to both dictionaries ("Editing breadcrumb" / "Trilha de edição") and swapped the component to `t(...)`, matching the file's existing i18n pattern (`t` was already in scope, used for the adjacent JSON-toggle button's aria-label).

To confirm: open a saved (global) section editor in `apps/web`, switch locale to pt-br, and inspect the breadcrumb nav's accessible name — it now reads the translated string instead of the hardcoded English one.

Locally ran: `bun run fmt` (clean), `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint` on the three changed files (0 errors/warnings). No test file exists for this component so no targeted test was run; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes the Saved Section Editor breadcrumb nav aria-label, replacing the hardcoded English text with i18n. Adds `sandbox.savedSectionEditor.editingBreadcrumb` to `en` and `pt-br` so screen readers announce the correct locale.

<sup>Written for commit c1c79cfd31008f5b02649a91d0c7fa7d916dc4a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

