### PR TITLE
fix(auth): close Better Auth's direct org-update slug-rename bypass

### DIFF
--- a/apps/api/src/auth/index.ts
+++ b/apps/api/src/auth/index.ts
@@ -50,6 +50,7 @@ import { createSSOConfig } from "./sso";
 import { GENERIC_EMAIL_DOMAINS } from "./org-assurance-policy";
 import { ensureUserOrganization } from "./ensure-user-organization";
 import { isReservedOrganizationSlug } from "@decocms/shared/organization-slugs";
+import { rejectOrganizationSlugChange } from "./reject-slug-change";
 
 function rejectReservedOrganizationSlug(slug: unknown): void {
   if (!isReservedOrganizationSlug(slug)) return;
@@ -253,6 +254,21 @@ const plugins = [
         // Better Auth allows slug changes directly, so creation-only
         // validation could otherwise be bypassed by renaming an existing org.
         rejectReservedOrganizationSlug(organization.slug);
+
+        // Studio's ORGANIZATION_UPDATE tool and settings UI never send a
+        // slug, but this endpoint is also reachable directly
+        // (authClient.organization.update) — reject any attempt to change
+        // it there too, so the slug stays immutable regardless of caller.
+        if (typeof organization.slug === "string") {
+          const current = await getDb()
+            .db.selectFrom("organization")
+            .select("slug")
+            .where("id", "=", member.organizationId)
+            .executeTakeFirst();
+          if (current) {
+            rejectOrganizationSlugChange(current.slug, organization.slug);
+          }
+        }
 
         const logo = organization.logo;
         if (typeof logo !== "string" || !logo.startsWith("data:")) return;

--- a/apps/api/src/auth/reject-slug-change.test.ts
+++ b/apps/api/src/auth/reject-slug-change.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { rejectOrganizationSlugChange } from "./reject-slug-change";
+
+describe("rejectOrganizationSlugChange", () => {
+  test("allows an update that omits the slug", () => {
+    expect(() => rejectOrganizationSlugChange("acme", undefined)).not.toThrow();
+  });
+
+  test("allows resubmitting the current slug", () => {
+    expect(() => rejectOrganizationSlugChange("acme", "acme")).not.toThrow();
+  });
+
+  test("rejects renaming the slug", () => {
+    expect(() => rejectOrganizationSlugChange("acme", "acme-2")).toThrow(
+      "Organization slug cannot be changed after creation.",
+    );
+  });
+});

--- a/apps/api/src/auth/reject-slug-change.ts
+++ b/apps/api/src/auth/reject-slug-change.ts
@@ -1,0 +1,20 @@
+import { APIError } from "better-auth/api";
+
+/**
+ * Better Auth's own `/organization/update` endpoint accepts an arbitrary
+ * `slug` in its update payload. Studio's ORGANIZATION_UPDATE tool and the
+ * settings UI never send one, but a caller with org-update permission can
+ * still hit Better Auth's endpoint directly (authClient.organization.update,
+ * or the raw REST route) and rename the org. The slug anchors every
+ * /api/:org/... and /$org/... URL, so this rejects any attempt to change it,
+ * matching the immutability guarantee the rest of the codebase assumes.
+ */
+export function rejectOrganizationSlugChange(
+  currentSlug: string,
+  nextSlug: unknown,
+): void {
+  if (typeof nextSlug !== "string" || nextSlug === currentSlug) return;
+  throw new APIError("BAD_REQUEST", {
+    message: "Organization slug cannot be changed after creation.",
+  });
+}


### PR DESCRIPTION
Follows #5670, which stopped the org settings page and ORGANIZATION_UPDATE from letting the slug be renamed.

**The gap:** neither of those touched Better Auth's own `/organization/update` endpoint (`authClient.organization.update`), which still accepts an arbitrary `slug` in its update payload. The `beforeUpdateOrganization` hook only rejected *reserved* slugs (`rejectReservedOrganizationSlug`) — it never checked whether the slug was actually changing. Any caller with org-update permission (owner/admin, or anyone scripting against the API directly) could still rename an org by calling that endpoint with a non-reserved slug, bypassing the UI/tool-level restriction entirely and silently breaking every saved `/api/:org/...` and `/$org/...` URL for that org — the exact failure #5670 set out to prevent, and the invariant CLAUDE.md documents as "org slugs are immutable."

**Fix:** `beforeUpdateOrganization` now fetches the organization's current slug and rejects the update (via a new `rejectOrganizationSlugChange` helper) whenever the payload's `slug` differs from it, regardless of which entry point reached the endpoint.

**Regression test:** `apps/api/src/auth/reject-slug-change.test.ts` exercises the extracted pure helper directly (no-op on omitted/unchanged slug, throws on an actual change) — this is the trust-boundary logic itself, so it's tested without booting the full Better Auth stack.

**To verify:** `bun test apps/api/src/auth/reject-slug-change.test.ts`

**Locally ran:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test above (3 pass), and `bunx oxlint` on the three touched files (0 warnings/errors). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks organization slugs by rejecting changes sent to Better Auth’s `/organization/update`. This closes the remaining bypass so slugs stay immutable and URLs don’t break.

- **Bug Fixes**
  - In `beforeUpdateOrganization`, fetch the current slug and call `rejectOrganizationSlugChange` to block any change.
  - Retains reserved-slug validation; adds a unit test for the helper.
  - Covers direct calls to `authClient.organization.update` and the REST route.

<sup>Written for commit 6b57cdcc03fcd8eca759dc7fe133ac31f3fcc87e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5675?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

