### PR TITLE
feat(task-board): task-run MCP surface and TASK_ADD_REPO

### DIFF
--- a/apps/api/src/api/routes/org-scoped.ts
+++ b/apps/api/src/api/routes/org-scoped.ts
@@ -23,6 +23,7 @@ import { createOrgScopedWellKnownProtectedResourceRoutes } from "./oauth-proxy";
 import { createSsoRoutes } from "./org-sso";
 import { createProxyRoutes } from "./proxy";
 import { createSelfRoutes } from "./self";
+import { createTaskRunMcpRoutes } from "./task-run-mcp";
 import { createHomeNextActionsRoutes } from "./home-next-actions";
 import { createCommerceDiagnosticShareRoutes } from "./commerce-diagnostic-share";
 import { createTaskBoardImportRoutes } from "./task-board-import";
@@ -122,6 +123,7 @@ export const createOrgScopedApi = (deps: OrgScopedDeps) => {
   app.use("/mcp/gateway/:virtualMcpId?", deps.mcpAuth);
   app.use("/mcp/virtual-mcp/:virtualMcpId?", deps.mcpAuth);
   app.use("/mcp/self", deps.mcpAuth);
+  app.use("/mcp/task-run/:threadId", deps.mcpAuth);
 
   // OAuth Protected-Resource discovery for connection MCPs (resource-relative
   // shape). Expands to
@@ -150,6 +152,9 @@ export const createOrgScopedApi = (deps: OrgScopedDeps) => {
     deps.betterAuthProtectedResourceHandler,
   );
 
+  // Before the proxy catch-all, whose `/mcp/:connectionId` would otherwise
+  // swallow `task-run` as a connection id.
+  app.route("/mcp/task-run", createTaskRunMcpRoutes());
   app.route("/mcp", createVirtualMcpRoutes());
   app.route("/mcp/self", createSelfRoutes());
   app.route("/mcp", createProxyRoutes());

--- a/apps/api/src/api/routes/task-run-mcp.ts
+++ b/apps/api/src/api/routes/task-run-mcp.ts
@@ -1,0 +1,49 @@
+/**
+ * Task-run MCP server — `POST /api/:org/mcp/task-run/:threadId`.
+ *
+ * The Studio surface a sandbox-hosted task run gets: the task-board tools it
+ * needs to report on the task it is doing, plus `TASK_ADD_REPO`. It used to be
+ * pointed at `/mcp/self`, i.e. every management tool Studio has.
+ *
+ * The run is identified by the PATH, not by a tool argument: the per-run API key
+ * is minted with full access, so a `threadId` input would let one run act on
+ * another run's sandbox. The org is already resolved (and membership checked) by
+ * `resolveOrgFromPath`, so a foreign thread id here is out-of-org and its tools
+ * find nothing.
+ */
+
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { Hono } from "hono";
+import type { StudioContext } from "../../core/studio-context";
+import { managementContextStore, toolSubsetMCP } from "../../tools";
+import {
+  TASK_RUN_TOOL_NAMES,
+  taskRunContextStore,
+} from "../../tools/task-board/task-run-context";
+import { serveMcpRequest } from "../utils/serve-mcp";
+
+type TaskRunEnv = { Variables: { studioContext: StudioContext } };
+
+export const createTaskRunMcpRoutes = () => {
+  const app = new Hono<TaskRunEnv>();
+
+  app.all("/:threadId", async (c) => {
+    const ctx = c.get("studioContext");
+    const threadId = c.req.param("threadId");
+    const server = toolSubsetMCP("mcp-task-run", TASK_RUN_TOOL_NAMES);
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      enableJsonResponse:
+        c.req.raw.headers.get("Accept")?.includes("application/json") ?? false,
+    });
+    await server.connect(transport);
+    // Tool handlers read both stores at call time, so the request must run
+    // inside their scope.
+    return managementContextStore.run(ctx, () =>
+      taskRunContextStore.run({ threadId }, () =>
+        serveMcpRequest(server, transport, c.req.raw, "mcp:task-run"),
+      ),
+    );
+  });
+
+  return app;
+};

--- a/apps/api/src/harnesses/lib/decopilot/run-stream.ts
+++ b/apps/api/src/harnesses/lib/decopilot/run-stream.ts
@@ -446,7 +446,7 @@ export async function* runDecopilotStream(
       }
     | undefined;
   const codingWorkspace =
