### PR TITLE
fix(task-board): reject resolving a reply comment

### DIFF
--- a/apps/api/src/storage/task-board-comments.integration.test.ts
+++ b/apps/api/src/storage/task-board-comments.integration.test.ts
@@ -90,4 +90,31 @@ describe("TaskBoardStorage comments", () => {
     );
     expect(ownDelete).toBe(true);
   });
+
+  it("rejects resolving a reply — resolved is a thread-root-only property", async () => {
+    const root = await storage.createComment({
+      taskBoardItemId: itemId,
+      organizationId: "org_test",
+      authorId: "user_1",
+      body: "root",
+    });
+    const reply = await storage.createComment({
+      taskBoardItemId: itemId,
+      organizationId: "org_test",
+      authorId: "user_1",
+      parentId: root!.id,
+      body: "reply",
+    });
+    expect(reply).not.toBeNull();
+
+    // Before fix: any reply could be marked resolved, a no-op the UI can't
+    // reflect since resolved only renders on the root.
+    const result = await storage.updateComment({
+      id: reply!.id,
+      organizationId: "org_test",
+      callerId: "user_123",
+      resolved: true,
+    });
+    expect(result).toBeNull();
+  });
 });

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -921,6 +921,11 @@ export class TaskBoardStorage {
     if (params.body !== undefined && existing.authorId !== params.callerId) {
       return null;
     }
+    // resolved is a thread property (see migration 159) — only a root carries
+    // it, so resolving a reply would silently no-op the intent.
+    if (params.resolved !== undefined && existing.parentId !== null) {
+      return null;
+    }
 
     const row = await this.db
       .updateTable("task_board_comments")
@@ -954,15 +959,15 @@ export class TaskBoardStorage {
   private async commentInOrg(
     id: string,
     organizationId: string,
-  ): Promise<{ authorId: string } | null> {
+  ): Promise<{ authorId: string; parentId: string | null } | null> {
     const row = await this.db
       .selectFrom("task_board_comments as c")
       .innerJoin("task_board_items as item", "item.id", "c.task_board_item_id")
-      .select(["c.id", "c.author_id"])
+      .select(["c.id", "c.author_id", "c.parent_id"])
       .where("c.id", "=", id)
       .where("item.organization_id", "=", organizationId)
       .executeTakeFirst();
-    return row ? { authorId: row.author_id } : null;
+    return row ? { authorId: row.author_id, parentId: row.parent_id } : null;
   }
 
   private itemFromDbRow(row: {


### PR DESCRIPTION
Follows the task-board comments feature (#5688/#5695): migration 159's own comment says "resolved is a thread property, so it only ever matters on a root", but `TaskBoardStorage.updateComment()` never enforced that — any org member could set `resolved: true`/`false` on a reply comment via `TASK_BOARD_COMMENT_UPDATE`.

Why it matters: the UI only ever renders `resolved` on a thread root, so this accepted a write with no way to observe or undo it, and leaves reply rows with meaningless `resolved` state in storage.

Fix: `updateComment()` now rejects (returns null, same 404-style contract as the existing not-found/not-author cases) any `resolved` update targeting a comment whose `parentId` is not null. Added a regression test in `task-board-comments.integration.test.ts` asserting a reply's resolve attempt returns null.

Reviewer check: `bun test apps/api/src/storage/task-board-comments.integration.test.ts` (needs local Postgres — CI runs this).

Locally verified: `bunx tsc --noEmit` (apps/api) green, `bunx oxlint` on both changed files clean, `bun run fmt` applied. Full CI covers the integration test run (no local Postgres in this environment).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject resolving reply comments in task-board storage. `updateComment()` now enforces that `resolved` is only allowed on thread roots, returning null for replies to prevent no-op writes.

- **Bug Fixes**
  - Guard in `updateComment()` rejects `resolved` updates on replies (returns null).
  - Added integration test to assert a reply resolve attempt returns null.

<sup>Written for commit 10776e8b2c556089b7c6c81f861554479628f6bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

