### PR TITLE
fix(sandbox): restore port-sniffer phrase gate + cross-chunk carry

### DIFF
--- a/packages/sandbox/daemon-go/internal/proc/portsniffer.go
+++ b/packages/sandbox/daemon-go/internal/proc/portsniffer.go
@@ -29,16 +29,21 @@ func IsWellKnownStarter(name string) bool {
 //	bun:   `Listening on http://localhost:3000`
 //	fresh: `Listening on http://0.0.0.0:8000/`
 //
-// The port must be followed by a `/` or whitespace (incl. the trailing newline)
-// so a chunk that splits mid-number ("...:51" | "73/") waits for its
+// The port must be followed by a non-digit ("/" for vite/fresh, ")" / "," /
+// whitespace / newline for the no-trailing-slash frameworks, or a leftover ANSI
+// ESC when the URL is colored). A trailing non-digit is required — rather than
+// nothing — so a chunk that splits mid-number ("...:51" | "73/") waits for its
 // continuation instead of locking the truncated "51".
 var urlPattern = regexp.MustCompile(
-	`(?:Local:|Listening on)[^\n]*?\bhttps?://(?:localhost|127\.0\.0\.1|0\.0\.0\.0):(\d+)[/\s]`,
+	`(?:Local:|Listening on)[^\n]*?\bhttps?://(?:localhost|127\.0\.0\.1|0\.0\.0\.0):(\d+)[^\d]`,
 )
 
-// ansiPattern mirrors the TS regex, which matches bracket sequences without
-// requiring the ESC prefix.
-var ansiPattern = regexp.MustCompile(`\[[0-9;?]*[a-zA-Z]`)
+// ansiPattern strips SGR/cursor escapes. The ESC prefix is optional so it also
+// eats bare bracket sequences (mirroring the TS regex), but consuming the ESC
+// when present matters: a leftover "\x1b" between the port and the newline of a
+// colored, no-trailing-slash bind URL would otherwise sit where the terminator
+// is inspected.
+var ansiPattern = regexp.MustCompile(`\x1b?\[[0-9;?]*[a-zA-Z]`)
 
 // carryLimit bounds the per-source tail kept across Observe calls. The longest
 // phrase+URL we need to span is well under 100 chars, so 200 leaves headroom.

--- a/packages/sandbox/daemon-go/internal/proc/portsniffer.go
+++ b/packages/sandbox/daemon-go/internal/proc/portsniffer.go
@@ -17,21 +17,47 @@ func IsWellKnownStarter(name string) bool {
 	return false
 }
 
-var urlPattern = regexp.MustCompile(`https?://(?:localhost|127\.0\.0\.1|0\.0\.0\.0):(\d+)`)
+// urlPattern requires one of the banner phrases ("Local:" / "Listening on") on
+// the SAME line as the bind URL — a bare `http://localhost:N` isn't enough.
+// `dev`/`start` often run more than one process (e.g. a framework that prints
+// the injected PORT, a proxied fetch, a sibling `node server.js`) whose stdout
+// interleaves on the same stream; without the phrase gate an unrelated URL
+// could win the lock before the real bind line arrives. Frameworks covered:
+//
+//	vite:  `Local:   http://localhost:5173/`
+//	next:  `- Local:        http://localhost:3000`
+//	bun:   `Listening on http://localhost:3000`
+//	fresh: `Listening on http://0.0.0.0:8000/`
+//
+// The port must be followed by a `/` or whitespace (incl. the trailing newline)
+// so a chunk that splits mid-number ("...:51" | "73/") waits for its
+// continuation instead of locking the truncated "51".
+var urlPattern = regexp.MustCompile(
+	`(?:Local:|Listening on)[^\n]*?\bhttps?://(?:localhost|127\.0\.0\.1|0\.0\.0\.0):(\d+)[/\s]`,
+)
 
 // ansiPattern mirrors the TS regex, which matches bracket sequences without
 // requiring the ESC prefix.
 var ansiPattern = regexp.MustCompile(`\[[0-9;?]*[a-zA-Z]`)
+
+// carryLimit bounds the per-source tail kept across Observe calls. The longest
+// phrase+URL we need to span is well under 100 chars, so 200 leaves headroom.
+const carryLimit = 200
 
 // PortSniffer locks in the first bind-URL port announced on a well-known
 // starter's stdout until Reset.
 type PortSniffer struct {
 	mu   sync.Mutex
 	port int
+	// PTY reads (child.onData) aren't line-buffered — a chunk boundary can land
+	// mid bind-line (e.g. "...Local:   http://localhost:51" | "73/\n"). Matching
+	// each chunk in isolation would miss the announcement forever, so we carry a
+	// bounded, ANSI-stripped tail per source and match against the concatenation.
+	carry map[string]string
 }
 
 func NewPortSniffer() *PortSniffer {
-	return &PortSniffer{}
+	return &PortSniffer{carry: map[string]string{}}
 }
 
 func (p *PortSniffer) Observe(source, data string) {
@@ -43,16 +69,29 @@ func (p *PortSniffer) Observe(source, data string) {
 	if !IsWellKnownStarter(source) {
 		return
 	}
-	stripped := ansiPattern.ReplaceAllString(data, "")
-	m := urlPattern.FindStringSubmatch(stripped)
+	combined := p.carry[source] + ansiPattern.ReplaceAllString(data, "")
+	m := urlPattern.FindStringSubmatch(combined)
 	if m == nil {
+		p.carry[source] = tail(combined, carryLimit)
 		return
 	}
 	parsed, err := strconv.Atoi(m[1])
 	if err != nil || parsed <= 0 || parsed > 65535 {
+		p.carry[source] = tail(combined, carryLimit)
 		return
 	}
+	delete(p.carry, source)
 	p.port = parsed
+}
+
+// tail returns the last n runes of s (rune-safe so a multibyte char like the
+// vite "➜" prefix is never split across a carry boundary).
+func tail(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[len(r)-n:])
 }
 
 // Current returns the sniffed port, 0 when nothing is locked in.
@@ -65,5 +104,6 @@ func (p *PortSniffer) Current() int {
 func (p *PortSniffer) Reset() {
 	p.mu.Lock()
 	p.port = 0
+	p.carry = map[string]string{}
 	p.mu.Unlock()
 }

--- a/packages/sandbox/daemon-go/internal/proc/proc_test.go
+++ b/packages/sandbox/daemon-go/internal/proc/proc_test.go
@@ -45,3 +45,34 @@ func TestPortSnifferLockIn(t *testing.T) {
 		t.Fatalf("got %d", s.Current())
 	}
 }
+
+// A bare `http://localhost:N` with no banner phrase must NOT lock — otherwise an
+// early line echoing the injected PORT (3000) hijacks the probe before vite's
+// real `Local: http://localhost:5173/` arrives. This is the granado regression:
+// the daemon dialed 3000 while vite served 5173.
+func TestPortSnifferIgnoresBareURLBeforeBanner(t *testing.T) {
+	s := NewPortSniffer()
+	s.Observe("dev", "[deco] proxying dev server at http://localhost:3000\r\n")
+	if s.Current() != 0 {
+		t.Fatalf("bare URL without a banner phrase must not lock, got %d", s.Current())
+	}
+	s.Observe("dev", "  \x1b[32m➜\x1b[0m  Local:   http://localhost:5173/\r\n")
+	if s.Current() != 5173 {
+		t.Fatalf("expected the real vite bind port 5173, got %d", s.Current())
+	}
+}
+
+// PTY output isn't line-buffered: the bind line can split across chunks. The
+// sniffer must carry a per-source tail so the announcement still matches once
+// its continuation arrives (the other half of the granado regression).
+func TestPortSnifferSpansChunkBoundary(t *testing.T) {
+	s := NewPortSniffer()
+	s.Observe("dev", "  ➜  Local:   http://localhost:51")
+	if s.Current() != 0 {
+		t.Fatal("partial bind line must not lock yet")
+	}
+	s.Observe("dev", "73/\r\n")
+	if s.Current() != 5173 {
+		t.Fatalf("split bind line must lock once completed, got %d", s.Current())
+	}
+}

--- a/packages/sandbox/daemon-go/internal/proc/proc_test.go
+++ b/packages/sandbox/daemon-go/internal/proc/proc_test.go
@@ -76,3 +76,61 @@ func TestPortSnifferSpansChunkBoundary(t *testing.T) {
 		t.Fatalf("split bind line must lock once completed, got %d", s.Current())
 	}
 }
