### PR TITLE
fix(settings): allow STUDIO_TOPUP_FEE_PERCENT=0 to waive the top-up fee

### DIFF
--- a/apps/api/src/settings/resolve-config.test.ts
+++ b/apps/api/src/settings/resolve-config.test.ts
@@ -500,13 +500,20 @@ describe("resolveConfig topup fee percent", () => {
   it("rejects a non-numeric value at boot (fail-fast, not a silent default)", () => {
     expect(() =>
       resolveConfig(flags, { STUDIO_TOPUP_FEE_PERCENT: "free" }),
-    ).toThrow("STUDIO_TOPUP_FEE_PERCENT must be a positive integer");
+    ).toThrow("STUDIO_TOPUP_FEE_PERCENT must be a non-negative integer");
   });
 
   it("rejects a value above 100 instead of silently overcharging top-ups", () => {
     expect(() =>
       resolveConfig(flags, { STUDIO_TOPUP_FEE_PERCENT: "150" }),
     ).toThrow("STUDIO_TOPUP_FEE_PERCENT must be at most 100");
+  });
+
+  it("allows 0 to waive the fee entirely (self-hosted deployments)", () => {
+    expect(
+      resolveConfig(flags, { STUDIO_TOPUP_FEE_PERCENT: "0" }).settings
+        .topupFeePercent,
+    ).toBe(0);
   });
 });
 

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -105,6 +105,26 @@ function toPositiveIntegerOrDefault(
   return toPositiveIntegerOrUndefined(name, value, max) ?? defaultValue;
 }
 
+/** Like `toPositiveIntegerOrDefault`, but 0 is a valid value (e.g. a fee a
+ *  self-hosted deployment wants to disable outright). */
+function toNonNegativeIntegerOrDefault(
+  name: string,
+  value: string | undefined,
+  defaultValue: number,
+  max?: number,
+): number {
+  if (value === undefined || value === "") return defaultValue;
+
+  const numberValue = Number(value);
+  if (!Number.isSafeInteger(numberValue) || numberValue < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+  if (max !== undefined && numberValue > max) {
+    throw new Error(`${name} must be at most ${max}`);
+  }
+  return numberValue;
+}
+
 /** Tri-state flag: unset/empty → `fallback`, otherwise parse as boolean. */
 function toBoolWithDefault(
   value: string | undefined,
@@ -278,8 +298,9 @@ export function resolveConfig(
     stripeSecretKey: envVars.STRIPE_SECRET_KEY,
     stripeOrgPriceId: envVars.STRIPE_ORG_PRICE_ID,
     // Capped at 100: above that is a fat-fingered misconfig ("150" for "15")
-    // that would silently more-than-double every top-up charge.
-    topupFeePercent: toPositiveIntegerOrDefault(
+    // that would silently more-than-double every top-up charge. 0 is valid —
+    // a self-hosted deployment may want to waive the fee entirely.
+    topupFeePercent: toNonNegativeIntegerOrDefault(
       "STUDIO_TOPUP_FEE_PERCENT",
       envVars.STUDIO_TOPUP_FEE_PERCENT,
       15,


### PR DESCRIPTION
Bug found while auditing resolve-config.ts's env-var validation.

`topupFeePercent` was validated with `toPositiveIntegerOrDefault`, which rejects `0` as invalid (throws "must be a positive integer"). But `0` is the only way to disable the AI-credit top-up fee entirely — a legitimate config for a self-hosted deployment that doesn't want to charge its own org for top-ups. Setting `STUDIO_TOPUP_FEE_PERCENT=0` currently crashes the process at boot instead of applying a 0% fee.

Fix: added `toNonNegativeIntegerOrDefault`, identical to the positive-integer helper except it accepts `0`, and used it for this one field only. The upper bound (100, guarding against a fat-fingered "150") is unchanged.

Failure scenario before the fix: any deployment setting `STUDIO_TOPUP_FEE_PERCENT=0` fails to start with `STUDIO_TOPUP_FEE_PERCENT must be a positive integer`. Added a regression test asserting `0` resolves to `topupFeePercent: 0`, and updated the existing invalid-value test's expected message (now "must be a non-negative integer").

To verify: `bun test apps/api/src/settings/resolve-config.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bun test apps/api/src/settings/resolve-config.test.ts` (91 pass), `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow `STUDIO_TOPUP_FEE_PERCENT=0` so self-hosted deployments can waive the AI-credit top-up fee without crashing at boot. The 100% upper cap is unchanged.

- **Bug Fixes**
  - Switched `topupFeePercent` validation to a non-negative integer parser that accepts `0`; still rejects values above 100.
  - Added a regression test asserting `0` resolves to `topupFeePercent: 0` and updated the invalid-value message to "non-negative integer".

<sup>Written for commit dc680d90929c2f62a5067321b1bc4ec78ce14f07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

