### PR TITLE
fix(oauth): correct protected-resource scheme for virtual MCP connections

### DIFF
--- a/apps/api/src/api/org-scoped.integration.test.ts
+++ b/apps/api/src/api/org-scoped.integration.test.ts
@@ -199,16 +199,9 @@ describe("org-scoped API coexistence", () => {
   });
 
   it("corrects the scheme on protected-resource metadata for virtual MCP connections", async () => {
-    // Virtual MCPs (`virtual://<id>`) hand back Better Auth's generic
-    // protected-resource metadata, whose `resource` field is derived from
-    // the server's static `baseURL` config — not the incoming request. Behind
-    // a TLS-terminating proxy (e.g. the native app's local reverse proxy)
-    // that config can be `http` while the client actually connects over
-    // `https`, and an uncorrected `resource` fails the MCP SDK's resource
-    // check (`checkResourceAllowed`). The handler must override `resource`
-    // with the request-derived, `fixProtocol`-corrected URL — same as the
-    // `self` branch above. "test" isn't a `.localhost`/`127.0.0.1` host, so
-    // `fixProtocol` forces https regardless of what `baseURL` says.
+    // "test" isn't a `.localhost`/`127.0.0.1` host, so `fixProtocol` forces
+    // https on the response regardless of what the server's static `baseURL`
+    // config says — see the `virtual://` branch in oauth-proxy.ts.
     const now = new Date().toISOString();
     await database.db
       .insertInto("connections")

--- a/apps/api/src/api/org-scoped.integration.test.ts
+++ b/apps/api/src/api/org-scoped.integration.test.ts
@@ -199,9 +199,7 @@ describe("org-scoped API coexistence", () => {
   });
 
   it("corrects the scheme on protected-resource metadata for virtual MCP connections", async () => {
-    // "test" isn't a `.localhost`/`127.0.0.1` host, so `fixProtocol` forces
-    // https on the response regardless of what the server's static `baseURL`
-    // config says — see the `virtual://` branch in oauth-proxy.ts.
+    // "test" is a non-local host, so the response must come back https.
     const now = new Date().toISOString();
     await database.db
       .insertInto("connections")

--- a/apps/api/src/api/org-scoped.integration.test.ts
+++ b/apps/api/src/api/org-scoped.integration.test.ts
@@ -198,6 +198,45 @@ describe("org-scoped API coexistence", () => {
     }
   });
 
+  it("corrects the scheme on protected-resource metadata for virtual MCP connections", async () => {
+    // Virtual MCPs (`virtual://<id>`) hand back Better Auth's generic
+    // protected-resource metadata, whose `resource` field is derived from
+    // the server's static `baseURL` config — not the incoming request. Behind
+    // a TLS-terminating proxy (e.g. the native app's local reverse proxy)
+    // that config can be `http` while the client actually connects over
+    // `https`, and an uncorrected `resource` fails the MCP SDK's resource
+    // check (`checkResourceAllowed`). The handler must override `resource`
+    // with the request-derived, `fixProtocol`-corrected URL — same as the
+    // `self` branch above. "test" isn't a `.localhost`/`127.0.0.1` host, so
+    // `fixProtocol` forces https regardless of what `baseURL` says.
+    const now = new Date().toISOString();
+    await database.db
+      .insertInto("connections")
+      .values({
+        id: "conn_virtual",
+        organization_id: "org_1",
+        created_by: "user_1",
+        title: "Test Virtual Connection",
+        connection_type: "VIRTUAL",
+        connection_url: "virtual://vmcp_1",
+        status: "active",
+        pinned: false,
+        created_at: now,
+        updated_at: now,
+      })
+      .execute();
+
+    const res = await app.fetch(
+      new Request(
+        "http://test/api/org_1/mcp/conn_virtual/.well-known/oauth-protected-resource",
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { resource: string };
+    expect(body.resource).toBe("https://test/api/org_1/mcp/conn_virtual");
+  });
+
   it("rejects an API key whose organization differs from the URL org", async () => {
     mockApiKey("user_1", "org_2", "org_2");
 

--- a/apps/api/src/api/routes/oauth-proxy.ts
+++ b/apps/api/src/api/routes/oauth-proxy.ts
@@ -458,13 +458,10 @@ export const protectedResourceMetadataHandler = async (c: {
   // which supports Dynamic Client Registration and therefore accepts an
   // external MCP client's own `redirect_uri` (e.g. Claude Desktop). The
   // connection `oauth-proxy` only accepts Studio's own origin, so it can't
-  // serve external clients. Hand back Better Auth's metadata instead — but
-  // override `resource` with the request-derived, `fixProtocol`-corrected URL
-  // like the `self` branch above. Better Auth derives `resource` from the
-  // server's static `baseURL` config, which doesn't necessarily match the
-  // scheme the client actually connected over (e.g. behind a TLS-terminating
-  // local proxy where the origin is `https` but `baseURL` is configured as
-  // `http`) — an uncorrected mismatch fails the MCP SDK's resource check.
+  // serve external clients. Hand back Better Auth's metadata instead — with
+  // the same request-derived `resource` override as the `self` branch above,
+  // since Better Auth's own value comes from the static `baseURL` config, not
+  // the request.
   if (connectionUrl.startsWith("virtual://")) {
     return studioProtectedResourceMetadata(
       c.req.raw,

--- a/apps/api/src/api/routes/oauth-proxy.ts
+++ b/apps/api/src/api/routes/oauth-proxy.ts
@@ -458,9 +458,18 @@ export const protectedResourceMetadataHandler = async (c: {
   // which supports Dynamic Client Registration and therefore accepts an
   // external MCP client's own `redirect_uri` (e.g. Claude Desktop). The
   // connection `oauth-proxy` only accepts Studio's own origin, so it can't
-  // serve external clients. Hand back Better Auth's metadata instead.
+  // serve external clients. Hand back Better Auth's metadata instead — but
+  // override `resource` with the request-derived, `fixProtocol`-corrected URL
+  // like the `self` branch above. Better Auth derives `resource` from the
+  // server's static `baseURL` config, which doesn't necessarily match the
+  // scheme the client actually connected over (e.g. behind a TLS-terminating
+  // local proxy where the origin is `https` but `baseURL` is configured as
+  // `http`) — an uncorrected mismatch fails the MCP SDK's resource check.
   if (connectionUrl.startsWith("virtual://")) {
-    return studioProtectedResourceMetadata(c.req.raw);
+    return studioProtectedResourceMetadata(
+      c.req.raw,
+      protectedResourceUrlFromDiscovery(requestUrl),
+    );
   }
 
   const prefix = buildPathPrefix(orgSlug);

--- a/apps/api/src/api/routes/oauth-proxy.ts
+++ b/apps/api/src/api/routes/oauth-proxy.ts
@@ -458,10 +458,8 @@ export const protectedResourceMetadataHandler = async (c: {
   // which supports Dynamic Client Registration and therefore accepts an
   // external MCP client's own `redirect_uri` (e.g. Claude Desktop). The
   // connection `oauth-proxy` only accepts Studio's own origin, so it can't
-  // serve external clients. Hand back Better Auth's metadata instead — with
-  // the same request-derived `resource` override as the `self` branch above,
-  // since Better Auth's own value comes from the static `baseURL` config, not
-  // the request.
+  // serve external clients. Hand back Better Auth's metadata instead, with
+  // the same `resource` override as the `self` branch above.
   if (connectionUrl.startsWith("virtual://")) {
     return studioProtectedResourceMetadata(
       c.req.raw,


### PR DESCRIPTION
## Summary
- Fixes an OAuth failure when importing via the native app: `Protected resource http://... does not match expected https://... (or origin)`.
- Virtual MCP connections (`virtual://<id>`) returned Better Auth's protected-resource metadata unmodified. Its `resource` field is derived from the server's static `baseURL` config rather than the incoming request — behind a TLS-terminating local proxy (the native app) where `baseURL` is `http` but the client connects over `https`, this fails the MCP SDK's resource check.
- Applies the same request-derived, scheme-corrected `resource` override that the sibling `self`-connection branch already uses.

## Testing notes
- `bun run fmt`, `bun run lint`, `bun run check` all pass.
- Added `apps/api/src/api/org-scoped.integration.test.ts` — "corrects the scheme on protected-resource metadata for virtual MCP connections", mirroring the existing `self` test. **Not run locally** (no Postgres/Docker available in this sandbox) — please run before merging:
  ```
  DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres \
    bun test apps/api/src/api/org-scoped.integration.test.ts -t "virtual MCP"
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth failures for virtual MCP connections by overriding protected-resource metadata to use the request-derived, scheme-corrected URL, preventing http/https mismatches behind TLS-terminating proxies. Aligns the `virtual://` branch with the existing `self` connection behavior.

- **Bug Fixes**
  - For `virtual://`, pass the corrected resource URL to `studioProtectedResourceMetadata` via `protectedResourceUrlFromDiscovery(requestUrl)` in `apps/api/src/api/routes/oauth-proxy.ts`.
  - Add an integration test in `apps/api/src/api/org-scoped.integration.test.ts` to verify scheme correction.

- **Refactors**
  - Compressed comments to a single line per review.

<sup>Written for commit 8a0b3ad0475621ad186f05aae98852cb059259be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

