### PR TITLE
fix(task-board): drop redundant as-cast reading session user image

### DIFF
--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -1274,7 +1274,7 @@ function ActivitySection({
   const me: CommentAuthor = {
     id: session?.user?.id ?? "me",
     name: session?.user?.name ?? t("taskBoard.taskDialog.commentYouLabel"),
-    image: (session?.user as { image?: string | null } | undefined)?.image,
+    image: session?.user?.image,
   };
   const comments = useTaskBoardComments(item.id);
 


### PR DESCRIPTION
**Source:** bug found while auditing task-dialog.tsx (recently touched by #5688, task comments).

**Why:** `ActivitySection` read the current user's avatar via `(session?.user as { image?: string | null } | undefined)?.image` — an inline `as`-cast onto better-auth's session type. The cast is unnecessary: `session.user.image` already exists on the real (better-auth) session type, as proven by `bunx tsc --noEmit` passing with the cast removed. An `as`-cast here is a latent risk, not a working-as-intended pattern: if the field were ever renamed/removed upstream, the cast would silently keep compiling and only fail at runtime instead of at compile time.

**Fix:** replaced the cast with a direct `session?.user?.image` read.

**Verify:** `cd apps/web && bunx tsc --noEmit` (clean, same as before — proving the cast added nothing) and `bunx oxlint apps/web/src/layouts/task-board/task-dialog.tsx` (0 warnings/errors).

**Checks run locally:** `bun run fmt`, targeted `tsc --noEmit` in apps/web, `bunx oxlint` on the touched file. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed a redundant `as` cast when reading the current user's avatar in ActivitySection of `task-dialog.tsx`, replacing it with `session?.user?.image`. This restores proper typing from `better-auth` and avoids masking type changes, with no behavior change.

<sup>Written for commit 38508c61f8cbf678a4432cf7f9b673bfafbb39c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5701?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

