### PR TITLE
refactor(sections-editor): dedupe resolveTargetConfigId between image/file fields

### DIFF
--- a/apps/web/src/components/sections-editor/fields/file-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/file-field.tsx
@@ -18,6 +18,7 @@ import { FieldLabel } from "./field-label";
 import type { FieldProps } from "./field-props";
 import { basename, extension } from "./media-filename";
 import { MediaTransformControls } from "./media-transform-controls";
+import { resolveTargetConfigId } from "./resolve-target-config-id";
 
 function ExtBadge({ ext }: { ext: string }) {
   if (!ext) return null;
@@ -51,18 +52,6 @@ export function FileField({
     sandbox?.siteSlug,
   );
 
-  function resolveTargetConfigId(): string | null {
-    if (lockedConfig) return lockedConfig.id;
-    const configs = configsQuery.data?.configs ?? [];
-    if (configs.length === 1) return configs[0]!.id;
-    if (configs.length === 0) return null;
-    const lastSelected =
-      typeof window !== "undefined"
-        ? window.localStorage.getItem(LAST_CONFIG_KEY)
-        : null;
-    return configs.some((c) => c.id === lastSelected) ? lastSelected : null;
-  }
-
   async function handleFiles(files: FileList | File[] | null) {
     if (!files) return;
     let list = Array.from(files);
@@ -75,7 +64,13 @@ export function FileField({
       }
     }
 
-    const targetConfigId = resolveTargetConfigId();
+    const targetConfigId = resolveTargetConfigId(
+      configsQuery.data?.configs ?? [],
+      lockedConfig?.id,
+      typeof window !== "undefined"
+        ? window.localStorage.getItem(LAST_CONFIG_KEY)
+        : null,
+    );
     if (!targetConfigId) {
       setPickerOpen(true);
       return;

--- a/apps/web/src/components/sections-editor/fields/image-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/image-field.tsx
@@ -18,6 +18,7 @@ import { FieldLabel } from "./field-label";
 import type { FieldProps } from "./field-props";
 import { basename, extension } from "./media-filename";
 import { MediaTransformControls } from "./media-transform-controls";
+import { resolveTargetConfigId } from "./resolve-target-config-id";
 
 const ACCEPTED_IMAGE_TYPES = new Set([
   "image/png",
@@ -66,25 +67,6 @@ export function ImageField({
     onChange(next);
   }
 
-  /**
-   * Pick which bucket a drop-on-field upload should target.
-   *   - 1 config: that one
-   *   - 2+ configs: the last-used (from localStorage), if it's still present
-   *   - 0 configs, or 2+ without a prior selection: null → open the dialog
-   *     so the user can configure / pick a bucket explicitly
-   */
-  function resolveTargetConfigId(): string | null {
-    if (lockedConfig) return lockedConfig.id;
-    const configs = configsQuery.data?.configs ?? [];
-    if (configs.length === 1) return configs[0]!.id;
-    if (configs.length === 0) return null;
-    const lastSelected =
-      typeof window !== "undefined"
-        ? window.localStorage.getItem(LAST_CONFIG_KEY)
-        : null;
-    return configs.some((c) => c.id === lastSelected) ? lastSelected : null;
-  }
-
   async function handleFiles(files: FileList | File[] | null) {
     if (!files) return;
     const list = Array.from(files).filter((f) =>
@@ -95,7 +77,13 @@ export function ImageField({
       return;
     }
 
-    const targetConfigId = resolveTargetConfigId();
+    const targetConfigId = resolveTargetConfigId(
+      configsQuery.data?.configs ?? [],
+      lockedConfig?.id,
+      typeof window !== "undefined"
+        ? window.localStorage.getItem(LAST_CONFIG_KEY)
+        : null,
+    );
     if (!targetConfigId) {
       // No deterministic target — defer to the dialog so the user can
       // pick a bucket (or be guided to configure one). The dialog won't

--- a/apps/web/src/components/sections-editor/fields/resolve-target-config-id.test.ts
+++ b/apps/web/src/components/sections-editor/fields/resolve-target-config-id.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { resolveTargetConfigId } from "./resolve-target-config-id";
+
+describe("resolveTargetConfigId", () => {
+  test("locked config always wins", () => {
+    expect(resolveTargetConfigId([{ id: "a" }, { id: "b" }], "b", "a")).toBe(
+      "b",
+    );
+  });
+
+  test("single config is used regardless of last-selected", () => {
+    expect(resolveTargetConfigId([{ id: "a" }], null, "other")).toBe("a");
+  });
+
+  test("no configs returns null", () => {
+    expect(resolveTargetConfigId([], null, "a")).toBe(null);
+  });
+
+  test("multiple configs use last-selected if still present", () => {
+    expect(resolveTargetConfigId([{ id: "a" }, { id: "b" }], null, "b")).toBe(
+      "b",
+    );
+  });
+
+  test("multiple configs with stale/missing last-selected returns null", () => {
+    expect(
+      resolveTargetConfigId([{ id: "a" }, { id: "b" }], null, "stale"),
+    ).toBe(null);
+    expect(resolveTargetConfigId([{ id: "a" }, { id: "b" }], null, null)).toBe(
+      null,
+    );
+  });
+});

--- a/apps/web/src/components/sections-editor/fields/resolve-target-config-id.ts
+++ b/apps/web/src/components/sections-editor/fields/resolve-target-config-id.ts
@@ -1,0 +1,21 @@
+/**
+ * Pick which file-config bucket a drop/browse upload should target, shared
+ * by ImageField and FileField.
+ *   - a locked (site-slug-matched) config always wins
+ *   - 1 config: that one
+ *   - 2+ configs: the last-used (from localStorage), if it's still present
+ *   - 0 configs, or 2+ without a prior selection: null → caller opens the
+ *     picker dialog so the user can configure / pick a bucket explicitly
+ */
+export function resolveTargetConfigId(
+  configs: Array<{ id: string }>,
+  lockedConfigId: string | null | undefined,
+  lastSelectedConfigId: string | null,
+): string | null {
+  if (lockedConfigId) return lockedConfigId;
+  if (configs.length === 1) return configs[0]!.id;
+  if (configs.length === 0) return null;
+  return configs.some((c) => c.id === lastSelectedConfigId)
+    ? lastSelectedConfigId
+    : null;
+}


### PR DESCRIPTION
**Source:** code-reduction (duplication) found while auditing the sections-editor field components (`any-of-field.tsx`, `enum-field.tsx`, `image-field.tsx`, `file-field.tsx`, `inline-union-field.tsx`).

**What:** `ImageField` and `FileField` each defined a byte-identical `resolveTargetConfigId()` closure — locked config wins, else the single config, else the last-selected config from localStorage if still present, else `null` (caller opens the file-picker dialog). Extracted it into `resolve-target-config-id.ts` as a plain pure function, mirroring the existing pattern in this same directory (`extract-url.ts`, `media-filename.ts` — both already shared by these two fields).

**Why a maintainer wants it:** removes a duplicated 11-line closure that would otherwise need to be kept in sync by hand across two files every time the config-resolution rule changes (e.g. the recent site-slug-locked-config addition already had to be applied in both places).

**Net effect:** the two consumer files shrink (-33/+21 combined) and the pure extraction adds a small dedicated test file (+33, mostly test) — a straight behavior-preserving move, not a rewrite. Confirmed unchanged behavior: same branching order, same inputs/outputs, just parameterized instead of closing over component state.

**How to verify:** `bun test apps/web/src/components/sections-editor/fields/resolve-target-config-id.test.ts`

**Checks run locally:**
- `bun run fmt`
- `cd apps/web && bunx tsc --noEmit` (clean)
- `bun test apps/web/src/components/sections-editor/fields/resolve-target-config-id.test.ts` (5 pass)
- `bunx oxlint` on all 4 touched files (0 warnings/errors)

Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicated the "choose upload target config" logic for image and file fields by extracting it into a shared `resolveTargetConfigId` helper. Behavior is unchanged and code size is reduced.

- **Refactors**
  - Extracted `resolveTargetConfigId` into `resolve-target-config-id.ts` and used it in `ImageField` and `FileField`.
  - Decision order remains: locked config → single config → last-selected (if still present) → null (open picker).

<sup>Written for commit 47ab023e24c963ca1fcfcb94dbc448cd17548f4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

