### PR TITLE
fix(harness-runner): don't crash when the studio MCP is still connecting

### DIFF
--- a/packages/harness-runner/claude-code.ts
+++ b/packages/harness-runner/claude-code.ts
@@ -246,17 +246,20 @@ export async function runClaudeCode(
               .join(" ") || "none configured"
           } | studio tools: ${studioToolCount}`,
         );
-        // Configured-but-empty is always a misconfiguration, never a valid run:
-        // the endpoint Studio mints for this harness is the org's management
-        // MCP, which always exposes its core tools. Zero means the run cannot
-        // touch Studio (no board update, no state change) while still producing
-        // a confident-looking answer — the exact failure that reads as success.
-        // Fail here so it surfaces as a broken run instead of a silent no-op.
-        if (input.mcp.url && studioToolCount === 0) {
+        // A run that cannot reach Studio (no board update, no state change)
+        // still produces a confident-looking answer — the failure that reads as
+        // success. Fail on it. Key off the server STATUS, not the tool count:
+        // an http MCP server connects asynchronously, so `pending` with zero
+        // mcp__ tools at init is the normal case, not a misconfiguration.
+        const broken = message.mcp_servers.filter((server) =>
+          ["failed", "needs-auth", "disabled"].includes(server.status),
+        );
+        if (input.mcp.url && broken.length > 0) {
           fail(
-            `studio MCP exposed no tools (${input.mcp.url}). The harness cannot ` +
-              `act on Studio; refusing to run rather than return a result that ` +
-              `changed nothing.`,
+            `studio MCP is unusable (${input.mcp.url}): ${broken
+              .map((server) => `${server.name}=${server.status}`)
+              .join(" ")}. The harness cannot act on Studio; refusing to run ` +
+              `rather than return a result that changed nothing.`,
           );
           return;
         }


### PR DESCRIPTION
## Problem

Runs in stg died immediately with:

```
harness_crashed: studio MCP exposed no tools (https://studio-stg.decocms.com/api/teste-franca/mcp/task-run/thrd_...)
```

Sandbox pod log (`studio-sandbox-stg-j7scm`) shows why:

```
[claude-code] sdk system/init +2s
[claude-code] mcp: studio=pending | studio tools: 0
```

The status is **pending**, not failed. An `http` MCP server connects asynchronously, so the SDK's `init` snapshot legitimately reports `pending` with no `mcp__` tools yet. The guard counted tools at that instant and treated the race as a misconfiguration, refusing to run. Server-side (`task-run-mcp.ts` / `TASK_RUN_TOOL_NAMES`) is fine.

## Fix

Key the guard off the server **status** — fail only on `failed` / `needs-auth` / `disabled`, which are the states that really mean the run can't touch Studio. `pending` proceeds; the log line still prints the tool count.

## Testing

Typecheck + fmt. Behavior verified against the stg pod log above; no test encoded the old tool-count check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-user Claude subscription support and prefer it for sandbox `claude-code` runs, billing the user's plan instead of org credits. Also fixes `harness-runner` to not crash when the Studio MCP is still connecting.

- **New Features**
  - Link a Claude Pro/Max token minted with `claude setup-token`; stored encrypted per user.
  - Sandbox `claude-code` runs use `CLAUDE_CODE_OAUTH_TOKEN` when linked and live; fall back to the org key if missing or expired.
  - New tools: `CLAUDE_SUBSCRIPTION_CONNECT`, `CLAUDE_SUBSCRIPTION_STATUS`, `CLAUDE_SUBSCRIPTION_DISCONNECT`; adds a Settings card to manage the token.
  - Adds `claude_subscriptions` table and storage APIs.

- **Bug Fixes**
  - `harness-runner`: guard now checks MCP server status and only fails on `failed`/`needs-auth`/`disabled` (no longer fails on `pending` with 0 tools).
  - Drops Smithery from OAuth discovery tests due to upstream 403.

<sup>Written for commit 9fcc3e5cdda77e7bc75f17bf45dd4cfa27fbbbb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

