### PR TITLE
fix(sandbox): persist cloneOnly through stripEnsureOpts

### DIFF
--- a/packages/sandbox/server/provider/agent-sandbox/runner.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.test.ts
@@ -28,6 +28,19 @@ describe("stripEnsureOpts", () => {
   it("drops orgFsConfigJson along with everything else when unset", () => {
     expect(stripEnsureOpts({})).toBeNull();
   });
+
+  // Without this, a recreated warm-pool pod's rebootstrap would compute
+  // `cloneOnly: false` from the persisted opts, silently re-enabling install +
+  // dev-server for a sandbox provisioned clone-only.
+  it("retains cloneOnly so resurrection doesn't silently install/start a dev server", () => {
+    const opts: EnsureOptions = { cloneOnly: true };
+    expect(stripEnsureOpts(opts)).toEqual({ cloneOnly: true });
+  });
+
+  it("drops cloneOnly: false rather than persisting a redundant flag", () => {
+    const opts: EnsureOptions = { cloneOnly: false, branch: "b" };
+    expect(stripEnsureOpts(opts)).toEqual({ branch: "b" });
+  });
 });
 
 describe("earlierShutdown", () => {

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -2997,6 +2997,11 @@ export function stripEnsureOpts(opts: EnsureOptions): EnsureOptions | null {
   if (opts.workload) out.workload = opts.workload;
   if (opts.env && Object.keys(opts.env).length > 0) out.env = opts.env;
   if (opts.tenant) out.tenant = opts.tenant;
+  // Without this, a recreated warm-pool pod's rebootstrap would compute
+  // `cloneOnly: false` (workloadConfigPayload only sees this persisted blob),
+  // silently re-enabling install + dev-server for a sandbox provisioned
+  // clone-only.
+  if (opts.cloneOnly) out.cloneOnly = true;
   // Without this, `resurrectByHandle` re-provisioning from these persisted
   // opts (no SANDBOX_START in that loop) would silently drop the org-fs
   // mounts a live sandbox had.


### PR DESCRIPTION
Bug found while auditing the agent-sandbox runner ↔ types.ts contract (EnsureOptions.cloneOnly's own doc comment says it "must be explicit and travel to the daemon").

**The bug:** `stripEnsureOpts()` — the function that decides which `EnsureOptions` fields survive into `PersistedK8sState.ensureOpts` for later resurrection — dropped `cloneOnly`. `resurrectByHandle()` uses that persisted `ensureOpts` to rebuild the daemon `/config` payload via `workloadConfigPayload()` when a warm-pool pod is recreated under a live claim (bootId mismatch → `rebootstrapDaemon`). Since `cloneOnly` never made it into the persisted blob, `workloadConfigPayload` recomputes `cloneOnly: opts?.cloneOnly === true` as `false` on every rebootstrap — silently flipping a clone-only sandbox (no install, no dev server) back to a normal workload the moment its pod gets recreated.

**Why it matters:** a clone-only sandbox exists specifically to skip dependency install/dev-server startup (e.g. a one-shot agent-loop dispatch with no preview). Losing that flag on pod recreation wastes resources and can surface an install/dev-server failure for a repo that was never meant to run one.

**Fix:** `stripEnsureOpts` now retains `cloneOnly` when true (mirrors the same pattern used for `branch`/`repo`/`workload`/`tenant`/`orgFsConfigJson`, all persisted for the identical resurrection reason).

Regression test: `runner.test.ts` — asserts `stripEnsureOpts({cloneOnly: true})` retains the flag, and that `cloneOnly: false` is still dropped (no redundant persisted field).

**To verify:** `bun test packages/sandbox/server/provider/agent-sandbox/runner.test.ts`

Locally ran: `bun run fmt`, `cd packages/sandbox && bunx tsc --noEmit`, the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures clone-only sandboxes remain clone-only after warm-pool pod resurrection. Previously `stripEnsureOpts` dropped `cloneOnly`, making rebootstrap set `cloneOnly: false` and re-enable dependency install and dev-server.

- **Bug Fixes**
  - `stripEnsureOpts` now persists `cloneOnly: true` in `ensureOpts`; `false` is still dropped.
  - Tests added in `packages/sandbox/server/provider/agent-sandbox/runner.test.ts` to verify retention and dropping behavior.

<sup>Written for commit fed521b65f6be31a2e1cdfe376369bfb4c656621. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

