### PR TITLE
refactor(shared): remove unused PermissionOption and PermissionGroup types

### DIFF
--- a/packages/shared/src/tools/registry-metadata.ts
+++ b/packages/shared/src/tools/registry-metadata.ts
@@ -247,24 +247,6 @@ export interface ToolMetadata {
   dangerous?: boolean; // Requires extra confirmation
 }
 
-/**
- * Permission option for UI components
- */
-export interface PermissionOption {
-  value: ToolName;
-  label: string;
-  dangerous?: boolean;
-}
-
-/**
- * Grouped permissions by category for UI
- */
-export interface PermissionGroup {
-  category: ToolCategory;
-  label: string;
-  permissions: PermissionOption[];
-}
-
 // ============================================================================
 // Tool Metadata (static - no server imports)
 // ============================================================================


### PR DESCRIPTION
**Source:** code audit of `packages/shared/src/tools/registry-metadata.ts` for dead code and unused exports.

**The problem:** `PermissionOption` and `PermissionGroup` interfaces (lines 250–266) were added in #3223 ("redesign org role permissions with capability-based UI") but never used in the codebase. They represent internal UI composition types that were likely superseded or abandoned.

**Behavior-preserving reduction:** `-18 / +0` lines. Verified with:
- `bunx tsc --noEmit` in packages/shared: green
- `bun test apps/api/src/tools/registry-metadata.test.ts`: 12 pass
- `bunx oxlint packages/shared/src/tools/registry-metadata.ts`: 0 errors
- `rg "PermissionOption|PermissionGroup"` over entire repo: zero references outside the deleted declarations

**Verifier steps:** `bun run fmt && bunx tsc --noEmit && bun test apps/api/src/tools/registry-metadata.test.ts && bunx oxlint packages/shared/src/tools/registry-metadata.ts`

**Checked locally:** all verification steps pass; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unused `PermissionOption` and `PermissionGroup` interfaces from `packages/shared/src/tools/registry-metadata.ts` to clean up dead code. No runtime or API changes.

- **Refactors**
  - Deleted `PermissionOption` and `PermissionGroup` types.
  - No references across the repo; TypeScript and tests pass.

<sup>Written for commit 3da0d5abea9a0b6c2095cb9591c6361634c23d4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

