### PR TITLE
fix(github): one repository, one connection — reuse instead of minting a duplicate

### DIFF
--- a/apps/api/migrations/158-drop-github-child-single-parent.ts
+++ b/apps/api/migrations/158-drop-github-child-single-parent.ts
@@ -1,0 +1,64 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * Retire the repo-scoped-github-child 1:1 trigger from migration 125.
+ *
+ * 125 asserted "one repo-scoped github child per agent" because the import
+ * flow minted a fresh child per agent. That is no longer true: one repository
+ * now has ONE connection, reused across every agent that imports it, so a
+ * child legitimately has N parents and the trigger rejects the second import.
+ *
+ * The bug 125 was defending against (a shared aggregation mutating, flipping
+ * the header's "is GitHub attached?" gate off and rendering nothing) was fixed
+ * in the same PR by `resolveGithubAttachment` + the detached reconnect pill,
+ * neither of which needs 1:1: the gate cross-checks a connection against THIS
+ * agent's own aggregation rows, and `virtualMcps.update` rewrites edges scoped
+ * to a single parent. The teardown assumption 125 also propped up
+ * (`tools/virtual/delete.ts`) now checks for other holders explicitly.
+ *
+ * `try_parse_jsonb` stays: it is a harmless standalone helper and dropping it
+ * would break 125's `down`.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TRIGGER IF EXISTS trg_repo_github_child_single_parent ON connection_aggregations;`.execute(
+    db,
+  );
+  await sql`DROP FUNCTION IF EXISTS enforce_repo_github_child_single_parent();`.execute(
+    db,
+  );
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  // Re-create 125's trigger verbatim. Rows that violate it are NOT deduped:
+  // under reuse they are valid data, and deleting an agent's only edge would
+  // detach a live repo.
+  await sql`
+    CREATE OR REPLACE FUNCTION enforce_repo_github_child_single_parent()
+    RETURNS trigger AS $fn$
+    BEGIN
+      IF EXISTS (
+        SELECT 1 FROM connections c
+        WHERE c.id = NEW.child_connection_id
+          AND jsonb_typeof(try_parse_jsonb(c.metadata) -> 'repoScope') = 'object'
+      ) AND EXISTS (
+        SELECT 1 FROM connection_aggregations existing
+        WHERE existing.child_connection_id = NEW.child_connection_id
+          AND existing.parent_connection_id <> NEW.parent_connection_id
+      ) THEN
+        RAISE EXCEPTION
+          'repo-scoped GitHub child % is already attached to another agent (1:1 invariant)',
+          NEW.child_connection_id
+          USING ERRCODE = 'unique_violation';
+      END IF;
+      RETURN NEW;
+    END;
+    $fn$ LANGUAGE plpgsql;
+  `.execute(db);
+
+  await sql`
+    CREATE TRIGGER trg_repo_github_child_single_parent
+      BEFORE INSERT ON connection_aggregations
+      FOR EACH ROW
+      EXECUTE FUNCTION enforce_repo_github_child_single_parent();
+  `.execute(db);
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -156,6 +156,7 @@ import * as migration154taskboardqaactivity from "./154-task-board-qa-activity.t
 import * as migration155taskboardreviewclaims from "./155-task-board-review-claims.ts";
 import * as migration156taskboardconflictactivity from "./156-task-board-conflict-activity.ts";
 import * as migration157dropseatbilling from "./157-drop-seat-billing.ts";
+import * as migration158dropgithubchildsingleparent from "./158-drop-github-child-single-parent.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -338,6 +339,8 @@ const migrations: Record<string, Migration> = {
   "155-task-board-review-claims": migration155taskboardreviewclaims,
   "156-task-board-conflict-activity": migration156taskboardconflictactivity,
   "157-drop-seat-billing": migration157dropseatbilling,
+  "158-drop-github-child-single-parent":
+    migration158dropgithubchildsingleparent,
 };
 
 export default migrations;

--- a/apps/api/src/tools/virtual/delete.ts
+++ b/apps/api/src/tools/virtual/delete.ts
@@ -5,7 +5,10 @@
  */
 
 import { z } from "zod";
