### PR TITLE
fix(task-board): restrict comment edit/delete to the comment's author

### DIFF
--- a/apps/api/src/storage/task-board-comments.integration.test.ts
+++ b/apps/api/src/storage/task-board-comments.integration.test.ts
@@ -1,0 +1,93 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+  seedCommonTestPgFixtures,
+} from "../database/test-db-pg";
+import type { StudioDatabase } from "../database";
+import { TaskBoardStorage } from "./task-board";
+
+describe("TaskBoardStorage comments", () => {
+  let database: StudioDatabase;
+  let storage: TaskBoardStorage;
+  let itemId: string;
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    await seedCommonTestPgFixtures(database);
+    storage = new TaskBoardStorage(database.db);
+
+    const item = await storage.create({
+      organizationId: "org_test",
+      title: "Task with comments",
+      by: "user_test",
+    });
+    itemId = item.id;
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  it("lets only the author edit a comment's body", async () => {
+    const comment = await storage.createComment({
+      taskBoardItemId: itemId,
+      organizationId: "org_test",
+      authorId: "user_1",
+      body: "original",
+    });
+    expect(comment).not.toBeNull();
+
+    // Before fix: any org member could edit anyone's comment body.
+    const stolen = await storage.updateComment({
+      id: comment!.id,
+      organizationId: "org_test",
+      callerId: "user_123",
+      body: "hijacked",
+    });
+    expect(stolen).toBeNull();
+
+    const own = await storage.updateComment({
+      id: comment!.id,
+      organizationId: "org_test",
+      callerId: "user_1",
+      body: "edited by author",
+    });
+    expect(own?.body).toBe("edited by author");
+  });
+
+  it("lets anyone resolve a thread, but only the author delete it", async () => {
+    const comment = await storage.createComment({
+      taskBoardItemId: itemId,
+      organizationId: "org_test",
+      authorId: "user_1",
+      body: "resolvable",
+    });
+    expect(comment).not.toBeNull();
+
+    const resolved = await storage.updateComment({
+      id: comment!.id,
+      organizationId: "org_test",
+      callerId: "user_123",
+      resolved: true,
+    });
+    expect(resolved?.resolved).toBe(true);
+
+    // Before fix: any org member could delete anyone's comment.
+    const stolenDelete = await storage.deleteComment(
+      comment!.id,
+      "org_test",
+      "user_123",
+    );
+    expect(stolenDelete).toBe(false);
+
+    const ownDelete = await storage.deleteComment(
+      comment!.id,
+      "org_test",
+      "user_1",
+    );
+    expect(ownDelete).toBe(true);
+  });
+});

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -906,15 +906,21 @@ export class TaskBoardStorage {
   }
 
   /** Edit a comment's body and/or a thread's resolved flag. Null when the
-   *  comment isn't in this org. */
+   *  comment isn't in this org, or a body edit is attempted by someone other
+   *  than its author — resolving a thread is a shared, not an authored,
+   *  action, so that one is open to anyone with access to the task. */
   async updateComment(params: {
     id: string;
     organizationId: string;
+    callerId: string;
     body?: string;
     resolved?: boolean;
   }): Promise<TaskBoardComment | null> {
-    const owned = await this.commentInOrg(params.id, params.organizationId);
-    if (!owned) return null;
+    const existing = await this.commentInOrg(params.id, params.organizationId);
+    if (!existing) return null;
+    if (params.body !== undefined && existing.authorId !== params.callerId) {
+      return null;
+    }
 
     const row = await this.db
       .updateTable("task_board_comments")
@@ -930,10 +936,14 @@ export class TaskBoardStorage {
   }
 
   /** Delete a comment; a root takes its replies with it (FK cascade). False
-   *  when the comment isn't in this org. */
-  async deleteComment(id: string, organizationId: string): Promise<boolean> {
-    const owned = await this.commentInOrg(id, organizationId);
-    if (!owned) return false;
+   *  when the comment isn't in this org, or isn't the caller's own. */
+  async deleteComment(
+    id: string,
+    organizationId: string,
+    callerId: string,
+  ): Promise<boolean> {
+    const existing = await this.commentInOrg(id, organizationId);
+    if (!existing || existing.authorId !== callerId) return false;
     await this.db
       .deleteFrom("task_board_comments")
       .where("id", "=", id)
@@ -944,15 +954,15 @@ export class TaskBoardStorage {
   private async commentInOrg(
     id: string,
     organizationId: string,
-  ): Promise<boolean> {
+  ): Promise<{ authorId: string } | null> {
     const row = await this.db
       .selectFrom("task_board_comments as c")
       .innerJoin("task_board_items as item", "item.id", "c.task_board_item_id")
-      .select("c.id")
+      .select(["c.id", "c.author_id"])
       .where("c.id", "=", id)
       .where("item.organization_id", "=", organizationId)
       .executeTakeFirst();
-    return !!row;
+    return row ? { authorId: row.author_id } : null;
   }
 
   private itemFromDbRow(row: {

--- a/apps/api/src/tools/task-board/comments.ts
+++ b/apps/api/src/tools/task-board/comments.ts
@@ -91,7 +91,8 @@ export const TASK_BOARD_COMMENT_CREATE = defineTool({
 export const TASK_BOARD_COMMENT_UPDATE = defineTool({
   name: "TASK_BOARD_COMMENT_UPDATE",
   description:
-    "Edit a comment's body, or resolve/unresolve a comment thread (root only).",
+    "Edit your own comment's body, or resolve/unresolve a comment thread " +
+    "(root only, any org member may toggle it).",
   annotations: {
     title: "Update Task Comment",
     readOnlyHint: false,
@@ -111,10 +112,15 @@ export const TASK_BOARD_COMMENT_UPDATE = defineTool({
     const comment = await ctx.storage.taskBoard.updateComment({
       id: input.id,
       organizationId: requireOrg(ctx),
+      callerId: getUserId(ctx)!,
       body: input.body,
       resolved: input.resolved,
     });
-    if (!comment) throw new Error("Comment not found");
+    if (!comment) {
+      throw new Error(
+        "Comment not found, or you can only edit your own comments",
+      );
+    }
     return { comment };
   },
 });
@@ -122,7 +128,7 @@ export const TASK_BOARD_COMMENT_UPDATE = defineTool({
 export const TASK_BOARD_COMMENT_DELETE = defineTool({
   name: "TASK_BOARD_COMMENT_DELETE",
   description:
-    "Delete a comment. Deleting a thread root deletes its replies too.",
+    "Delete your own comment. Deleting a thread root deletes its replies too.",
   annotations: {
     title: "Delete Task Comment",
     readOnlyHint: false,
@@ -138,6 +144,7 @@ export const TASK_BOARD_COMMENT_DELETE = defineTool({
     const deleted = await ctx.storage.taskBoard.deleteComment(
       input.id,
       requireOrg(ctx),
+      getUserId(ctx)!,
     );
     return { success: deleted };
   },


### PR DESCRIPTION
**Source:** post-merge hardening follow-up to #5688 (task comments, persisted).

**The gap:** `TASK_BOARD_COMMENT_UPDATE` and `TASK_BOARD_COMMENT_DELETE` scoped their mutation to the organization (via `commentInOrg`) but never checked the caller against the comment's `authorId`. Any org member with task-board access could edit another member's comment body, or delete their comment outright — the frontend doesn't gate this either (`CommentThreadCard`/`CommentEntry` render the edit/delete affordance for every comment regardless of author), so the tool was the only enforcement point and it wasn't checking.

**Why a maintainer wants this:** comment tampering/deletion across users is a real, silent data-integrity and trust issue in a feature that just shipped — worth closing before more orgs pick it up.

**Fix:** `updateComment`/`deleteComment` in `apps/api/src/storage/task-board.ts` now compare the existing comment's `author_id` against the caller for a body edit or a delete, returning null/false (→ the tool's existing "not found" error) when they don't match. Resolving/unresolving a thread stays open to any org member — that matches the existing UI, which treats "settle this thread" as a shared action, not an authored one.

**Regression test:** `apps/api/src/storage/task-board-comments.integration.test.ts` — asserts a non-author update/delete is rejected and the author's own succeeds (and that anyone can still toggle `resolved`). It needs a real Postgres connection (the `Storage Integration` CI workflow), which this sandbox doesn't have — I could not run it locally.

**Reviewer check:** `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres bun test apps/api/src/storage/task-board-comments.integration.test.ts` against a local Postgres with migrations applied.

**Locally verified:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint` on the three touched files (clean). Full CI (including the Storage Integration workflow) validates the new test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts task-board comment edits and deletes to the comment’s author to prevent tampering; resolving threads stays open to any org member. Adds a regression test and updates storage/tool APIs to enforce the check.

- **Bug Fixes**
  - Storage: `updateComment` and `deleteComment` now verify the caller matches the comment `authorId`; reject body edits/deletes on mismatch.
  - Tools: `TASK_BOARD_COMMENT_UPDATE`/`TASK_BOARD_COMMENT_DELETE` pass the caller id and return a clear error when editing someone else’s comment.
  - Tests: New integration test covers non-author edit/delete rejection, author success, and open resolve/unresolve behavior.

<sup>Written for commit e9f2b7c7c617945bc70f60942c0633c8cbf7b7ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

