### PR TITLE
fix(chat): translate ConnectionsBanner's hardcoded description string

### DIFF
--- a/apps/web/src/components/chat/connections-banner.tsx
+++ b/apps/web/src/components/chat/connections-banner.tsx
@@ -1,5 +1,6 @@
 import { cn } from "@deco/ui/lib/utils.ts";
 import { ChevronRight } from "@untitledui/icons";
+import { useT } from "@/i18n/use-t.ts";
 
 const FEATURED_ICONS = [
   { src: "/connections/github.png", name: "GitHub" },
@@ -30,6 +31,7 @@ interface ConnectionsBannerProps {
 }
 
 export function ConnectionsBanner({ onClick }: ConnectionsBannerProps) {
+  const t = useT();
   return (
     <button
       type="button"
@@ -41,7 +43,7 @@ export function ConnectionsBanner({ onClick }: ConnectionsBannerProps) {
       )}
     >
       <p className="flex-1 text-xs text-muted-foreground truncate text-left">
-        Connect tools and get more done
+        {t("chat.connectionsBanner.description")}
       </p>
 
       <FeaturedIcons />

--- a/apps/web/src/i18n/en/chat.ts
+++ b/apps/web/src/i18n/en/chat.ts
@@ -84,6 +84,7 @@ export const chat = {
     "useChatTask must be used within ChatContextProvider",
   "chat.collapsibleHighlight.closeLabel": "Close",
   "chat.collapsibleHighlight.closeTitle": "Close",
+  "chat.connectionsBanner.description": "Connect tools and get more done",
   "chat.connectionList.connectionNoun": "connections",
   "chat.connectionList.emptySummary":
     "This organization hasn't connected any MCPs.",

--- a/apps/web/src/i18n/pt-br/chat.ts
+++ b/apps/web/src/i18n/pt-br/chat.ts
@@ -89,6 +89,7 @@ export const chat = {
     "useChatTask deve ser usado dentro de ChatContextProvider",
   "chat.collapsibleHighlight.closeLabel": "Fechar",
   "chat.collapsibleHighlight.closeTitle": "Fechar",
+  "chat.connectionsBanner.description": "Conecte ferramentas e faça mais",
   "chat.connectionList.connectionNoun": "conexões",
   "chat.connectionList.emptySummary":
     "Esta organização não conectou nenhum MCP.",


### PR DESCRIPTION
**Source:** i18n hardening — the repo's CLAUDE.md rule that every user-facing string in `apps/web/src` must go through `t()`. `ConnectionsBanner` (rendered in the chat composer, `input.tsx` via `showConnectionsBanner`) had a raw English string with no translation.

**Why:** pt-br users see this English string with no way to localize it; it's a straightforward miss that the i18n compile-time check (`en`/`pt-br` key parity) doesn't catch because the string was never keyed at all.

**Change:** added `chat.connectionsBanner.description` to `i18n/en/chat.ts` and `i18n/pt-br/chat.ts`, and swapped the hardcoded JSX text for `t("chat.connectionsBanner.description")`.

**Verify:** `cd apps/web && bunx tsc --noEmit` (confirms the mirrored pt-br key satisfies `Record<keyof typeof enChat, string>`); render the chat composer with `showConnectionsBanner` true and toggle language in preferences to see the string switch.

**Checks run locally:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint` on the 3 touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localized the ConnectionsBanner description in the chat composer by replacing the hardcoded English text with `t("chat.connectionsBanner.description")`. pt-br users now see the correct translation.

- **Bug Fixes**
  - Added `chat.connectionsBanner.description` to `i18n/en/chat.ts` and `i18n/pt-br/chat.ts`.
  - Imported `useT` and replaced the JSX string in `apps/web/src/components/chat/connections-banner.tsx`.

<sup>Written for commit 734677b3c8307f5fe9d69b672775babac39e23ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

