### PR TITLE
fix(task-board): don't yank a reassigned task back from a stale reviewer bounce

### DIFF
--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -489,12 +489,17 @@ export class TaskBoardStorage {
 
   /**
    * Atomically claim a task for a reviewer's `request_changes` bounce: move it
-   * from In Review to In Progress ONLY if it's still In Review, returning the
-   * updated item to the single winner and null to everyone else. QA and Code
-   * Reviewer run concurrently, and either can independently decide changes are
-   * needed — without this fence both would bounce the task and each enqueue
-   * its own Super Agent run on the SAME PR, racing to push conflicting commits.
-   * Same atomic-conditional-UPDATE pattern as `claimConflictResolution`.
+   * from In Review to In Progress ONLY if it's still In Review AND still
+   * assigned to the Super Agent, returning the updated item to the single
+   * winner and null to everyone else. QA and Code Reviewer run concurrently,
+   * and either can independently decide changes are needed — without this
+   * fence both would bounce the task and each enqueue its own Super Agent run
+   * on the SAME PR, racing to push conflicting commits. The assignee re-check
+   * closes a second race: a human can reassign the task away from the Super
+   * Agent while a reviewer run is still in flight, and that reviewer's later
+   * `request_changes` must not yank the task back and re-enqueue the Super
+   * Agent out from under the new owner. Same atomic-conditional-UPDATE pattern
+   * as `claimConflictResolution`.
    */
   async claimReviewChangesBounce(
     id: string,
@@ -511,6 +516,7 @@ export class TaskBoardStorage {
       .where("id", "=", id)
       .where("organization_id", "=", organizationId)
       .where("status", "=", "in_review")
+      .where("assignee_id", "=", SUPER_AGENT_ASSIGNEE_ID)
       .returningAll()
       .executeTakeFirst();
     if (!row) return null;

--- a/apps/api/src/tools/task-board/review-decision.ts
+++ b/apps/api/src/tools/task-board/review-decision.ts
@@ -133,9 +133,12 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
       // run concurrently, and either can independently decide changes are
       // needed; without this fence both would win a plain update and each
       // enqueue its own Super Agent run on the SAME PR, racing to push
-      // conflicting commits. The decision is still recorded either way (see
-      // below) — only the second reviewer's re-enqueue is skipped, since the
-      // first winner's run already carries the fix forward.
+      // conflicting commits. The claim also re-checks the assignee is still
+      // the Super Agent, so a human who took the task over mid-review isn't
+      // overridden by a reviewer run that started before the reassignment. The
+      // decision is still recorded either way (see below) — only the losing
+      // reviewer's re-enqueue is skipped, since either the first winner's run
+      // already carries the fix forward, or the task has a new owner now.
       const updated = await ctx.storage.taskBoard.claimReviewChangesBounce(
         taskBoardItemId,
         organizationId,


### PR DESCRIPTION
Follows #5669, which fenced `request_changes` against two reviewers racing each other, but only checked `status = in_review` — not the assignee. This closes the second race the sibling `claimConflictResolution` (in the same file) already guards against but `claimReviewChangesBounce` didn't.

Scenario: a task is In Review, assigned to the Super Agent, with QA and Code Review running. A human reassigns the task to themselves (or another agent) mid-review — status stays In Review, only `assigneeId` changes. A reviewer that started before the reassignment then finishes and calls `request_changes`. Today `claimReviewChangesBounce`'s conditional UPDATE only checks `status = 'in_review'`, so it still succeeds: the task gets yanked back to In Progress and a brand-new Super Agent run is enqueued on the PR out from under the new owner, even though a human explicitly took it over.

Fix: add `.where("assignee_id", "=", SUPER_AGENT_ASSIGNEE_ID)` to the same conditional UPDATE, mirroring `claimConflictResolution`'s existing pattern in this file. Under the normal flow (assignee is always the Super Agent while a reviewer run is live) this is a no-op; it only changes behavior on the reassignment race, where the claim now correctly returns null and the handler's existing `!updated` branch (already added in #5669) leaves the task with its new owner instead of re-enqueueing the Super Agent.

How to verify: `cd apps/api && bunx tsc --noEmit` (clean) — this is a storage-layer conditional-UPDATE change identical in shape to the already-shipped `claimConflictResolution`, and this repo has no local Postgres to run an integration test against (same reason #5669 itself shipped `claimReviewChangesBounce` without one).

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api), `bunx oxlint` on both touched files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a stale reviewer from yanking a task back to In Progress after it’s reassigned mid-review. We now only bounce if the task is still In Review and still assigned to the Super Agent.

- **Bug Fixes**
  - Add an assignee check to `TaskBoardStorage.claimReviewChangesBounce` so the claim only succeeds when `assignee_id` is the Super Agent, matching `claimConflictResolution`.
  - Update `review-decision.ts` comments and flow to clarify that losing reviewers skip re-enqueue when the task was reassigned or another reviewer already won.

<sup>Written for commit 42f9993cffdd9187e5f3c986b4076cc2f5b31171. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

