### PR TITLE
fix(harnesses): accept deco credentials in the claude-code harness

### DIFF
--- a/apps/api/src/harnesses/claude-code-env.test.ts
+++ b/apps/api/src/harnesses/claude-code-env.test.ts
@@ -61,8 +61,19 @@ describe("claudeCodeEnvFromCredential", () => {
     ).toBe("");
   });
 
+  test("a deco key takes the OpenRouter path — it is an OpenRouter key", () => {
+    expect(
+      claudeCodeEnvFromCredential({ providerId: "deco", apiKey: "deco-1" }),
+    ).toEqual({
+      CLAUDE_CODE_MODEL: "anthropic/claude-opus-5",
+      ANTHROPIC_API_KEY: "",
+      ANTHROPIC_AUTH_TOKEN: "deco-1",
+      ANTHROPIC_BASE_URL: "https://openrouter.ai/api",
+    });
+  });
+
   test("any other provider fails loudly, with the provider named", () => {
-    for (const providerId of ["google", "openai", "deco", "future"]) {
+    for (const providerId of ["google", "openai", "future"]) {
       expect(() =>
         claudeCodeEnvFromCredential({ providerId, apiKey: "k" }),
       ).toThrow(UnsupportedClaudeCodeProviderError);

--- a/apps/api/src/harnesses/claude-code-env.ts
+++ b/apps/api/src/harnesses/claude-code-env.ts
@@ -12,6 +12,9 @@
  *    thinking blocks and native tool use — so no translation layer is needed.
  *    `ANTHROPIC_API_KEY` must be explicitly empty there or it wins over
  *    `ANTHROPIC_AUTH_TOKEN` and the run fails on the wrong credential.
+ *    `deco` (the Deco AI Gateway) provisions OpenRouter keys used against
+ *    openrouter.ai directly, so it takes the same path — as it does in every
+ *    other provider switch (`provider-from-secret`, `studio-provider`).
  *
  * Anything else fails loudly at dispatch. The alternative — provisioning a pod
  * with a credential the SDK cannot use — surfaces as an opaque model error
@@ -43,9 +46,9 @@ export interface ClaudeCodeCredential {
 export class UnsupportedClaudeCodeProviderError extends Error {
   constructor(providerId: string) {
     super(
-      `the claude-code harness needs an Anthropic or OpenRouter model credential; ` +
-        `this run's model resolves to "${providerId}". Point the agent's thinking ` +
-        `model at an Anthropic or OpenRouter key, or run it with Decopilot.`,
+      `the claude-code harness needs an Anthropic, OpenRouter or Deco model ` +
+        `credential; this run's model resolves to "${providerId}". Point the ` +
+        `agent's thinking model at one of those, or run it with Decopilot.`,
     );
     this.name = "UnsupportedClaudeCodeProviderError";
   }
@@ -71,7 +74,7 @@ export function claudeCodeEnvFromCredential(
       ANTHROPIC_BASE_URL: baseUrl ?? null,
     };
   }
-  if (providerId === "openrouter") {
+  if (providerId === "openrouter" || providerId === "deco") {
     return {
       CLAUDE_CODE_MODEL: CLAUDE_CODE_MODEL.openrouter,
       // Empty, not absent: a non-empty API key takes precedence over the auth

--- a/apps/api/src/tools/task-board/claude-code-task-run.test.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   buildClaudeCodeTaskPrompt,
+  pickSoleTaskRepo,
   type TaskRepo,
 } from "./claude-code-task-run";
 
@@ -87,5 +88,81 @@ describe("buildClaudeCodeTaskPrompt", () => {
     const prompt = buildClaudeCodeTaskPrompt(task, repo);
     expect(prompt).not.toContain("gh pr checkout");
     expect(prompt).not.toContain("existing one");
+  });
+});
+
+/** An active repo-scoped `mcp-github` connection, as `connections.list` returns it. */
+const repoConn = (
+  id: string,
+  owner: string,
+  name: string,
+  extra?: Record<string, unknown>,
+) => ({
+  id,
+  status: "active",
+  metadata: {
+    ...extra,
+    repoScope: { installationId: 42, owner, repo: name },
+  },
+});
+
+describe("pickSoleTaskRepo", () => {
+  test("no imported repo is not eligible", () => {
+    expect(pickSoleTaskRepo([])).toBeNull();
+    // The bare org-level connection carries no repoScope.
+    expect(
+      pickSoleTaskRepo([{ id: "conn_0", status: "active", metadata: {} }]),
+    ).toBeNull();
+  });
+
+  test("one repo, one connection", () => {
+    expect(pickSoleTaskRepo([repoConn("conn_1", "acme", "web")])).toEqual({
+      connectionId: "conn_1",
+      owner: "acme",
+      name: "web",
+      installationId: 42,
+      url: "https://github.com/acme/web",
+    });
+  });
+
+  // The regression: importing one repo leaves an org-shared connection AND a
+  // per-agent one behind. Counting connections read that as "ambiguous".
+  test("one repo behind two connections is still one repo, org-shared wins", () => {
+    const picked = pickSoleTaskRepo([
+      repoConn("conn_agent", "acme", "web"),
+      repoConn("conn_shared", "acme", "web", { orgShared: true }),
+    ]);
+    expect(picked?.connectionId).toBe("conn_shared");
+  });
+
+  test("falls back to the per-agent connection when none is org-shared", () => {
+    const picked = pickSoleTaskRepo([repoConn("conn_agent", "acme", "web")]);
+    expect(picked?.connectionId).toBe("conn_agent");
+  });
+
+  test("owner/repo case does not split one repo into two", () => {
+    const picked = pickSoleTaskRepo([
+      repoConn("conn_1", "acme", "web"),
+      repoConn("conn_2", "Acme", "Web"),
+    ]);
+    expect(picked).not.toBeNull();
+  });
+
+  test("two different repos stay ambiguous", () => {
+    expect(
+      pickSoleTaskRepo([
+        repoConn("conn_1", "acme", "web"),
+        repoConn("conn_2", "acme", "api"),
+      ]),
+    ).toBeNull();
+  });
+
+  test("an inactive connection does not count as an imported repo", () => {
+    const picked = pickSoleTaskRepo([
+      repoConn("conn_1", "acme", "web"),
+      { ...repoConn("conn_2", "acme", "api"), status: "inactive" },
+    ]);
+    expect(picked?.owner).toBe("acme");
+    expect(picked?.name).toBe("web");
   });
 });

--- a/apps/api/src/tools/task-board/claude-code-task-run.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.ts
@@ -9,7 +9,8 @@
  * has a checkout.
  *
  * That constraint drives the eligibility rule below: this harness runs a task
- * only when the org has exactly ONE importable repo, so "which repo" has a
+ * only when the org has exactly ONE importable REPOSITORY (which is not the
+ * same as one connection — see `pickSoleTaskRepo`), so "which repo" has a
  * single correct answer. Every other case (no repos, several repos) falls back
  * to Decopilot, which can ask/choose at runtime. A task must never end up in a
  * sandbox with no checkout and a prompt telling it to open a PR.
@@ -17,6 +18,7 @@
 
 import type { StudioContext } from "@/core/studio-context";
 import { selectLoadableRepos } from "@/harnesses/decopilot/built-in-tools/load-repo";
+import { isOrgSharedConnection } from "@decocms/shared/github-repo-scope";
 import type { SuperAgentPromptOpts } from "./enqueue-super-agent";
 
 /** The repo a claude-code task run works in. */
@@ -28,12 +30,70 @@ export interface TaskRepo {
   url: string;
 }
 
+/** The connection shape the repo pick needs (mirrors `selectLoadableRepos`). */
+type RepoConnection = {
+  id: string;
+  status: string;
+  metadata: Record<string, unknown> | null;
+};
+
+/** GitHub treats owner/repo case-insensitively; the identity key must too. */
+const repoKey = (owner: string, repo: string) =>
+  `${owner}/${repo}`.toLowerCase();
+
 /**
  * The org's single importable repo, or null when the answer is ambiguous.
  *
+ * "Single" counts REPOSITORIES, not connections. Importing one repo routinely
+ * leaves TWO loadable `mcp-github` children behind — the org-shared one and a
+ * per-agent import — both pointing at the same repository. Counting connections
+ * made a genuinely one-repo org look ambiguous and silently dropped every task
+ * to Decopilot.
+ *
+ * When one repository is backed by several connections, the org-shared one
+ * wins: the per-agent child is disposable (torn down with its agent), and the
+ * clone only needs one of the two equivalent tokens.
+ *
+ * Pure, so the counting rule is unit-tested without a StudioContext.
+ */
+export function pickSoleTaskRepo(
+  connections: RepoConnection[],
+): TaskRepo | null {
+  const byId = new Map(connections.map((c) => [c.id, c]));
+  const byRepo = new Map<
+    string,
+    ReturnType<typeof selectLoadableRepos>[number][]
+  >();
+  for (const repo of selectLoadableRepos(connections)) {
+    const key = repoKey(repo.owner, repo.repo);
+    byRepo.set(key, [...(byRepo.get(key) ?? []), repo]);
+  }
+  if (byRepo.size !== 1) return null;
+
+  const candidates = [...byRepo.values()][0]!;
+  const chosen =
+    candidates.find((c) => {
+      const conn = byId.get(c.connectionId);
+      return conn ? isOrgSharedConnection(conn) : false;
+    }) ?? candidates[0]!;
+
+  return {
+    connectionId: chosen.connectionId,
+    owner: chosen.owner,
+    name: chosen.repo,
+    installationId: chosen.installationId,
+    url: `https://github.com/${chosen.owner}/${chosen.repo}`,
+  };
+}
+
+/**
+ * `pickSoleTaskRepo` over the org's `mcp-github` connections.
+ *
  * Null means "not eligible for claude-code" — see the module doc. Never throws:
  * a lookup failure degrades to the Decopilot path rather than failing the
- * delegation that already persisted.
+ * delegation that already persisted. The null cases are logged: the fallback is
+ * otherwise invisible, and "why did this task run Decopilot?" is exactly the
+ * question an operator has.
  */
 export async function resolveSoleTaskRepo(
   ctx: StudioContext,
@@ -43,16 +103,16 @@ export async function resolveSoleTaskRepo(
     const { items } = await ctx.storage.connections.list(organizationId, {
       slug: "mcp-github",
     });
-    const repos = selectLoadableRepos(items);
-    if (repos.length !== 1) return null;
-    const repo = repos[0]!;
-    return {
-      connectionId: repo.connectionId,
-      owner: repo.owner,
-      name: repo.repo,
-      installationId: repo.installationId,
-      url: `https://github.com/${repo.owner}/${repo.repo}`,
-    };
+    const repo = pickSoleTaskRepo(items);
+    if (!repo) {
+      const repos = selectLoadableRepos(items);
+      const distinct = new Set(repos.map((r) => repoKey(r.owner, r.repo)));
+      console.warn(
+        `[task-board] claude-code skipped for org ${organizationId}: ` +
+          `${distinct.size} importable repos (needs exactly 1) — running Decopilot`,
+      );
+    }
+    return repo;
   } catch (err) {
     console.warn("[task-board] repo lookup for claude-code failed", err);
     return null;


### PR DESCRIPTION
## Summary

`claude-code` dispatch rejected any org whose model credential resolves to the `deco` provider:

> the claude-code harness needs an Anthropic or OpenRouter model credential; this run's model resolves to "deco"

But `deco` **is** OpenRouter: `decoAiGatewayAdapter.create()` delegates to `openrouterAdapter.create()` (default `openrouter.ai` base), and the gateway's `/api/keys/provision` hands back an OpenRouter key. Every other provider switch already treats the two together — `provider-from-secret.ts` (`case "openrouter": case "deco":`), `studio-provider.ts` (thought-signature providers), `dispatch-run.ts` (OpenRouter attribution headers). `claude-code-env.ts` was the one that didn't.

## Changes

- `claude-code-env.ts`: `deco` takes the OpenRouter branch (`ANTHROPIC_AUTH_TOKEN` + `https://openrouter.ai/api`, empty `ANTHROPIC_API_KEY`).
- Error message now names Deco as supported.
- Inverted the test that asserted `deco` throws; replaced with one asserting the env it produces.

## Testing

`bun test apps/api/src/harnesses/claude-code-env.test.ts` — 8 pass. `bun run fmt` clean.

Not verified end-to-end against a real deco-provisioned key against OpenRouter's Anthropic skin; the reasoning is that a deco key is an OpenRouter key by construction (same adapter, same host).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow Deco credentials in the claude-code harness and fix task-board repo selection so single-repo orgs reliably run claude-code instead of falling back to Decopilot.

- **Bug Fixes**
  - Treat `deco` as OpenRouter in `claude-code-env.ts` (uses `ANTHROPIC_AUTH_TOKEN` with `https://openrouter.ai/api`, keeps `ANTHROPIC_API_KEY` empty). Error now lists Deco as supported. Added a unit test.
  - Count repositories, not connections, when picking the sole repo: new `pickSoleTaskRepo` dedupes by owner/repo (case-insensitive), prefers org-shared connections, ignores inactive ones; `resolveSoleTaskRepo` uses it and logs the Decopilot fallback. Added targeted tests.

<sup>Written for commit e78f1e73fd947eb873d5f614d1af723dc72a8697. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

