### PR TITLE
fix(task-board): stop swallowing a paywall rejection in review-decision re-enqueues

### DIFF
--- a/apps/api/src/tools/task-board/review-decision.ts
+++ b/apps/api/src/tools/task-board/review-decision.ts
@@ -15,6 +15,7 @@ import { enqueueSuperAgentForTask } from "./enqueue-super-agent";
 import { mergeLinkedPr } from "./merge-pr";
 import { fetchPrConflict } from "./prs-get";
 import { reactToApprovedPrConflict } from "./conflict-reaction";
+import { TaskQuotaError } from "@/billing/task-quota";
 
 /**
  * True when EVERY enabled reviewer has a token-VERIFIED `approve` as its latest
@@ -175,6 +176,10 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
         feedback: `${REVIEWER_LABEL[reviewer]}: ${notes}`,
         pr: pr ? { number: pr.number, url: pr.url } : undefined,
       }).catch((err) => {
+        // A paywall rejection is NOT best-effort — swallowing it would leave
+        // the task bounced-but-never-re-running with only a log line (same
+        // reasoning as reactToSuperAgentDelegation).
+        if (err instanceof TaskQuotaError) throw err;
         console.error("[task-board] request_changes re-enqueue failed", err);
       });
       return { status: updated.status, merged: false };
@@ -257,6 +262,9 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
             pr: { number: pr.number, url: pr.url },
             conflict: await fetchPrConflict(ctx, organizationId, pr),
           }).catch((err) => {
+            // Same paywall exception as above — a TaskQuotaError must
+            // surface, not be swallowed as a routine auto-resolve failure.
+            if (err instanceof TaskQuotaError) throw err;
             console.error("[task-board] conflict auto-resolve failed", err);
             return false;
           })


### PR DESCRIPTION
Bug found while auditing task-board orchestration error handling.

`enqueue-super-agent.ts`'s `reactToSuperAgentDelegation` deliberately rethrows `TaskQuotaError` instead of swallowing it (see its own comment: "A paywall rejection is NOT best-effort — swallowing it would leave the task delegated-but-never-running with only a log line"). `review-decision.ts` has two more call sites that dispatch a fresh Super Agent run via the same `enqueueSuperAgentForTask` — the `request_changes` bounce re-enqueue, and the auto-merge conflict auto-resolve — but both wrap it in a generic `.catch()` that logs and swallows *every* error, including `TaskQuotaError`.

Failure scenario: a reports-pushed task (the only kind the quota gates) is In Review and out of quota. A reviewer requests changes, or an approved PR hits a merge conflict under auto-merge. The activity/status write already committed (review recorded, task bounced to In Progress), but the re-enqueue throws `TaskQuotaError`, which the generic catch silently logs and discards — the task sits assigned to the Super Agent with nothing running behind it, and neither the reviewer nor the user is told why, exactly the state the sibling comment in `enqueue-super-agent.ts` calls out as the thing that must never happen.

Fix: both catch blocks now check `err instanceof TaskQuotaError` and rethrow, matching the pattern already used in `reactToSuperAgentDelegation`; every other error is still swallowed as before (dispatch/model-config failures stay best-effort, per the existing comments).

How to verify: `cd apps/api && bunx tsc --noEmit` (green); `bunx oxlint apps/api/src/tools/task-board/review-decision.ts` (0 warnings/errors). No test added — this function needs a live StudioContext + storage (integration/e2e tier per TESTING.md), and the existing `TaskQuotaError`-rethrow pattern in the sibling file has no unit test either since it's the same shape of fix.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api), `bunx oxlint` on the changed file. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop swallowing paywall (`TaskQuotaError`) rejections in `review-decision` re-enqueues so tasks don’t get stuck delegated with nothing running. Quota errors now surface instead of being silently logged.

- **Bug Fixes**
  - `request_changes` re-enqueue: rethrow `TaskQuotaError`; other errors remain best-effort.
  - Auto-merge conflict auto-resolve re-enqueue: rethrow `TaskQuotaError`; other errors remain best-effort.

<sup>Written for commit 8dd79abf6810ac11a57a252d576e85a27d65e62c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

