### PR TITLE
fix(connection): block SSRF on CONNECTION_TEST's health-check fetch

### DIFF
--- a/apps/api/src/storage/connection.integration.test.ts
+++ b/apps/api/src/storage/connection.integration.test.ts
@@ -510,6 +510,20 @@ describe("ConnectionStorage", () => {
       expect(result.healthy).toBe(false);
       expect(result.latencyMs).toBeGreaterThan(0);
     });
+
+    it("should return unhealthy instead of probing a private-network URL", async () => {
+      const created = await storage.create({
+        organization_id: "org_123",
+        created_by: "user_123",
+        title: "Private target",
+        connection_type: "HTTP",
+        connection_url: "http://169.254.169.254/latest/meta-data/",
+      });
+
+      const result = await storage.testConnection(created.id);
+
+      expect(result.healthy).toBe(false);
+    });
   });
 
   describe("JSON deserialization", () => {

--- a/apps/api/src/storage/connection.ts
+++ b/apps/api/src/storage/connection.ts
@@ -25,6 +25,10 @@ import type {
   StdioConnectionParameters,
 } from "../tools/connection/schema";
 import { isStdioParameters } from "../tools/connection/schema";
+import {
+  createNoRedirectFetch,
+  guardAgainstPrivateUrl,
+} from "../tools/registry/discover-tools";
 import { generatePrefixedId } from "@decocms/shared/utils/generate-id";
 import {
   getWellKnownDecopilotConnection,
@@ -438,26 +442,44 @@ export class ConnectionStorage implements ConnectionStoragePort {
     }
 
     try {
+      // connection_url is user-supplied — a plain `fetch` here would let a
+      // URL that resolves privately (or 302s to one) reach an internal/
+      // metadata address on every test call, even if the address was safe at
+      // create/update time. Reuse the same SSRF guard the fetch-tools path
+      // applies, plus a no-redirect fetch to close the redirect-based bypass.
+      const guardError = await guardAgainstPrivateUrl(
+        connection.connection_url,
+      );
+      if (guardError) {
+        return {
+          healthy: false,
+          latencyMs: Date.now() - startTime,
+        };
+      }
+
       const httpParams = connection.connection_headers as {
         headers?: Record<string, string>;
       } | null;
 
-      const response = await fetch(connection.connection_url, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          ...(connection.connection_token && {
-            Authorization: `Bearer ${connection.connection_token}`,
+      const response = await createNoRedirectFetch()(
+        connection.connection_url,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            ...(connection.connection_token && {
+              Authorization: `Bearer ${connection.connection_token}`,
+            }),
+            ...httpParams?.headers,
+            ...headers,
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            method: "ping",
+            id: 1,
           }),
-          ...httpParams?.headers,
-          ...headers,
         },
-        body: JSON.stringify({
-          jsonrpc: "2.0",
-          method: "ping",
-          id: 1,
-        }),
-      });
+      );
 
       return {
         healthy: response.ok || response.status === 404,


### PR DESCRIPTION
**Source**: bug found while auditing MCP connection tooling (focus area: connection cleanup/validation), specifically `CONNECTION_TEST`'s backing storage method.

**Why**: `ConnectionStorage.testConnection()` (`apps/api/src/storage/connection.ts`) probes `connection.connection_url` with a raw `fetch(...)` on every health check — no `guardAgainstPrivateUrl` check and no redirect blocking. Connection create/update already run the same user-supplied `connection_url` through `guardAgainstPrivateUrl` + `createNoRedirectFetch()` before fetching tools (`apps/api/src/tools/connection/fetch-tools.ts`), precisely because a remote server can 302-redirect a request to a private/cloud-metadata address (this is the same vuln class fixed for registry discovery in #5488/#4986 and for connection tool-fetch in #5516). `testConnection` never got the equivalent guard, so any org member who can create/update a connection can point `connection_url` at an attacker-controlled host that redirects `CONNECTION_TEST`'s POST to `http://169.254.169.254/...` or another internal address — and it fires on every manual "test connection" click, unlike the one-time create/update fetch.

**Failure scenario**: create an HTTP connection with `connection_url` pointing at a URL you control; have it return a 302 to a private/metadata IP; call `CONNECTION_TEST` — the health-check request follows the redirect and hits the internal address.

**Fix**: reuse the existing `guardAgainstPrivateUrl` + `createNoRedirectFetch` helpers from `tools/registry/discover-tools.ts` in `testConnection`, returning `{ healthy: false }` instead of probing a private/redirect-guarded address. Added a regression test in `connection.integration.test.ts` asserting a connection pointed at `169.254.169.254` reports unhealthy rather than being fetched.

**Reviewer check**: `cd apps/api && bunx tsc --noEmit`; the new integration test needs Postgres (`bun test apps/api/src/storage/connection.integration.test.ts` under CI) — not runnable in this sandbox.

**Verified locally**: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint apps/api/src/storage/connection.ts apps/api/src/storage/connection.integration.test.ts` (0 warnings/errors). Full CI runs the integration test against real Postgres.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent SSRF in `CONNECTION_TEST` by validating `connection_url` and disabling redirects during health checks. Private or redirecting URLs are not probed; the check returns unhealthy.

- **Bug Fixes**
  - Use `guardAgainstPrivateUrl` and `createNoRedirectFetch()` in `ConnectionStorage.testConnection()`.
  - Add an integration test to ensure `169.254.169.254` is treated as unhealthy without being fetched.

<sup>Written for commit e59075c5970a2056854b6547611d3de619a372ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

