### PR TITLE
fix(task-board): log the merge→done reconcile in the activity timeline

### DIFF
--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -8,6 +8,7 @@ import type { TaskBoardItemPrRef } from "@/storage/types";
 import { getRepoScope } from "@decocms/shared/github-repo-scope";
 import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
 import { TaskBoardItemPrSchema } from "./schema";
+import { recordTaskActivity } from "./activity";
 import { emitTaskBoardUpdated } from "./run-reactions";
 import { enqueueEnabledReviewers } from "./enqueue-reviewer";
 import { reactToApprovedPrConflict } from "./conflict-reaction";
@@ -745,6 +746,17 @@ export const TASK_BOARD_ITEM_PRS_GET = defineTool({
             { status: "done" },
             item.updatedBy,
           );
+          // Every other path that moves a card to Done (the review-decision
+          // auto-merge, "Ship to production") logs a `status_changed` timeline
+          // entry — this reconcile silently skipped it, so a task auto-completed
+          // by a human merging its PR directly on GitHub left no trace of the
+          // move in the Activity feed.
+          await recordTaskActivity(ctx, {
+            taskBoardItemId,
+            action: "status_changed",
+            actorId: null,
+            data: { from: item.status, to: "done" },
+          });
           emitTaskBoardUpdated(organizationId, updated);
         }
       } catch (err) {


### PR DESCRIPTION
**Source:** bug found while auditing the task-board tool suite's status-transition paths (every write site that moves a card to `done` — `review-decision.ts`'s auto-merge, `promote-to-production.ts`'s "Ship to production" — logs a `status_changed` activity entry; `TASK_BOARD_ITEM_PRS_GET`'s poll-driven merge→done reconcile did not).

**Payoff:** `TASK_BOARD_ITEM_PRS_GET` is the *only* place that notices a PR merged directly on GitHub (no webhook — see the existing `ponytail: reconcile-on-view` comment) and forward-moves the card to Done on the next poll. Because that path skipped `recordTaskActivity`, a task auto-completed this way left no trace in the card's Activity timeline — silently inconsistent with every other way a task reaches Done, and confusing for anyone auditing "who/what moved this to Done."

**Failure scenario → fix:** a Super Agent's PR gets merged by a human directly on GitHub (not through the reviewer auto-merge or the Ship button). The next time anyone opens that task's PR modal, `TASK_BOARD_ITEM_PRS_GET` observes `merged: true` and flips the card to `done` — but the Activity tab shows no `status_changed` entry for it, unlike the identical transition taken through the other two paths. Now it records one (`actorId: null`, matching the other machine-driven `status_changed` entries in `advanceTaskBoardForRun` / `review-decision.ts`).

**Verify:** `cd apps/api && bunx tsc --noEmit` (clean) and `bunx oxlint apps/api/src/tools/task-board/prs-get.ts` (clean) — no existing unit test covers this handler (it needs a live StudioContext + GitHub MCP client, which per `TESTING.md` belongs in e2e, not a mocked unit test), so this is a pure logic-consistency fix reusing the already-tested `recordTaskActivity` helper.

**Local checks run:** `bun run fmt`, `bunx tsc --noEmit` (apps/api), `bunx oxlint` on the changed file. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the poll-driven merge→done reconcile logs a `status_changed` entry so tasks merged directly on GitHub show an Activity timeline event. This aligns the `TASK_BOARD_ITEM_PRS_GET` path with review auto-merge and “Ship to production.”

- **Bug Fixes**
  - In `apps/api/src/tools/task-board/prs-get.ts`, `TASK_BOARD_ITEM_PRS_GET` now calls `recordTaskActivity` when moving a card to `done` after detecting `merged: true` (uses `actorId: null` and `{ from: item.status, to: "done" }`).

<sup>Written for commit 198b091f4f2a9bddb02ea9b5041fb91cfcd3de3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

