### PR TITLE
fix(sandbox): derive the claim handle from projectRef alone

### DIFF
--- a/apps/api/src/api/routes/sandbox-proxy.ts
+++ b/apps/api/src/api/routes/sandbox-proxy.ts
@@ -174,10 +174,7 @@ const resolveVmClaim = createMiddleware<VmEnv>(async (c, next) => {
   // handle never existed — /events reported `claiming` forever and every other
   // route 404'd. See `resolveSandboxUserId`.
   const sandboxUserId = await resolveSandboxUserId(ctx, branch, userId);
-  const claimName = computeClaimHandle(
-    { userId: sandboxUserId, projectRef },
-    branch,
-  );
+  const claimName = computeClaimHandle({ userId: sandboxUserId, projectRef });
   const virtualMcpMetadata =
     (virtualMcp.metadata as Record<string, unknown>) ?? null;
 

--- a/apps/api/src/sandbox/claim-handle.test.ts
+++ b/apps/api/src/sandbox/claim-handle.test.ts
@@ -1,15 +1,29 @@
+import { computeHandle } from "@decocms/sandbox/provider";
 import { describe, expect, it } from "bun:test";
 import { computeClaimHandle } from "./claim-handle";
 
 describe("computeClaimHandle", () => {
   it("uses hashLen=16 regardless of the configured runner", () => {
-    // Both live provider kinds (agent-sandbox, user-desktop) expose preview URLs as
-    // public hostnames, so the handle hash must be long enough to resist
-    // guessing at an unrate-limited gateway. The hashLen no longer varies by
-    // kind, so the handle is env-agnostic.
-    const h = computeClaimHandle({ userId: "u", projectRef: "p" }, "main");
+    // Preview URLs expose the handle as a public hostname, so the hash must be
+    // long enough to resist guessing at an unrate-limited gateway. The hashLen
+    // does not vary by runner kind, so the handle is env-agnostic.
+    const h = computeClaimHandle({
+      userId: "u",
+      projectRef: "agent:org:vmcp:main",
+    });
     // computeHandle output: "<slug>-<hash>"; assert the hash segment length.
     const hash = h.split("-").pop()!;
     expect(hash.length).toBe(16);
+  });
+
+  it("matches what the runner composes for the same id — no branch to disagree on", () => {
+    const id = {
+      userId: "u",
+      projectRef: "agent:org:vmcp:thread:thrd_1/conn_2",
+    };
+    // The proxy knows the synthetic key; the runner may only know the derived
+    // git ref (`sandbox/thread-thrd_1-conn_2`). Neither can influence the
+    // handle, so both sides land on the same claim name.
+    expect(computeClaimHandle(id)).toBe(computeHandle(id));
   });
 });

--- a/apps/api/src/sandbox/claim-handle.ts
+++ b/apps/api/src/sandbox/claim-handle.ts
@@ -1,17 +1,16 @@
 import { computeHandle, type SandboxId } from "@decocms/sandbox/provider";
 
 /**
- * Compute the claim handle for a sandbox. Both live provider kinds
- * (agent-sandbox and user-desktop) expose preview URLs as public hostnames
- * (`<handle>.cluster.host` and `<handle>.localhost` respectively), so both
- * use hashLen=16 — shorter hashes are brute-forceable at an unrate-limited
- * gateway.
+ * Compute the claim handle for a sandbox. Preview URLs expose the handle as a
+ * public hostname (`<handle>.cluster.host`), so hashLen=16 — shorter hashes are
+ * brute-forceable at an unrate-limited gateway.
  *
- * Single source of truth — import this everywhere a claimName must match
- * what a runner stored (vm-events, vm-exec, etc.). The matching
- * `hashLen=16` lives in `desktop/runner.ts` so both sides agree by
- * construction.
+ * Single source of truth — import this everywhere a claimName must match what a
+ * runner stored (vm-events, vm-exec, etc.). It agrees with the runner by
+ * construction: both call `computeHandle`, which derives the whole handle from
+ * `projectRef`. There is deliberately no branch parameter — passing one that
+ * disagreed with the ref is what produced duplicate claims.
  */
-export function computeClaimHandle(id: SandboxId, branch: string): string {
-  return computeHandle(id, branch);
+export function computeClaimHandle(id: SandboxId): string {
+  return computeHandle(id);
 }

--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -571,11 +571,8 @@ async function provisionSandbox(
   const sandbox = await runner.ensure(
     { userId: sandboxUserId, projectRef },
     {
-      // Pass branch explicitly so the runner-side `computeHandle` agrees with
-      // the sandbox-proxy's `computeClaimHandle`. Without it, a repo-less
-      // VM falls back to `s-<hash>` while the proxy looks up `<branch>-<hash>`
-      // and every proxy call 404s with `unknown handle` (see resilience
-      // scenarios `link-dispatch-ws-partition` / `link-dispatch-log-replay`).
+      // Annotation only — the handle comes from `projectRef`, which already
+      // carries this branch, so runner and proxy agree without being told.
       branch,
       repo: repoOpts,
       workload,

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -496,17 +496,23 @@ export class AgentSandboxProvider implements SandboxProvider {
   // ---- SandboxProvider surface ------------------------------------------------
 
   async ensure(id: SandboxId, opts: EnsureOptions = {}): Promise<Sandbox> {
-    // Branch is the slug source. Prefer the explicit top-level `opts.branch`
-    // (which `sandbox-proxy.ts`'s `computeClaimHandle` also uses) over
-    // `opts.repo?.branch` so a repo-less SANDBOX_START — i.e. a virtual MCP
-    // with no GitHub connection — still composes the same handle the proxy
-    // looks up. The fallback to bare-hash (`s-<hash>`) survives only for
-    // legacy tool-only / smoke-test callers that drive `ensure` without
-    // ever touching the sandbox-proxy.
-    const handle = composeBranchHandle(
-      id,
-      opts.branch ?? opts.repo?.branch ?? null,
-    );
+    // Identity comes from `id` alone — slug and hash both derive from
+    // `id.projectRef`, so this agrees with `sandbox-proxy.ts`'s
+    // `computeClaimHandle` by construction. It used to take a branch argument
+    // (`opts.branch ?? opts.repo?.branch ?? null`); callers that omitted the
+    // top-level field fell through to `repo.branch` — the DERIVED git ref, not
+    // the synthetic isolation key — and posted a second claim for one sandbox.
+    const handle = composeBranchHandle(id);
+    // An unsluggable ref is a caller bug, not something to recover from: the
+    // old silent `s-<hash>` fallback is exactly how a repo-less sandbox got a
+    // duplicate pod in prod (`s-<hash>` alongside `ephemeral-<hash>`, 0.4s
+    // apart, same hash — the `s-` one never received a dispatch and idled to
+    // its 15-min TTL).
+    if (handle.startsWith("s-")) {
+      throw new Error(
+        `ensure: projectRef has no slug source: ${id.projectRef}`,
+      );
+    }
     return this.inflight.run(handle, () =>
       withSandboxLock(this.stateStore, id, RUNNER_KIND, (ops) =>
         this.ensureLocked(id, handle, opts, ops),
@@ -1940,6 +1946,14 @@ export class AgentSandboxProvider implements SandboxProvider {
           repo: await this.withFreshCloneUrl(persistedOpts.repo),
         }
       : persistedOpts;
+    // The row must resolve back to the handle we were asked to resurrect.
+    // Structurally guaranteed now that both derive from `id.projectRef`, which
+    // is the point of asserting it: if a future ref encoding breaks the
+    // identity, resurrecting would post a SECOND claim under a different name
+    // while the caller kept waiting on this one. 404 instead — the UI's
+    // notFound → SANDBOX_START flow re-supplies correct opts.
+    const resurrected = composeBranchHandle(row.id);
+    if (resurrected !== handle) return null;
     // ensure() is idempotent + advisory-locked, so concurrent resurrections
     // for the same handle collapse to a single provision. The lock is keyed
     // on (userId, projectRef, kind), the same identity our state-store row
@@ -2507,10 +2521,10 @@ function tenantAttrs(tenant: RunnerTenant | null): {
  */
 export function stripEnsureOpts(opts: EnsureOptions): EnsureOptions | null {
   const out: EnsureOptions = {};
-  // The handle's slug source. Dropping it made `resurrectByHandle` fall back to
-  // `repo.branch` (the derived git ref, not the synthetic isolation key), so the
-  // re-ensure computed a DIFFERENT handle and posted a SECOND SandboxClaim for
-  // one thread — while the handle the caller was waiting on stayed unknown.
+  // Kept for the claim's `git-branch` annotation on reprovision. It no longer
+  // affects the handle (that comes from `projectRef`), so losing it can't fork a
+  // claim the way it once did — persist it anyway so a resurrected claim carries
+  // the same operator-facing annotation as the original.
   if (opts.branch) out.branch = opts.branch;
   if (opts.repo) out.repo = opts.repo;
   if (opts.workload) out.workload = opts.workload;

--- a/packages/sandbox/server/provider/sandbox-ref.test.ts
+++ b/packages/sandbox/server/provider/sandbox-ref.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { composeSandboxRef } from "./sandbox-ref";
+import { composeSandboxRef, refSlugSource } from "./sandbox-ref";
 
 describe("composeSandboxRef", () => {
   it("composes agent ref from org + virtualMcp + branch", () => {
@@ -41,5 +41,43 @@ describe("composeSandboxRef", () => {
 
   it("rejects empty threadId", () => {
     expect(() => composeSandboxRef({ threadId: "" })).toThrow();
+  });
+});
+
+describe("refSlugSource", () => {
+  it("returns the branch of an agent ref", () => {
+    expect(refSlugSource("agent:org_1:vm_2:deco/silver-fox")).toBe(
+      "deco/silver-fox",
+    );
+  });
+
+  it("keeps every segment past the third, so a branch may contain ':'", () => {
+    // A thread-scoped branch is itself `thread:<threadId>/<connId>`; splitting
+    // on ":" and taking parts[3] alone would truncate it to "thread".
+    expect(refSlugSource("agent:o:v:thread:thrd_abc/conn_Def")).toBe(
+      "thread:thrd_abc/conn_Def",
+    );
+  });
+
+  it("returns the threadId of a thread ref", () => {
+    expect(refSlugSource("thread:thr_xyz")).toBe("thr_xyz");
+  });
+
+  it("returns '' for a ref in neither encoding", () => {
+    expect(refSlugSource("legacy-opaque")).toBe("");
+  });
+
+  it("returns '' for a truncated agent ref", () => {
+    expect(refSlugSource("agent:org:vmcp")).toBe("");
+  });
+
+  it("round-trips composeSandboxRef for both encodings", () => {
+    const branch = "thread:thrd_1/conn_2";
+    expect(
+      refSlugSource(
+        composeSandboxRef({ orgId: "o", virtualMcpId: "v", branch }),
+      ),
+    ).toBe(branch);
+    expect(refSlugSource(composeSandboxRef({ threadId: "t_1" }))).toBe("t_1");
   });
 });

--- a/packages/sandbox/server/provider/sandbox-ref.ts
+++ b/packages/sandbox/server/provider/sandbox-ref.ts
@@ -28,3 +28,28 @@ export function composeSandboxRef(input: SandboxRefInput): string {
   }
   return `agent:${input.orgId}:${input.virtualMcpId}:${input.branch}`;
 }
+
+/**
+ * The human-readable part of a ref, used as the handle's slug source: the
+ * branch for `agent:` refs, the threadId for `thread:` refs.
+ *
+ * Exists so `computeHandle` derives its slug from the SAME value it hashes.
+ * When the slug came from a separate `branch` argument the two could disagree,
+ * and since the claim name IS the dedupe key that produced two claims and two
+ * pods for one logical sandbox — observed in prod 2026-08-04, where
+ * `thread:<id>/<conn>` and its derived git ref `sandbox/thread-<id>-<conn>`
+ * hashed identically but slugged differently.
+ *
+ * Returns "" for a ref in neither encoding (legacy/test callers); the caller
+ * falls back to a bare hash.
+ */
+export function refSlugSource(projectRef: string): string {
+  if (projectRef.startsWith("thread:"))
+    return projectRef.slice("thread:".length);
+  if (!projectRef.startsWith("agent:")) return "";
+  // agent:<orgId>:<vmcpId>:<branch> — the branch itself may contain ":" (a
+  // thread-scoped branch is `thread:<threadId>/<connId>`), so keep every
+  // segment past the third.
+  const parts = projectRef.split(":");
+  return parts.length >= 4 ? parts.slice(3).join(":") : "";
+}

--- a/packages/sandbox/server/provider/shared/handle.test.ts
+++ b/packages/sandbox/server/provider/shared/handle.test.ts
@@ -1,37 +1,41 @@
 import { describe, expect, it } from "bun:test";
-import { computeHandle, hashSandboxId } from "./handle";
 import type { SandboxId } from "../types";
+import { computeHandle, hashSandboxId } from "./handle";
 
-const ID: SandboxId = {
-  userId: "u_1",
-  projectRef: "agent:org:vmcp:deco/mellow-flint",
-};
+const idFor = (projectRef: string, userId = "u_1"): SandboxId => ({
+  userId,
+  projectRef,
+});
+
+const ID = idFor("agent:org:vmcp:deco/mellow-flint");
 
 describe("computeHandle", () => {
   it("strips the prefix before the last `/` from the branch slug", () => {
-    const handle = computeHandle(ID, "deco/mellow-flint");
-    expect(handle).toMatch(/^mellow-flint-[0-9a-f]{16}$/);
+    expect(computeHandle(ID)).toMatch(/^mellow-flint-[0-9a-f]{16}$/);
   });
 
   it("strips multi-segment prefixes, keeping only the last segment", () => {
-    const handle = computeHandle(ID, "tlgimenes/unified-sandbox-daemon");
+    const handle = computeHandle(
+      idFor("agent:org:vmcp:tlgimenes/unified-sandbox-daemon"),
+    );
     expect(handle).toMatch(/^unified-sandbox-daemon-[0-9a-f]{16}$/);
   });
 
   it("lowercases and replaces non-alphanumeric chars with `-`", () => {
-    const handle = computeHandle(ID, "Foo_Bar.Baz");
-    expect(handle).toMatch(/^foo-bar-baz-[0-9a-f]{16}$/);
+    expect(computeHandle(idFor("agent:org:vmcp:Foo_Bar.Baz"))).toMatch(
+      /^foo-bar-baz-[0-9a-f]{16}$/,
+    );
   });
 
   it("collapses repeated separators and trims leading/trailing dashes", () => {
-    const handle = computeHandle(ID, "feat///___refactor---");
-    expect(handle).toMatch(/^refactor-[0-9a-f]{16}$/);
+    expect(
+      computeHandle(idFor("agent:org:vmcp:feat///___refactor---")),
+    ).toMatch(/^refactor-[0-9a-f]{16}$/);
   });
 
   it("truncates the slug to 24 chars before joining the hash", () => {
     const handle = computeHandle(
-      ID,
-      "a-very-long-branch-name-that-exceeds-the-limit",
+      idFor("agent:org:vmcp:a-very-long-branch-name-that-exceeds-the-limit"),
     );
     const match = handle.match(/^([a-z0-9-]+)-([0-9a-f]{16})$/);
     expect(match).not.toBeNull();
@@ -39,51 +43,63 @@ describe("computeHandle", () => {
     expect(match![1]!.endsWith("-")).toBe(false);
   });
 
-  it("returns s-<hash> when branch is null (DNS-1035: must start with letter)", () => {
-    const handle = computeHandle(ID, null);
-    expect(handle).toMatch(/^s-[0-9a-f]{16}$/);
-  });
-
-  it("returns s-<hash> when branch is undefined", () => {
-    const handle = computeHandle(ID);
-    expect(handle).toMatch(/^s-[0-9a-f]{16}$/);
-  });
-
-  it("returns s-<hash> when branch is empty string", () => {
-    const handle = computeHandle(ID, "");
-    expect(handle).toMatch(/^s-[0-9a-f]{16}$/);
-  });
-
-  it("returns s-<hash> when branch sanitizes to empty", () => {
-    const handle = computeHandle(ID, "///");
-    expect(handle).toMatch(/^s-[0-9a-f]{16}$/);
-  });
-
-  it("returns s-<hash> when branch is whitespace-only", () => {
-    const handle = computeHandle(ID, "   ");
-    expect(handle).toMatch(/^s-[0-9a-f]{16}$/);
-  });
-
-  it("is deterministic for the same (id, branch) pair", () => {
-    const a = computeHandle(ID, "deco/foo");
-    const b = computeHandle(ID, "deco/foo");
-    expect(a).toBe(b);
-  });
-
-  it("uses the SandboxId for the hash, so different ids with the same slug differ", () => {
-    const handleA = computeHandle(ID, "deco/foo");
-    const handleB = computeHandle(
-      { userId: "u_2", projectRef: "agent:org:vmcp:deco/foo" },
-      "deco/foo",
+  it("slugs a thread ref from its threadId", () => {
+    expect(computeHandle(idFor("thread:thr_xyz"))).toMatch(
+      /^thr-xyz-[0-9a-f]{16}$/,
     );
-    expect(handleA).not.toBe(handleB);
-    expect(handleA.split("-").slice(0, -1).join("-")).toBe(
-      handleB.split("-").slice(0, -1).join("-"),
+  });
+
+  it("keeps the connection id as the slug for a thread-scoped branch", () => {
+    // `thread:<threadId>/<connId>` — last `/`-segment wins, and the ":" inside
+    // the branch must not be mistaken for a ref delimiter.
+    const handle = computeHandle(
+      idFor("agent:org:vmcp:thread:thrd_abc/conn_Def456"),
+    );
+    expect(handle).toMatch(/^conn-def456-[0-9a-f]{16}$/);
+  });
+
+  it("returns s-<hash> for a ref in neither encoding (DNS-1035: must start with letter)", () => {
+    expect(computeHandle(idFor("legacy-opaque-ref"))).toMatch(
+      /^s-[0-9a-f]{16}$/,
+    );
+  });
+
+  it("returns s-<hash> when the ref's branch sanitizes to empty", () => {
+    expect(computeHandle(idFor("agent:org:vmcp:///"))).toMatch(
+      /^s-[0-9a-f]{16}$/,
+    );
+  });
+
+  it("is deterministic for the same id", () => {
+    const ref = "agent:org:vmcp:deco/foo";
+    expect(computeHandle(idFor(ref))).toBe(computeHandle(idFor(ref)));
+  });
+
+  it("hashes the SandboxId, so different users with the same branch differ", () => {
+    const ref = "agent:org:vmcp:deco/foo";
+    const a = computeHandle(idFor(ref, "u_1"));
+    const b = computeHandle(idFor(ref, "u_2"));
+    expect(a).not.toBe(b);
+    // ...but they share the slug.
+    expect(a.split("-").slice(0, -1).join("-")).toBe(
+      b.split("-").slice(0, -1).join("-"),
     );
   });
 
   it("hash is the 16-char hashSandboxId of the id", () => {
-    const handle = computeHandle(ID, "deco/foo");
-    expect(handle.endsWith(`-${hashSandboxId(ID)}`)).toBe(true);
+    expect(computeHandle(ID).endsWith(`-${hashSandboxId(ID)}`)).toBe(true);
+  });
+
+  // The regression this signature exists to prevent. Prod 2026-08-04: the
+  // synthetic isolation key and its derived git ref hash identically (same
+  // projectRef) but used to slug differently, yielding `conn-rot3ncf1…-<hash>`
+  // and `thread-4719cbc0…-<hash>` — two claims, two pods, one logical sandbox,
+  // both pushing the same git branch. With the branch argument gone there is no
+  // input that can split one ref into two names.
+  it("one ref yields exactly one handle", () => {
+    const ref = "agent:org:vmcp:thread:4719cbc0-cebb-44ac/conn_RoT3ncf1";
+    const handle = computeHandle(idFor(ref));
+    expect(computeHandle(idFor(ref))).toBe(handle);
+    expect(handle).toContain(hashSandboxId(idFor(ref)));
   });
 });

--- a/packages/sandbox/server/provider/shared/handle.ts
+++ b/packages/sandbox/server/provider/shared/handle.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { refSlugSource } from "../sandbox-ref";
 import { sandboxIdKey, type SandboxId } from "../types";
 
 const SLUG_MAX = 24;
@@ -12,13 +13,18 @@ export function hashSandboxId(id: SandboxId, length = 16): string {
 }
 
 /**
- * Human-readable URL handle for a sandbox: `<slug>-<hash16>`, where `slug` is
- * derived from the last `/`-segment of the branch and `hash16` is the first
- * 16 hex chars (~64 bits) of `SHA256(userId:projectRef)`. Falls back to a
- * bare hash when the branch is missing or sanitizes to empty.
+ * Human-readable URL handle for a sandbox: `<slug>-<hash16>`, where `hash16` is
+ * the first 16 hex chars (~64 bits) of `SHA256(userId:projectRef)` and `slug` is
+ * derived from the last `/`-segment of that SAME `projectRef`'s branch. Falls
+ * back to a bare hash for a ref in neither known encoding.
  *
- * Both live runners expose the handle as a public hostname (agent-sandbox
- * preview URLs; the user-desktop `<handle>.localhost` ingress), so the handle
+ * Takes ONLY the id, deliberately. The slug used to come from a separate
+ * `branch` argument, which let it disagree with the hashed ref — and since the
+ * claim name is the dedupe key, disagreement meant two claims and two pods for
+ * one logical sandbox. Deriving both from `id` makes that unrepresentable; do
+ * not re-add a branch parameter.
+ *
+ * The handle is exposed as a public hostname (agent-sandbox preview URLs), so it
  * is the only authorization on those URLs — a 64-bit hash resists brute-force
  * at an unrate-limited gateway (a shorter 20-bit hash would fall in ~17 min
  * at 1k req/s).
@@ -26,9 +32,9 @@ export function hashSandboxId(id: SandboxId, length = 16): string {
  * Total max length: 24 + 1 + 16 = 41 chars (under the 63-char DNS label cap
  * with room for a runner-specific prefix).
  */
-export function computeHandle(id: SandboxId, branch?: string | null): string {
+export function computeHandle(id: SandboxId): string {
   const hash = hashSandboxId(id);
-  const slug = slugifyBranch(branch);
+  const slug = slugifyBranch(refSlugSource(id.projectRef));
   return slug ? `${slug}-${hash}` : `s-${hash}`;
 }
 

--- a/packages/sandbox/server/provider/types.ts
+++ b/packages/sandbox/server/provider/types.ts
@@ -42,13 +42,18 @@ export interface Workload {
 
 export interface EnsureOptions {
   /**
-   * Branch slug for handle composition. The sandbox proxy
-   * (`apps/api/src/api/routes/sandbox-proxy.ts`) ALWAYS derives the claim
-   * handle from the URL-path branch, so the runner MUST agree or every
-   * proxy call 404s with `unknown handle`. Callers that also drive the
-   * proxy (i.e. SANDBOX_START / ensureSandbox) MUST pass this; `repo.branch`
-   * remains as a fallback only because legacy/test callers without a proxy
-   * surface still use it. When both are set, this top-level field wins.
+   * The synthetic isolation key, recorded as the claim's `git-branch`
+   * ANNOTATION for operators reading `kubectl get sandboxclaim -o yaml`.
+   *
+   * NOT an identity input — the handle derives its slug and its hash from
+   * `projectRef` alone (see `computeHandle`). Setting this wrong costs you a
+   * misleading annotation, nothing more. It used to feed the handle's slug,
+   * which is how a caller passing the derived git ref here instead of the
+   * synthetic key got a second claim for one sandbox.
+   *
+   * Prefer it over `repo.branch` for the annotation: `repo.branch` is the real
+   * git ref the daemon checks out, which for thread-scoped work is the derived
+   * `sandbox/thread-*` name rather than the isolation key.
    */
   branch?: string;
   /**


### PR DESCRIPTION
## Summary

`computeHandle(id, branch)` hashed `id.projectRef` — which already contains the branch — but slugged a **separate** `branch` argument. The two could disagree, and since the claim name **is** the dedupe key (`runner.ts` `name: handle`, and the whole create/adopt ladder keys on exact name), disagreement produced two claims and two pods for one logical sandbox, both pushing the same git branch.

Fix: drop the parameter. `refSlugSource` pulls the slug source out of the ref itself, so slug and hash share one input and forking a ref into two names is unrepresentable.

## Evidence (prod, eks-serverless, 2026-08-04)

Two live claims, same hash — same `userId:projectRef`, so the same logical sandbox:

```
hash 5ebbd7b76476aa24
  conn-rot3ncf1rdqj9tj557o-…   branch  thread:4719cbc0…/conn_RoT3ncf1RDQj9TJ557oC5
  thread-4719cbc0-cebb-44a-…   branch  sandbox/thread-4719cbc0…-conn_RoT3ncf1RDQj9TJ557oC5
```

The second slug is the *derived git ref* (`syntheticBranchToGitRef`) leaking into identity. The `s-<hash>` fallback did the same thing twice in one hour:

```
17:00:22.509  SandboxAdopted  s-67468eb31139dbc4          ← 0 dispatches
17:00:22.883  SandboxAdopted  ephemeral-67468eb31139dbc4  ← same hash, 0.4s later
17:11:02      SandboxReaped   s-67468eb31139dbc4          ← idled to TTL, never used
```

~14% of live claims were duplicates of this shape.

## Changes

- `computeHandle(id)` — slug from `refSlugSource(id.projectRef)`, no branch param.
- `ensure()` no longer resolves `opts.branch ?? opts.repo?.branch ?? null`. Callers omitting the top-level field were slugging `repo.branch`, the derived ref. An unsluggable ref now throws instead of silently becoming `s-<hash>`.
- `resurrectByHandle` asserts the state-store row resolves back to the handle it was asked to resurrect — it could otherwise provision a second claim under a different name while the caller waited on the first. That was the likely `s-`/`ephemeral-` trigger.
- `EnsureOptions.branch` survives as the `git-branch` annotation only, documented as such.

## Testing

- `handle.test.ts` — inverted the cases that encoded the two-arg signature (per CLAUDE.md, rather than appending); added thread-ref slugging, a branch containing `:`, and the one-ref-one-handle regression.
- `sandbox-ref.test.ts` — `refSlugSource` incl. the `:`-in-branch case and a `composeSandboxRef` round-trip.
- `claim-handle.test.ts` — asserts proxy and runner agree for one id.
- `bun test packages/sandbox apps/api/src/sandbox` → 583 pass, 0 fail. `bun run fmt`, typecheck clean.

No e2e added: with the parameter gone there is no input that can split a ref, so the unit test is the complete check — an e2e would need a live agent-sandbox cluster to add nothing.

## Migration

None. Handles change only for claims whose slug disagreed with their ref — exactly the broken ones. Claim TTL is 15 min, so the fleet rolls over on its own.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compute the sandbox claim handle from projectRef only to prevent duplicate claims/pods when slug and hash disagreed. Runner and proxy now derive the same name from the same input.

- **Bug Fixes**
  - Removed the branch parameter from handle composition; `computeHandle(id)` now slugs via `refSlugSource(id.projectRef)`, and the proxy uses `computeClaimHandle(id)`.
  - Runner `ensure()` builds the handle from the id only and throws on unsluggable refs (no more silent `s-<hash>` during provisioning/resurrection).
  - `resurrectByHandle` verifies the state row resolves back to the requested handle to avoid spawning a second claim under a different name.
  - `EnsureOptions.branch` is annotation-only (`git-branch`) and no longer affects identity; added `refSlugSource` and tests for thread refs and `:` in branches.

- **Migration**
  - No action needed. Only mismatched handles change; claims expire in ~15 minutes and roll over naturally.

<sup>Written for commit bc56718026fc6a61b071c39c9bd85d4c594b3500. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