-    input.workspace.cwd === "/repo"
+    input.workspace.cwd === "/repo" && input.workspace.repo
       ? {
           repo: input.workspace.repo,
           branch: input.workspace.branch,

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -47,6 +47,7 @@ import { ensureSandbox } from "@/tools/sandbox/start";
 import {
   getThreadGithubRepo,
   syntheticBranchToGitRef,
+  threadBranch,
 } from "@/tools/sandbox/thread-repo";
 
 /**
@@ -161,16 +162,29 @@ export class SandboxDispatchClient implements SandboxClient {
   /**
    * Where the harness works, and on what.
    *
-   * `cwd: "/repo"` is only meaningful with a repo behind it — the wire shape
-   * makes that explicit, and it is the honest thing to send: a run whose thread
-   * has no bound repo got an `ephemeral` sandbox with no checkout, so naming a
-   * working directory there would describe a directory that doesn't exist.
+   * `cwd: "/repo"` normally comes with a repo behind it. The one case it doesn't
+   * is a task run dispatched on the bare `thread:<id>` key: that run got its own
+   * (repo-less) sandbox precisely so it could clone a repo into this directory
+   * mid-run with `TASK_ADD_REPO`, and the daemon creates the directory at boot,
+   * so pointing the harness at it up front is honest — and it is the only way
+   * the harness ends up standing in the checkout, since its cwd is fixed when
+   * the process spawns.
+   *
+   * A thread with no repo on any OTHER key shares the `ephemeral` sandbox, which
+   * has no checkout at all — `cwd: null` stays correct there.
    */
   private async resolveWorkspace(
     threadId: string,
   ): Promise<HarnessStreamInput["workspace"]> {
     const repo = await getThreadGithubRepo(this.ctx, threadId);
-    if (!repo) return { cwd: null };
+    if (!repo) {
+      return this.branch === threadBranch(threadId)
+        ? {
+            cwd: SANDBOX_REPO_CWD,
+            branch: syntheticBranchToGitRef(this.branch),
+          }
+        : { cwd: null };
+    }
     return {
       cwd: SANDBOX_REPO_CWD,
       repo: {
@@ -219,12 +233,16 @@ export class SandboxDispatchClient implements SandboxClient {
       // daemon rejects the envelope outright, and the org's tools (moving
       // the task on the board, for one) would be unreachable anyway.
       //
-      // The management surface, NOT the agent's own: super-agent task runs
+      // The task-run surface, NOT the agent's own: super-agent task runs
       // dispatch as Decopilot, which by design aggregates no connections
       // (`storage/virtual.ts` findById returns `connections: []`) because
       // hosted Decopilot reaches TASK_BOARD_* by `subtask`-delegating to the
       // Task Manager agent. This harness has no `subtask`, so pointing it at
       // the agent's virtual MCP yielded `connected` with zero tools.
+      //
+      // Scoped to this run (thread id in the path) and narrow: the task-board
+      // tools plus `TASK_ADD_REPO`. It used to be `/mcp/self` — every management
+      // tool Studio has, ~200 of them, for the two this harness calls.
       //
       // ponytail: one surface, not both — the agent's aggregated connections
       // are not merged in. Add a second MCP server on the wire if a
@@ -234,7 +252,8 @@ export class SandboxDispatchClient implements SandboxClient {
         this.virtualMcpId,
         organization,
         `${this.harnessId}-run`,
-        "management",
+        "task-run",
+        input.threadId,
       ),
       // Hosted Decopilot mounts no working directory; this harness edits the
       // checkout the daemon prepared.

--- a/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.test.ts
+++ b/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.test.ts
@@ -54,3 +54,31 @@ describe("mcpEndpointUrl", () => {
     ).toBe("https://studio.example.com/mcp/virtual-mcp/vir_123");
   });
 });
+
+describe("mcpEndpointUrl task-run", () => {
+  // The task-run surface is scoped by PATH, not by a tool argument — the per-run
+  // key is minted with full access, so a threadId input would let one run act on
+  // another run's sandbox.
+  it("a task-run endpoint carries the run thread id in the path", () => {
+    expect(
+      mcpEndpointUrl({
+        publicUrl,
+        agentId: "vir_ignored",
+        organization,
+        target: "task-run",
+        threadId: "thrd 1/2",
+      }),
+    ).toBe("https://studio.example.com/api/acme/mcp/task-run/thrd%201%2F2");
+  });
+
+  it("a task-run endpoint without a thread id throws before a key is minted", () => {
+    expect(() =>
+      mcpEndpointUrl({
+        publicUrl,
+        agentId: "vir_1",
+        organization,
+        target: "task-run",
+      }),
+    ).toThrow(/threadId is required/);
+  });
+});

--- a/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.ts
+++ b/apps/api/src/mcp-clients/virtual-mcp/mint-endpoint.ts
@@ -28,12 +28,15 @@ const MCP_KEY_TTL_SECONDS = 3600;
  * - `"management"` — `/api/<slug>/mcp/self`: Studio's own management tools
  *   (TASK_BOARD_*, connections, agents...). Needed by any out-of-process
  *   harness expected to act on Studio itself.
+ * - `"task-run"` — `/api/<slug>/mcp/task-run/<threadId>`: the narrow surface for
+ *   a sandbox-hosted task run (task board + `TASK_ADD_REPO`), scoped to the run
+ *   in the path. `agentId` is unused; the run thread id identifies it.
  *
  * Explicit per caller rather than inferred from the agent: a run that silently
  * picks the wrong surface reports `connected` with an empty tool list, which
  * reads as "the agent ignored its instructions" instead of a misconfiguration.
  */
-export type McpEndpointTarget = "agent-tools" | "management";
+export type McpEndpointTarget = "agent-tools" | "management" | "task-run";
 
 export class MissingOrganizationSlugError extends Error {
   constructor(organizationId: string) {
@@ -58,13 +61,23 @@ export function mcpEndpointUrl(args: {
   agentId: string;
   organization: { id: string; slug?: string };
   target: McpEndpointTarget;
+  /** Required by `target: "task-run"` — the run the surface is scoped to. */
+  threadId?: string;
 }): string {
-  const { publicUrl, agentId, organization, target } = args;
+  const { publicUrl, agentId, organization, target, threadId } = args;
   if (target === "agent-tools") {
     return `${publicUrl}/mcp/virtual-mcp/${agentId}`;
   }
   if (!organization.slug) {
     throw new MissingOrganizationSlugError(organization.id);
+  }
+  if (target === "task-run") {
+    if (!threadId) {
+      throw new Error(
+        "a task-run MCP endpoint is scoped to a run: threadId is required",
+      );
+    }
+    return `${publicUrl}/api/${organization.slug}/mcp/task-run/${encodeURIComponent(threadId)}`;
   }
   return `${publicUrl}/api/${organization.slug}/mcp/self`;
 }
@@ -75,6 +88,8 @@ export async function mintMcpEndpoint(
   organization: { id: string; slug?: string; name?: string },
   apiKeyName: string,
   target: McpEndpointTarget = "agent-tools",
+  /** Required by `target: "task-run"`. */
+  threadId?: string,
 ): Promise<{
   url: string;
   headers: Record<string, string>;
@@ -87,6 +102,7 @@ export async function mintMcpEndpoint(
     agentId,
     organization,
     target,
+    ...(threadId ? { threadId } : {}),
   });
   const apiKey = await ctx.boundAuth.apiKey.create({
     name: apiKeyName,

--- a/apps/api/src/tools/index.ts
+++ b/apps/api/src/tools/index.ts
@@ -61,6 +61,7 @@ export const CORE_TOOLS = [
   TaskBoardTools.TASK_BOARD_COMMENT_CREATE,
   TaskBoardTools.TASK_BOARD_COMMENT_UPDATE,
   TaskBoardTools.TASK_BOARD_COMMENT_DELETE,
+  TaskBoardTools.TASK_ADD_REPO,
   OrganizationTools.BRAND_CONTEXT_LIST,
   OrganizationTools.BRAND_CONTEXT_GET,
   OrganizationTools.BRAND_CONTEXT_CREATE,
@@ -229,6 +230,39 @@ export type CoreTools = typeof CORE_TOOLS;
 export const TOOL_BY_NAME: Map<string, RegistrableTool> = new Map(
   (CORE_TOOLS as unknown as RegistrableTool[]).map((tool) => [tool.name, tool]),
 );
+
+/**
+ * An MCP server exposing just the named management tools — no prompts, no brand
+ * prompts, no resources.
+ *
+ * For a machine consumer that needs a handful of tools and pays for the rest in
+ * context: the whole management surface is ~200 tools, and a harness handed all
+ * of them has to find the two it was told to call inside that list. Unknown
+ * names are skipped rather than thrown on, so a renamed tool degrades to a
+ * missing tool instead of a dead endpoint.
+ */
+export const toolSubsetMCP = (
+  name: string,
+  toolNames: readonly string[],
+): McpServer => {
+  const server = new McpServer(
+    { name, version: "1.0.0" },
+    {
+      capabilities: { tools: {} },
+      jsonSchemaValidator: sharedJsonSchemaValidator,
+    },
+  );
+  for (const toolName of toolNames) {
+    const tool = TOOL_BY_NAME.get(toolName);
+    if (!tool) {
+      console.warn(`[${name}] unknown tool "${toolName}" — not registered`);
+      continue;
+    }
+    const { config, handler } = getToolRegistration(tool);
+    server.registerTool(tool.name, config, handler);
+  }
+  return server;
+};
 
 export const managementMCP = async (ctx: StudioContext) => {
   // Create MCP server directly

--- a/apps/api/src/tools/sandbox/thread-repo.test.ts
+++ b/apps/api/src/tools/sandbox/thread-repo.test.ts
@@ -114,3 +114,44 @@ test("different threads of one repo-agent never share a branch", () => {
     resolveSandboxBranch({ threadId: "t2", threadRepo: null, agentRepo }),
   );
 });
+
+// A task run dispatched with no repo runs on the bare `thread:<id>` key and
+// clones into that pod mid-run (TASK_ADD_REPO). Re-deriving the key from the
+// repo it added would move the claim handle off the pod holding the agent loop.
+test("the bare thread key survives a repo bound mid-run", () => {
+  expect(
+    resolveSandboxBranch({
+      threadId: "t1",
+      threadRepo: { connectionId: "conn_a" } as GithubRepo,
+      runBranch: "thread:t1",
+    }),
+  ).toBe("thread:t1");
+});
+
+test("only the bare key pins — load_repo's repo-scoped key still switches", () => {
+  expect(
+    resolveSandboxBranch({
+      threadId: "t1",
+      threadRepo: { connectionId: "conn_b" } as GithubRepo,
+      runBranch: "thread:t1/conn_a",
+    }),
+  ).toBe("thread:t1/conn_b");
+  // Another thread's bare key must not pin this one.
+  expect(
+    resolveSandboxBranch({
+      threadId: "t1",
+      threadRepo: { connectionId: "conn_a" } as GithubRepo,
+      runBranch: "thread:t2",
+    }),
+  ).toBe("thread:t1/conn_a");
+});
+
+test("a repo-less run pinned to its own bare key does not join the ephemeral pool", () => {
+  expect(
+    resolveSandboxBranch({
+      threadId: "t1",
+      threadRepo: null,
+      runBranch: "thread:t1",
+    }),
+  ).toBe("thread:t1");
+});

--- a/apps/api/src/tools/sandbox/thread-repo.ts
+++ b/apps/api/src/tools/sandbox/thread-repo.ts
@@ -194,6 +194,16 @@ export function resolveSandboxBranch(args: {
   /** Explicit branch for this run, when the caller has one. */
   runBranch?: string | null;
 }): string {
+  // A run dispatched on the BARE `thread:<id>` key keeps it, repo or not: that
+  // is a sandbox-hosted task run that started with no repo and had one bound
+  // mid-run by `TASK_ADD_REPO`. Deriving from the repo instead would move the
+  // key (and therefore the claim handle) out from under the pod the agent loop
+  // is running in, so a re-dispatch would 404 the live pod and fork an empty
+  // one. Only the bare key qualifies — `load_repo` always includes a connection
+  // id, so its repo-switch isolation is untouched.
+  if (args.runBranch && args.runBranch === threadBranch(args.threadId)) {
+    return args.runBranch;
+  }
   if (args.threadRepo) {
     return threadBranch(args.threadId, args.threadRepo.connectionId);
   }

--- a/apps/api/src/tools/task-board/add-repo.test.ts
+++ b/apps/api/src/tools/task-board/add-repo.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test";
+import { parseRepoProbe } from "./add-repo";
+
+// The probe is what decides "you can start reading files now". A HEAD ref lands
+// before the checkout does on a lagging FS, so the marker alone must NOT count
+// as ready — that false positive returns success on an empty directory.
+test("the HEAD marker alone is not a checkout", () => {
+  expect(parseRepoProbe("__CLONED__\n")).toEqual({
+    cloned: false,
+    listing: "",
+  });
+  expect(parseRepoProbe("__CLONED__\n.git\n")).toEqual({
+    cloned: false,
+    listing: "",
+  });
+});
+
+test("working-tree entries are, and .git is not one of them", () => {
+  expect(parseRepoProbe("__CLONED__\n.git\npackage.json\nsrc\n")).toEqual({
+    cloned: true,
+    listing: "package.json\nsrc",
+  });
+});
+
+test("an empty directory is not cloned", () => {
+  expect(parseRepoProbe("")).toEqual({ cloned: false, listing: "" });
+});

--- a/apps/api/src/tools/task-board/add-repo.ts
+++ b/apps/api/src/tools/task-board/add-repo.ts
@@ -1,0 +1,361 @@
+/**
+ * `TASK_ADD_REPO` — clone one of the org's repos into the sandbox a task run is
+ * ALREADY running in.
+ *
+ * Why not `load_repo`: that tool provisions a NEW sandbox on a repo-specific
+ * branch, which is fine for Decopilot (in-process, its fs tools can be rebound)
+ * and useless here — the claude-code agent loop lives inside a pod, and its
+ * `bash`/read/write hit that pod's disk. The repo has to land in the pod the run
+ * is already in. So this tool touches the pod, not the pool: it binds the repo
+ * to the thread, pushes a credentialed clone URL onto the running daemon's
+ * config channel, and waits for the checkout.
+ *
+ * That is what lets a task run start before "which repo" is answered. Before
+ * this, claude-code took a task only when the org had exactly ONE importable
+ * repo (`pickSoleTaskRepo`) because the checkout was resolved at dispatch;
+ * everything else fell back to Decopilot.
+ *
+ * The sandbox key stays the BARE `thread:<id>` for the whole run — see
+ * `resolveSandboxBranch`. Deriving it from the repo (as `load_repo` does) would
+ * move the claim handle out from under the live pod.
+ */
+
+import { z } from "zod";
+import { defineTool } from "@/core/define-tool";
+import {
+  getUserId,
+  requireAuth,
+  requireOrganization,
+  type StudioContext,
+} from "@/core/studio-context";
+import { selectLoadableRepos } from "@/harnesses/decopilot/built-in-tools/load-repo";
+import { resolveSandboxProvider } from "@/sandbox/resolve-provider";
+import {
+  buildCloneInfo,
+  ensureGithubCloneToken,
+} from "@/shared/github-clone-info";
+import { resolveVm } from "@/tools/sandbox/sandbox-map";
+import {
+  getThreadSandboxMap,
+  resolveSandboxUserId,
+  syntheticBranchToGitRef,
+  threadBranch,
+} from "@/tools/sandbox/thread-repo";
+import { sleep } from "@decocms/shared/std";
+import type { SandboxProvider } from "@decocms/sandbox/provider";
+import { requireTaskRunContext } from "./task-run-context";
+
+/**
+ * Re-mint the clone credential unless it has at least this much life left.
+ *
+ * A GitHub App installation token lives 1h from mint and cannot be issued for
+ * longer, so asking for "at least an hour" means "freshly minted": the stored
+ * token is minutes old at best (the pod booted with it) and would strand the
+ * run's `git push`/`gh` halfway through. 55min (rather than a flat 60) leaves
+ * room for mint latency, so a token minted by THIS call is never immediately
+ * re-minted by the next one.
+ */
+const CLONE_TOKEN_MIN_TTL_MS = 55 * 60 * 1000;
+
+/** Wait at most this long for the checkout before answering anyway. */
+const CLONE_TIMEOUT_MS = 180_000;
+const CLONE_POLL_MS = 1_500;
+/** Consecutive probe failures that mean the pod is gone, not slow. */
+const CLONE_MAX_CONSECUTIVE_FAILURES = 5;
+
+/** One bash command in the run's pod. Throws on a non-2xx from the daemon. */
+async function podBash(
+  provider: SandboxProvider,
+  handle: string,
+  threadId: string,
+  command: string,
+): Promise<{ stdout: string; exitCode: number }> {
+  const res = await provider.proxyDaemonRequest(handle, "/_sandbox/bash", {
+    method: "POST",
+    // `x-thread-id` keeps the daemon's org-fs link pointed at THIS run's
+    // subtree; without it the workspace routes repoint it to the plain repo
+    // link, undoing what the run's own dispatch set up.
+    headers: new Headers({
+      "content-type": "application/json",
+      "x-thread-id": threadId,
+    }),
+    body: JSON.stringify({ command }),
+  });
+  if (!res.ok) {
+    throw new Error(`sandbox bash failed (${res.status} ${res.statusText})`);
+  }
+  const body = (await res.json()) as { stdout?: string; exitCode?: number };
+  return { stdout: body.stdout ?? "", exitCode: body.exitCode ?? 0 };
+}
+
+/**
+ * Interpret the clone probe (`__CLONED__` marker + `ls -A`). A HEAD ref can
+ * appear before the checkout does, so entries — not the marker — are what make
+ * it ready. Pure, so the readiness rule is unit-tested.
+ */
+export function parseRepoProbe(stdout: string): {
+  cloned: boolean;
+  listing: string;
+} {
+  const entries = stdout
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l && l !== ".git" && l !== "__CLONED__");
+  return { cloned: entries.length > 0, listing: entries.join("\n") };
+}
+
+/**
+ * Point `gh` at the credential the clone just stored on `origin`.
+ *
+ * The harness process was spawned before the repo existed, and the daemon builds
+ * `GH_TOKEN` from the clone URL at spawn time (`RunEnv`) — so this run's `gh`
+ * has no token and no way to be handed one through its environment.
+ * `hosts.yml` is the other place `gh` looks. The token is read out of `origin`
+ * inside the pod, so it never crosses the wire a second time and never lands in
+ * a command line.
+ */
+const GH_AUTH_COMMAND = [
+  'token=$(git remote get-url origin | sed -n "s|.*x-access-token:\\([^@]*\\)@.*|\\1|p")',
+  '[ -n "$token" ] || exit 0',
+  'mkdir -p "${HOME:-/root}/.config/gh"',
+  "umask 077",
+  'printf "github.com:\\n  oauth_token: %s\\n  git_protocol: https\\n" "$token" > "${HOME:-/root}/.config/gh/hosts.yml"',
+].join("\n");
+
+/** The org's importable repos, newest lookup each call (an import can land
+ *  while a run is in flight). */
+async function listOrgRepos(ctx: StudioContext, orgId: string) {
+  const { items } = await ctx.storage.connections.list(orgId, {
+    slug: "mcp-github",
+  });
+  return selectLoadableRepos(items);
+}
+
+export const TASK_ADD_REPO = defineTool({
+  name: "TASK_ADD_REPO",
+  description:
+    "Clone one of this organization's repositories into your working directory. " +
+    "Your working directory is EMPTY until you call this — do not look for " +
+    "files, and do not run git, before it returns. Call it once, with the " +
+    "repository the task is about; it waits for the checkout and returns the " +
+    "repository root listing, so you can start reading files immediately after. " +
+    "`git` and `gh` are authenticated once it returns. Call TASK_ADD_REPO with " +
+    "no arguments to list the repositories available.",
+  annotations: {
+    title: "Add Repository",
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  inputSchema: z.object({
+    connectionId: z
+      .string()
+      .optional()
+      .describe(
+        "connectionId of the repository to clone. Omit to list the available repositories.",
+      ),
+  }),
+  outputSchema: z.object({
+    success: z.boolean(),
+    /** Set when no repo was cloned — either a listing request or a bad id. */
+    repositories: z
+      .array(z.object({ connectionId: z.string(), repo: z.string() }))
+      .optional(),
+    repo: z.string().optional(),
+    cloned: z.boolean().optional(),
+    /** The repository root, one entry per line. */
+    files: z.string().optional(),
+    message: z.string(),
+  }),
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const organization = requireOrganization(ctx);
+    const userId = getUserId(ctx);
+    if (!userId) throw new Error("User ID required");
+    const { threadId } = requireTaskRunContext();
+
+    const repos = await listOrgRepos(ctx, organization.id);
+    const repo = input.connectionId
+      ? repos.find((r) => r.connectionId === input.connectionId)
+      : undefined;
+    if (!repo) {
+      const repositories = repos.map((r) => ({
+        connectionId: r.connectionId,
+        repo: `${r.owner}/${r.repo}`,
+      }));
+      return {
+        success: false,
+        repositories,
+        message: input.connectionId
+          ? `No imported repository for connectionId "${input.connectionId}". Pick one of the repositories listed.`
+          : repositories.length === 0
+            ? "This organization has no repositories imported, so none can be cloned."
+            : "Pick a repository and call TASK_ADD_REPO again with its connectionId.",
+      };
+    }
+
+    const thread = await ctx.storage.threads.get(threadId);
+    if (!thread) throw new Error(`Thread not found: ${threadId}`);
+
+    // The pod is keyed by the BARE thread branch — the key this run was
+    // dispatched on, and the one `resolveSandboxBranch` keeps returning for it.
+    const branch = threadBranch(threadId);
+    const sandboxUserId = await resolveSandboxUserId(ctx, branch, userId);
+    const { provider, kind } = await resolveSandboxProvider(ctx, {
+      userId: sandboxUserId,
+      branch,
+      virtualMcpMetadata: null,
+    });
+    const record = resolveVm(
+      await getThreadSandboxMap(ctx, threadId),
+      sandboxUserId,
+      branch,
+      kind,
+    );
+    if (!record) {
+      throw new Error(
+        `No sandbox is registered for this run (thread ${threadId}), so there ` +
+          `is nowhere to clone into.`,
+      );
+    }
+
+    // Fresh credential BEFORE anything is written: a clone URL is only useful
+    // with a live token behind it, and this is the failure worth reporting
+    // as "could not add the repo" rather than half-binding one.
+    await ensureGithubCloneToken({
+      ctx,
+      connectionId: repo.connectionId,
+      organizationId: organization.id,
+      forceRefresh: true,
+      onLegacyMintError: (error) =>
+        console.error("[TASK_ADD_REPO] legacy repo-scoped mint failed", {
+          connectionId: repo.connectionId,
+          error: (error as Error).message,
+        }),
+    });
+    const { cloneUrl, gitUserName, gitUserEmail } = await buildCloneInfo(
+      repo.connectionId,
+      repo.owner,
+      repo.repo,
+      ctx.db,
+      ctx.vault,
+      { bufferMs: CLONE_TOKEN_MIN_TTL_MS },
+    );
+
+    // Bind the repo to the thread. This is what every later consumer reads —
+    // the shutdown git sync, a re-provision's credential refresh, the board's
+    // PR extraction — so it has to be persisted, not just handed to the daemon.
+    await ctx.storage.threads.update(threadId, {
+      metadata: {
+        ...(thread.metadata ?? {}),
+        githubRepo: {
+          url: `https://github.com/${repo.owner}/${repo.repo}`,
+          owner: repo.owner,
+          name: repo.repo,
+          installationId: repo.installationId,
+          connectionId: repo.connectionId,
+        },
+      },
+      updated_by: userId,
+    });
+
+    // The daemon reads its clone target off the config channel. Adding a
+    // repository (and its branch) to a config that had none classifies as a
+    // branch-change, which runs its clone step; `cloneOnly` was already set at
+    // provision, so no install and no dev server follow. The explicit
+    // `setup/clone` behind it makes the outcome independent of that
+    // classification — the step no-ops when the checkout is already there.
+    const gitRef = syntheticBranchToGitRef(branch);
+    const configRes = await provider.proxyDaemonRequest(
+      record.sandboxHandle,
+      "/_sandbox/config",
+      {
+        method: "PUT",
+        headers: new Headers({ "content-type": "application/json" }),
+        // ⚠️ SECURITY: `cloneUrl` embeds a GitHub token. Never log this body.
+        body: JSON.stringify({
+          git: {
+            repository: {
+              cloneUrl,
+              branch: gitRef,
+              repoName: `${repo.owner}/${repo.repo}`,
+            },
+            identity: { userName: gitUserName, userEmail: gitUserEmail },
+          },
+        }),
+      },
+    );
+    if (!configRes.ok) {
+      throw new Error(
+        `the sandbox rejected the repository (${configRes.status} ${configRes.statusText})`,
+      );
+    }
+    await provider
+      .proxyDaemonRequest(record.sandboxHandle, "/_sandbox/setup/clone", {
+        method: "POST",
+        headers: new Headers({ "content-type": "application/json" }),
+        body: "{}",
+      })
+      .catch((err) => {
+        // The config push above already triggers the clone; this is the belt.
+        console.warn("[TASK_ADD_REPO] explicit clone kick failed", err);
+      });
+
+    // Wait for the checkout: the whole point is that the model can read files on
+    // the next tool call instead of polling an empty directory itself.
+    const deadline = Date.now() + CLONE_TIMEOUT_MS;
+    let cloned = false;
+    let listing = "";
+    let failures = 0;
+    // A checkout is revealed progressively, so one non-empty listing can still
+    // be mid-clone. Require it to STABILIZE across two probes.
+    let previous: string | null = null;
+    while (Date.now() < deadline) {
+      const probe = await podBash(
+        provider,
+        record.sandboxHandle,
+        threadId,
+        "if git rev-parse HEAD >/dev/null 2>&1; then echo __CLONED__; fi; ls -A 2>/dev/null",
+      ).catch(() => null);
+      if (!probe) {
+        if (++failures >= CLONE_MAX_CONSECUTIVE_FAILURES) break;
+        await sleep(CLONE_POLL_MS);
+        continue;
+      }
+      failures = 0;
+      const result = parseRepoProbe(probe.stdout);
+      if (result.cloned && result.listing === previous) {
+        cloned = true;
+        listing = result.listing;
+        break;
+      }
+      previous = result.cloned ? result.listing : null;
+      await sleep(CLONE_POLL_MS);
+    }
+
+    if (cloned) {
+      await podBash(
+        provider,
+        record.sandboxHandle,
+        threadId,
+        GH_AUTH_COMMAND,
+      ).catch((err) =>
+        console.warn("[TASK_ADD_REPO] gh auth setup failed", err),
+      );
+    }
+
+    return {
+      success: cloned,
+      repo: `${repo.owner}/${repo.repo}`,
+      cloned,
+      files: listing,
+      message: cloned
+        ? `${repo.owner}/${repo.repo} is checked out at your working directory on branch ${gitRef}. \`git\` and \`gh\` are authenticated. Start working.`
+        : `The clone of ${repo.owner}/${repo.repo} did not finish within ${Math.round(
+            CLONE_TIMEOUT_MS / 1000,
+          )}s. It may still be in progress — check your working directory before calling this again.`,
+    };
+  },
+});

--- a/apps/api/src/tools/task-board/claude-code-task-run.test.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.test.ts
@@ -166,3 +166,21 @@ describe("pickSoleTaskRepo", () => {
     expect(picked?.name).toBe("web");
   });
 });
+
+describe("buildClaudeCodeTaskPrompt with no repo (several in the org)", () => {
+  test("says the working directory is empty and to call TASK_ADD_REPO first", () => {
+    const prompt = buildClaudeCodeTaskPrompt(task, null);
+    expect(prompt).toContain("EMPTY");
+    expect(prompt).toContain("TASK_ADD_REPO");
+    // The failure this wording exists to prevent: the model opening with a
+    // file hunt in a directory nothing has cloned into yet.
+    expect(prompt).toContain("Do not read files");
+    expect(prompt).not.toContain("is already cloned");
+  });
+
+  test("still says how to finish", () => {
+    const prompt = buildClaudeCodeTaskPrompt(task, null);
+    expect(prompt).toContain("TASK_BOARD_ITEM_UPDATE");
+    expect(prompt).toContain("in_review");
+  });
+});

--- a/apps/api/src/tools/task-board/claude-code-task-run.test.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.test.ts
@@ -184,3 +184,22 @@ describe("buildClaudeCodeTaskPrompt with no repo (several in the org)", () => {
     expect(prompt).toContain("in_review");
   });
 });
+
+describe("buildClaudeCodeTaskPrompt repo choices", () => {
+  test("names the candidate repos so the run doesn't have to ask", () => {
+    const prompt = buildClaudeCodeTaskPrompt(task, null, {
+      repoChoices: [
+        { connectionId: "conn_1", repo: "acme/web" },
+        { connectionId: "conn_2", repo: "acme/api" },
+      ],
+    });
+    expect(prompt).toContain("acme/web (connectionId: conn_1)");
+    expect(prompt).toContain("acme/api (connectionId: conn_2)");
+    expect(prompt).toContain("Pick the one the task is about");
+  });
+
+  test("falls back to the listing call when no candidates were resolved", () => {
+    const prompt = buildClaudeCodeTaskPrompt(task, null);
+    expect(prompt).toContain("with no arguments to list them");
+  });
+});

--- a/apps/api/src/tools/task-board/claude-code-task-run.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.ts
@@ -92,7 +92,11 @@ export function pickSoleTaskRepo(
  * How a claude-code task run gets its repo, from the org's `mcp-github`
  * connections:
  * - `{ repo }` — one importable repository, bound before dispatch.
- * - `"pick"` — several, so the run picks one with `TASK_ADD_REPO` mid-run.
+ * - `{ choices }` — several, so the run picks one with `TASK_ADD_REPO` mid-run.
+ *   The list travels with the choice so the PROMPT can name the candidates: the
+ *   model would otherwise open with a `TASK_ADD_REPO` call just to find out what
+ *   exists, and a tool description can't carry them (it is built once at module
+ *   load, with no org in scope).
  * - `null` — none imported, so this harness can't run the task at all.
  *
  * Never throws: a lookup failure degrades to the Decopilot path rather than
@@ -100,7 +104,17 @@ export function pickSoleTaskRepo(
  * logged — "why did this task run Decopilot?" (or "why did it have to pick?")
  * is otherwise invisible.
  */
-export type TaskRepoChoice = { repo: TaskRepo } | "pick" | null;
+export type TaskRepoChoice =
+  | { repo: TaskRepo }
+  | { choices: TaskRepoChoiceOption[] }
+  | null;
+
+/** One repository the run may clone, as the prompt names it. */
+export interface TaskRepoChoiceOption {
+  connectionId: string;
+  /** `owner/name`. */
+  repo: string;
+}
 
 export async function resolveTaskRepoChoice(
   ctx: StudioContext,
@@ -112,9 +126,20 @@ export async function resolveTaskRepoChoice(
     });
     const repo = pickSoleTaskRepo(items);
     if (repo) return { repo };
-    const distinct = new Set(
-      selectLoadableRepos(items).map((r) => repoKey(r.owner, r.repo)),
-    );
+    // One entry per REPOSITORY: importing a repo routinely leaves two loadable
+    // connections behind (org-shared + per-agent), and offering the same repo
+    // twice reads as two different choices.
+    const byRepo = new Map<string, TaskRepoChoiceOption>();
+    for (const r of selectLoadableRepos(items)) {
+      const key = repoKey(r.owner, r.repo);
+      if (!byRepo.has(key)) {
+        byRepo.set(key, {
+          connectionId: r.connectionId,
+          repo: `${r.owner}/${r.repo}`,
+        });
+      }
+    }
+    const distinct = byRepo;
     if (distinct.size === 0) {
       console.warn(
         `[task-board] claude-code skipped for org ${organizationId}: ` +
@@ -126,7 +151,7 @@ export async function resolveTaskRepoChoice(
       `[task-board] claude-code for org ${organizationId}: ` +
         `${distinct.size} importable repos — the run picks one with TASK_ADD_REPO`,
     );
-    return "pick";
+    return { choices: [...distinct.values()] };
   } catch (err) {
     console.warn("[task-board] repo lookup for claude-code failed", err);
     return null;
@@ -165,7 +190,7 @@ export async function claudeCodeEnabledForOrg(
 export function buildClaudeCodeTaskPrompt(
   task: { id: string; title: string; description: string | null },
   repo: TaskRepo | null,
-  opts?: SuperAgentPromptOpts,
+  opts?: SuperAgentPromptOpts & { repoChoices?: TaskRepoChoiceOption[] },
 ): string {
   const lines: string[] = [
     "You've been assigned this task. Complete it and finish with a pull request.",
@@ -181,13 +206,24 @@ export function buildClaudeCodeTaskPrompt(
     "",
     repo
       ? `The repository ${repo.owner}/${repo.name} is already cloned at your working directory, on its own branch. \`git\` and \`gh\` are authenticated.`
-      : "Your working directory is EMPTY: this organization has several repositories, so " +
-          "nothing has been cloned yet. FIRST call `mcp__studio__TASK_ADD_REPO` — with no " +
-          "arguments it lists the repositories, and with a connectionId it clones that one " +
-          "into your working directory and waits for the checkout. Do not read files, run " +
-          "`git`, or run `gh` before it returns; there is nothing there yet. Once it " +
-          "returns, the repository is checked out on its own branch and `git` and `gh` are " +
-          "authenticated.",
+      : [
+          "Your working directory is EMPTY: this organization has several repositories, so " +
+            "nothing has been cloned yet. FIRST call `mcp__studio__TASK_ADD_REPO` with the " +
+            "connectionId of the repository this task is about. It clones that repository " +
+            "into your working directory and waits for the checkout, so once it returns the " +
+            "repository is there on its own branch and `git` and `gh` are authenticated. " +
+            "Do not read files, run `git`, or run `gh` before it returns; there is nothing " +
+            "there yet.",
+          "",
+          "Repositories in this organization:",
+          ...(opts?.repoChoices ?? []).map(
+            (c) => `- ${c.repo} (connectionId: ${c.connectionId})`,
+          ),
+          opts?.repoChoices?.length
+            ? "Pick the one the task is about. If the task doesn't say and the names don't " +
+              "settle it, take the first."
+            : "Call `mcp__studio__TASK_ADD_REPO` with no arguments to list them.",
+        ].join("\n"),
     "",
   );
 

--- a/apps/api/src/tools/task-board/claude-code-task-run.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.ts
@@ -1,19 +1,21 @@
 /**
  * Running a delegated task with the sandbox-hosted `claude-code` harness.
  *
- * Decopilot picks its repo mid-run with `load_repo`. claude-code cannot: the
- * sandbox branch and the clone are both resolved BEFORE dispatch, and the fs
- * layer binds the branch at run start — so a repo chosen later never reaches
- * the run. The repo therefore has to be decided here, up front, and bound to
- * the thread so `resolveSandboxBranch` puts the run in a sandbox that actually
- * has a checkout.
+ * Two ways in, depending on whether "which repo" has one answer:
  *
- * That constraint drives the eligibility rule below: this harness runs a task
- * only when the org has exactly ONE importable REPOSITORY (which is not the
- * same as one connection — see `pickSoleTaskRepo`), so "which repo" has a
- * single correct answer. Every other case (no repos, several repos) falls back
- * to Decopilot, which can ask/choose at runtime. A task must never end up in a
- * sandbox with no checkout and a prompt telling it to open a PR.
+ * - Exactly ONE importable REPOSITORY in the org (not the same as one
+ *   connection — see `pickSoleTaskRepo`): the repo is decided here, bound to the
+ *   thread before dispatch, and the pod boots with the checkout already in it.
+ *   Nothing to ask, nothing to wait for.
+ * - SEVERAL repos: the run is dispatched with no repo, on the bare `thread:<id>`
+ *   sandbox key, and picks one with `TASK_ADD_REPO` — which clones into the pod
+ *   the agent loop is already running in. This is NOT `load_repo`'s trick (that
+ *   one provisions a different sandbox, which is useless to a harness whose bash
+ *   runs inside this one).
+ *
+ * Either way the harness must never be handed a prompt that says "open a PR"
+ * with no repo and no way to get one: with no repos imported at all, the task
+ * falls back to Decopilot.
  */
 
 import type { StudioContext } from "@/core/studio-context";
@@ -87,32 +89,44 @@ export function pickSoleTaskRepo(
 }
 
 /**
- * `pickSoleTaskRepo` over the org's `mcp-github` connections.
+ * How a claude-code task run gets its repo, from the org's `mcp-github`
+ * connections:
+ * - `{ repo }` — one importable repository, bound before dispatch.
+ * - `"pick"` — several, so the run picks one with `TASK_ADD_REPO` mid-run.
+ * - `null` — none imported, so this harness can't run the task at all.
  *
- * Null means "not eligible for claude-code" — see the module doc. Never throws:
- * a lookup failure degrades to the Decopilot path rather than failing the
- * delegation that already persisted. The null cases are logged: the fallback is
- * otherwise invisible, and "why did this task run Decopilot?" is exactly the
- * question an operator has.
+ * Never throws: a lookup failure degrades to the Decopilot path rather than
+ * failing the delegation that already persisted. Both non-bound outcomes are
+ * logged — "why did this task run Decopilot?" (or "why did it have to pick?")
+ * is otherwise invisible.
  */
-export async function resolveSoleTaskRepo(
+export type TaskRepoChoice = { repo: TaskRepo } | "pick" | null;
+
+export async function resolveTaskRepoChoice(
   ctx: StudioContext,
   organizationId: string,
-): Promise<TaskRepo | null> {
+): Promise<TaskRepoChoice> {
   try {
     const { items } = await ctx.storage.connections.list(organizationId, {
       slug: "mcp-github",
     });
     const repo = pickSoleTaskRepo(items);
-    if (!repo) {
-      const repos = selectLoadableRepos(items);
-      const distinct = new Set(repos.map((r) => repoKey(r.owner, r.repo)));
+    if (repo) return { repo };
+    const distinct = new Set(
+      selectLoadableRepos(items).map((r) => repoKey(r.owner, r.repo)),
+    );
+    if (distinct.size === 0) {
       console.warn(
         `[task-board] claude-code skipped for org ${organizationId}: ` +
-          `${distinct.size} importable repos (needs exactly 1) — running Decopilot`,
+          `no importable repos — running Decopilot`,
       );
+      return null;
     }
-    return repo;
+    console.warn(
+      `[task-board] claude-code for org ${organizationId}: ` +
+        `${distinct.size} importable repos — the run picks one with TASK_ADD_REPO`,
+    );
+    return "pick";
   } catch (err) {
     console.warn("[task-board] repo lookup for claude-code failed", err);
     return null;
@@ -138,15 +152,19 @@ export async function claudeCodeEnabledForOrg(
  * selection is unit-tested.
  *
  * Deliberately shorter than the Decopilot prompt: most of that one exists to
- * steer tool choice (`load_repo`, "prefer the GitHub tool", "don't hunt for the
- * dev-server port"). Here the repo is already checked out at the working
- * directory and the harness has real `git` and `gh`, so the prompt only has to
- * say what "done" means — including the part Decopilot gets from its own tools
- * and this harness only has over MCP: moving the task on the board.
+ * steer tool choice ("prefer the GitHub tool", "don't hunt for the dev-server
+ * port"). The harness has real `git` and `gh`, so the prompt only has to say
+ * what "done" means — including the part Decopilot gets from its own tools and
+ * this harness only has over MCP: moving the task on the board.
+ *
+ * `repo: null` is the several-repos case: the working directory is EMPTY and the
+ * first instruction is to clone one. That has to be stated up front and
+ * unambiguously — a model that starts by looking for files it was told exist
+ * spends its first steps concluding the sandbox is broken.
  */
 export function buildClaudeCodeTaskPrompt(
   task: { id: string; title: string; description: string | null },
-  repo: TaskRepo,
+  repo: TaskRepo | null,
   opts?: SuperAgentPromptOpts,
 ): string {
   const lines: string[] = [
@@ -161,7 +179,15 @@ export function buildClaudeCodeTaskPrompt(
   if (task.description) lines.push("", "Description:", task.description);
   lines.push(
     "",
-    `The repository ${repo.owner}/${repo.name} is already cloned at your working directory, on its own branch. \`git\` and \`gh\` are authenticated.`,
+    repo
+      ? `The repository ${repo.owner}/${repo.name} is already cloned at your working directory, on its own branch. \`git\` and \`gh\` are authenticated.`
+      : "Your working directory is EMPTY: this organization has several repositories, so " +
+          "nothing has been cloned yet. FIRST call `mcp__studio__TASK_ADD_REPO` — with no " +
+          "arguments it lists the repositories, and with a connectionId it clones that one " +
+          "into your working directory and waits for the checkout. Do not read files, run " +
+          "`git`, or run `gh` before it returns; there is nothing there yet. Once it " +
+          "returns, the repository is checked out on its own branch and `git` and `gh` are " +
+          "authenticated.",
     "",
   );
 
@@ -195,6 +221,10 @@ export function buildClaudeCodeTaskPrompt(
     "- Change only what the task needs. Don't refactor around it.",
     `- Then move this task to review on the board: call \`mcp__studio__TASK_BOARD_ITEM_UPDATE\` with id "${task.id}" and status "in_review". Pass ONLY the fields you are changing.`,
     "- If the task turns out to need no code change, say why in your final message and move it to review anyway so a human can close it out.",
+    // The board is where a human reads this task, so anything a reviewer needs
+    // to know belongs there too — a final message they never open is not a
+    // report. Optional: a comment per run, not per step.
+    `- Anything a reviewer should know (a decision you made, something you found and deliberately left alone, a question) goes on the task as a comment: \`mcp__studio__TASK_BOARD_COMMENT_CREATE\` with taskBoardItemId "${task.id}". Read what's already there first with \`mcp__studio__TASK_BOARD_COMMENT_LIST\` — a comment may be addressed to you.`,
     "",
     `(task id: ${task.id})`,
   );

--- a/apps/api/src/tools/task-board/comments.ts
+++ b/apps/api/src/tools/task-board/comments.ts
@@ -8,6 +8,8 @@ import { z } from "zod";
 import { defineTool } from "@/core/define-tool";
 import { getUserId, requireAuth } from "@/core/studio-context";
 import type { StudioContext } from "@/core/studio-context";
+import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
+import { taskRunContextStore } from "./task-run-context";
 
 const TaskBoardCommentSchema = z.object({
   id: z.string(),
@@ -80,7 +82,14 @@ export const TASK_BOARD_COMMENT_CREATE = defineTool({
       taskBoardItemId: input.taskBoardItemId,
       organizationId: requireOrg(ctx),
       parentId: input.parentId ?? null,
-      authorId: getUserId(ctx)!,
+      // A comment from a task run is the Super Agent's, not the user's whose
+      // credential the run acts under (the assigner). Attributing it to that
+      // person reads as them writing about work they didn't do. Same id the
+      // board already uses for the agent as an assignee, so the UI renders it
+      // as the agent without a second concept.
+      authorId: taskRunContextStore.getStore()
+        ? SUPER_AGENT_ASSIGNEE_ID
+        : getUserId(ctx)!,
       body: input.body,
     });
     if (!comment) throw new Error("Task board item not found");

--- a/apps/api/src/tools/task-board/enqueue-super-agent.ts
+++ b/apps/api/src/tools/task-board/enqueue-super-agent.ts
@@ -6,7 +6,7 @@ import { enqueueAgentRunForTask } from "./enqueue-task-run";
 import {
   buildClaudeCodeTaskPrompt,
   claudeCodeEnabledForOrg,
-  resolveSoleTaskRepo,
+  resolveTaskRepoChoice,
 } from "./claude-code-task-run";
 
 /**
@@ -139,21 +139,23 @@ export async function enqueueSuperAgentForTask(
   // BEFORE the write; here the claim is the enforcement.
   await claimTaskExecution(ctx, task);
 
-  // Sandbox-hosted claude-code takes the task when the org opted in AND the
-  // repo is unambiguous — it must be chosen before dispatch (see
-  // `claude-code-task-run.ts`). Anything else runs Decopilot exactly as before,
-  // so no existing board behavior changes until both conditions hold.
-  const repo = (await claudeCodeEnabledForOrg(ctx, task.organizationId))
-    ? await resolveSoleTaskRepo(ctx, task.organizationId)
+  // Sandbox-hosted claude-code takes the task when the org opted in AND has a
+  // repo it could work in — bound before dispatch when there's exactly one,
+  // otherwise chosen mid-run with `TASK_ADD_REPO` (see
+  // `claude-code-task-run.ts`). An org with no repos imported runs Decopilot
+  // exactly as before.
+  const choice = (await claudeCodeEnabledForOrg(ctx, task.organizationId))
+    ? await resolveTaskRepoChoice(ctx, task.organizationId)
     : null;
 
-  if (repo) {
+  if (choice) {
+    const repo = choice === "pick" ? null : choice.repo;
     await enqueueAgentRunForTask(ctx, task, {
       title: `Super Agent: ${task.title}`,
       prompt: buildClaudeCodeTaskPrompt(task, repo, opts),
       temperature: 0.5,
       harnessId: "claude-code",
-      repo,
+      ...(repo ? { repo } : {}),
     });
     return;
   }

--- a/apps/api/src/tools/task-board/enqueue-super-agent.ts
+++ b/apps/api/src/tools/task-board/enqueue-super-agent.ts
@@ -149,10 +149,15 @@ export async function enqueueSuperAgentForTask(
     : null;
 
   if (choice) {
-    const repo = choice === "pick" ? null : choice.repo;
+    const repo = "repo" in choice ? choice.repo : null;
     await enqueueAgentRunForTask(ctx, task, {
       title: `Super Agent: ${task.title}`,
-      prompt: buildClaudeCodeTaskPrompt(task, repo, opts),
+      prompt: buildClaudeCodeTaskPrompt(task, repo, {
+        ...opts,
+        // Names the candidates in the prompt so the run doesn't spend its first
+        // step asking what exists.
+        ...("choices" in choice ? { repoChoices: choice.choices } : {}),
+      }),
       temperature: 0.5,
       harnessId: "claude-code",
       ...(repo ? { repo } : {}),

--- a/apps/api/src/tools/task-board/enqueue-task-run.ts
+++ b/apps/api/src/tools/task-board/enqueue-task-run.ts
@@ -28,10 +28,10 @@ export async function enqueueAgentRunForTask(
     /** Hosted harness for this run. Defaults to Decopilot. */
     harnessId?: HostedHarnessId;
     /**
-     * Repo to bind to the run's thread BEFORE dispatch. Required for
-     * `claude-code`, which resolves its sandbox branch (and therefore its
-     * checkout) at dispatch time and cannot pick a repo mid-run the way
-     * Decopilot's `load_repo` does.
+     * Repo to bind to the run's thread BEFORE dispatch, so the pod boots with
+     * the checkout already in it. Omitted for a `claude-code` run in an org with
+     * several repos: that run gets its own repo-less sandbox on the bare
+     * `thread:<id>` key and clones into it with `TASK_ADD_REPO`.
      */
     repo?: TaskRepo;
   },
@@ -79,11 +79,20 @@ export async function enqueueAgentRunForTask(
         }
       : {}),
   };
+  // A sandbox-hosted run with no repo still needs a sandbox of its OWN: it is
+  // about to clone into it (`TASK_ADD_REPO`), and the repo-less default is the
+  // "ephemeral" sandbox SHARED across the user's threads — two task runs cloning
+  // different repos into one pod. The bare `thread:<id>` key is what
+  // `resolveSandboxBranch` holds onto for the whole run even once a repo lands,
+  // so the claim handle can't move out from under the live pod.
+  const sandboxBranch = opts.repo
+    ? threadBranch(thread.id, opts.repo.connectionId)
+    : harnessRunsInSandbox(harnessId)
+      ? threadBranch(thread.id)
+      : null;
   await ctx.storage.threads.update(thread.id, {
     metadata,
-    ...(opts.repo
-      ? { branch: threadBranch(thread.id, opts.repo.connectionId) }
-      : {}),
+    ...(sandboxBranch ? { branch: sandboxBranch } : {}),
     updated_by: userId,
   });
 
@@ -128,6 +137,11 @@ export async function enqueueAgentRunForTask(
       userId,
       harnessId,
       sandboxProviderKind: "agent-sandbox",
+      // Only meaningful for the repo-less sandbox run above: `resolveSandboxBranch`
+      // derives the key from the thread's repo when there is one, and needs the
+      // explicit bare key when there isn't. Carried in the durable snapshot, so a
+      // recovered re-dispatch resolves the same pod.
+      ...(opts.repo ? {} : sandboxBranch ? { branch: sandboxBranch } : {}),
       taskId: thread.id,
       // Reports tasks carry the subscription-billing stamp: their AI usage
       // is included in the org subscription (billing/subsidized-runs.ts).

--- a/apps/api/src/tools/task-board/index.ts
+++ b/apps/api/src/tools/task-board/index.ts
@@ -1,3 +1,4 @@
+export { TASK_ADD_REPO } from "./add-repo";
 export { TASK_BOARD_ITEM_CREATE } from "./create";
 export { TASK_BOARD_ITEM_LIST } from "./list";
 export { TASK_BOARD_ITEM_UPDATE } from "./update";

--- a/apps/api/src/tools/task-board/task-run-context.ts
+++ b/apps/api/src/tools/task-board/task-run-context.ts
@@ -1,0 +1,51 @@
+/**
+ * The run a task-board MCP request belongs to.
+ *
+ * The sandbox-hosted harness reaches Studio over HTTP at
+ * `/api/<slug>/mcp/task-run/<threadId>`, so the run it is serving is in the URL
+ * — not in any tool's input. That is deliberate: the per-run API key is minted
+ * with full access, so a `threadId` argument would let a run act on another
+ * run's sandbox. The route puts the path value here; `TASK_ADD_REPO` reads it.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { ToolName } from "@decocms/shared/tools/registry-metadata";
+
+export interface TaskRunContext {
+  /** The run thread this MCP session belongs to. */
+  threadId: string;
+}
+
+export const taskRunContextStore = new AsyncLocalStorage<TaskRunContext>();
+
+export function requireTaskRunContext(): TaskRunContext {
+  const ctx = taskRunContextStore.getStore();
+  if (!ctx) {
+    throw new Error(
+      "This tool is only available on a task run's MCP endpoint " +
+        "(/api/<org>/mcp/task-run/<threadId>).",
+    );
+  }
+  return ctx;
+}
+
+/**
+ * The tools a task run's MCP endpoint exposes.
+ *
+ * A narrow surface, not the whole management catalog: the harness used to get
+ * every Studio tool (~200) and had to find the two it needed in that list.
+ *
+ * Deliberately absent: creating and deleting tasks, `TASK_BOARD_REVIEW_DECISION`
+ * and `TASK_BOARD_PROMOTE_TO_PRODUCTION` — an agent must not approve or merge
+ * its own work.
+ */
+export const TASK_RUN_TOOL_NAMES: readonly ToolName[] = [
+  "TASK_ADD_REPO",
+  "TASK_BOARD_ITEM_LIST",
+  "TASK_BOARD_ITEM_UPDATE",
+  "TASK_BOARD_ITEM_PRS_GET",
+  "TASK_BOARD_ACTIVITY_LIST",
+  "TASK_BOARD_COMMENT_LIST",
+  "TASK_BOARD_COMMENT_CREATE",
+  "TASK_BOARD_COMMENT_UPDATE",
+];

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -1279,8 +1279,17 @@ function ActivitySection({
   const comments = useTaskBoardComments(item.id);
 
   /** A comment's author, resolved from the org's members; falls back to the id
-   *  so a comment from a since-removed member still renders. */
+   *  so a comment from a since-removed member still renders. The Super Agent
+   *  writes its own comments during a task run and is not a member, so it is
+   *  resolved first — `isAgent` is what renders its glyph. */
   const authorOf = (userId: string): CommentAuthor => {
+    if (userId === SUPER_AGENT_ASSIGNEE_ID) {
+      return {
+        id: userId,
+        name: t("taskBoard.taskDialog.superAgentLabel"),
+        isAgent: true,
+      };
+    }
     if (userId === me.id) return me;
     const member = memberByUserId.get(userId);
     return {

--- a/packages/sandbox/dispatch/schemas.test.ts
+++ b/packages/sandbox/dispatch/schemas.test.ts
@@ -281,10 +281,20 @@ describe("harnessStreamInputSchema (v3)", () => {
         workspace: { cwd: "/tmp" },
       }).success,
     ).toBe(false);
+    // `/repo` with no repo facts is VALID: a sandbox-hosted task run can be
+    // dispatched into the (empty) working directory before its repo is chosen,
+    // and clone one into that same directory mid-run (`TASK_ADD_REPO`). The
+    // branch is still required — it names the ref the daemon checks out.
     expect(
       harnessStreamInputSchema.safeParse({
         ...minimalV3,
         workspace: { cwd: "/repo", branch: "main" },
+      }).success,
+    ).toBe(true);
+    expect(
+      harnessStreamInputSchema.safeParse({
+        ...minimalV3,
+        workspace: { cwd: "/repo" },
       }).success,
     ).toBe(false);
   });

--- a/packages/sandbox/dispatch/schemas.ts
+++ b/packages/sandbox/dispatch/schemas.ts
@@ -98,13 +98,16 @@ const harnessWorkspaceSchema = z.discriminatedUnion("cwd", [
   z
     .object({
       cwd: z.literal("/repo"),
+      // Optional: a task run can be dispatched into the (empty) working
+      // directory before its repo is chosen — see HarnessWorkspace.
       repo: z
         .object({
           owner: z.string(),
           name: z.string(),
           connectedGithub: z.boolean(),
         })
-        .strict(),
+        .strict()
+        .optional(),
       branch: z.string().nullable(),
     })
     .strict(),

--- a/packages/shared/src/harness/types.ts
+++ b/packages/shared/src/harness/types.ts
@@ -76,7 +76,14 @@ export type ChatMessage = UIMessage;
 export type HarnessWorkspace =
   | {
       cwd: "/repo";
-      repo: {
+      /**
+       * Absent while the checkout is still to come: a sandbox-hosted task run
+       * can be dispatched before "which repo" is answered and clone one into
+       * this same directory mid-run (`TASK_ADD_REPO`). The directory exists
+       * either way — the daemon creates it at boot — so the harness can be
+       * pointed at it before it has contents.
+       */
+      repo?: {
         owner: string;
         name: string;
         connectedGithub: boolean;

--- a/packages/shared/src/tools/registry-metadata.ts
+++ b/packages/shared/src/tools/registry-metadata.ts
@@ -228,6 +228,7 @@ const ALL_TOOL_NAMES = [
   "TASK_BOARD_COMMENT_CREATE",
   "TASK_BOARD_COMMENT_UPDATE",
   "TASK_BOARD_COMMENT_DELETE",
+  "TASK_ADD_REPO",
 ] as const;
 
 /**
@@ -1081,6 +1082,12 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
   {
     name: "TASK_BOARD_COMMENT_DELETE",
     description: "Delete a comment (a thread root takes its replies)",
+    category: "Task Board",
+  },
+  {
+    name: "TASK_ADD_REPO",
+    description:
+      "Clone an organization repository into the sandbox of the task run calling it",
     category: "Task Board",
   },
 ];


### PR DESCRIPTION
Builds on #5688 (merged; rebased onto `main`).

The sandbox-hosted `claude-code` harness was already pointed at an MCP server — `/mcp/self`, i.e. **every** management tool Studio has (~200) for the two it actually calls. So this PR narrows that surface rather than adding a second one, and gives the harness a way to get a repo when the org has more than one.

## What ships

- **`POST /api/:org/mcp/task-run/:threadId`** — the task-board tools (item list/update, PRs, activity, comment list/create/update) plus `TASK_ADD_REPO`. Item create/delete, `TASK_BOARD_REVIEW_DECISION` and `TASK_BOARD_PROMOTE_TO_PRODUCTION` are deliberately absent: an agent must not approve or merge its own work. The run is identified by the **path**, not a tool argument — the per-run API key is minted `{"*":["*"]}`, so a `threadId` input would let one run act on another run's sandbox.
- **`TASK_ADD_REPO`** clones into the pod the agent loop is *already* in: bind the repo to the thread → PUT a credentialed clone URL onto the running daemon's config channel (adding a repository classifies as a branch-change, so its clone step runs; `cloneOnly` was set at provision, so no install and no dev server follow) → wait for the checkout → return the root listing. `load_repo` can't be reused: it provisions a *different* sandbox, which is useless to a harness whose `bash` runs inside this one. **No daemon changes.**
- **Eligibility** moves from "exactly one importable repo" to "at least one". With several, the run dispatches repo-less on its own sandbox and picks the repo mid-run. An org with no repos still falls back to Decopilot.
- **The prompt** now also tells the agent to leave anything a reviewer needs to know on the task as a comment, and to read existing comments first — one may be addressed to it.

## The three things most likely to bite

- **The sandbox key stays the bare `thread:<id>` for the whole run.** Deriving it from the repo added mid-run (what `load_repo` does) would move the claim handle off the pod holding the agent loop, and a recovery re-dispatch would 404 the live pod and fork an empty one. `resolveSandboxBranch` pins the bare key when it arrives as `runBranch`; `load_repo`'s keys always carry a connection id, so its repo-switch isolation is untouched. Three tests pin that boundary.
- **`gh` needed separate handling.** The daemon derives `GH_TOKEN` from the clone URL at *spawn* time (`RunEnv`), so a run that clones later has no token and no way to be handed one through its environment. After the clone, `hosts.yml` is written from the token already on `origin`, inside the pod — it never crosses the wire twice and never lands in a command line. The clone credential itself is force-re-minted with a 55min floor; a GitHub App installation token caps at 1h, so that's the ceiling, not a choice.
- **The empty working directory** is stated bluntly in the prompt ("your working directory is EMPTY … do not read files, run `git`, or run `gh` before it returns"). A model told files exist spends its first steps concluding the sandbox is broken.

## Testing

- `bun run --cwd=apps/api check`, `bun run lint` (0 errors), `knip` clean, `bun test` over the touched areas green.
- Unit tests: the branch-pinning boundary (including that `load_repo` still switches), the clone-readiness probe (a HEAD ref without working-tree entries is **not** ready), the repo-less prompt, and the task-run endpoint URL.
- **Not covered:** no e2e over the new route, and the clone path has not been exercised against a live pod — that needs a cluster with the org flag on. Follow-up.
- `bun run generate:tool-contracts` degraded `tool-io.ts`/`chat-tools.ts` to stubs locally, so both are left untouched; everything type-checks without regenerating, but worth a look on CI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a run-scoped MCP endpoint and a `TASK_ADD_REPO` tool so `claude-code` task runs can clone a repo into the sandbox they’re already in and see only the task‑board tools they need. This enables multi‑repo orgs and reduces the exposed tool surface.

- **New Features**
  - `POST /api/:org/mcp/task-run/:threadId` exposes only task‑board tools plus `TASK_ADD_REPO`; path‑scoped to the run and excludes approval/merge tools.
  - `TASK_ADD_REPO` binds a repo to the thread, pushes a credentialed clone URL to the live daemon, waits for checkout, and returns the repo root listing; `git`/`gh` are set up from the clone; tokens refresh with a ~55‑min floor.
  - Eligibility is now “at least one imported repo”: with several, the run starts repo‑less and uses `TASK_ADD_REPO`; the prompt says the working dir is EMPTY, lists repo choices (one per repository), tells the agent to call `TASK_ADD_REPO` before reading files or using `git`/`gh`, and to leave reviewer notes as task comments.

- **Refactors**
  - Sandbox branch is pinned to the bare `thread:<id>` for the entire run so recovery does not swap pods; `resolveSandboxBranch` and tests updated.
  - MCP endpoint minting supports `target: "task-run"` and requires `threadId`; server uses a `toolSubsetMCP` to expose just the needed tools; route is mounted before the proxy catch‑all.
  - Harness workspace allows `cwd: "/repo"` without an initial repo; `run-stream` handles missing repo; schemas/types updated. Tests cover endpoint URL, clone‑readiness probe, repo‑less prompt, and branch pinning.
  - Task‑run comments are authored by the Super Agent, and the UI renders them with the agent label.

<sup>Written for commit 2acc5725444a97a8dfb7f5acca43509a669e2b8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

