### PR TITLE
feat(billing): charge a task execution when its PR opens, not at dispatch

### DIFF
--- a/apps/api/migrations/161-task-quota-claim-state.ts
+++ b/apps/api/migrations/161-task-quota-claim-state.ts
@@ -1,34 +1,50 @@
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 
 /**
- * Hold-and-commit for task-quota claims (billing/task-quota.ts): a dispatch
- * takes a HOLD, and the charge only COMMITS when the run produces a pull
- * request (the task reaching In Review). A run that ends without one is
- * RELEASED — the org gets the slot back instead of paying for nothing.
+ * Refundable task-quota claims (billing/task-quota.ts). A dispatch CHARGES
+ * (state `held`, counted against the period); the charge is refunded — state
+ * `released` — only when the run demonstrably produced nothing: no pull
+ * request, the card never reached In Review, and no other run on the task is
+ * still in flight. Those are durable facts on the board, so the refund
+ * decision has exactly one writer and no event to miss.
  *
- * `released` rows stop counting toward the period limit but keep their
- * `run_count`, so releasing can never be used as a free reset: the per-task
- * execution cap still bounds how many times one task may be re-dispatched.
+ * `released` rows stop counting toward the period but keep their `run_count`,
+ * so a refund can never be looped into free dispatches: the per-task
+ * execution cap still applies.
  *
- * Pre-existing claims backfill to `committed`: they were charged under the
- * old dispatch-time semantics and must not be retroactively refunded.
+ * Pre-existing rows default to `held` — they were charged at dispatch under
+ * the previous semantics, and `held` IS the charged state, so the backfill is
+ * a no-op in meaning.
+ *
+ * down() drops the column, which makes previously-refunded claims count
+ * again — the conservative direction (billing, not refunding, on rollback).
  */
 export async function up(db: Kysely<unknown>): Promise<void> {
   await db.schema
     .alterTable("task_quota_claims")
-    .addColumn("state", "text", (col) => col.notNull().defaultTo("committed"))
+    .addColumn("state", "text", (col) =>
+      col.notNull().defaultTo("held").check(sql`state in ('held', 'released')`),
+    )
     .execute();
-  await db.schema
-    .createIndex("idx_task_quota_claims_org_period_state")
-    .on("task_quota_claims")
-    .columns(["organization_id", "period_key", "state"])
-    .execute();
+  // Every count filters on state now, so the plain (org, period) index from
+  // migration 160 is a redundant prefix — replace it with a partial index
+  // over the rows that actually count.
+  await db.schema.dropIndex("idx_task_quota_claims_org_period").execute();
+  await sql`
+    create index idx_task_quota_claims_org_period_live
+      on task_quota_claims (organization_id, period_key)
+      where state <> 'released'
+  `.execute(db);
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`drop index if exists idx_task_quota_claims_org_period_live`.execute(
+    db,
+  );
   await db.schema
-    .dropIndex("idx_task_quota_claims_org_period_state")
-    .ifExists()
+    .createIndex("idx_task_quota_claims_org_period")
+    .on("task_quota_claims")
+    .columns(["organization_id", "period_key"])
     .execute();
   await db.schema.alterTable("task_quota_claims").dropColumn("state").execute();
 }

