### PR TITLE
feat(sandbox): regenerate blocks.gen.json in the Go daemon's /read when absent

### DIFF
--- a/packages/sandbox/daemon-e2e/daemon.decofile.e2e.test.ts
+++ b/packages/sandbox/daemon-e2e/daemon.decofile.e2e.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Daemon conformance suite — DECOFILE /read fallback.
+ *
+ * `.deco/blocks.gen.json` is the runtime's merge of every `.deco/blocks/*.json`;
+ * repos commonly gitignore it, so a fresh sandbox has the block sources but not
+ * the merged artifact. When the file is absent, GET-equivalent POST /read must
+ * synthesize the merge on the fly (keyed by the decoded filename stem) so the
+ * CMS is readable before the dev server boots — instead of the plain
+ * "File not found" a normal absent file gets. Black-box throughout.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+
+import {
+  type Daemon,
+  HOOK_TIMEOUT_MS,
+  jsonAuthHeaders,
+  startDaemon,
+  stopDaemon,
+  url,
+  writeRepoFile,
+} from "./daemon.e2e.helpers";
+
+const toBody = (obj: unknown) => JSON.stringify(obj);
+
+const read = (d: Daemon, path: string) =>
+  fetch(url(d, "/_sandbox/read"), {
+    method: "POST",
+    headers: jsonAuthHeaders(),
+    body: toBody({ path, full: true }),
+  });
+
+describe("daemon e2e: decofile /read fallback", () => {
+  let d: Daemon;
+  beforeAll(async () => {
+    d = await startDaemon();
+  }, HOOK_TIMEOUT_MS);
+  afterAll(async () => {
+    await stopDaemon(d);
+  }, HOOK_TIMEOUT_MS);
+
+  it("synthesizes blocks.gen.json from .deco/blocks/*.json when absent", async () => {
+    await writeRepoFile(d, "site-a/.deco/blocks/b.json", `{"n":2}`);
+    await writeRepoFile(d, "site-a/.deco/blocks/a.json", `{"n":1}`);
+
+    const res = await read(d, "site-a/.deco/blocks.gen.json");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { kind: string; content: string };
+    expect(body.kind).toBe("text");
+    // Sorted by filename, keyed by decoded stem, spliced raw — deterministic.
+    expect(body.content).toBe(`{"a":{"n":1},"b":{"n":2}}`);
+    // The consumer strips a leading `^\d+\t` per line; the payload must not
+    // carry one, so JSON.parse of the (no-op) stripped content still works.
+    expect(JSON.parse(body.content)).toEqual({ a: { n: 1 }, b: { n: 2 } });
+  });
+
+  it("decodes percent-encoded block stems until stable", async () => {
+    await writeRepoFile(
+      d,
+      "site-b/.deco/blocks/Compre%2520Junto.json",
+      `{"x":1}`,
+    );
+    const res = await read(d, "site-b/.deco/blocks.gen.json");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { content: string };
+    expect(JSON.parse(body.content)).toEqual({ "Compre Junto": { x: 1 } });
+  });
+
+  it("still 400s for a genuinely absent file with no blocks dir", async () => {
+    const res = await read(d, "site-c/.deco/blocks.gen.json");
+    expect(res.status).toBe(400);
+  });
+
+  it("does not synthesize for a non-decofile absent file", async () => {
+    const res = await read(d, "site-a/nope.json");
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/sandbox/daemon-e2e/daemon.decofile.e2e.test.ts
+++ b/packages/sandbox/daemon-e2e/daemon.decofile.e2e.test.ts
@@ -22,6 +22,16 @@ import {
 
 const toBody = (obj: unknown) => JSON.stringify(obj);
 
+// Inlined copy of the web consumer's stripLineNumbers (read-committed-file.ts →
+// file-explorer/utils.ts): strips a leading `^\d+\t` from every `\n`-split line.
+// The e2e can't import app code (ban-e2e-app-imports), so it owns this contract
+// — a divergence from the real consumer is a wire-contract regression signal.
+const stripLineNumbers = (content: string): string =>
+  content
+    .split("\n")
+    .map((line) => line.replace(/^\d+\t/, ""))
+    .join("\n");
+
 const read = (d: Daemon, path: string) =>
   fetch(url(d, "/_sandbox/read"), {
     method: "POST",
@@ -51,6 +61,26 @@ describe("daemon e2e: decofile /read fallback", () => {
     // The consumer strips a leading `^\d+\t` per line; the payload must not
     // carry one, so JSON.parse of the (no-op) stripped content still works.
     expect(JSON.parse(body.content)).toEqual({ a: { n: 1 }, b: { n: 2 } });
+  });
+
+  it("survives the consumer's stripLineNumbers on pretty-printed blocks", async () => {
+    // Blocks are written to disk pretty-printed (JSON.stringify(data, null, 2)),
+    // so the merged blob is multi-line. The real consumer always does
+    // JSON.parse(stripLineNumbers(content)) — exercise that exact path, not a
+    // bare JSON.parse, so a regression that re-numbers this response is caught.
+    const hero = JSON.stringify({ title: "Hi", count: 3 }, null, 2);
+    const shelf = JSON.stringify({ items: [1, 2] }, null, 2);
+    await writeRepoFile(d, "site-pretty/.deco/blocks/hero.json", hero);
+    await writeRepoFile(d, "site-pretty/.deco/blocks/shelf.json", shelf);
+
+    const res = await read(d, "site-pretty/.deco/blocks.gen.json");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { content: string };
+    expect(body.content).toContain("\n"); // genuinely multi-line
+    expect(JSON.parse(stripLineNumbers(body.content))).toEqual({
+      hero: { title: "Hi", count: 3 },
+      shelf: { items: [1, 2] },
+    });
   });
 
   it("decodes percent-encoded block stems until stable", async () => {

--- a/packages/sandbox/daemon-go/internal/decofile/decofile.go
+++ b/packages/sandbox/daemon-go/internal/decofile/decofile.go
@@ -1,7 +1,12 @@
-// Package decofile guards `.deco/blocks/*.json` — machine-managed pure JSON
-// where a single malformed file breaks the entire site render. The byte-level
-// /write and /edit endpoints can produce invalid JSON, and publish would commit
-// those bytes verbatim onto the user's branch.
+// Package decofile owns the `.deco/blocks/*.json` domain on both sides:
+//
+//   - validation: the byte-level /write and /edit endpoints can produce invalid
+//     JSON, and publish would commit those bytes verbatim onto the user's
+//     branch, so a single malformed file — which breaks the entire site render —
+//     must be rejected at write time (IsBlockPath, InvalidBlockJSON).
+//   - generation: merging every block source into the `blocks.gen.json` artifact
+//     the runtime emits (GenerateFromBlocksDeduped), so the CMS is readable
+//     before the dev server has regenerated it.
 package decofile
 
 import (

--- a/packages/sandbox/daemon-go/internal/decofile/merge.go
+++ b/packages/sandbox/daemon-go/internal/decofile/merge.go
@@ -1,6 +1,7 @@
 package decofile
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/url"
 	"os"
@@ -28,7 +29,8 @@ const (
 // reference resolves. Mirrors the frontend's documented decoBlockKeyFromFileStem
 // fallback: an invalid-encoding stem keeps its last successfully decoded form.
 // url.PathUnescape (not QueryUnescape) so a literal `+` in a block name is left
-// alone, matching JS decodeURIComponent.
+// alone, matching JS decodeURIComponent. Terminates: PathUnescape only collapses
+// `%XX` triples, so each pass strictly shortens the string until stable or errs.
 func decodeUntilStable(stem string) string {
 	key := stem
 	for {
@@ -40,7 +42,7 @@ func decodeUntilStable(stem string) string {
 	}
 }
 
-// GenerateFromBlocks rebuilds the merged decofile from the sibling
+// generateFromBlocks rebuilds the merged decofile from the sibling
 // `.deco/blocks/*.json` files so the CMS is readable before the dev server is
 // up. Maps each file to `{ [decodeUntilStable(stem)]: <file contents> }`,
 // sorted by filename for a deterministic, byte-for-byte result.
@@ -49,11 +51,13 @@ func decodeUntilStable(stem string) string {
 // unmarshal/marshal round-tripping through Go values — this payload is
 // routinely multi-MB, and a malformed block isn't caught here; the client's
 // parse fails and falls back to "no snapshot", same as the read/write/edit
-// handlers already gate.
+// handlers already gate. The merge is deliberately all-or-nothing: one bad block
+// blanks the whole snapshot rather than silently dropping a block and rendering
+// a partial site.
 //
 // Returns ok=false when there's no blocks dir (nothing to merge) so the caller
 // falls through to its normal "file not found" path.
-func GenerateFromBlocks(blocksDir string) (string, bool) {
+func generateFromBlocks(blocksDir string) (string, bool) {
 	entries, err := os.ReadDir(blocksDir)
 	if err != nil {
 		return "", false
@@ -78,9 +82,10 @@ func GenerateFromBlocks(blocksDir string) (string, bool) {
 		if err != nil {
 			continue
 		}
-		content := strings.TrimSpace(string(raw))
+		// bytes.TrimSpace avoids a full-payload string copy per block.
+		content := bytes.TrimSpace(raw)
 		// Skip empty files — `"key":` with no value would break the merged JSON.
-		if content == "" {
+		if len(content) == 0 {
 			continue
 		}
 		keyJSON, err := json.Marshal(decodeUntilStable(stem))
@@ -93,7 +98,7 @@ func GenerateFromBlocks(blocksDir string) (string, bool) {
 		first = false
 		b.Write(keyJSON)
 		b.WriteByte(':')
-		b.WriteString(content)
+		b.Write(content)
 	}
 	b.WriteByte('}')
 	return b.String(), true
@@ -126,12 +131,16 @@ func GenerateFromBlocksDeduped(blocksDir string) (string, bool) {
 	decofileInFlight[blocksDir] = b
 	decofileBuildMu.Unlock()
 
-	b.text, b.ok = GenerateFromBlocks(blocksDir)
+	// Clear the in-flight entry and wake followers even if the merge panics —
+	// otherwise a single bad build leaves a stale entry and every present and
+	// future waiter on this blocksDir blocks on b.done forever.
+	defer func() {
+		decofileBuildMu.Lock()
+		delete(decofileInFlight, blocksDir)
+		decofileBuildMu.Unlock()
+		close(b.done)
+	}()
 
-	decofileBuildMu.Lock()
-	delete(decofileInFlight, blocksDir)
-	decofileBuildMu.Unlock()
-	close(b.done)
-
+	b.text, b.ok = generateFromBlocks(blocksDir)
 	return b.text, b.ok
 }

--- a/packages/sandbox/daemon-go/internal/decofile/merge.go
+++ b/packages/sandbox/daemon-go/internal/decofile/merge.go
@@ -1,0 +1,137 @@
+package decofile
+
+import (
+	"encoding/json"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// GenBasename is the on-disk name of the merged decofile artifact, and
+// BlocksDirname its sibling source directory. `.deco/blocks.gen.json` is the
+// runtime's merge of every `.deco/blocks/*.json`; many repos gitignore it (a
+// multi-MB single line that conflicts on every content PR and is regenerated
+// on dev cold-start), so a fresh sandbox has the block sources but not the
+// merged file.
+const (
+	GenBasename   = "blocks.gen.json"
+	BlocksDirname = "blocks"
+)
+
+// decodeUntilStable repeatedly percent-decodes a filename stem until it stops
+// changing. Real repos carry both single- and double-encoded stems
+// (`Compre%20Junto.json`, `Compre%2520Junto.json`); a single decode leaves the
+// double-encoded one keyed `Compre%20Junto`, a key no `__resolveType`
+// reference resolves. Mirrors the frontend's documented decoBlockKeyFromFileStem
+// fallback: an invalid-encoding stem keeps its last successfully decoded form.
+// url.PathUnescape (not QueryUnescape) so a literal `+` in a block name is left
+// alone, matching JS decodeURIComponent.
+func decodeUntilStable(stem string) string {
+	key := stem
+	for {
+		decoded, err := url.PathUnescape(key)
+		if err != nil || decoded == key {
+			return key
+		}
+		key = decoded
+	}
+}
+
+// GenerateFromBlocks rebuilds the merged decofile from the sibling
+// `.deco/blocks/*.json` files so the CMS is readable before the dev server is
+// up. Maps each file to `{ [decodeUntilStable(stem)]: <file contents> }`,
+// sorted by filename for a deterministic, byte-for-byte result.
+//
+// The merged text is built by splicing raw file bytes rather than
+// unmarshal/marshal round-tripping through Go values — this payload is
+// routinely multi-MB, and a malformed block isn't caught here; the client's
+// parse fails and falls back to "no snapshot", same as the read/write/edit
+// handlers already gate.
+//
+// Returns ok=false when there's no blocks dir (nothing to merge) so the caller
+// falls through to its normal "file not found" path.
+func GenerateFromBlocks(blocksDir string) (string, bool) {
+	entries, err := os.ReadDir(blocksDir)
+	if err != nil {
+		return "", false
+	}
+	var names []string
+	for _, e := range entries {
+		if e.Type().IsRegular() && strings.HasSuffix(strings.ToLower(e.Name()), ".json") {
+			names = append(names, e.Name())
+		}
+	}
+	if len(names) == 0 {
+		return "", false
+	}
+	sort.Strings(names)
+
+	var b strings.Builder
+	b.WriteByte('{')
+	first := true
+	for _, name := range names {
+		stem := name[:len(name)-len(".json")]
+		raw, err := os.ReadFile(filepath.Join(blocksDir, name))
+		if err != nil {
+			continue
+		}
+		content := strings.TrimSpace(string(raw))
+		// Skip empty files — `"key":` with no value would break the merged JSON.
+		if content == "" {
+			continue
+		}
+		keyJSON, err := json.Marshal(decodeUntilStable(stem))
+		if err != nil {
+			continue
+		}
+		if !first {
+			b.WriteByte(',')
+		}
+		first = false
+		b.Write(keyJSON)
+		b.WriteByte(':')
+		b.WriteString(content)
+	}
+	b.WriteByte('}')
+	return b.String(), true
+}
+
+type decofileBuild struct {
+	done chan struct{}
+	text string
+	ok   bool
+}
+
+var (
+	decofileBuildMu  sync.Mutex
+	decofileInFlight = map[string]*decofileBuild{}
+)
+
+// GenerateFromBlocksDeduped coalesces concurrent merges for the same blocksDir
+// onto one build: concurrent cold reads (multiple tabs/users on a shared
+// sandbox during boot) would otherwise each redo the same multi-MB merge. The
+// in-flight entry is removed once the build settles, so this is a coalescer,
+// not a cache — the next read after settle rebuilds.
+func GenerateFromBlocksDeduped(blocksDir string) (string, bool) {
+	decofileBuildMu.Lock()
+	if b, inFlight := decofileInFlight[blocksDir]; inFlight {
+		decofileBuildMu.Unlock()
+		<-b.done
+		return b.text, b.ok
+	}
+	b := &decofileBuild{done: make(chan struct{})}
+	decofileInFlight[blocksDir] = b
+	decofileBuildMu.Unlock()
+
+	b.text, b.ok = GenerateFromBlocks(blocksDir)
+
+	decofileBuildMu.Lock()
+	delete(decofileInFlight, blocksDir)
+	decofileBuildMu.Unlock()
+	close(b.done)
+
+	return b.text, b.ok
+}

--- a/packages/sandbox/daemon-go/internal/decofile/merge_test.go
+++ b/packages/sandbox/daemon-go/internal/decofile/merge_test.go
@@ -1,0 +1,80 @@
+package decofile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeBlock(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func TestGenerateFromBlocks(t *testing.T) {
+	t.Run("missing dir → ok=false", func(t *testing.T) {
+		if _, ok := GenerateFromBlocks(filepath.Join(t.TempDir(), "nope")); ok {
+			t.Fatal("expected ok=false for a missing blocks dir")
+		}
+	})
+
+	t.Run("empty dir → ok=false", func(t *testing.T) {
+		if _, ok := GenerateFromBlocks(t.TempDir()); ok {
+			t.Fatal("expected ok=false for a dir with no .json files")
+		}
+	})
+
+	t.Run("merges sorted, keyed by decoded stem", func(t *testing.T) {
+		dir := t.TempDir()
+		// Deliberately out of alphabetical write order to prove the sort.
+		writeBlock(t, dir, "b.json", `{"n":2}`)
+		writeBlock(t, dir, "a.json", `{"n":1}`)
+		merged, ok := GenerateFromBlocks(dir)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		want := `{"a":{"n":1},"b":{"n":2}}`
+		if merged != want {
+			t.Fatalf("merged = %q, want %q", merged, want)
+		}
+	})
+
+	t.Run("skips non-json and empty files", func(t *testing.T) {
+		dir := t.TempDir()
+		writeBlock(t, dir, "keep.json", `{"ok":true}`)
+		writeBlock(t, dir, "notes.txt", "ignored")
+		writeBlock(t, dir, "blank.json", "   \n  ")
+		merged, ok := GenerateFromBlocks(dir)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if merged != `{"keep":{"ok":true}}` {
+			t.Fatalf("merged = %q", merged)
+		}
+	})
+
+	t.Run("decodes percent-encoded stems until stable", func(t *testing.T) {
+		dir := t.TempDir()
+		// Double-encoded stem: a single decode would key it `Compre%20Junto`,
+		// which no __resolveType reference resolves.
+		writeBlock(t, dir, "Compre%2520Junto.json", `{"x":1}`)
+		merged, ok := GenerateFromBlocks(dir)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if merged != `{"Compre Junto":{"x":1}}` {
+			t.Fatalf("merged = %q, want key decoded to `Compre Junto`", merged)
+		}
+	})
+}
+
+func TestGenerateFromBlocksDeduped(t *testing.T) {
+	dir := t.TempDir()
+	writeBlock(t, dir, "a.json", `{"n":1}`)
+	merged, ok := GenerateFromBlocksDeduped(dir)
+	if !ok || merged != `{"a":{"n":1}}` {
+		t.Fatalf("deduped merge = %q ok=%v", merged, ok)
+	}
+}

--- a/packages/sandbox/daemon-go/internal/decofile/merge_test.go
+++ b/packages/sandbox/daemon-go/internal/decofile/merge_test.go
@@ -1,8 +1,12 @@
 package decofile
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
 	"testing"
 )
 
@@ -15,13 +19,13 @@ func writeBlock(t *testing.T, dir, name, content string) {
 
 func TestGenerateFromBlocks(t *testing.T) {
 	t.Run("missing dir → ok=false", func(t *testing.T) {
-		if _, ok := GenerateFromBlocks(filepath.Join(t.TempDir(), "nope")); ok {
+		if _, ok := generateFromBlocks(filepath.Join(t.TempDir(), "nope")); ok {
 			t.Fatal("expected ok=false for a missing blocks dir")
 		}
 	})
 
 	t.Run("empty dir → ok=false", func(t *testing.T) {
-		if _, ok := GenerateFromBlocks(t.TempDir()); ok {
+		if _, ok := generateFromBlocks(t.TempDir()); ok {
 			t.Fatal("expected ok=false for a dir with no .json files")
 		}
 	})
@@ -31,7 +35,7 @@ func TestGenerateFromBlocks(t *testing.T) {
 		// Deliberately out of alphabetical write order to prove the sort.
 		writeBlock(t, dir, "b.json", `{"n":2}`)
 		writeBlock(t, dir, "a.json", `{"n":1}`)
-		merged, ok := GenerateFromBlocks(dir)
+		merged, ok := generateFromBlocks(dir)
 		if !ok {
 			t.Fatal("expected ok=true")
 		}
@@ -46,7 +50,7 @@ func TestGenerateFromBlocks(t *testing.T) {
 		writeBlock(t, dir, "keep.json", `{"ok":true}`)
 		writeBlock(t, dir, "notes.txt", "ignored")
 		writeBlock(t, dir, "blank.json", "   \n  ")
-		merged, ok := GenerateFromBlocks(dir)
+		merged, ok := generateFromBlocks(dir)
 		if !ok {
 			t.Fatal("expected ok=true")
 		}
@@ -60,12 +64,55 @@ func TestGenerateFromBlocks(t *testing.T) {
 		// Double-encoded stem: a single decode would key it `Compre%20Junto`,
 		// which no __resolveType reference resolves.
 		writeBlock(t, dir, "Compre%2520Junto.json", `{"x":1}`)
-		merged, ok := GenerateFromBlocks(dir)
+		merged, ok := generateFromBlocks(dir)
 		if !ok {
 			t.Fatal("expected ok=true")
 		}
 		if merged != `{"Compre Junto":{"x":1}}` {
 			t.Fatalf("merged = %q, want key decoded to `Compre Junto`", merged)
+		}
+	})
+
+	// Blocks are written to disk pretty-printed (`JSON.stringify(data, null, 2)`),
+	// so the merged blob is multi-line. The fallback returns it un-numbered, and
+	// the consumer runs it through stripLineNumbers (strip `^\d+\t` per line)
+	// before JSON.parse — a no-op ONLY if no line begins with a digit+tab. Valid
+	// pretty JSON never does (lines open with `{`, `}`, `"`, or space indent), so
+	// the round-trip must survive. Lock that invariant in.
+	t.Run("multi-line pretty-printed blocks survive the line-number strip", func(t *testing.T) {
+		dir := t.TempDir()
+		pretty := func(v any) string {
+			b, err := json.MarshalIndent(v, "", "  ")
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			return string(b)
+		}
+		writeBlock(t, dir, "hero.json", pretty(map[string]any{"title": "Hi", "count": 3}))
+		writeBlock(t, dir, "shelf.json", pretty(map[string]any{"items": []int{1, 2}}))
+
+		merged, ok := generateFromBlocks(dir)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if !strings.Contains(merged, "\n") {
+			t.Fatal("expected a multi-line merged blob to exercise the strip round-trip")
+		}
+		// No line may start with `^\d+\t` — that's what stripLineNumbers eats.
+		lineNum := regexp.MustCompile(`(?m)^\d+\t`)
+		if lineNum.MatchString(merged) {
+			t.Fatalf("a merged line starts with a line-number prefix; strip would corrupt it:\n%s", merged)
+		}
+		// The un-numbered blob must still be valid JSON with both blocks.
+		var got map[string]any
+		if err := json.Unmarshal([]byte(merged), &got); err != nil {
+			t.Fatalf("merged blob is not valid JSON: %v\n%s", err, merged)
+		}
+		if _, ok := got["hero"]; !ok {
+			t.Fatalf("missing hero block: %s", merged)
+		}
+		if _, ok := got["shelf"]; !ok {
+			t.Fatalf("missing shelf block: %s", merged)
 		}
 	})
 }
@@ -76,5 +123,37 @@ func TestGenerateFromBlocksDeduped(t *testing.T) {
 	merged, ok := GenerateFromBlocksDeduped(dir)
 	if !ok || merged != `{"a":{"n":1}}` {
 		t.Fatalf("deduped merge = %q ok=%v", merged, ok)
+	}
+}
+
+// The coalescer's whole point is concurrent cold reads; exercise it under
+// `go test -race` so a data race on decofileInFlight or a coalescing regression
+// surfaces. All callers on one blocksDir must agree.
+func TestGenerateFromBlocksDeduped_Concurrent(t *testing.T) {
+	dir := t.TempDir()
+	writeBlock(t, dir, "a.json", `{"n":1}`)
+	writeBlock(t, dir, "b.json", `{"n":2}`)
+	const want = `{"a":{"n":1},"b":{"n":2}}`
+
+	const goroutines = 32
+	var wg sync.WaitGroup
+	results := make([]string, goroutines)
+	for i := range results {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			merged, ok := GenerateFromBlocksDeduped(dir)
+			if !ok {
+				t.Errorf("goroutine %d: ok=false", i)
+				return
+			}
+			results[i] = merged
+		}(i)
+	}
+	wg.Wait()
+	for i, got := range results {
+		if got != want {
+			t.Fatalf("goroutine %d: merged = %q, want %q", i, got, want)
+		}
 	}
 }

--- a/packages/sandbox/daemon-go/internal/routes/fs.go
+++ b/packages/sandbox/daemon-go/internal/routes/fs.go
@@ -90,6 +90,24 @@ func Read(deps FsDeps) http.HandlerFunc {
 		}
 		stat, err := os.Stat(filePath)
 		if err != nil {
+			// Decofile fallback: `.deco/blocks.gen.json` is commonly gitignored
+			// (a multi-MB single line the runtime regenerates on dev cold-start),
+			// so a fresh sandbox has the block sources but not the merged file.
+			// Rebuild it on the fly from the sibling `.deco/blocks/*.json` so the
+			// CMS is readable before the dev server boots. Returned un-numbered:
+			// the decofile is consumed as one blob and the client's line-number
+			// strip is a no-op on content that lacks the `^\d+\t` prefix.
+			if filepath.Base(filePath) == decofile.GenBasename {
+				blocksDir := filepath.Join(filepath.Dir(filePath), decofile.BlocksDirname)
+				if merged, ok := decofile.GenerateFromBlocksDeduped(blocksDir); ok {
+					httpx.JSON(w, 200, map[string]any{
+						"kind":      "text",
+						"content":   merged,
+						"lineCount": 1,
+					})
+					return
+				}
+			}
 			httpx.Error(w, 400, fmt.Sprintf("File not found: %s", body.Path))
 			return
 		}

--- a/packages/sandbox/daemon-go/internal/routes/fs.go
+++ b/packages/sandbox/daemon-go/internal/routes/fs.go
@@ -97,7 +97,12 @@ func Read(deps FsDeps) http.HandlerFunc {
 			// CMS is readable before the dev server boots. Returned un-numbered:
 			// the decofile is consumed as one blob and the client's line-number
 			// strip is a no-op on content that lacks the `^\d+\t` prefix.
-			if filepath.Base(filePath) == decofile.GenBasename {
+			//
+			// Only for relative paths: those are SafePath-confined to appRoot by
+			// resolveReadPath, so the sibling `blocks` dir can't escape the
+			// project. An absolute `body.Path` bypasses SafePath, so refuse to
+			// turn it into a directory glob (the CMS only ever sends relative).
+			if !filepath.IsAbs(body.Path) && filepath.Base(filePath) == decofile.GenBasename {
 				blocksDir := filepath.Join(filepath.Dir(filePath), decofile.BlocksDirname)
 				if merged, ok := decofile.GenerateFromBlocksDeduped(blocksDir); ok {
 					httpx.JSON(w, 200, map[string]any{

--- a/packages/sandbox/daemon-go/internal/routes/fs_test.go
+++ b/packages/sandbox/daemon-go/internal/routes/fs_test.go
@@ -1,0 +1,77 @@
+package routes
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// seedBlocks lays a repo with two `.deco/blocks/*.json` sources but NO merged
+// `.deco/blocks.gen.json`, and returns FsDeps pointed at it.
+func seedBlocks(t *testing.T) FsDeps {
+	t.Helper()
+	repoDir := t.TempDir()
+	blocksDir := filepath.Join(repoDir, ".deco", "blocks")
+	if err := os.MkdirAll(blocksDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for name, content := range map[string]string{
+		"a.json": `{"n":1}`,
+		"b.json": `{"n":2}`,
+	} {
+		if err := os.WriteFile(filepath.Join(blocksDir, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	return FsDeps{AppRoot: filepath.Dir(repoDir), RepoDir: repoDir}
+}
+
+func readReq(t *testing.T, deps FsDeps, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	body, _ := json.Marshal(map[string]any{"path": path, "full": true})
+	req := httptest.NewRequest(http.MethodPost, "/read", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	Read(deps)(rec, req)
+	return rec
+}
+
+// A relative request for the absent gen artifact falls back to the on-the-fly
+// merge of the sibling blocks sources.
+func TestReadDecofileFallbackRelative(t *testing.T) {
+	deps := seedBlocks(t)
+	rec := readReq(t, deps, ".deco/blocks.gen.json")
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	var got struct {
+		Kind    string `json:"kind"`
+		Content string `json:"content"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Kind != "text" || got.Content != `{"a":{"n":1},"b":{"n":2}}` {
+		t.Fatalf("kind=%q content=%q", got.Kind, got.Content)
+	}
+}
+
+// The fallback must refuse an ABSOLUTE path even when it points straight at the
+// real repo's gen artifact — an absolute path bypasses SafePath, so allowing it
+// would turn the merge into an arbitrary sibling-`blocks/` directory glob. This
+// is the precise guard proof: the blocks exist and the relative form (above)
+// merges them, yet the absolute form to the very same location still 400s.
+func TestReadDecofileFallbackRefusesAbsolute(t *testing.T) {
+	deps := seedBlocks(t)
+	abs := filepath.Join(deps.RepoDir, ".deco", "blocks.gen.json")
+	if !filepath.IsAbs(abs) {
+		t.Fatalf("test setup: %q is not absolute", abs)
+	}
+	rec := readReq(t, deps, abs)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400 (no merge for absolute path); body = %s", rec.Code, rec.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

Restores the on-the-fly `.deco/blocks.gen.json` merge in the **Go daemon's `/read`** endpoint — the behavior that lets the CMS/Blocks UI render **without a committed `blocks.gen.json`** while the dev server is still booting (or crashed).

`.deco/blocks.gen.json` is the runtime's merge of every `.deco/blocks/*.json`. Most repos gitignore it (multi-MB single line, regenerated on dev cold-start), so a fresh sandbox has the block sources but not the merged file. The web CMS reads it through the daemon's `/read` proxy (`readCommittedJson` → `use-decofile`), so it must be readable before the dev script is up.

### Why it regressed
- The **TypeScript daemon** synthesized this merge in `/read` when the file was absent (added in #5084).
- That daemon was **deleted** (#5575) and the fallback was **never ported to Go**.
- Result on `main` today: `/read` returns `400 File not found`, and the CMS shows *"decofile unavailable (preview down, no committed snapshot)"* until the dev server boots.

This is a **Go-only** restore, independent of the pull-based Fast Preview work in #5363 (which adds a *separate* dedicated `GET /_sandbox/decofile` route + SSE, but does **not** restore the `/read` fallback the existing web consumer relies on).

## Changes
- `internal/decofile/merge.go` — `GenerateFromBlocks` / `GenerateFromBlocksDeduped`: deterministic, byte-spliced merge keyed by the **decode-until-stable** filename stem (fixes the double-encoded-stem bug the old decode-once path had), single-flight coalesced so concurrent cold reads share one multi-MB build.
- `internal/routes/fs.go` — `Read` falls back to the merge **only** when the absent path's basename is `blocks.gen.json`; every other absent file still `400`s.

## Testing
- `go vet ./...`, `go test -race ./...` ✅ (added `merge_test.go`: sort order, decoded keys, skip empty/non-json, double-encoded stems, dedup).
- New black-box e2e `daemon.decofile.e2e.test.ts` ✅ (synthesizes when absent, decodes stems, still `400`s for a genuinely-absent file / non-decofile path).
- Core fs e2e suite (114 tests) still green — no `/read` regression.

## Affected areas
Sandbox daemon `/read`; the web CMS decofile snapshot path (`use-decofile` / `readCommittedJson`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores on-the-fly generation of `.deco/blocks.gen.json` in the Go daemon `/read` when missing so the CMS/Blocks UI loads before the dev server boots. Fallback is limited to `blocks.gen.json` and only for relative paths.

- **New Features**
  - Rebuilds `blocks.gen.json` from `.deco/blocks/*.json` when absent.
  - Security: only handles relative requests; absolute paths still 400.
  - Deterministic merge: files sorted; stems percent-decoded until stable; skips empty/non-JSON.
  - Single-flight coalescing with safe cleanup; returns `kind: "text"` with no line numbers.

<sup>Written for commit d2b5dbe51e845a74f4c131c984a9cb9f84d64fde. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

