### PR TITLE
refactor(shared): remove dead Event Bus tool category

### DIFF
--- a/packages/shared/src/tools/registry-metadata.ts
+++ b/packages/shared/src/tools/registry-metadata.ts
@@ -26,7 +26,6 @@ export type ToolCategory =
   | "Monitoring"
   | "Users"
   | "API Keys"
-  | "Event Bus"
   | "Tags"
   | "AI Providers"
   | "Secrets"
@@ -1599,7 +1598,6 @@ export function getToolsByCategory(): Record<ToolCategory, ToolMetadata[]> {
     Monitoring: [],
     Users: [],
     "API Keys": [],
-    "Event Bus": [],
     Tags: [],
     "AI Providers": [],
     Secrets: [],


### PR DESCRIPTION
**Source:** dead-code cleanup found while auditing `packages/shared/src/tools/registry-metadata.ts` for tool I/O and registry metadata consistency.

**Payoff:** `"Event Bus"` is a `ToolCategory` union member with zero tools ever assigned to it — no entry in `MANAGEMENT_TOOLS`, no `EVENT_*` tool registered anywhere in `apps/api/src/tools/index.ts`'s `CORE_TOOLS`. It only exists as an always-empty bucket in `getToolsByCategory()`'s returned record, silently misleading anyone reading the type as "this category has tools."

**Verification of behavior-preservation:** `rg -n "Event Bus"` across `packages/` and `apps/` (excluding this file) confirms zero other references to the category string — the only other "Event Bus" hits are unrelated code comments. `getToolsByCategory()`'s return type narrows (one fewer always-empty key) but no caller destructures/reads the `"Event Bus"` key, so this is behavior-preserving.

**Net delta:** -2 / +0.

**Command to confirm:** `cd packages/shared && bunx tsc --noEmit`

**Checks run locally:** `bun run fmt`, targeted `bunx tsc --noEmit` in `packages/shared` (clean), `bunx oxlint packages/shared/src/tools/registry-metadata.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused "Event Bus" `ToolCategory` and its empty entry in `getToolsByCategory()` in `packages/shared/src/tools/registry-metadata.ts`. This cleans up the type and avoids exposing a category with no tools.

<sup>Written for commit 5ada4b66dd7adbcb366bd063769f53281b14eadd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