+
+// The no-trailing-slash frameworks (next, bun) end the port with a newline, not
+// a "/". When the URL is also colored, the ANSI stripper must consume the ESC so
+// the port isn't shielded from the terminator check — otherwise the sniffer
+// misses and the daemon dials the wrong configured port.
+func TestPortSnifferColoredNoTrailingSlash(t *testing.T) {
+	s := NewPortSniffer()
+	s.Observe("dev", "Listening on \x1b[1mhttp://localhost:3000\x1b[0m\r\n")
+	if s.Current() != 3000 {
+		t.Fatalf("colored no-slash bind URL must lock 3000, got %d", s.Current())
+	}
+}
+
+// A port terminated by a non-"/", non-space char (e.g. a closing paren) must
+// still lock — the terminator only has to be a non-digit so a split mid-number
+// keeps waiting.
+func TestPortSnifferNonSlashTerminator(t *testing.T) {
+	s := NewPortSniffer()
+	s.Observe("dev", "  Local: (http://localhost:3000)\n")
+	if s.Current() != 3000 {
+		t.Fatalf("paren-terminated port must lock 3000, got %d", s.Current())
+	}
+}
+
+// Reset must clear the carry, not just the port — otherwise a partial bind line
+// carried from a previous cycle can splice with a new fragment into a false
+// match (e.g. a leftover "…:51" + a fresh "73/").
+func TestPortSnifferResetClearsCarry(t *testing.T) {
+	s := NewPortSniffer()
+	s.Observe("dev", "  Local:   http://localhost:51")
+	s.Reset()
+	s.Observe("dev", "73/\r\n")
+	if s.Current() != 0 {
+		t.Fatalf("stale carry survived Reset and produced a false lock: %d", s.Current())
+	}
+}
+
+// The phrase gate + line-bound `[^\n]*?` must ignore an unrelated localhost URL
+// from a sibling line that precedes the real bind banner in the same chunk.
+func TestPortSnifferIgnoresSiblingURLBeforeBanner(t *testing.T) {
+	s := NewPortSniffer()
+	s.Observe("dev", "API ready on http://localhost:4000/graphql\n  Local:   http://localhost:3000/\n")
+	if s.Current() != 3000 {
+		t.Fatalf("must lock the banner's port 3000, not the sibling 4000, got %d", s.Current())
+	}
+}
+
+// Each starter source carries independently: a chunk on `start` must not corrupt
+// a partial bind line carried on `dev`.
+func TestPortSnifferPerSourceCarryIsolation(t *testing.T) {
+	s := NewPortSniffer()
+	s.Observe("dev", "  Local:   http://localhost:51")
+	s.Observe("start", "Listening on http://localhost:80")
+	s.Observe("dev", "73/\r\n")
+	if s.Current() != 5173 {
+		t.Fatalf("dev carry corrupted by start chunk, got %d", s.Current())
+	}
+}


