### PR TITLE
fix(reports): stack auth-gate card above blurred backdrop

### DIFF
--- a/apps/web/src/routes/reports/auth-gate.tsx
+++ b/apps/web/src/routes/reports/auth-gate.tsx
@@ -514,7 +514,7 @@ export function ReportAuthOverlay({
       onClick={onClose}
     >
       <div className="absolute inset-0 bg-white/70 backdrop-blur-sm" />
-      <div onClick={(e) => e.stopPropagation()}>
+      <div className="relative z-10" onClick={(e) => e.stopPropagation()}>
         <ReportAuthCard domain={domain} />
       </div>
     </div>


### PR DESCRIPTION
## What is this contribution about?
On the `/report/$domain` route, the in-deck login overlay (`ReportAuthOverlay`, shown when an unauthenticated visitor tries to advance past the cover slide) rendered its sign-in card without an explicit stacking position. The sibling `backdrop-blur-sm` layer could paint above it, making the whole login card (including the "Continue" button and social-proof logos) appear blurred instead of just the background behind it. Added `relative z-10` to the card wrapper, matching the same pattern already used in the full-page `ReportAuthGate`.

## How did you verify your code works?
Verified manually by inspecting the DOM stacking of `ReportAuthOverlay` and confirming the card wrapper now has a higher effective z-index than the backdrop-blur sibling. No automated test covers this purely visual CSS stacking issue.

## Screenshots/Demonstration
N/A — one-line CSS class fix.

## How to Test
1. Go to `/report/<any-domain>` while logged out.
2. Advance past the first (cover) slide.
3. Confirm the login card (button, logos, text) renders sharp/legible, with only the background behind it blurred.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the login overlay on /report/:domain so the sign-in card renders above the blurred backdrop, staying sharp and clickable. Adds `relative z-10` to the card wrapper in `ReportAuthOverlay` to match `ReportAuthGate`.

<sup>Written for commit 6e6d7cec8aa1170fdda52ce5435283b70ee05d67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