-import { getRepoScope } from "@decocms/shared/github-repo-scope";
+import {
+  getRepoScope,
+  isOrgSharedConnection,
+} from "@decocms/shared/github-repo-scope";
 import { DownstreamTokenStorage } from "@/storage/downstream-token";
 import { defineTool } from "../../core/define-tool";
 import {
@@ -102,7 +105,8 @@ export const COLLECTION_VIRTUAL_MCP_DELETE = defineTool({
       await deleteAgentPrompts(ctx.orgFs, input.id, getUserId(ctx) ?? "system");
     }
 
-    // Tear down the per-agent repo-scoped mcp-github child connection (if any).
+    // Tear down this agent's repo-scoped mcp-github child connection, if the
+    // connection is in fact this agent's alone (see the checks below).
     // Best-effort: the agent is already deleted, so a cleanup hiccup must not
     // fail the user's delete (worst case it orphans a child whose minted token
     // self-expires within ~1h). Self-revoke the token first, then delete the
@@ -116,12 +120,27 @@ export const COLLECTION_VIRTUAL_MCP_DELETE = defineTool({
           childConnectionId,
           organization.id,
         );
-        // No need to check whether the child is aggregated under another agent:
-        // the import flow creates a fresh child per agent (1:1), and the
-        // ON DELETE RESTRICT FK on connection_aggregations.child_connection_id
-        // makes connections.delete throw (caught + logged below) rather than
-        // orphan a still-referenced child.
-        if (child && getRepoScope(child)) {
+        // A repo connection is NOT this agent's to delete when someone else
+        // holds it. Import reuses an existing connection for a repository the
+        // org already has, so the old 1:1 child-per-agent assumption is gone:
+        //
+        //  - org-shared ("Add repo") belongs to the org, not to any agent;
+        //  - still-aggregated means another agent lists it (this agent's own
+        //    rows were dropped by `virtualMcps.delete` above).
+        //
+        // Both checks run BEFORE the revoke. Relying on the ON DELETE RESTRICT
+        // FK to stop the delete is not enough: the token would already have
+        // been revoked by then, leaving a live connection with a dead grant.
+        const heldBySomeoneElse =
+          child &&
+          (isOrgSharedConnection(child) ||
+            (
+              await ctx.storage.virtualMcps.listByConnectionId(
+                organization.id,
+                childConnectionId,
+              )
+            ).length > 0);
+        if (child && getRepoScope(child) && !heldBySomeoneElse) {
           const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
           const tok = await tokenStorage.get(childConnectionId);
           if (tok?.accessToken) {

--- a/apps/web/src/components/github-repo-picker.tsx
+++ b/apps/web/src/components/github-repo-picker.tsx
@@ -294,15 +294,16 @@ function PickerContent({
         };
       }
 
-      const { childConnectionId } = await provisionRepoScopedGithubConnection({
-        orgSlug: org.slug,
-        sourceConnection: effectiveConnection,
-        installationId,
-        owner: repo.owner,
-        repo: repo.name,
-        githubCallTool: (req) => githubClient.callTool(req),
-        selfCallTool: (req) => selfClient.callTool(req),
-      });
+      const { childConnectionId, reused } =
+        await provisionRepoScopedGithubConnection({
+          orgSlug: org.slug,
+          sourceConnection: effectiveConnection,
+          installationId,
+          owner: repo.owner,
+          repo: repo.name,
+          githubCallTool: (req) => githubClient.callTool(req),
+          selfCallTool: (req) => selfClient.callTool(req),
+        });
 
       let createdAgentId: string | null = null;
 
@@ -358,9 +359,12 @@ function PickerContent({
           item: payload.item,
         };
       } catch (err) {
-        // Rollback: leave nothing behind. If the agent was created, delete it
-        // (which also tears down its repo-scoped child via server-side cleanup);
-        // always attempt the child delete as a harmless belt-and-suspenders.
+        // Rollback: leave nothing behind THAT WE CREATED. If the agent was
+        // created, delete it (which also tears down its repo-scoped child via
+        // server-side cleanup); then the child, as belt-and-suspenders.
+        //
+        // A reused connection predates this import and other agents may hold
+        // it — rolling it back would revoke a repo the org still uses.
         if (createdAgentId) {
           await selfClient
             .callTool({
@@ -369,12 +373,14 @@ function PickerContent({
             })
             .catch(() => {});
         }
-        await selfClient
-          .callTool({
-            name: "COLLECTION_CONNECTIONS_DELETE",
-            arguments: { id: childConnectionId, force: true },
-          })
-          .catch(() => {});
+        if (!reused) {
+          await selfClient
+            .callTool({
+              name: "COLLECTION_CONNECTIONS_DELETE",
+              arguments: { id: childConnectionId, force: true },
+            })
+            .catch(() => {});
+        }
         throw err;
       }
     },

--- a/apps/web/src/components/import-from-deco-dialog.tsx
+++ b/apps/web/src/components/import-from-deco-dialog.tsx
@@ -254,8 +254,8 @@ export function ImportFromDecoDialog({
         }
         decoConnId = connId;
 
-        const { childConnectionId } = await provisionRepoScopedGithubConnection(
-          {
+        const { childConnectionId, reused } =
+          await provisionRepoScopedGithubConnection({
             orgSlug: org.slug,
             sourceConnection: effectiveGithubConnection,
             installationId: githubInstallation.installationId,
@@ -263,9 +263,10 @@ export function ImportFromDecoDialog({
             repo: githubRepo.name,
             githubCallTool: (req) => githubClient.callTool(req),
             selfCallTool: (req) => client.callTool(req),
-          },
-        );
-        githubChildConnId = childConnectionId;
+          });
+        // Only a connection this import created may be rolled back — a reused
+        // one predates it and other agents may hold it.
+        githubChildConnId = reused ? null : childConnectionId;
 
         const projectIcon = connBody.icon ?? null;
         const slug = generateSlug(siteName);

--- a/apps/web/src/lib/provision-repo-scoped-github-connection.ts
+++ b/apps/web/src/lib/provision-repo-scoped-github-connection.ts
@@ -1,6 +1,8 @@
 import type { ConnectionEntity } from "@/sdk";
 import {
+  findReusableRepoConnection,
   GITHUB_SCOPED_PERMISSIONS,
+  isOrgSharedConnection,
   mintRepoTokenWithChecksFallback,
 } from "@decocms/shared/github-repo-scope";
 
@@ -42,6 +44,49 @@ export function normalizeRepositoryId(value: unknown): number | undefined {
     : undefined;
 }
 
+/**
+ * The org's repo-scoped GitHub connections, as the collection tool returns
+ * them. Narrow on purpose: only what repo identity needs.
+ */
+type ExistingConnection = {
+  id: string;
+  status?: string;
+  metadata: Record<string, unknown> | null;
+};
+
+/**
+ * Look for a connection that already covers this repository.
+ *
+ * ponytail: read-then-create, so two imports of the same repo racing in two
+ * tabs can still both create. Rare, self-healing on the next import, and the
+ * consumers dedupe on read — a uniqueness constraint would have to live on a
+ * value inside the metadata JSON, which is not worth a migration for that.
+ */
+async function findExistingRepoConnection(params: {
+  selfCallTool: McpCallTool;
+  appName: string | null | undefined;
+  owner: string;
+  repo: string;
+}): Promise<ExistingConnection | null> {
+  const { selfCallTool, appName, owner, repo } = params;
+  if (!appName) return null;
+  try {
+    const res = (await selfCallTool({
+      name: "COLLECTION_CONNECTIONS_LIST",
+      arguments: {
+        where: { field: ["app_name"], operator: "eq", value: appName },
+      },
+    })) as { structuredContent?: { items?: ExistingConnection[] } };
+    const items = res.structuredContent?.items ?? [];
+    return findReusableRepoConnection(items, owner, repo);
+  } catch (err) {
+    // A failed lookup must not block the import: fall through and provision.
+    // Worst case we create the duplicate this function exists to avoid.
+    console.warn("[github-import] existing repo connection lookup failed", err);
+    return null;
+  }
+}
+
 export async function provisionRepoScopedGithubConnection(params: {
   orgSlug: string;
   sourceConnection: ConnectionEntity;
@@ -52,7 +97,7 @@ export async function provisionRepoScopedGithubConnection(params: {
   selfCallTool: McpCallTool;
   /** Mark the connection as available to every agent ("Add repo" flow). */
   orgShared?: boolean;
-}): Promise<{ childConnectionId: string }> {
+}): Promise<{ childConnectionId: string; reused: boolean }> {
   const {
     orgSlug,
     sourceConnection,
@@ -63,6 +108,33 @@ export async function provisionRepoScopedGithubConnection(params: {
     selfCallTool,
     orgShared,
   } = params;
+
+  // One repository, one connection. Reusing skips the mint entirely — the
+  // existing connection's grant refreshes itself through the normal token path.
+  //
+  // A repo imported before `checks:read` was requested keeps its narrower
+  // permission set; re-importing no longer widens it. Delete the connection and
+  // import again if the PR Checks tab 403s.
+  const existing = await findExistingRepoConnection({
+    selfCallTool,
+    appName: sourceConnection.app_name,
+    owner,
+    repo,
+  });
+  if (existing) {
+    // "Add repo" on a repo an agent already imported promotes that connection
+    // to org-shared rather than minting a second one beside it.
+    if (orgShared && !isOrgSharedConnection(existing)) {
+      await selfCallTool({
+        name: "COLLECTION_CONNECTIONS_UPDATE",
+        arguments: {
+          id: existing.id,
+          data: { metadata: { ...(existing.metadata ?? {}), orgShared: true } },
+        },
+      });
+    }
+    return { childConnectionId: existing.id, reused: true };
+  }
 
   type MintResult = {
     isError?: boolean;
@@ -197,5 +269,5 @@ export async function provisionRepoScopedGithubConnection(params: {
     throw new Error("Failed to persist the repo-scoped token");
   }
 
-  return { childConnectionId };
+  return { childConnectionId, reused: false };
 }

--- a/apps/web/src/routes/commerce-onboarding/companion-forms/github-config-form.tsx
+++ b/apps/web/src/routes/commerce-onboarding/companion-forms/github-config-form.tsx
@@ -28,6 +28,7 @@ import {
   findGithubInstallation,
 } from "@/lib/github-installations";
 import { provisionRepoScopedGithubConnection } from "@/lib/provision-repo-scoped-github-connection";
+import { isOrgSharedConnection } from "@decocms/shared/github-repo-scope";
 import {
   parseRepoFullName,
   planAgentConnections,
@@ -297,8 +298,8 @@ export function GitHubConfigForm({
             t("commerceOnboarding.githubConfigForm.githubConnectionNotFound"),
           );
         }
-        const { childConnectionId } = await provisionRepoScopedGithubConnection(
-          {
+        const { childConnectionId, reused } =
+          await provisionRepoScopedGithubConnection({
             orgSlug: org.slug,
             sourceConnection,
             installationId,
@@ -306,10 +307,11 @@ export function GitHubConfigForm({
             repo: name,
             githubCallTool: (req) => companionClient.callTool(req),
             selfCallTool: (req) => selfClient.callTool(req),
-          },
-        );
+          });
         repoConnectionId = childConnectionId;
-        provisionedConnectionId = childConnectionId;
+        // Only roll back a connection this save created; a reused one predates
+        // it and other agents may hold it.
+        provisionedConnectionId = reused ? undefined : childConnectionId;
       }
 
       // Aggregate the repo-scoped connection onto the agent — `git publish`
@@ -344,13 +346,26 @@ export function GitHubConfigForm({
             },
           },
         });
+        // The previously-linked repo connection is only ours to delete when
+        // it's ours alone. An org-shared one ("Add repo") belongs to the org
+        // and has no aggregation row to protect it. A connection another agent
+        // aggregates IS protected — child_connection_id is ON DELETE RESTRICT,
+        // so the delete throws into the catch below and the row survives.
         if (staleConnectionId) {
-          await selfClient
-            .callTool({
-              name: "COLLECTION_CONNECTIONS_DELETE",
-              arguments: { id: staleConnectionId, force: true },
-            })
-            .catch(() => {});
+          const stale = unwrapToolResult<{ item: ConnectionEntity | null }>(
+            await selfClient.callTool({
+              name: "COLLECTION_CONNECTIONS_GET",
+              arguments: { id: staleConnectionId },
+            }),
+          ).item;
+          if (stale && !isOrgSharedConnection(stale)) {
+            await selfClient
+              .callTool({
+                name: "COLLECTION_CONNECTIONS_DELETE",
+                arguments: { id: staleConnectionId, force: true },
+              })
+              .catch(() => {});
+          }
         }
       } catch (err) {
         // The connectionId lives only on the metadata we just failed to write,

--- a/packages/e2e/tests/github-import-repo-scope.spec.ts
+++ b/packages/e2e/tests/github-import-repo-scope.spec.ts
@@ -432,6 +432,227 @@ test.describe("GitHub import repo-scoped connections", () => {
   });
 
   /**
+   * Scenario 2b — a repo connection someone else holds survives the teardown.
+   *
+   * Import reuses an existing connection when the org already has that
+   * repository, so "the child belongs to this agent" no longer holds. Two ways
+   * it can be someone else's:
+   *   - `metadata.orgShared` — the org's own "Add repo" connection;
+   *   - still aggregated by another agent after this one is deleted.
+   *
+   * Both must survive WITH their token: the revoke used to run before the
+   * delete, so relying on the ON DELETE RESTRICT FK to block the delete would
+   * still leave a live connection holding a revoked grant.
+   */
+  test("deleting an agent keeps an org-shared repo connection and its token", async ({
+    playwright,
+  }) => {
+    const ctx = await newApiContext(playwright);
+    const user = await signUpViaApi(ctx);
+    const org = user.orgSlug;
+
+    const orgConn = await createHttpConnection(ctx, org, {
+      title: `Org GitHub ${Date.now()}`,
+      url: "https://example.com/mcp",
+    });
+
+    // The org's shared repo connection — "Add repo", not owned by any agent.
+    const shared = await callSelfMcpTool<{ item: { id: string } }>(
+      ctx,
+      org,
+      "COLLECTION_CONNECTIONS_CREATE",
+      {
+        data: {
+          title: `GitHub: acme/shared ${Date.now()}`,
+          app_name: "mcp-github",
+          connection_type: "HTTP",
+          connection_url: "https://example.com/mcp",
+          metadata: {
+            orgShared: true,
+            repoScope: {
+              sourceConnectionId: orgConn.id,
+              installationId: 1,
+              owner: "acme",
+              repo: "shared",
+              permissions: { contents: "write" },
+            },
+          },
+        },
+      },
+    );
+    const sharedId = shared.item.id;
+
+    const agent = await callSelfMcpTool<{ item: { id: string } }>(
+      ctx,
+      org,
+      "COLLECTION_VIRTUAL_MCP_CREATE",
+      {
+        data: {
+          title: `shared-consumer ${Date.now()}`,
+          metadata: {
+            githubRepo: {
+              owner: "acme",
+              name: "shared",
+              url: "https://github.com/acme/shared",
+              installationId: 1,
+              connectionId: sharedId,
+            },
+          },
+          connections: [{ connection_id: sharedId }],
+        },
+      },
+    );
+
+    const tokenRes = await ctx.post(
+      `/api/${org}/connections/${sharedId}/oauth-token`,
+      {
+        data: { accessToken: "ghs_e2e_dummy", expiresIn: 3600 },
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+    expect(tokenRes.ok()).toBe(true);
+
+    const db = await connectDevDb();
+    try {
+      await callSelfMcpTool(ctx, org, "COLLECTION_VIRTUAL_MCP_DELETE", {
+        id: agent.item.id,
+      });
+
+      // The agent is gone...
+      const agentRow = await db.query(
+        "SELECT 1 FROM connections WHERE id = $1",
+        [agent.item.id],
+      );
+      expect(agentRow.rowCount).toBe(0);
+
+      // ...but the org keeps its repo, token included.
+      const sharedRow = await db.query(
+        "SELECT 1 FROM connections WHERE id = $1",
+        [sharedId],
+      );
+      expect(sharedRow.rowCount).toBe(1);
+      const tokRows = await db.query(
+        'SELECT 1 FROM downstream_tokens WHERE "connectionId" = $1',
+        [sharedId],
+      );
+      expect(tokRows.rowCount).toBe(1);
+    } finally {
+      await db.end();
+      await ctx.dispose();
+    }
+  });
+
+  test("deleting one agent keeps a repo connection another agent still aggregates", async ({
+    playwright,
+  }) => {
+    const ctx = await newApiContext(playwright);
+    const user = await signUpViaApi(ctx);
+    const org = user.orgSlug;
+
+    const orgConn = await createHttpConnection(ctx, org, {
+      title: `Org GitHub ${Date.now()}`,
+      url: "https://example.com/mcp",
+    });
+
+    // NOT org-shared: a plain repo child, but two agents were imported against
+    // the same repository, so both list it.
+    const child = await callSelfMcpTool<{ item: { id: string } }>(
+      ctx,
+      org,
+      "COLLECTION_CONNECTIONS_CREATE",
+      {
+        data: {
+          title: `GitHub: acme/two-agents ${Date.now()}`,
+          app_name: "mcp-github",
+          connection_type: "HTTP",
+          connection_url: "https://example.com/mcp",
+          metadata: {
+            repoScope: {
+              sourceConnectionId: orgConn.id,
+              installationId: 1,
+              owner: "acme",
+              repo: "two-agents",
+              permissions: { contents: "write" },
+            },
+          },
+        },
+      },
+    );
+    const childId = child.item.id;
+
+    const makeAgent = (label: string) =>
+      callSelfMcpTool<{ item: { id: string } }>(
+        ctx,
+        org,
+        "COLLECTION_VIRTUAL_MCP_CREATE",
+        {
+          data: {
+            title: `${label} ${Date.now()}`,
+            metadata: {
+              githubRepo: {
+                owner: "acme",
+                name: "two-agents",
+                url: "https://github.com/acme/two-agents",
+                installationId: 1,
+                connectionId: childId,
+              },
+            },
+            connections: [{ connection_id: childId }],
+          },
+        },
+      );
+    const first = await makeAgent("first");
+    const second = await makeAgent("second");
+
+    const tokenRes = await ctx.post(
+      `/api/${org}/connections/${childId}/oauth-token`,
+      {
+        data: { accessToken: "ghs_e2e_dummy", expiresIn: 3600 },
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+    expect(tokenRes.ok()).toBe(true);
+
+    const db = await connectDevDb();
+    try {
+      await callSelfMcpTool(ctx, org, "COLLECTION_VIRTUAL_MCP_DELETE", {
+        id: first.item.id,
+      });
+
+      // The second agent still holds the repo — connection and token intact.
+      const childRow = await db.query(
+        "SELECT 1 FROM connections WHERE id = $1",
+        [childId],
+      );
+      expect(childRow.rowCount).toBe(1);
+      const tokRows = await db.query(
+        'SELECT 1 FROM downstream_tokens WHERE "connectionId" = $1',
+        [childId],
+      );
+      expect(tokRows.rowCount).toBe(1);
+      const aggRows = await db.query(
+        "SELECT 1 FROM connection_aggregations WHERE child_connection_id = $1",
+        [childId],
+      );
+      expect(aggRows.rowCount).toBe(1);
+
+      // Deleting the LAST holder does tear it down — the rule is "someone else
+      // holds it", not "never delete".
+      await callSelfMcpTool(ctx, org, "COLLECTION_VIRTUAL_MCP_DELETE", {
+        id: second.item.id,
+      });
+      const goneRow = await db.query(
+        "SELECT 1 FROM connections WHERE id = $1",
+        [childId],
+      );
+      expect(goneRow.rowCount).toBe(0);
+    } finally {
+      await db.end();
+      await ctx.dispose();
+    }
+  });
+
+  /**
    * Scenario 3 — runtime refresh of a repo grant.
    *
    * A source-less repo-scoped child has no org-parent soft link. Calling a tool

--- a/packages/shared/src/github-repo-scope.test.ts
+++ b/packages/shared/src/github-repo-scope.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  findReusableRepoConnection,
   getOrgGithubConnections,
   getRepoScope,
   GITHUB_SCOPED_PERMISSIONS,
@@ -337,5 +338,96 @@ describe("isOrgSharedConnection", () => {
     expect(isOrgSharedConnection({ metadata: { orgShared: "yes" } })).toBe(
       false,
     );
+  });
+});
+
+describe("findReusableRepoConnection", () => {
+  const repoConn = (
+    id: string,
+    owner: string,
+    repo: string,
+    extra?: Record<string, unknown>,
+  ) => ({
+    id,
+    status: "active",
+    metadata: {
+      ...extra,
+      repoScope: { installationId: 1, owner, repo },
+    },
+  });
+
+  it("finds nothing when the repo was never imported", () => {
+    expect(findReusableRepoConnection([], "acme", "web")).toBeNull();
+    expect(
+      findReusableRepoConnection(
+        [repoConn("c1", "acme", "api")],
+        "acme",
+        "web",
+      ),
+    ).toBeNull();
+  });
+
+  it("ignores the bare org connection (no repoScope)", () => {
+    expect(
+      findReusableRepoConnection(
+        [{ id: "c0", status: "active", metadata: { orgShared: true } }],
+        "acme",
+        "web",
+      ),
+    ).toBeNull();
+  });
+
+  it("reuses the connection already covering the repo", () => {
+    expect(
+      findReusableRepoConnection([repoConn("c1", "acme", "web")], "acme", "web")
+        ?.id,
+    ).toBe("c1");
+  });
+
+  it("prefers the org-shared connection — it outlives any single agent", () => {
+    expect(
+      findReusableRepoConnection(
+        [
+          repoConn("c_agent", "acme", "web"),
+          repoConn("c_shared", "acme", "web", { orgShared: true }),
+        ],
+        "acme",
+        "web",
+      )?.id,
+    ).toBe("c_shared");
+  });
+
+  it("matches owner/repo case-insensitively, like GitHub", () => {
+    expect(
+      findReusableRepoConnection([repoConn("c1", "Acme", "Web")], "acme", "web")
+        ?.id,
+    ).toBe("c1");
+  });
+
+  it("skips inactive connections", () => {
+    expect(
+      findReusableRepoConnection(
+        [{ ...repoConn("c1", "acme", "web"), status: "inactive" }],
+        "acme",
+        "web",
+      ),
+    ).toBeNull();
+  });
+
+  it("tolerates a connection list without a status field", () => {
+    expect(
+      findReusableRepoConnection(
+        [
+          {
+            id: "c1",
+            metadata: {
+              repoScope: { installationId: 1, owner: "acme", repo: "web" },
+            },
+          },
+        ],
+        "acme",
+        "web",
+      )?.id,
+    ).toBe("c1");
   });
 });

--- a/packages/shared/src/github-repo-scope.ts
+++ b/packages/shared/src/github-repo-scope.ts
@@ -1,14 +1,16 @@
 /**
  * Repo-scoped GitHub connection — shared, pure helpers.
  *
- * A "repo-scoped" mcp-github connection is a per-agent child connection for
- * exactly one repository. New refreshable repo children persist a GitHub MCP
- * repo grant in downstream_tokens and refresh through the normal OAuth-shaped
- * token path. Legacy repo children may still carry `sourceConnectionId` so
- * callers can mint with deco/mcp-github's MINT_REPO_TOKEN during compatibility
- * flows. The repo grant metadata lives on the connection's metadata under
- * `repoScope`; its presence also marks the connection as a disposable per-agent
- * child for teardown.
+ * A "repo-scoped" mcp-github connection is a child connection for exactly one
+ * repository, shared by every agent that imported that repository (see
+ * `findReusableRepoConnection`). New refreshable repo children persist a GitHub
+ * MCP repo grant in downstream_tokens and refresh through the normal
+ * OAuth-shaped token path. Legacy repo children may still carry
+ * `sourceConnectionId` so callers can mint with deco/mcp-github's
+ * MINT_REPO_TOKEN during compatibility flows. The repo grant metadata lives on
+ * the connection's metadata under `repoScope`; its presence marks the
+ * connection as disposable once its LAST holder goes away, not as any single
+ * agent's to tear down.
  *
  * Pure module (no DB / network / node deps) so both the server
  * (oauth/github-mint) and the web import flow (github-repo-picker) can import it.

--- a/packages/shared/src/github-repo-scope.ts
+++ b/packages/shared/src/github-repo-scope.ts
@@ -199,3 +199,32 @@ export function isOrgSharedConnection(connection: {
 }): boolean {
   return connection.metadata?.orgShared === true;
 }
+
+/** GitHub treats owner/repo case-insensitively; repo identity must too. */
+const repoIdentity = (owner: string, repo: string) =>
+  `${owner}/${repo}`.toLowerCase();
+
+/**
+ * An existing connection that already grants access to `owner/repo`, or null.
+ *
+ * One repository should have ONE connection. Provisioning used to mint and
+ * create unconditionally, so importing a repo org-wide and then again from an
+ * agent left two connections behind for the same repository — which every
+ * consumer of `getRepoScope` then had to dedupe (and mostly didn't: the task
+ * board read the duplicate as "which repo?" and refused to run).
+ *
+ * The org-shared connection wins when both exist: it outlives any single agent,
+ * so reusing it can't hand an agent a connection that disappears with a
+ * teammate's agent.
+ */
+export function findReusableRepoConnection<
+  T extends { status?: string; metadata: Record<string, unknown> | null },
+>(connections: T[] | undefined | null, owner: string, repo: string): T | null {
+  const wanted = repoIdentity(owner, repo);
+  const matches = (connections ?? []).filter((connection) => {
+    if (connection.status && connection.status !== "active") return false;
+    const scope = getRepoScope(connection);
+    return scope !== null && repoIdentity(scope.owner, scope.repo) === wanted;
+  });
+  return matches.find(isOrgSharedConnection) ?? matches[0] ?? null;
+}


### PR DESCRIPTION
## Summary

A repository should have **one** connection. It didn't: `provisionRepoScopedGithubConnection` minted a token and created a connection unconditionally, so importing a repo org-wide ("Add repo") and then again from an agent — or twice from two agents — left several `mcp-github` connections behind, all carrying a `repoScope` for the same repository.

Every `getRepoScope` consumer (20 sites) then had to dedupe, and most don't. The visible symptom: `resolveSoleTaskRepo` counts importable repos to decide whether the sandbox-hosted claude-code harness may run a task, saw two connections for one repo, called it ambiguous, and silently fell back to Decopilot. On staging, `teste-franca` had exactly this — `conn_h2Wlxn2sDsPV3__8ULqGu` and `conn_SsbCkcdExkAszmmxeimll`, both `deco-sites/decocms-tanstack`. Fixing the count (#5671) treats the symptom; this fixes the source.

## What changed

**Reuse before mint.** Provisioning looks for an existing active connection covering `owner/repo` (case-insensitively — GitHub is) and returns it instead of creating a second one. When both an org-shared and a per-agent connection exist, the org-shared one wins: it outlives any single agent, so reuse can't hand an agent a connection that vanishes with a teammate's. "Add repo" on a repo an agent already imported *promotes* that connection to `orgShared` rather than minting beside it.

**Then the ownership fallout.** Reuse invalidates the assumption three delete paths were built on — "this repo connection belongs to this agent, 1:1". Each now checks before deleting:

- **Agent teardown** (`tools/virtual/delete.ts`) skips a connection that is org-shared, or that another agent still aggregates (this agent's own aggregation rows are already gone by then). Both checks run **before** the token revoke — relying on the `ON DELETE RESTRICT` FK to block the delete is not enough, because the revoke has already happened by the time it throws, leaving a live connection holding a dead grant. That's a latent bug today, not only under reuse.
- **Import rollback** (all three call sites) only deletes a connection the import itself created — `provisionRepoScopedGithubConnection` now returns `reused`. Rolling back a reused connection would revoke a repo the org still uses.
- **The report agent's stale-repo cleanup** skips org-shared connections. A connection another agent aggregates is already protected here by the FK (this path has no preceding revoke, so a blocked delete is harmless).

## Testing

- `bun test packages/shared/src/github-repo-scope.test.ts` — 32 pass. New: `findReusableRepoConnection` over no-match, bare org connection, org-shared preference, casing, inactive, and a list without `status`.
- Two new e2e in `github-import-repo-scope.spec.ts`: an org-shared repo connection (plus its token) survives deleting an agent that used it; a connection two agents aggregate survives deleting the first and *is* torn down when the last holder goes — the rule is "someone else holds it", not "never delete".
- `bun run --cwd=apps/api check`, `--cwd=apps/web check`, `--cwd=packages/shared check`, `--cwd=packages/e2e check`; `bun run lint` (0 errors); `bun run fmt`.

**Not run locally:** the two new e2e. My local dev DB has a stale migration row (`154-task-board-comments`, renamed on main) that stops the API server from booting; resetting it would wipe local data. They typecheck and follow the existing scenario-2 test in the same file line for line — CI runs them on a fresh DB.

## Notes

- Reuse is read-then-create, so two imports of the same repo racing in two tabs can still both create. Marked `ponytail:` in the code: rare, self-healing on the next import, and consumers dedupe on read. The airtight fix would be a uniqueness constraint on a value inside the metadata JSON — not worth a migration for this.
- A repo imported before `checks:read` was requested keeps its narrower permissions; re-importing no longer widens them (it reuses). Delete and re-import if the PR Checks tab 403s. Called out in a comment at the reuse site.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure one repository has one GitHub connection by reusing an existing repo-scoped connection instead of creating duplicates. This prevents double-counting and stops tasks from failing due to ambiguous repos.

- **Bug Fixes**
  - Reuse the existing active connection for the same `owner/repo` (case-insensitive). Prefer org-shared; promote to org-shared when “Add repo” is used.
  - Agent deletion skips connections that are org-shared or still aggregated by another agent, and does these checks before revoking tokens.
  - Import rollback and onboarding only delete connections created by that flow; reused connections are not revoked or removed.
  - Report agent’s stale-repo cleanup skips org-shared connections.
  - Added a helper to find reusable connections and new tests (unit + e2e) to cover reuse and safe teardown.

- **Migration**
  - Dropped the 1:1 trigger that blocked attaching a repo-scoped GitHub child to multiple agents; reuse now legally aggregates the same repo connection across agents.
  - Repos imported before requesting `checks:read` keep narrower perms after reuse. Delete the connection and re-import to widen if PR Checks are 403ing.

<sup>Written for commit 843a7d18c892eacf311b5363696b3f7fae3174f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

