### PR TITLE
fix(sandbox-dispatch): surface a clear error on a malformed daemon frame line

### DIFF
--- a/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
@@ -5,8 +5,18 @@ import {
   dispatchWithContinuation,
   harnessRunsInSandbox,
   isUnreachableStatus,
+  ndjsonLines,
   SandboxUnreachableError,
 } from "./sandbox-dispatch-client";
+
+function bodyOf(text: string): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(text));
+      controller.close();
+    },
+  });
+}
 
 describe("harnessRunsInSandbox", () => {
   test("claude-code is sandbox-hosted", () => {
@@ -66,6 +76,25 @@ describe("the dispatch result wire", () => {
       true,
     );
     expect(harnessRunResultSchema.parse({ chunks: [] }).done).toBe(false);
+  });
+});
+
+describe("ndjsonLines", () => {
+  test("a corrupt line throws a clear error instead of a bare SyntaxError", async () => {
+    const seen: unknown[] = [];
+    let thrown: unknown;
+    try {
+      for await (const line of ndjsonLines(
+        bodyOf('{"chunks":[]}\nnot json\n'),
+      )) {
+        seen.push(line);
+      }
+    } catch (err) {
+      thrown = err;
+    }
+    expect(seen).toEqual([{ chunks: [] }]);
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).message).toMatch(/non-JSON line/);
   });
 });
 

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -535,7 +535,7 @@ async function* dispatchToDaemon(args: {
  * `withLivenessHeartbeat` keeps publishing on Studio's clock, so the run looks
  * healthy to the reaper and holds its thread's queue slot indefinitely.
  */
-async function* ndjsonLines(
+export async function* ndjsonLines(
   body: ReadableStream<Uint8Array>,
   signal?: AbortSignal,
 ): AsyncIterable<unknown> {
@@ -545,7 +545,20 @@ async function* ndjsonLines(
     const lines = buffer.split("\n");
     buffer = rest ? (lines.pop() ?? "") : "";
     for (const line of lines) {
-      if (line.trim().length > 0) yield JSON.parse(line) as unknown;
+      if (line.trim().length === 0) continue;
+      try {
+        yield JSON.parse(line) as unknown;
+      } catch (err) {
+        // Not the daemon's keepalive (blank) and not valid JSON either — the
+        // stream itself is corrupt, distinct from a well-formed frame failing
+        // schema validation upstream. Surface which line, since a bare
+        // SyntaxError gives no way to tell which byte of a long-running turn
+        // broke.
+        throw new Error(
+          `sandbox dispatch produced a non-JSON line: ${err instanceof Error ? err.message : String(err)} ` +
+            `(line: ${line.slice(0, 256)})`,
+        );
+      }
     }
   };
   const reader = (body as unknown as AsyncIterable<Uint8Array>)[


### PR DESCRIPTION
**Source**: bug found while hardening `apps/api/src/harnesses/sandbox-dispatch-client.ts` (this tick's focus area: sandbox dispatch client hardening) against malformed daemon messages.

**The bug**: `ndjsonLines()` reads the daemon's `/_sandbox/dispatch` response body as newline-delimited JSON and calls `JSON.parse(line)` on every non-blank line with no error handling. If the daemon (or the proxy between Studio and it) ever emits a truncated or otherwise non-JSON line — a real possibility on this trust boundary, since the transport note in this file explicitly documents the pod disappearing mid-stream — the raw `SyntaxError` propagates uncaught with no run id, handle, or offending line attached, making the failure much harder to diagnose than the neighboring error paths in this same function (which are already careful to attribute what happened).

**Fix**: wrap the `JSON.parse` in a try/catch and rethrow a descriptive `Error` naming the failure and echoing (truncated) the offending line, matching the attribution style already used elsewhere in `dispatchToDaemon`/`ndjsonLines`.

**Regression test**: added `describe("ndjsonLines")` in the test file — feeds a stream with one valid frame followed by a corrupt line and asserts the valid frame is still yielded first, then a clear `/non-JSON line/` error is thrown (not a bare `SyntaxError`). Exported `ndjsonLines` (previously module-private) so the test can exercise it directly.

**To confirm**: `bun test apps/api/src/harnesses/sandbox-dispatch-client.test.ts`

**Locally verified**: `bun run fmt`, `bunx tsc --noEmit` (apps/api), `bunx oxlint` on both changed files, and the targeted test file above — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Catches malformed NDJSON lines in sandbox dispatch and throws a clear, attributed error with the offending line snippet. This replaces bare SyntaxErrors and makes debugging stream issues much easier.

- **Bug Fixes**
  - Wrap `JSON.parse` in `ndjsonLines` with try/catch and rethrow a descriptive error that includes a truncated copy of the non-JSON line, matching `dispatchToDaemon` attribution.
  - Preserve good frames before the corrupt line; added a test to assert this and exported `ndjsonLines` for direct testing.

<sup>Written for commit a44d5472c4ac1cca5473ba1b0bb6dc421f68bbd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