### PR DESCRIPTION
## Problem

TanStack/Vite migration previews (e.g. `granadobr-tanstack`) are stuck on the boot skeleton / "Server is starting…" even though the `dev` terminal shows `VITE ready` on `http://localhost:5173/`.

Reading the daemon log directly (`fetch("/_sandbox/events")` on the preview host, bypassing the Studio `/api/.../events` proxy) shows the smoking gun:

```
[daemon] proxy error GET / port=3000  dial tcp 127.0.0.1:3000: connect: connection refused
phase: "starting"   (never "running")   ·   132× refused   ·   0× "[probe] server responded"
```

The daemon dials **3000** while Vite serves **5173**.

## Root cause — a regression in the TS→Go daemon rewrite

The Go port sniffer became the default in #5568 and the TS daemon was deleted in #5575. The Go `portsniffer.go` was an **incomplete port** of the TS `port-sniffer.ts` — it dropped two safeguards:

| Safeguard | TS (worked) | Go (regressed) |
|---|---|---|
| **Phrase gate** (`Local:` / `Listening on` on the URL line) | ✅ | ❌ bare `http://localhost:N` matches |
| **Cross-chunk carry** (PTY line-split reassembly) | ✅ 200-char tail per source | ❌ matches each chunk in isolation |

Either gap makes the sniffer miss Vite's `5173`. `getDevPort()` then falls back to the configured `application.port` (`DEFAULT_DEV_PORT = 3000`) → the proxy (`proxy.go`) and probe (`probe.go`) dial a dead port → `StartingHTML` + lifecycle stuck at `starting`. Apps that bind the injected `PORT` (e.g. `casaevideo-tanstack`, which serves on 3000) were unaffected; apps relying on the sniffer to learn a dynamic port broke.

## Fix

Restore both safeguards in `portsniffer.go`:

- **Phrase gate** — the bind URL must follow `Local:` / `Listening on` on the same line, so an early bare `localhost:3000` (a framework echoing `PORT`, a proxied fetch, a sibling process) can't hijack the lock.
- **Cross-chunk carry** — carry a bounded, ANSI-stripped tail per source and match the concatenation. The port must also be terminated by `/` or whitespace, so a chunk splitting mid-number (`...:51` | `73/`) waits for its continuation instead of locking the truncated `51`.

## Tests

`proc_test.go` gains coverage for both failure modes:
- `TestPortSnifferIgnoresBareURLBeforeBanner` — an early bare `localhost:3000` does not lock; the later `Local: …:5173/` does.
- `TestPortSnifferSpansChunkBoundary` — a split bind line locks once completed.

Regex + carry logic validated against all cases (existing lock-in, phrase gate, mid-port split, colon split, casaevideo `Local:3000`).

## Testing notes

Go isn't installed locally, so I couldn't run `go test` here — relying on the `sandbox-daemon` CI (`go vet` / `go test -race` / `go build`). Logic was validated with an equivalent-regex simulation covering every scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dev previews getting stuck by restoring safeguards in the Go port sniffer. It now reliably detects the real dev server port (e.g., Vite 5173 and Next/Bun without a trailing slash) instead of falling back to 3000.

- **Bug Fixes**
  - Reinstate phrase gate: only lock URLs on lines with “Local:” or “Listening on”; ignore bare or sibling localhost URLs.
  - Handle split PTY chunks with per-source carry; require a non-digit terminator so mid-number splits don’t lock.
  - Consume ANSI ESC in color codes and clear carry on Reset; updated `portsniffer.go` and expanded tests in `proc_test.go` (colored no-slash, non-slash terminator, reset carry, sibling-before-banner, per-source isolation).

<sup>Written for commit eb8b7f5ed8fbcbb35b124c3f95f411bf5e53368e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

