### PR TITLE
fix(reports): pin auth gate card to light theme in dark mode

### DIFF
--- a/apps/web/src/routes/reports/auth-gate.tsx
+++ b/apps/web/src/routes/reports/auth-gate.tsx
@@ -1,3 +1,4 @@
+import type { CSSProperties } from "react";
 import { AuthEntry } from "@/components/auth-entry";
 import type {
   AuthFlowEvent,
@@ -15,6 +16,32 @@ import {
   updateReportAuthAttempt,
 } from "./track";
 import { DECK } from "./templates/tokens";
+
+/** The deck is a fixed-light "paper" surface (see `DECK` above) regardless of
+ *  the app's dark mode, but `AuthEntry`/`UnifiedAuthForm` are shadcn
+ *  components styled with the app's theme CSS variables, which still resolve
+ *  to dark-mode values here (the `.dark` class lives on `<html>`, above this
+ *  card). Pinning those variables to their light values keeps the card
+ *  readable instead of rendering washed-out dark-mode buttons/inputs on a
+ *  white card. Values mirror `:root` in `packages/ui/src/styles/global.css`. */
+const FORCE_LIGHT_AUTH_VARS = {
+  "--background": "oklch(0.99 0.003 73)",
+  "--foreground": "oklch(0.145 0.01 60)",
+  "--card": "oklch(1 0 0)",
+  "--card-foreground": "oklch(0.145 0.01 60)",
+  "--muted-foreground": "oklch(0.46 0.012 60)",
+  "--accent": "oklch(0.955 0.008 80)",
+  "--accent-foreground": "oklch(0.2 0.01 60)",
+  "--border": "oklch(0.915 0.005 80)",
+  "--input": "oklch(0.88 0.006 80)",
+  "--ring": "oklch(0.205 0.012 60)",
+  "--primary": "oklch(0.205 0.012 60)",
+  "--primary-foreground": "oklch(0.98 0.005 60)",
+  "--destructive": "oklch(0.58 0.22 27)",
+  "--destructive-foreground": "oklch(0.97 0.01 17)",
+  "--success": "oklch(0.6 0.17 149)",
+  "--success-foreground": "oklch(0.98 0.02 156)",
+} as CSSProperties;
 
 function getReportAuthCopy(
   t: ReturnType<typeof useT>,
@@ -414,6 +441,7 @@ function ReportAuthCard({ domain }: { domain: string }) {
       aria-modal="true"
       aria-label={t("reports.authGate.accessYourReport")}
       className="w-full max-w-[440px] rounded-2xl bg-white px-6 py-6 card-shadow sm:rounded-3xl sm:px-8 sm:py-8"
+      style={FORCE_LIGHT_AUTH_VARS}
     >
       <AuthEntry
         callbackUrl={callbackUrl(domain)}


### PR DESCRIPTION
## What is this contribution about?
The report auth gate card (`ReportAuthGate`/`ReportAuthOverlay`) is a deliberately fixed-light "paper" surface, but the embedded sign-in form (`AuthEntry`/`UnifiedAuthForm`) uses the app's theme CSS variables. Since the `.dark` class lives on `<html>`, those variables still resolved to dark-mode values while the app is in dark mode, producing washed-out gray buttons and inputs on the white card. This pins the relevant CSS variables on the card to their light-mode values, mirroring `packages/ui/src/styles/global.css`'s `:root` block.

## How did you verify your code works?
Ran `bun run --cwd=apps/web check` (passes) and `bun run fmt` on the changed file. No automated test covers this visual-only fix; verified the variable values against the app's light theme tokens.

## Screenshots/Demonstration
N/A (fix targets dark-mode rendering of the existing report auth gate; no screenshot captured in this session).

## How to Test
1. Switch the app to dark mode (Settings > preferences, or OS dark mode with "system" theme).
2. Visit a report URL that shows the auth gate (`/report/:domain`) while unauthenticated.
3. Expected outcome: the "Continue with Google" button, email input, and "Continue" button render with normal light-theme colors instead of washed-out gray.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes washed-out buttons and inputs on the report auth gate in dark mode by forcing the embedded sign-in form to use light theme tokens on the white card.

- **Bug Fixes**
  - Pins form CSS variables to light values via `FORCE_LIGHT_AUTH_VARS` on the card, mirroring `:root` in `packages/ui/src/styles/global.css`.

<sup>Written for commit cbd195230d4e8231b0b1d777701656188808330a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

