### PR TITLE
refactor(storage): remove dead InflightAsyncJob type and column declaration

### DIFF
--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -911,21 +911,6 @@ export interface ConnectionAggregationTable {
 /** Stored thread statuses (persisted in DB). Canonical source: @decocms/shared/sdk */
 export type { ThreadStatus } from "@decocms/shared/sdk";
 
-export interface InflightAsyncJob {
-  /** Tool call that submitted this job (for diagnostics; not the resume key). */
-  toolCallId: string;
-  /** Adapter id that owns this job — must equal `StudioProvider.info.id`. */
-  provider: string;
-  /** Provider-side model id, e.g. `deep-research-preview-04-2026`. */
-  modelId: string;
-  /** Original query text — used together with provider+modelId to deduplicate on resume. */
-  query: string;
-  /** Adapter-opaque handle (e.g. Gemini interaction id) — passed back to `resume()`. */
-  jobId: string;
-  /** ISO timestamp set when the job was submitted. */
-  startedAt: string;
-}
-
 export interface ThreadTable {
   id: string;
   organization_id: string;
@@ -945,17 +930,6 @@ export interface ThreadTable {
     Date | null,
     Date | string | null,
     Date | string | null
-  >;
-  /**
-   * Long-running provider jobs (`AsyncResearchProvider`) still in flight for
-   * this thread. Each entry is removed when the underlying job reaches a
-   * terminal state. Surviving entries are how a fresh pod re-attaches to a
-   * job after a crash.
-   */
-  inflight_async_jobs: ColumnType<
-    InflightAsyncJob[] | null,
-    string | null,
-    string | null
   >;
   /** Virtual MCP (agent) this thread was initiated with */
   virtual_mcp_id: string;


### PR DESCRIPTION
Dead-code cleanup found while auditing thread storage/ports for consistency.

**What:** removes the `InflightAsyncJob` interface and the `ThreadTable.inflight_async_jobs` column declaration from `apps/api/src/storage/types.ts`.

**Why it's dead:** migration `080-async-research-jobs.ts` replaced `threads.inflight_async_jobs` with the dedicated `async_research_jobs` table; its own comment says the JSONB column "stays in place for now" until a later drop migration. That drop never landed, but no application code reads or writes the column any more — `rg -n "inflight_async_jobs|InflightAsyncJob" apps/api/src` returns zero hits outside `types.ts` (and the migration files' comments) after this change.

**Net line delta:** -26 / +0, one file.

**Behavior:** unchanged. This only removes a Kysely type-level column declaration — the physical DB column is untouched (no migration needed), so nothing that reads real rows is affected; `selectAll()` callers never referenced this field anyway (`threadFromDbRow` doesn't accept or return it).

**How to verify:** `cd apps/api && bunx tsc --noEmit` stays green (confirms no code depended on the removed types).

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint apps/api/src/storage/types.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove dead `InflightAsyncJob` type and the `ThreadTable.inflight_async_jobs` column declaration from `apps/api/src/storage/types.ts`. This is a type-only cleanup after migration `080-async-research-jobs` moved data to `async_research_jobs`; no behavior change and no DB migration required.

<sup>Written for commit 803a1016a78e4a3c451baeaa0f0fc2918b22541e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

