### PR TITLE
refactor(chat): remove dead pendingOptimistic set from ThreadManagerStore

### DIFF
--- a/apps/web/src/components/chat/store/thread-manager-store.ts
+++ b/apps/web/src/components/chat/store/thread-manager-store.ts
@@ -88,7 +88,6 @@ export class ThreadManagerStore {
   readonly hasMore = new Store<boolean>(false);
   readonly isFetchingMore = new Store<boolean>(false);
 
-  private pendingOptimistic = new Set<string>();
   /**
    * Short-lived block list of just-archived thread ids. Read by every code
    * path that could re-insert a row (`decopilot.thread.*` patch handler,
@@ -261,7 +260,6 @@ export class ThreadManagerStore {
   ): Promise<void> {
     if (!this.client) throw new Error("ThreadManagerStore: no MCP client");
     const snapshot = this.threads.get();
-    this.pendingOptimistic.add(id);
     this.threads.update((list) =>
       applyPatch(list, {
         ...(patch as unknown as RowPatch),
@@ -280,15 +278,12 @@ export class ThreadManagerStore {
     } catch (err) {
       this.threads.set(snapshot);
       throw err;
-    } finally {
-      this.pendingOptimistic.delete(id);
     }
   }
 
   private async optimisticHide(id: string): Promise<void> {
     if (!this.client) throw new Error("ThreadManagerStore: no MCP client");
     const snapshot = this.threads.get();
-    this.pendingOptimistic.add(id);
     // Tombstone BEFORE filtering the row out so any late `decopilot.thread.*`
     // event for this thread (e.g., the finish event for a run that was still
     // streaming at archive time) is dropped by handleFrame instead of
@@ -310,8 +305,6 @@ export class ThreadManagerStore {
       // silently dropped.
       this.archivedTombstones.delete(id);
       throw err;
-    } finally {
-      this.pendingOptimistic.delete(id);
     }
   }
 


### PR DESCRIPTION
A net-code-reduction cleanup found while auditing the chat thread-manager store for stability issues.

`ThreadManagerStore.pendingOptimistic` (a private `Set<string>`) is added to in `optimisticUpdate`/`optimisticHide` and deleted from in their `finally` blocks, but is never read anywhere — not in this file, not anywhere else in the repo (`rg pendingOptimistic` across `apps/web` and `packages` shows only the write sites in this one file). It tracks no visible behavior; it's pure write-only dead state.

Removing it is behavior-preserving: no reads existed to begin with, so nothing downstream changes. Net delta: -7 lines, +0.

How to confirm:
- `rg pendingOptimistic apps/web packages` shows zero references on main before this change, and zero after (the field is gone).
- `cd apps/web && bunx tsc --noEmit` is clean.
- `bun test apps/web/src/components/chat/store/thread-manager-store.test.ts` — 41 pass, 0 fail (existing coverage of `optimisticUpdate`/`optimisticHide` is untouched).

Locally ran: `bun run fmt`, targeted `tsc --noEmit` in `apps/web`, the one targeted test file above, and `bunx oxlint` on the touched file (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `pendingOptimistic` Set from `ThreadManagerStore` and its writes in `optimisticUpdate` and `optimisticHide`. No behavior change; this cleans up dead state and reduces code.

<sup>Written for commit 77da9fbd8ff748fc048ebd304068d57b251930a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