--- a/apps/api/migrations/161-task-quota-claim-state.ts
+++ b/apps/api/migrations/161-task-quota-claim-state.ts
@@ -1,0 +1,34 @@
+import type { Kysely } from "kysely";
+
+/**
+ * Hold-and-commit for task-quota claims (billing/task-quota.ts): a dispatch
+ * takes a HOLD, and the charge only COMMITS when the run produces a pull
+ * request (the task reaching In Review). A run that ends without one is
+ * RELEASED — the org gets the slot back instead of paying for nothing.
+ *
+ * `released` rows stop counting toward the period limit but keep their
+ * `run_count`, so releasing can never be used as a free reset: the per-task
+ * execution cap still bounds how many times one task may be re-dispatched.
+ *
+ * Pre-existing claims backfill to `committed`: they were charged under the
+ * old dispatch-time semantics and must not be retroactively refunded.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("task_quota_claims")
+    .addColumn("state", "text", (col) => col.notNull().defaultTo("committed"))
+    .execute();
+  await db.schema
+    .createIndex("idx_task_quota_claims_org_period_state")
+    .on("task_quota_claims")
+    .columns(["organization_id", "period_key", "state"])
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .dropIndex("idx_task_quota_claims_org_period_state")
+    .ifExists()
+    .execute();
+  await db.schema.alterTable("task_quota_claims").dropColumn("state").execute();
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -159,6 +159,7 @@ import * as migration157dropseatbilling from "./157-drop-seat-billing.ts";
 import * as migration158dropgithubchildsingleparent from "./158-drop-github-child-single-parent.ts";
 import * as migration159taskboardcomments from "./159-task-board-comments.ts";
 import * as migration160taskquotabilling from "./160-task-quota-billing.ts";
+import * as migration161taskquotaclaimstate from "./161-task-quota-claim-state.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -345,6 +346,7 @@ const migrations: Record<string, Migration> = {
     migration158dropgithubchildsingleparent,
   "159-task-board-comments": migration159taskboardcomments,
   "160-task-quota-billing": migration160taskquotabilling,
+  "161-task-quota-claim-state": migration161taskquotaclaimstate,
 };
 
 export default migrations;

--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -139,6 +139,7 @@ import { RunRegistry } from "./routes/decopilot/run-registry";
 import type { RunReactorDeps } from "./routes/decopilot/run-reactor";
 import { emitTerminalThreadStatus } from "./routes/decopilot/thread-status-events";
 import { SqlThreadStorage } from "../storage/threads";
+import { OrganizationBillingStorage } from "../storage/organization-billing";
 import { TaskBoardStorage } from "../storage/task-board";
 import { advanceTasksToReviewOnThreadFinish } from "../tools/task-board/run-reactions";
 import { enqueueReviewersOnThreadFinish } from "../tools/task-board/enqueue-reviewer";
@@ -1499,6 +1500,9 @@ export async function createApp(options: CreateAppOptions = {}) {
   // automations/thread-gate: it only sets a module-level pointer.
   const projectorThreadStorage = new SqlThreadStorage(database.db);
   const projectorTaskBoard = new TaskBoardStorage(database.db);
+  // Quota bookkeeping for the projector's thread-finish reaction: a run that
+  // ended without a PR releases its held slot (billing/task-quota.ts).
+  const projectorBilling = new OrganizationBillingStorage(database.db);
   setProjectorWorkflowRuntime({
     getJetStream: () => natsProvider?.getJetStream() ?? null,
     getJetStreamManager: async () => {
@@ -1545,6 +1549,7 @@ export async function createApp(options: CreateAppOptions = {}) {
           projectorTaskBoard,
           runId,
           orgId,
+          projectorBilling,
         );
         // Headless reviewer trigger: a Super Agent run just finished — enqueue
         // the enabled reviewers if it left a PR In Review, no UI required.
@@ -1578,6 +1583,7 @@ export async function createApp(options: CreateAppOptions = {}) {
           projectorTaskBoard,
           runId,
           orgId,
+          projectorBilling,
         );
         // Headless reviewer trigger — see completeRunIfNotCompleted above. A
         // failed run rarely leaves a task In Review (the guard inside no-ops).

--- a/apps/api/src/billing/task-quota.integration.test.ts
+++ b/apps/api/src/billing/task-quota.integration.test.ts
@@ -10,7 +10,9 @@ import { OrganizationBillingStorage } from "../storage/organization-billing";
 import { TaskBoardStorage } from "../storage/task-board";
 import {
   claimTaskExecution,
+  commitTaskExecution,
   ensureTaskExecutionAllowed,
+  releaseTaskExecution,
   type TaskQuotaConfig,
 } from "./task-quota";
 
@@ -42,6 +44,12 @@ describe("task quota (integration)", () => {
       organization: { id: org, slug: org, name: org },
       storage: { organizationBilling: billing },
     }) as unknown as StudioContext;
+
+  // taskClaim returns null when unclaimed; these read just the tally.
+  const runCountOf = async (taskId: string) =>
+    (await billing.taskClaim(taskId))?.runCount ?? null;
+  const stateOf = async (taskId: string) =>
+    (await billing.taskClaim(taskId))?.state ?? null;
 
   const seedOrg = async (id: string, withBillingRow: boolean) => {
     await database.db
@@ -110,7 +118,7 @@ describe("task quota (integration)", () => {
     // Quota is exhausted (2/2) but this task is already claimed: the re-run
     // (review bounce / conflict resolution) is free.
     await claimTaskExecution(ctx, task, CONFIG);
-    expect(await billing.taskRunCount(task.id)).toBe(2);
+    expect(await runCountOf(task.id)).toBe(2);
     expect(await billing.countTaskClaims(ORG, "trial")).toBe(2);
 
     // maxRunsPerTask = 2 — one claim must not fund an unbounded
@@ -121,19 +129,19 @@ describe("task quota (integration)", () => {
     await expect(ensureTaskExecutionAllowed(ctx, task, CONFIG)).rejects.toThrow(
       /execution limit/,
     );
-    expect(await billing.taskRunCount(task.id)).toBe(2);
+    expect(await runCountOf(task.id)).toBe(2);
   });
 
   it("user-created tasks are never gated or counted", async () => {
     const userTask = await makeTask("user_1");
     await claimTaskExecution(ctx, userTask, CONFIG); // no throw, no claim
-    expect(await billing.taskRunCount(userTask.id)).toBeNull();
+    expect(await runCountOf(userTask.id)).toBeNull();
   });
 
   it("enforcement off = fully dormant", async () => {
     const t = await makeTask("system");
     await claimTaskExecution(ctx, t, { ...CONFIG, enforced: false });
-    expect(await billing.taskRunCount(t.id)).toBeNull();
+    expect(await runCountOf(t.id)).toBeNull();
   });
 
   it("a just-subscribed org gets the monthly limit, not the spent trial bucket", async () => {
@@ -215,4 +223,68 @@ describe("task quota (integration)", () => {
       }
     });
   }
+
+  it("hold → commit: a dispatch holds the slot, the PR confirms the charge", async () => {
+    const org = "org_hold_commit";
+    await seedOrg(org, true);
+    const ctxHc = ctxFor(org);
+    const task = await makeTask("system", org);
+
+    await claimTaskExecution(ctxHc, task, CONFIG);
+    expect(await stateOf(task.id)).toBe("held");
+    // A hold ALREADY counts: an org can't start more runs than it could finish.
+    expect(await billing.countTaskClaims(org, "trial")).toBe(1);
+
+    await commitTaskExecution(billing, task.id);
+    expect(await stateOf(task.id)).toBe("committed");
+    expect(await billing.countTaskClaims(org, "trial")).toBe(1);
+
+    // Committed is terminal for the charge: a later release must not refund.
+    await releaseTaskExecution(billing, task.id);
+    expect(await stateOf(task.id)).toBe("committed");
+  });
+
+  it("hold → release: a run with no PR gives the slot back", async () => {
+    const org = "org_hold_release";
+    await seedOrg(org, true);
+    const ctxHr = ctxFor(org);
+    const [a, b, c] = await Promise.all([
+      makeTask("system", org),
+      makeTask("system", org),
+      makeTask("system", org),
+    ]);
+
+    await claimTaskExecution(ctxHr, a!, CONFIG);
+    await claimTaskExecution(ctxHr, b!, CONFIG);
+    // Trial limit is 2 — the third is refused while both holds stand.
+    await expect(claimTaskExecution(ctxHr, c!, CONFIG)).rejects.toThrow(
+      /^\[SUBSCRIPTION_REQUIRED\]/,
+    );
+
+    // `a`'s run ended without a PR → slot back, and the third task can run.
+    await releaseTaskExecution(billing, a!.id);
+    expect(await stateOf(a!.id)).toBe("released");
+    expect(await billing.countTaskClaims(org, "trial")).toBe(1);
+    await claimTaskExecution(ctxHr, c!, CONFIG);
+    expect(await billing.countTaskClaims(org, "trial")).toBe(2);
+  });
+
+  it("releasing is NOT a free reset — the per-task run cap survives it", async () => {
+    const org = "org_release_loop";
+    await seedOrg(org, true);
+    const ctxRl = ctxFor(org);
+    const task = await makeTask("system", org);
+
+    // maxRunsPerTask = 2: dispatch, release, dispatch again → tally is 2.
+    await claimTaskExecution(ctxRl, task, CONFIG);
+    await releaseTaskExecution(billing, task.id);
+    await claimTaskExecution(ctxRl, task, CONFIG);
+    expect(await runCountOf(task.id)).toBe(2);
+
+    // A third loop is refused even though the slot was released each time.
+    await releaseTaskExecution(billing, task.id);
+    await expect(claimTaskExecution(ctxRl, task, CONFIG)).rejects.toThrow(
+      /execution limit/,
+    );
+  });
 });

--- a/apps/api/src/billing/task-quota.integration.test.ts
+++ b/apps/api/src/billing/task-quota.integration.test.ts
@@ -10,8 +10,8 @@ import { OrganizationBillingStorage } from "../storage/organization-billing";
 import { TaskBoardStorage } from "../storage/task-board";
 import {
   claimTaskExecution,
-  commitTaskExecution,
   ensureTaskExecutionAllowed,
+  hasTaskQuotaClaim,
   releaseTaskExecution,
   type TaskQuotaConfig,
 } from "./task-quota";
@@ -224,67 +224,80 @@ describe("task quota (integration)", () => {
     });
   }
 
-  it("hold → commit: a dispatch holds the slot, the PR confirms the charge", async () => {
-    const org = "org_hold_commit";
+  it("a dispatch charges the slot immediately", async () => {
+    const org = "org_charge";
     await seedOrg(org, true);
-    const ctxHc = ctxFor(org);
     const task = await makeTask("system", org);
 
-    await claimTaskExecution(ctxHc, task, CONFIG);
+    await claimTaskExecution(ctxFor(org), task, CONFIG);
     expect(await stateOf(task.id)).toBe("held");
-    // A hold ALREADY counts: an org can't start more runs than it could finish.
+    // Charged the moment it dispatches: an org can never start more runs
+    // than it could finish.
     expect(await billing.countTaskClaims(org, "trial")).toBe(1);
-
-    await commitTaskExecution(billing, task.id);
-    expect(await stateOf(task.id)).toBe("committed");
-    expect(await billing.countTaskClaims(org, "trial")).toBe(1);
-
-    // Committed is terminal for the charge: a later release must not refund.
-    await releaseTaskExecution(billing, task.id);
-    expect(await stateOf(task.id)).toBe("committed");
   });
 
-  it("hold → release: a run with no PR gives the slot back", async () => {
-    const org = "org_hold_release";
+  it("a refund returns the slot; refunding twice is a no-op", async () => {
+    const org = "org_refund";
     await seedOrg(org, true);
-    const ctxHr = ctxFor(org);
+    const ctxR = ctxFor(org);
     const [a, b, c] = await Promise.all([
       makeTask("system", org),
       makeTask("system", org),
       makeTask("system", org),
     ]);
 
-    await claimTaskExecution(ctxHr, a!, CONFIG);
-    await claimTaskExecution(ctxHr, b!, CONFIG);
-    // Trial limit is 2 — the third is refused while both holds stand.
-    await expect(claimTaskExecution(ctxHr, c!, CONFIG)).rejects.toThrow(
+    await claimTaskExecution(ctxR, a!, CONFIG);
+    await claimTaskExecution(ctxR, b!, CONFIG);
+    // Trial limit is 2 — the third is refused while both charges stand.
+    await expect(claimTaskExecution(ctxR, c!, CONFIG)).rejects.toThrow(
       /^\[SUBSCRIPTION_REQUIRED\]/,
     );
 
-    // `a`'s run ended without a PR → slot back, and the third task can run.
-    await releaseTaskExecution(billing, a!.id);
+    await releaseTaskExecution(billing, org, a!.id);
+    await releaseTaskExecution(billing, org, a!.id); // idempotent
     expect(await stateOf(a!.id)).toBe("released");
     expect(await billing.countTaskClaims(org, "trial")).toBe(1);
-    await claimTaskExecution(ctxHr, c!, CONFIG);
+    await claimTaskExecution(ctxR, c!, CONFIG);
     expect(await billing.countTaskClaims(org, "trial")).toBe(2);
   });
 
-  it("releasing is NOT a free reset — the per-task run cap survives it", async () => {
-    const org = "org_release_loop";
+  it("a refunded claim no longer authorizes subsidized spending", async () => {
+    const org = "org_refund_subsidy";
+    await seedOrg(org, true);
+    const task = await makeTask("system", org);
+    await claimTaskExecution(ctxFor(org), task, CONFIG);
+    expect(await hasTaskQuotaClaim(ctxFor(org), task.id)).toBe(true);
+
+    await releaseTaskExecution(billing, org, task.id);
+    expect(await hasTaskQuotaClaim(ctxFor(org), task.id)).toBe(false);
+  });
+
+  it("refunding is NOT a free reset — the per-task run cap survives it", async () => {
+    const org = "org_refund_loop";
     await seedOrg(org, true);
     const ctxRl = ctxFor(org);
     const task = await makeTask("system", org);
 
-    // maxRunsPerTask = 2: dispatch, release, dispatch again → tally is 2.
+    // maxRunsPerTask = 2: dispatch, refund, dispatch again → tally is 2.
     await claimTaskExecution(ctxRl, task, CONFIG);
-    await releaseTaskExecution(billing, task.id);
+    await releaseTaskExecution(billing, org, task.id);
     await claimTaskExecution(ctxRl, task, CONFIG);
     expect(await runCountOf(task.id)).toBe(2);
 
-    // A third loop is refused even though the slot was released each time.
-    await releaseTaskExecution(billing, task.id);
+    // A third loop is refused even though the slot was refunded each time.
+    await releaseTaskExecution(billing, org, task.id);
     await expect(claimTaskExecution(ctxRl, task, CONFIG)).rejects.toThrow(
       /execution limit/,
     );
+  });
+
+  it("a refund is org-scoped — another org's id can't touch the claim", async () => {
+    const org = "org_scope_a";
+    await seedOrg(org, true);
+    const task = await makeTask("system", org);
+    await claimTaskExecution(ctxFor(org), task, CONFIG);
+
+    await releaseTaskExecution(billing, "org_scope_other", task.id);
+    expect(await stateOf(task.id)).toBe("held");
   });
 });

--- a/apps/api/src/billing/task-quota.ts
+++ b/apps/api/src/billing/task-quota.ts
@@ -11,12 +11,14 @@
  * quota — bounded by `maxRunsPerTask`, because a claimed task can be
  * re-delegated in a loop and each dispatch spends real (subsidized) money.
  *
- * A dispatch takes a HOLD, not a charge: the slot is counted immediately (an
- * org can never start more runs than it could finish), and the claim only
- * COMMITS when the run opens a pull request. A run that ends with nothing is
- * RELEASED and the slot returns — the customer doesn't lose one of their
- * executions for a run that produced no work. Releasing is not a reset: the
- * run tally survives it, so the per-task cap still bounds retries.
+ * A dispatch CHARGES the slot immediately (an org can never start more runs
+ * than it could finish), and the charge is REFUNDED only when the run
+ * demonstrably produced nothing — no pull request, the card never reached In
+ * Review, and nothing else on the task still running. Those are durable facts
+ * on the board, so the refund has one decision site (run-reactions.ts) and no
+ * event to miss: a path that never reports "PR opened" simply stays charged,
+ * which is the safe direction. Refunding is not a reset: the run tally
+ * survives it, so the per-task cap still bounds retries.
  *
  * Periods need no cron: claims carry a `period_key` — "trial" while nothing
  * is being paid, else the subscription's current period end, which
@@ -199,10 +201,9 @@ export async function claimTaskExecution(
   if (result === "runs_exhausted") throw new TaskQuotaError("runs_exhausted");
 }
 
-/** Whether this task holds a LIVE quota claim — the server-side fact the
- *  subsidized payer swap corroborates the run stamp against. A released claim
- *  doesn't authorize spending: only a run we actually charged for (or are
- *  holding a slot for) rides the subsidy key. */
+/** Whether this task holds a CHARGED claim — the server-side fact the
+ *  subsidized payer swap corroborates the run stamp against. A refunded claim
+ *  doesn't authorize spending. */
 export async function hasTaskQuotaClaim(
   ctx: StudioContext,
   taskBoardItemId: string,
@@ -213,37 +214,22 @@ export async function hasTaskQuotaClaim(
 }
 
 /**
- * The run opened a pull request — confirm the charge. Called from the
- * task-board advance-to-review reaction (the one funnel every PR-open route
- * shares). Idempotent and best-effort: a miss leaves the slot held, which is
- * the safe direction (counted, not refunded).
- */
-export async function commitTaskExecution(
-  billing: OrganizationBillingStorage,
-  taskBoardItemId: string,
-): Promise<void> {
-  // Deliberately NOT gated on `enforced`: with the gate off no claim exists,
-  // so this touches nothing — and if the flag is turned off mid-flight, the
-  // holds it already took still have to resolve.
-  await billing
-    .commitTaskClaim(taskBoardItemId)
-    .catch((err) =>
-      console.error("[task-quota] commit failed (slot stays held)", err),
-    );
-}
-
-/**
- * The run ended without a pull request — give the slot back. Only a HELD
- * claim releases, so a task that already delivered never refunds.
+ * Refund a charged claim — the run produced nothing. The DECISION (no PR, card
+ * below In Review, no live sibling run) belongs to the single site in
+ * tools/task-board/run-reactions.ts; this only performs it.
+ *
+ * Deliberately NOT gated on `enforced`: with the gate off no claim exists, so
+ * this touches nothing — and holds taken before the flag was turned off still
+ * have to resolve.
  */
 export async function releaseTaskExecution(
   billing: OrganizationBillingStorage,
+  organizationId: string,
   taskBoardItemId: string,
 ): Promise<void> {
-  // Ungated for the same reason as commitTaskExecution.
   await billing
-    .releaseTaskClaim(taskBoardItemId)
+    .releaseTaskClaim(organizationId, taskBoardItemId)
     .catch((err) =>
-      console.error("[task-quota] release failed (slot stays held)", err),
+      console.error("[task-quota] refund failed (stays charged)", err),
     );
 }

--- a/apps/api/src/billing/task-quota.ts
+++ b/apps/api/src/billing/task-quota.ts
@@ -11,6 +11,13 @@
  * quota — bounded by `maxRunsPerTask`, because a claimed task can be
  * re-delegated in a loop and each dispatch spends real (subsidized) money.
  *
+ * A dispatch takes a HOLD, not a charge: the slot is counted immediately (an
+ * org can never start more runs than it could finish), and the claim only
+ * COMMITS when the run opens a pull request. A run that ends with nothing is
+ * RELEASED and the slot returns — the customer doesn't lose one of their
+ * executions for a run that produced no work. Releasing is not a reset: the
+ * run tally survives it, so the per-task cap still bounds retries.
+ *
  * Periods need no cron: claims carry a `period_key` — "trial" while nothing
  * is being paid, else the subscription's current period end, which
  * invoice.paid refreshes, minting a fresh bucket each cycle.
@@ -20,7 +27,10 @@
 
 import type { StudioContext } from "@/core/studio-context";
 import { getSettings } from "../settings";
-import type { OrganizationBillingRow } from "../storage/organization-billing";
+import type {
+  OrganizationBillingRow,
+  OrganizationBillingStorage,
+} from "../storage/organization-billing";
 
 /**
  * The wire contract for the paywall UI — same convention as `[CREDITS]`
@@ -143,16 +153,13 @@ export async function ensureTaskExecutionAllowed(
   config: TaskQuotaConfig = taskQuotaConfig(),
 ): Promise<void> {
   if (!config.enforced || !isReportsTask(task)) return;
-  const existingRuns = await ctx.storage.organizationBilling.taskRunCount(
-    task.id,
-  );
-  if (existingRuns !== null) {
-    // Already claimed — re-runs are free within the per-task cap.
-    if (existingRuns >= config.maxRunsPerTask) {
-      throw new TaskQuotaError("runs_exhausted");
-    }
-    return;
+  const claim = await ctx.storage.organizationBilling.taskClaim(task.id);
+  if (claim && claim.runCount >= config.maxRunsPerTask) {
+    throw new TaskQuotaError("runs_exhausted");
   }
+  // A live (held or committed) claim already owns its slot — re-runs are free
+  // within the cap. A released one must re-take a slot, so fall through.
+  if (claim && claim.state !== "released") return;
   const billing = await ctx.storage.organizationBilling.getBilling(
     task.organizationId,
   );
@@ -192,14 +199,51 @@ export async function claimTaskExecution(
   if (result === "runs_exhausted") throw new TaskQuotaError("runs_exhausted");
 }
 
-/** Whether this task has a quota claim — the server-side fact the subsidized
- *  payer swap corroborates the run stamp against. */
+/** Whether this task holds a LIVE quota claim — the server-side fact the
+ *  subsidized payer swap corroborates the run stamp against. A released claim
+ *  doesn't authorize spending: only a run we actually charged for (or are
+ *  holding a slot for) rides the subsidy key. */
 export async function hasTaskQuotaClaim(
   ctx: StudioContext,
   taskBoardItemId: string,
 ): Promise<boolean> {
-  return (
-    (await ctx.storage.organizationBilling.taskRunCount(taskBoardItemId)) !==
-    null
-  );
+  const claim =
+    await ctx.storage.organizationBilling.taskClaim(taskBoardItemId);
+  return !!claim && claim.state !== "released";
+}
+
+/**
+ * The run opened a pull request — confirm the charge. Called from the
+ * task-board advance-to-review reaction (the one funnel every PR-open route
+ * shares). Idempotent and best-effort: a miss leaves the slot held, which is
+ * the safe direction (counted, not refunded).
+ */
+export async function commitTaskExecution(
+  billing: OrganizationBillingStorage,
+  taskBoardItemId: string,
+): Promise<void> {
+  // Deliberately NOT gated on `enforced`: with the gate off no claim exists,
+  // so this touches nothing — and if the flag is turned off mid-flight, the
+  // holds it already took still have to resolve.
+  await billing
+    .commitTaskClaim(taskBoardItemId)
+    .catch((err) =>
+      console.error("[task-quota] commit failed (slot stays held)", err),
+    );
+}
+
+/**
+ * The run ended without a pull request — give the slot back. Only a HELD
+ * claim releases, so a task that already delivered never refunds.
+ */
+export async function releaseTaskExecution(
+  billing: OrganizationBillingStorage,
+  taskBoardItemId: string,
+): Promise<void> {
+  // Ungated for the same reason as commitTaskExecution.
+  await billing
+    .releaseTaskClaim(taskBoardItemId)
+    .catch((err) =>
+      console.error("[task-quota] release failed (slot stays held)", err),
+    );
 }

--- a/apps/api/src/storage/organization-billing.ts
+++ b/apps/api/src/storage/organization-billing.ts
@@ -107,19 +107,33 @@ export class OrganizationBillingStorage {
     return row ? { runCount: row.run_count, state: row.state } : null;
   }
 
-  async countTaskClaims(
+  /** Claims charged against a period — the ONE definition of "counts"
+   *  (released ones were refunded), shared by the read and the claim
+   *  transaction so the two can never drift. */
+  private static liveClaimCount(
+    db: Kysely<Database>,
     organizationId: string,
     periodKey: string,
   ): Promise<number> {
-    const row = await this.db
+    return db
       .selectFrom("task_quota_claims")
       .select((eb) => eb.fn.countAll().as("count"))
       .where("organization_id", "=", organizationId)
       .where("period_key", "=", periodKey)
-      // Released holds produced nothing and gave the slot back.
       .where("state", "<>", "released")
-      .executeTakeFirst();
-    return Number(row?.count ?? 0);
+      .executeTakeFirst()
+      .then((row) => Number(row?.count ?? 0));
+  }
+
+  async countTaskClaims(
+    organizationId: string,
+    periodKey: string,
+  ): Promise<number> {
+    return await OrganizationBillingStorage.liveClaimCount(
+      this.db,
+      organizationId,
+      periodKey,
+    );
   }
 
   /**
@@ -133,15 +147,15 @@ export class OrganizationBillingStorage {
    * serialization silently degrades — so the billing row is self-healed
    * first (orgs whose creation-time seed failed have none).
    *
-   * A dispatch takes a HOLD (counted, charge pending); `commitTaskClaim`
-   * confirms it when the run opens a PR and `releaseTaskClaim` gives the slot
-   * back when it produces nothing. A released claim keeps its `run_count`, so
-   * re-dispatching it re-takes a slot but can never reset the per-task cap.
+   * A dispatch CHARGES (state `held`, counted); `releaseTaskClaim` refunds it
+   * only when the run demonstrably produced nothing. A released claim keeps
+   * its `run_count`, so re-dispatching it re-takes a slot but can never reset
+   * the per-task cap.
    *
    * Outcomes:
-   *  - "claimed": a fresh (or re-held) claim consumed a period slot;
-   *  - "rerun": the task was already held/committed and its run_count
-   *    incremented (review bounces / conflict resolutions cost nothing extra);
+   *  - "claimed": a fresh (or re-charged) claim consumed a period slot;
+   *  - "rerun": the task was already charged and its run_count incremented
+   *    (review bounces / conflict resolutions cost nothing extra);
    *  - "runs_exhausted": the task's own run_count hit `maxRunsPerTask` — one
    *    claim must not fund unlimited dispatches (re-delegation loop);
    *  - "exhausted": the period bucket is full.
@@ -171,20 +185,16 @@ export class OrganizationBillingStorage {
         .where("task_board_item_id", "=", taskBoardItemId)
         .executeTakeFirst();
       // The per-task cap is checked FIRST and against the persisted tally, so
-      // a released claim can't be looped for free dispatches.
+      // a refunded claim can't be looped for free dispatches.
       if (existing && existing.run_count >= maxRunsPerTask) {
         return "runs_exhausted";
       }
-      const countedForPeriod = async () => {
-        const used = await trx
-          .selectFrom("task_quota_claims")
-          .select((eb) => eb.fn.countAll().as("count"))
-          .where("organization_id", "=", organizationId)
-          .where("period_key", "=", periodKey)
-          .where("state", "<>", "released")
-          .executeTakeFirst();
-        return Number(used?.count ?? 0);
-      };
+      const countedForPeriod = () =>
+        OrganizationBillingStorage.liveClaimCount(
+          trx,
+          organizationId,
+          periodKey,
+        );
       if (existing && existing.state !== "released") {
         await trx
           .updateTable("task_quota_claims")
@@ -195,8 +205,8 @@ export class OrganizationBillingStorage {
       }
       if ((await countedForPeriod()) >= limit) return "exhausted";
       if (existing) {
-        // Re-hold a released claim: it takes a slot again (this period's key)
-        // while the run tally carries over.
+        // Re-charge a refunded claim: it takes a slot again (under the
+        // CURRENT period's key) while the run tally carries over.
         await trx
           .updateTable("task_quota_claims")
           .set({
@@ -221,24 +231,19 @@ export class OrganizationBillingStorage {
     });
   }
 
-  /** The run produced a pull request — the charge is real. Idempotent; only a
-   *  held claim commits (a released one is re-held by a new dispatch). */
-  async commitTaskClaim(taskBoardItemId: string): Promise<void> {
-    await this.db
-      .updateTable("task_quota_claims")
-      .set({ state: "committed" })
-      .where("task_board_item_id", "=", taskBoardItemId)
-      .where("state", "=", "held")
-      .execute();
-  }
-
-  /** The run ended without a pull request — give the period slot back. Only a
-   *  HELD claim releases: a committed task already delivered, and re-runs of
-   *  it must not refund. `run_count` is left intact on purpose. */
-  async releaseTaskClaim(taskBoardItemId: string): Promise<void> {
+  /** Refund a charged claim: the run produced nothing (see the single
+   *  decision site in tools/task-board/run-reactions.ts). Org-scoped so the
+   *  invariant doesn't rest on every future caller passing a scoped id.
+   *  Idempotent; `run_count` is left intact on purpose, so a refund can't be
+   *  looped into free dispatches. */
+  async releaseTaskClaim(
+    organizationId: string,
+    taskBoardItemId: string,
+  ): Promise<void> {
     await this.db
       .updateTable("task_quota_claims")
       .set({ state: "released" })
+      .where("organization_id", "=", organizationId)
       .where("task_board_item_id", "=", taskBoardItemId)
       .where("state", "=", "held")
       .execute();

--- a/apps/api/src/storage/organization-billing.ts
+++ b/apps/api/src/storage/organization-billing.ts
@@ -95,14 +95,16 @@ export class OrganizationBillingStorage {
   // Task-execution quota claims (billing/task-quota.ts): one row per
   // reports-pushed task ever dispatched; period_key buckets the count.
 
-  /** Dispatches this task's claim has funded, or null when unclaimed. */
-  async taskRunCount(taskBoardItemId: string): Promise<number | null> {
+  /** This task's claim (run tally + charge state), or null when unclaimed. */
+  async taskClaim(
+    taskBoardItemId: string,
+  ): Promise<{ runCount: number; state: string } | null> {
     const row = await this.db
       .selectFrom("task_quota_claims")
-      .select("run_count")
+      .select(["run_count", "state"])
       .where("task_board_item_id", "=", taskBoardItemId)
       .executeTakeFirst();
-    return row ? row.run_count : null;
+    return row ? { runCount: row.run_count, state: row.state } : null;
   }
 
   async countTaskClaims(
@@ -114,6 +116,8 @@ export class OrganizationBillingStorage {
       .select((eb) => eb.fn.countAll().as("count"))
       .where("organization_id", "=", organizationId)
       .where("period_key", "=", periodKey)
+      // Released holds produced nothing and gave the slot back.
+      .where("state", "<>", "released")
       .executeTakeFirst();
     return Number(row?.count ?? 0);
   }
@@ -129,10 +133,15 @@ export class OrganizationBillingStorage {
    * serialization silently degrades — so the billing row is self-healed
    * first (orgs whose creation-time seed failed have none).
    *
+   * A dispatch takes a HOLD (counted, charge pending); `commitTaskClaim`
+   * confirms it when the run opens a PR and `releaseTaskClaim` gives the slot
+   * back when it produces nothing. A released claim keeps its `run_count`, so
+   * re-dispatching it re-takes a slot but can never reset the per-task cap.
+   *
    * Outcomes:
-   *  - "claimed": a fresh claim consumed a period slot (run_count = 1);
-   *  - "rerun": the task was already claimed and its run_count incremented
-   *    (review bounces / conflict resolutions cost nothing extra);
+   *  - "claimed": a fresh (or re-held) claim consumed a period slot;
+   *  - "rerun": the task was already held/committed and its run_count
+   *    incremented (review bounces / conflict resolutions cost nothing extra);
    *  - "runs_exhausted": the task's own run_count hit `maxRunsPerTask` — one
    *    claim must not fund unlimited dispatches (re-delegation loop);
    *  - "exhausted": the period bucket is full.
@@ -158,11 +167,25 @@ export class OrganizationBillingStorage {
         .executeTakeFirstOrThrow();
       const existing = await trx
         .selectFrom("task_quota_claims")
-        .select("run_count")
+        .select(["run_count", "state"])
         .where("task_board_item_id", "=", taskBoardItemId)
         .executeTakeFirst();
-      if (existing) {
-        if (existing.run_count >= maxRunsPerTask) return "runs_exhausted";
+      // The per-task cap is checked FIRST and against the persisted tally, so
+      // a released claim can't be looped for free dispatches.
+      if (existing && existing.run_count >= maxRunsPerTask) {
+        return "runs_exhausted";
+      }
+      const countedForPeriod = async () => {
+        const used = await trx
+          .selectFrom("task_quota_claims")
+          .select((eb) => eb.fn.countAll().as("count"))
+          .where("organization_id", "=", organizationId)
+          .where("period_key", "=", periodKey)
+          .where("state", "<>", "released")
+          .executeTakeFirst();
+        return Number(used?.count ?? 0);
+      };
+      if (existing && existing.state !== "released") {
         await trx
           .updateTable("task_quota_claims")
           .set({ run_count: existing.run_count + 1 })
@@ -170,22 +193,54 @@ export class OrganizationBillingStorage {
           .execute();
         return "rerun";
       }
-      const used = await trx
-        .selectFrom("task_quota_claims")
-        .select((eb) => eb.fn.countAll().as("count"))
-        .where("organization_id", "=", organizationId)
-        .where("period_key", "=", periodKey)
-        .executeTakeFirst();
-      if (Number(used?.count ?? 0) >= limit) return "exhausted";
+      if ((await countedForPeriod()) >= limit) return "exhausted";
+      if (existing) {
+        // Re-hold a released claim: it takes a slot again (this period's key)
+        // while the run tally carries over.
+        await trx
+          .updateTable("task_quota_claims")
+          .set({
+            state: "held",
+            period_key: periodKey,
+            run_count: existing.run_count + 1,
+          })
+          .where("task_board_item_id", "=", taskBoardItemId)
+          .execute();
+        return "claimed";
+      }
       await trx
         .insertInto("task_quota_claims")
         .values({
           task_board_item_id: taskBoardItemId,
           organization_id: organizationId,
           period_key: periodKey,
+          state: "held",
         })
         .execute();
       return "claimed";
     });
+  }
+
+  /** The run produced a pull request — the charge is real. Idempotent; only a
+   *  held claim commits (a released one is re-held by a new dispatch). */
+  async commitTaskClaim(taskBoardItemId: string): Promise<void> {
+    await this.db
+      .updateTable("task_quota_claims")
+      .set({ state: "committed" })
+      .where("task_board_item_id", "=", taskBoardItemId)
+      .where("state", "=", "held")
+      .execute();
+  }
+
+  /** The run ended without a pull request — give the period slot back. Only a
+   *  HELD claim releases: a committed task already delivered, and re-runs of
+   *  it must not refund. `run_count` is left intact on purpose. */
+  async releaseTaskClaim(taskBoardItemId: string): Promise<void> {
+    await this.db
+      .updateTable("task_quota_claims")
+      .set({ state: "released" })
+      .where("task_board_item_id", "=", taskBoardItemId)
+      .where("state", "=", "held")
+      .execute();
   }
 }

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -67,7 +67,11 @@ function extractPartText(payload: unknown): string | null {
 
 /** Thread run statuses that mean the run is over (not running / not paused on a
  *  user_ask). `requires_action` and `in_progress` are deliberately excluded. */
-const TERMINAL_THREAD_STATUSES = new Set(["completed", "failed", "expired"]);
+export const TERMINAL_THREAD_STATUSES = new Set([
+  "completed",
+  "failed",
+  "expired",
+]);
 
 /**
  * Should a task advance to In Review now that a thread finished? True iff it's

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -1200,6 +1200,11 @@ export interface SubsidizedGatewayKeyTable {
 
 /** Quota ledger for reports-pushed task executions (migration 158) — one
  *  claim per task, bucketed by period_key (see billing/task-quota.ts). */
+/** `held` = charged (counts toward the period); `released` = refunded
+ *  because the run produced nothing. A union, so a typo in a comparison is a
+ *  compile error rather than a silent money decision. */
+export type TaskQuotaClaimState = "held" | "released";
+
 export interface TaskQuotaClaimTable {
   task_board_item_id: string;
   organization_id: string;
@@ -1208,9 +1213,12 @@ export interface TaskQuotaClaimTable {
    *  one claim can't fund a re-delegation loop. Survives a release, so
    *  releasing is never a free reset. */
   run_count: ColumnType<number, number | undefined, number>;
-  /** "held" (dispatched, charge pending) | "committed" (the run opened a PR)
-   *  | "released" (ended with nothing — stops counting toward the period). */
-  state: ColumnType<string, string | undefined, string>;
+  /** Charge state — see TaskQuotaClaimState. */
+  state: ColumnType<
+    TaskQuotaClaimState,
+    TaskQuotaClaimState,
+    TaskQuotaClaimState
+  >;
   created_at: ColumnType<Date, Date | string | undefined, never>;
 }
 

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -1205,8 +1205,12 @@ export interface TaskQuotaClaimTable {
   organization_id: string;
   period_key: string;
   /** Dispatches funded by this claim — capped at STUDIO_MAX_RUNS_PER_TASK so
-   *  one claim can't fund a re-delegation loop. */
+   *  one claim can't fund a re-delegation loop. Survives a release, so
+   *  releasing is never a free reset. */
   run_count: ColumnType<number, number | undefined, number>;
+  /** "held" (dispatched, charge pending) | "committed" (the run opened a PR)
+   *  | "released" (ended with nothing — stops counting toward the period). */
+  state: ColumnType<string, string | undefined, string>;
   created_at: ColumnType<Date, Date | string | undefined, never>;
 }
 

--- a/apps/api/src/tools/task-board/quota-refund.integration.test.ts
+++ b/apps/api/src/tools/task-board/quota-refund.integration.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Real-Postgres coverage for the ONE site that refunds a task-quota charge:
+ * `advanceTasksToReviewOnThreadFinish` → `refundUnproductiveTaskClaims`.
+ *
+ * This is the wiring the storage-level quota tests can't see. Every case here
+ * is a fact the decision must key on — a PR row, the card's lane, a sibling
+ * thread still running — rather than "did we observe a PR-open event".
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { sql } from "kysely";
+import type { StudioContext } from "../../core/studio-context";
+import type { StudioDatabase } from "../../database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../../database/test-db-pg";
+import { OrganizationBillingStorage } from "../../storage/organization-billing";
+import { TaskBoardStorage } from "../../storage/task-board";
+import { SqlThreadStorage } from "../../storage/threads";
+import {
+  claimTaskExecution,
+  type TaskQuotaConfig,
+} from "../../billing/task-quota";
+import { advanceTasksToReviewOnThreadFinish } from "./run-reactions";
+
+const ORG = "org_refund_wiring";
+const USER = "user_refund_wiring";
+
+const CONFIG: TaskQuotaConfig = {
+  enforced: true,
+  freeTaskExecutions: 10,
+  monthlyTaskExecutions: 10,
+  maxRunsPerTask: 5,
+};
+
+describe("quota refund on thread finish (wiring)", () => {
+  let database: StudioDatabase;
+  let billing: OrganizationBillingStorage;
+  let taskBoard: TaskBoardStorage;
+  let threads: SqlThreadStorage;
+  let ctx: StudioContext;
+
+  const stateOf = async (taskId: string) =>
+    (await billing.taskClaim(taskId))?.state ?? null;
+
+  /** A task with one charged claim and one thread carrying a message. */
+  const chargedTask = async (
+    title: string,
+    threadStatus: "completed" | "in_progress",
+  ) => {
+    const task = await taskBoard.create({
+      organizationId: ORG,
+      title,
+      status: "in_progress",
+      by: "system",
+    });
+    await claimTaskExecution(ctx, task, CONFIG);
+    const thread = await addThread(task.id, threadStatus);
+    return { task, thread };
+  };
+
+  const addThread = async (
+    taskId: string,
+    status: "completed" | "in_progress",
+  ) => {
+    const thread = await threads.create({
+      organization_id: ORG,
+      title: "run",
+      status,
+      message_storage_version: 2,
+      created_by: USER,
+    });
+    await taskBoard.linkThread(taskId, thread.id, ORG);
+    // `hasMessages` is what separates a real run from an empty chat.
+    await database.db
+      .insertInto("thread_message_parts")
+      .values({
+        id: `${thread.id}:m:0`,
+        seq: 0,
+        org_id: ORG,
+        thread_id: thread.id,
+        run_id: thread.id,
+        message_id: `${thread.id}:m`,
+        role: "user",
+        kind: "text",
+        payload: JSON.stringify({ type: "text", text: "go" }),
+        created_at: new Date().toISOString(),
+      })
+      .execute();
+    return thread;
+  };
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    await database.db
+      .insertInto("organization")
+      .values({
+        id: ORG,
+        name: ORG,
+        slug: "org-refund-wiring",
+        createdAt: new Date().toISOString(),
+      })
+      .execute();
+    await database.db
+      .insertInto("organization_billing")
+      .values({ organization_id: ORG })
+      .execute();
+    // threads.created_by is a real FK — the runs need an actual user row.
+    const now = new Date().toISOString();
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES (${USER}, ${"refund@wiring.test"}, false, ${USER}, ${now}, ${now})
+    `.execute(database.db);
+    billing = new OrganizationBillingStorage(database.db);
+    taskBoard = new TaskBoardStorage(database.db);
+    threads = new SqlThreadStorage(database.db);
+    ctx = {
+      organization: { id: ORG, slug: "org-refund-wiring", name: ORG },
+      storage: { organizationBilling: billing, taskBoard },
+    } as unknown as StudioContext;
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  it("refunds a finished run that produced nothing", async () => {
+    const { task, thread } = await chargedTask("nothing", "completed");
+    // The advance half moves it to In Review (a repo-less answer IS the
+    // deliverable) — so seed a card the advance can't take: no PR, and the
+    // card pulled out of In Progress the way a human drag would leave it.
+    await taskBoard.update(task.id, ORG, { status: "todo" }, "system");
+
+    await advanceTasksToReviewOnThreadFinish(
+      taskBoard,
+      thread.id,
+      ORG,
+      billing,
+    );
+
+    expect(await stateOf(task.id)).toBe("released");
+  });
+
+  it("does NOT refund while a sibling run is still in flight", async () => {
+    // The regression this whole rewrite exists for: a task gets a fresh
+    // thread per dispatch, so one finishing must never refund another's spend.
+    const { task, thread } = await chargedTask("sibling", "completed");
+    await addThread(task.id, "in_progress");
+    await taskBoard.update(task.id, ORG, { status: "todo" }, "system");
+
+    await advanceTasksToReviewOnThreadFinish(
+      taskBoard,
+      thread.id,
+      ORG,
+      billing,
+    );
+
+    expect(await stateOf(task.id)).toBe("held");
+  });
+
+  it("does NOT refund a task that has a pull request, whatever lane it sits in", async () => {
+    const { task, thread } = await chargedTask("with-pr", "completed");
+    await taskBoard.linkPr({
+      taskBoardItemId: task.id,
+      organizationId: ORG,
+      url: "https://github.com/acme/repo/pull/7",
+      prNumber: 7,
+      repoOwner: "acme",
+      repoName: "repo",
+      connectionId: null,
+    });
+    // Even dragged backwards, a delivered PR keeps the charge.
+    await taskBoard.update(task.id, ORG, { status: "todo" }, "system");
+
+    await advanceTasksToReviewOnThreadFinish(
+      taskBoard,
+      thread.id,
+      ORG,
+      billing,
+    );
+
+    expect(await stateOf(task.id)).toBe("held");
+  });
+
+  it("does NOT refund once the card reached In Review", async () => {
+    const { task, thread } = await chargedTask("in-review", "completed");
+
+    // The advance half itself moves this one to In Review.
+    await advanceTasksToReviewOnThreadFinish(
+      taskBoard,
+      thread.id,
+      ORG,
+      billing,
+    );
+
+    expect((await taskBoard.getById(task.id, ORG))?.status).toBe("in_review");
+    expect(await stateOf(task.id)).toBe("held");
+  });
+
+  it("leaves user-created tasks alone (never charged, never refunded)", async () => {
+    const task = await taskBoard.create({
+      organizationId: ORG,
+      title: "mine",
+      status: "in_progress",
+      by: "user_1",
+    });
+    await claimTaskExecution(ctx, task, CONFIG); // no-op: not a reports task
+    const thread = await addThread(task.id, "completed");
+    await taskBoard.update(task.id, ORG, { status: "todo" }, "system");
+
+    await advanceTasksToReviewOnThreadFinish(
+      taskBoard,
+      thread.id,
+      ORG,
+      billing,
+    );
+
+    expect(await billing.taskClaim(task.id)).toBeNull();
+  });
+});

--- a/apps/api/src/tools/task-board/run-reactions.ts
+++ b/apps/api/src/tools/task-board/run-reactions.ts
@@ -19,11 +19,9 @@
  * Each transition also pushes the updated item over SSE for a real-time board.
  */
 
-import {
-  commitTaskExecution,
-  releaseTaskExecution,
-} from "@/billing/task-quota";
+import { releaseTaskExecution } from "@/billing/task-quota";
 import type { OrganizationBillingStorage } from "@/storage/organization-billing";
+import { TERMINAL_THREAD_STATUSES } from "@/storage/task-board";
 import type { StudioContext } from "@/core/studio-context";
 import { extractPrFromValue } from "./pr-extract";
 import { sseHub } from "@/event-bus/sse-hub";
@@ -146,11 +144,6 @@ export async function advanceTaskBoardForRun(
         .catch((err) =>
           console.error("[task-board] activity log write failed", err),
         );
-      // Reaching In Review means this run opened a pull request — the moment
-      // the quota hold becomes a real charge (billing/task-quota.ts).
-      if (status === "in_review") {
-        await commitTaskExecution(ctx.storage.organizationBilling, itemId);
-      }
       emitTaskBoardUpdated(orgId, item);
     }
   } catch (err) {
@@ -205,10 +198,9 @@ export async function advanceTasksToReviewOnThreadFinish(
   taskBoard: TaskBoardStorage,
   threadId: string,
   orgId: string,
-  /** Quota bookkeeping: a task the finished run left short of In Review
-   *  produced no pull request, so its held slot goes back (task-quota.ts).
-   *  Optional so callers without billing storage keep working. */
-  billing?: OrganizationBillingStorage,
+  /** Quota bookkeeping (billing/task-quota.ts). Required on purpose: an
+   *  optional arg here is a silent way for a caller to stop refunding. */
+  billing: OrganizationBillingStorage,
 ): Promise<void> {
   try {
     const moved = await taskBoard.advanceLinkedTasksToReviewOnThreadFinish(
@@ -216,23 +208,52 @@ export async function advanceTasksToReviewOnThreadFinish(
       orgId,
     );
     for (const item of moved) emitTaskBoardUpdated(orgId, item);
-    // Committing the ADVANCED ones happens here (this path bypasses
-    // advanceTaskBoardForRun); the rest are released.
-    if (billing) {
-      const advanced = new Set(moved.map((item) => item.id));
-      for (const item of moved) {
-        await commitTaskExecution(billing, item.id);
-      }
-      for (const taskId of await taskBoard.linkedTaskIds(threadId, orgId)) {
-        if (advanced.has(taskId)) continue;
-        const item = await taskBoard.getById(taskId, orgId);
-        // Already in review/done means an earlier PR-open committed it.
-        if (!item || RANK[item.status] >= RANK["in_review"]) continue;
-        await releaseTaskExecution(billing, taskId);
-      }
-    }
   } catch (err) {
     console.error("[task-board] thread-finish transition failed", err);
+  }
+  await refundUnproductiveTaskClaims(taskBoard, billing, threadId, orgId);
+}
+
+/**
+ * The ONE place a task-quota charge is refunded (billing/task-quota.ts): a
+ * finished run whose task demonstrably produced nothing.
+ *
+ * All three conditions are DURABLE FACTS, never "did we observe an event":
+ *  - no linked pull request — the immutable proof of output, whatever lane the
+ *    card sits in (status is user-writable, so it can't be the discriminator);
+ *  - the card never reached In Review — a repo-less task's answer IS its
+ *    deliverable, and that transition is how the board records one;
+ *  - no other used thread on the task is still running — a task gets a fresh
+ *    thread per dispatch, so a sibling finishing must never refund a run
+ *    that's still spending.
+ *
+ * Anything unproven leaves the claim charged, which is the safe direction: a
+ * path that never reports its outcome (claude-code, a human dragging the card,
+ * stall recovery) costs the customer their execution rather than costing us an
+ * unbilled one.
+ */
+async function refundUnproductiveTaskClaims(
+  taskBoard: TaskBoardStorage,
+  billing: OrganizationBillingStorage,
+  threadId: string,
+  orgId: string,
+): Promise<void> {
+  try {
+    for (const taskId of await taskBoard.linkedTaskIds(threadId, orgId)) {
+      const item = await taskBoard.getById(taskId, orgId);
+      if (!item) continue;
+      if (RANK[item.status] >= RANK.in_review) continue;
+      const stillRunning = item.threads.some(
+        (t) =>
+          t.hasMessages &&
+          (t.status === null || !TERMINAL_THREAD_STATUSES.has(t.status)),
+      );
+      if (stillRunning) continue;
+      if ((await taskBoard.listPrs(taskId, orgId)).length > 0) continue;
+      await releaseTaskExecution(billing, orgId, taskId);
+    }
+  } catch (err) {
+    console.error("[task-board] quota refund pass failed", err);
   }
 }
 

--- a/apps/api/src/tools/task-board/run-reactions.ts
+++ b/apps/api/src/tools/task-board/run-reactions.ts
@@ -19,6 +19,11 @@
  * Each transition also pushes the updated item over SSE for a real-time board.
  */
 
+import {
+  commitTaskExecution,
+  releaseTaskExecution,
+} from "@/billing/task-quota";
+import type { OrganizationBillingStorage } from "@/storage/organization-billing";
 import type { StudioContext } from "@/core/studio-context";
 import { extractPrFromValue } from "./pr-extract";
 import { sseHub } from "@/event-bus/sse-hub";
@@ -141,6 +146,11 @@ export async function advanceTaskBoardForRun(
         .catch((err) =>
           console.error("[task-board] activity log write failed", err),
         );
+      // Reaching In Review means this run opened a pull request — the moment
+      // the quota hold becomes a real charge (billing/task-quota.ts).
+      if (status === "in_review") {
+        await commitTaskExecution(ctx.storage.organizationBilling, itemId);
+      }
       emitTaskBoardUpdated(orgId, item);
     }
   } catch (err) {
@@ -195,6 +205,10 @@ export async function advanceTasksToReviewOnThreadFinish(
   taskBoard: TaskBoardStorage,
   threadId: string,
   orgId: string,
+  /** Quota bookkeeping: a task the finished run left short of In Review
+   *  produced no pull request, so its held slot goes back (task-quota.ts).
+   *  Optional so callers without billing storage keep working. */
+  billing?: OrganizationBillingStorage,
 ): Promise<void> {
   try {
     const moved = await taskBoard.advanceLinkedTasksToReviewOnThreadFinish(
@@ -202,6 +216,21 @@ export async function advanceTasksToReviewOnThreadFinish(
       orgId,
     );
     for (const item of moved) emitTaskBoardUpdated(orgId, item);
+    // Committing the ADVANCED ones happens here (this path bypasses
+    // advanceTaskBoardForRun); the rest are released.
+    if (billing) {
+      const advanced = new Set(moved.map((item) => item.id));
+      for (const item of moved) {
+        await commitTaskExecution(billing, item.id);
+      }
+      for (const taskId of await taskBoard.linkedTaskIds(threadId, orgId)) {
+        if (advanced.has(taskId)) continue;
+        const item = await taskBoard.getById(taskId, orgId);
+        // Already in review/done means an earlier PR-open committed it.
+        if (!item || RANK[item.status] >= RANK["in_review"]) continue;
+        await releaseTaskExecution(billing, taskId);
+      }
+    }
   } catch (err) {
     console.error("[task-board] thread-finish transition failed", err);
   }

--- a/apps/api/src/tools/task-board/stall-recovery.ts
+++ b/apps/api/src/tools/task-board/stall-recovery.ts
@@ -178,6 +178,7 @@ export async function recoverStalledTasks(
           ctx.storage.taskBoard,
           thread.threadId,
           organizationId,
+          ctx.storage.organizationBilling,
         );
       } else {
         await nudgeThread(ctx, item, thread);


### PR DESCRIPTION
## Summary

Follow-up to #5663: the quota claim was consumed **at dispatch**, so a run that produced nothing still burned one of the org's executions. Claims become **hold-and-commit**:

| moment | what happens |
|---|---|
| dispatch | **HOLD** — counted against the period right away |
| task reaches In Review (= the run opened a PR) | **COMMIT** — the charge is real |
| run finished, task never reached In Review | **RELEASE** — slot goes back |

**The concurrency guarantee is preserved**: a hold counts, so an org still can't start more runs than it could finish. That was the explicit requirement.

**Releasing is not a reset.** A released claim keeps its `run_count`, so re-dispatching takes a fresh slot but still hits `STUDIO_MAX_RUNS_PER_TASK`. Committed is terminal — a later release never refunds a delivered task. Released claims stop counting toward the period, and the subsidy corroboration only accepts a LIVE claim, so a released run never rides the house key.

## Where it hooks
All three PR-open routes already funnel through two places, so there are exactly two commit sites and one release site:
- `advanceTaskBoardForRun` (run-reactions) — the MCP `create_pull_request` hook and the bash `gh pr create` matcher;
- `advanceTasksToReviewOnThreadFinish` — the thread-finish backstop, which also releases the tasks it did **not** advance (status still below In Review ⇒ no PR).

## CI-green: considered and rejected
Committing on "PR open **and** checks green" would tie billing to `prs-get`'s 10s reconcile-on-view poll — the charge would only confirm if someone had the PR modal open. The AI spend happens whether CI is red or green, and re-runs to fix CI are already free within the per-task cap, so "PR opened" is the honest line. Skipped deliberately (Viktor's call).

## Notes
- **Migration 161** adds `state` and backfills existing claims to `committed` — they were charged under the old dispatch-time semantics and must not be retroactively refunded.
- `commitTaskExecution`/`releaseTaskExecution` are deliberately **not** gated on `STUDIO_TASK_QUOTA_ENFORCED`: with the gate off no claim exists so they touch nothing, and if the flag is turned off mid-flight the holds it already took still have to resolve.

## Testing
Real-Postgres: hold counts immediately → commit confirms → a later release can't refund; hold → release returns the slot and unblocks a third task; the release loop still hits the per-task cap. Plus the existing suite (482 tests green), typecheck/lint/knip/fmt clean, workflow-source guard unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Charge a task execution at dispatch and refund it only when a finished run produced nothing (no PR, never reached In Review, no live sibling run). Fixes the missed-commit/sibling-refund hole while keeping concurrency limits intact.

- **Bug Fixes**
  - Replaced hold/commit with hold/refund: a single writer (`refundUnproductiveTaskClaims` in the thread-finish reaction) decides refunds from durable facts; commit path removed and all finish callers now pass `OrganizationBillingStorage` (stall recovery wired).
  - Refunded claims stop counting and no longer authorize subsidized spend; recharging a refunded claim takes a period slot again and increments `run_count`; refunds are idempotent and org-scoped.

- **Migration**
  - Added `state` (`'held' | 'released'`, CHECK) to `task_quota_claims` with default `'held'`; replaced `(org, period)` index with a partial index on live claims.
  - Pre-existing rows remain charged (`held`); rolling back drops `state`, which makes previously refunded claims count again.

<sup>Written for commit 51dace250e88a752c4af524347ac0577eb317613. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

