### PR TITLE
fix(sandbox): allow a repo-less /repo workspace in dispatch validation

### DIFF
--- a/packages/sandbox/daemon-go/internal/dispatch/dispatch_test.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/dispatch_test.go
@@ -102,6 +102,36 @@ func TestValidateHarnessInputAcceptsMinimalFrame(t *testing.T) {
 	}
 }
 
+// A task run on the bare `thread:<id>` key mounts /repo with no repo behind it
+// yet — it clones one mid-run with TASK_ADD_REPO.
+func TestValidateHarnessInputAcceptsRepolessRepoCwd(t *testing.T) {
+	frame := func(ws string) json.RawMessage {
+		return json.RawMessage(`{
+			"threadId": "t1",
+			"userMessage": {"role": "user"},
+			"harness": {},
+			"workspace": ` + ws + `,
+			"models": {"thinking": {"id": "m", "title": "M", "credentialId": "c"}},
+			"mcp": {"url": "https://example.com/mcp", "headers": {}, "expiresAt": 123},
+			"mode": "default",
+			"temperature": 0.5,
+			"toolApprovalLevel": "auto",
+			"user": {"id": "u", "email": "u@example.com"},
+			"organizationId": "org",
+			"agent": {"id": "a"}
+		}`)
+	}
+	if reason := ValidateHarnessInput(frame(`{"cwd": "/repo", "branch": "b"}`)); reason != "" {
+		t.Fatalf("repo-less /repo workspace rejected: %s", reason)
+	}
+	if reason := ValidateHarnessInput(frame(`{"cwd": "/repo", "branch": "b", "repo": {"owner": "o"}}`)); reason == "" {
+		t.Fatal("partial repo must be rejected")
+	}
+	if reason := ValidateHarnessInput(frame(`{"cwd": "/repo"}`)); reason == "" {
+		t.Fatal("missing branch must be rejected")
+	}
+}
+
 func TestRebaseWorkspaceCwd(t *testing.T) {
 	if got := RebaseWorkspaceCwd("/repo", "/work"); got == nil || *got != "/work/repo" {
 		t.Fatalf("got %v", got)

--- a/packages/sandbox/daemon-go/internal/dispatch/validate.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/validate.go
@@ -156,8 +156,12 @@ func validateWorkspace(raw json.RawMessage) string {
 	if *ws.Cwd != "/repo" {
 		return "workspace.cwd: must be \"/repo\" or null"
 	}
-	if ws.Repo == nil || ws.Repo.Owner == nil || ws.Repo.Name == nil || ws.Repo.ConnectedGithub == nil {
-		return "workspace.repo: required"
+	// `repo` is optional: a task run on the bare `thread:<id>` key gets a
+	// repo-less sandbox and clones into /repo mid-run via TASK_ADD_REPO. When
+	// present it must be complete.
+	if ws.Repo != nil &&
+		(ws.Repo.Owner == nil || ws.Repo.Name == nil || ws.Repo.ConnectedGithub == nil) {
+		return "workspace.repo: owner, name and connectedGithub are required"
 	}
 	if _, ok := probe["branch"]; !ok {
 		return "workspace.branch: required"


### PR DESCRIPTION
## Summary

A task run dispatched on the bare `thread:<id>` key gets its own repo-less sandbox and is expected to clone a repository into `/repo` mid-run via `TASK_ADD_REPO` (see the comment on `resolveWorkspace` in `apps/api/src/harnesses/sandbox-dispatch-client.ts`). Studio therefore sends `workspace: { cwd: "/repo", branch }` with no `repo`.

The Go daemon's dispatch validator required `workspace.repo` whenever `cwd === "/repo"`, so every such run died at dispatch with:

```
sandbox dispatch failed (400): {"detail":"workspace.repo: required","error":"bad_input"}
```

`repo` is now optional; when present it must still be complete (owner + name + connectedGithub). `branch` stays required. Nothing else in the daemon reads `workspace.repo`, and `/repo` is created at boot (`main.go`), so pointing the harness at it up front is safe.

## Testing

`go test ./internal/dispatch/` — added `TestValidateHarnessInputAcceptsRepolessRepoCwd` (accepts repo-less, still rejects a partial repo and a missing branch).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow repo-less `/repo` workspaces and add a run‑scoped MCP with `TASK_ADD_REPO` so sandbox task runs can clone a repo mid‑run and keep working in the same pod. Fixes daemon 400s and improves multi‑repo workflows with `claude-code`.

- **New Features**
  - Added a run-scoped MCP endpoint `POST /api/:org/mcp/task-run/:threadId` exposing task-board tools plus `TASK_ADD_REPO`; minted via `mcpEndpointUrl(..., target: "task-run", threadId)`.
  - Introduced `TASK_ADD_REPO` to bind a repo to the thread, push a credentialed clone to the daemon, wait for checkout, and set up `gh`; the task prompt now instructs when to call it and can list candidates.
  - Harness targets the task‑run surface and supports a repo‑less `/repo` on the bare `thread:<id>` key; the sandbox key stays bare for the whole run.

- **Bug Fixes**
  - Go daemon validation now accepts `cwd: "/repo"` without `workspace.repo` (still requires `branch`); if `repo` is present it must include `owner`, `name`, and `connectedGithub`.

<sup>Written for commit 58a31f99f4034df1819b86fb227233142590a0bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

