### PR TITLE
fix(web): don't leak a raw parse error on a non-JSON tool success response

### DIFF
--- a/apps/web/src/lib/studio-tools.test.ts
+++ b/apps/web/src/lib/studio-tools.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { callStudioTool } from "./studio-tools";
+
+let originalFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("callStudioTool", () => {
+  test("returns the parsed JSON body on success", async () => {
+    const body = { id: "conn_1", healthy: true, latencyMs: 12 };
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify(body), {
+        status: 200,
+      })) as unknown as typeof globalThis.fetch;
+
+    const result = await callStudioTool("acme", "CONNECTION_TEST", {
+      id: "conn_1",
+    });
+    expect(result).toEqual(body);
+  });
+
+  test("throws a StudioToolError with the server message on non-2xx", async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ error: "not found" }), {
+        status: 404,
+      })) as unknown as typeof globalThis.fetch;
+
+    await expect(
+      callStudioTool("acme", "CONNECTION_TEST", { id: "conn_1" }),
+    ).rejects.toMatchObject({ message: "not found", status: 404 });
+  });
+
+  test("falls back to a generic message when the error body isn't JSON", async () => {
+    globalThis.fetch = (async () =>
+      new Response("<html>502 Bad Gateway</html>", {
+        status: 502,
+      })) as unknown as typeof globalThis.fetch;
+
+    await expect(
+      callStudioTool("acme", "CONNECTION_TEST", { id: "conn_1" }),
+    ).rejects.toMatchObject({
+      message: "CONNECTION_TEST failed (502)",
+      status: 502,
+    });
+  });
+
+  test("throws a StudioToolError instead of a raw parse error when a 2xx body isn't JSON", async () => {
+    globalThis.fetch = (async () =>
+      new Response("<html>upstream proxy glitch</html>", {
+        status: 200,
+      })) as unknown as typeof globalThis.fetch;
+
+    await expect(
+      callStudioTool("acme", "CONNECTION_TEST", { id: "conn_1" }),
+    ).rejects.toMatchObject({
+      name: "StudioToolError",
+      message: "CONNECTION_TEST returned a non-JSON response",
+      status: 200,
+    });
+  });
+});

--- a/apps/web/src/lib/studio-tools.ts
+++ b/apps/web/src/lib/studio-tools.ts
@@ -59,7 +59,14 @@ export async function callStudioTool<N extends StudioToolName>(
     throw new StudioToolError(message, res.status);
   }
 
-  return (await res.json()) as StudioToolIO[N]["output"];
+  try {
+    return (await res.json()) as StudioToolIO[N]["output"];
+  } catch {
+    throw new StudioToolError(
+      `${name} returned a non-JSON response`,
+      res.status,
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
Dispatched focus area was `packages/shared/src/tools/tool-io.ts`, but that file (and its siblings `chat-tools.ts`/`registry-metadata.ts`) is 100% generated type-only contracts with zero runtime logic — nothing to add type guards or error handling to. Widened one step to the actual runtime I/O path built on top of it: `apps/web/src/lib/studio-tools.ts`'s `callStudioTool()`, the typed REST client every builtin-tool caller in the web app goes through (~50 call sites).

**Bug:** `callStudioTool()` wraps `res.json()` in try/catch on the *error* branch (falls back to a generic message on a non-JSON error body) but not on the *success* branch. If the server returns a 2xx with a malformed/non-JSON body — e.g. an edge/CDN or reverse-proxy glitch that returns an HTML page with a 200 status, or a truncated response — the function throws a raw, unhandled `SyntaxError` ("Unexpected end of JSON input" or similar) instead of the same typed `StudioToolError` every other failure path produces. Callers that check `error instanceof StudioToolError` or read `.status`/`.message` for user-facing error text get an inconsistent, uninformative failure in this one case.

**Fix:** wrap the success-path parse in the same try/catch, throwing `StudioToolError("<tool> returned a non-JSON response", res.status)` — matching the shape of every other error this client produces.

**Test:** `apps/web/src/lib/studio-tools.test.ts` (new file, none existed) covers: success returns the parsed body, error with a JSON body surfaces the server message, error with a non-JSON body falls back to the generic message, and the new case — a 2xx with a non-JSON body throws `StudioToolError` instead of a raw parse error.

Reviewer check: `cd apps/web && bun test src/lib/studio-tools.test.ts`

Ran locally: `bun run fmt`, `bunx tsc --noEmit` (apps/web), the targeted test file above, and `bunx oxlint` on both touched files. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `callStudioTool()` to handle 2xx responses with non‑JSON bodies by throwing a `StudioToolError` with the tool name and status instead of a raw JSON parse error. Adds tests covering success, JSON error, non‑JSON error, and non‑JSON on 2xx cases.

<sup>Written for commit 176d6dffab94d6547ef64ee9692bdcaf019e44ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

