### PR TITLE
fix(harness-runner): don't crash when the studio MCP is still connecting + ship it (sandbox 1.40.2)

### DIFF
--- a/.github/workflows/release-studio-sandbox.yaml
+++ b/.github/workflows/release-studio-sandbox.yaml
@@ -5,6 +5,10 @@ on:
     branches: [main]
     paths:
       - "packages/sandbox/**"
+      # The harness runner is packed INTO the image (see image/Dockerfile), so a
+      # fix there ships nothing without a rebuild. The version gate below still
+      # applies: bump packages/sandbox/package.json or the tag is reused.
+      - "packages/harness-runner/**"
   workflow_dispatch:
 
 env:

--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -67,7 +67,7 @@ type: application
 # 0.8.0: org-fs sidecar (orgFs.*) — privileged rclone mounter + main-container
 # mounts. NOTE: the publish workflow skips existing versions, so this MUST
 # stay ahead of the latest published chart (0.7.5 at time of writing).
-version: 0.10.14
+version: 0.10.15
 # appVersion tracks the studio-sandbox image version (image.tag default).
-appVersion: "1.40.1"
+appVersion: "1.40.2"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -46,7 +46,7 @@ image:
   # instead of silently moving with `:latest`. Bump in lockstep with
   # packages/sandbox/package.json — release-studio-sandbox.yaml tags
   # images using that version. NEVER set this to "latest" in prod.
-  tag: "1.40.1"
+  tag: "1.40.2"
   # Override to Never on local kind clusters that load via `kind load`.
   pullPolicy: IfNotPresent
 

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/sandbox",
-  "version": "1.40.1",
+  "version": "1.40.2",
   "private": true,
   "type": "module",
   "description": "Sandbox runtime for isolated Studio tool execution",


### PR DESCRIPTION
Supersedes #5712 (GitHub stopped syncing that PR's head to the pushed branch).

## Problem

stg runs die immediately:

```
harness_crashed: studio MCP exposed no tools (https://studio-stg.decocms.com/api/teste-franca/mcp/task-run/thrd_...)
```

Sandbox pod log:

```
[claude-code] sdk system/init +2s
[claude-code] mcp: studio=pending | studio tools: 0
```

Status is **pending**, not failed — an `http` MCP server connects asynchronously, so the SDK's `init` snapshot legitimately shows no `mcp__` tools yet. The guard counted tools at that instant and refused to run. Verified the endpoint is healthy from inside the stg sandbox pod (`curl` → 401 in 49ms), and the server side (`task-run-mcp.ts`, 8 tools) is fine. Not a claim/dispatch timeout.

## Fix

1. Guard on the server **status** — fail only on `failed` / `needs-auth` / `disabled`. `pending` proceeds; the log line still prints the tool count.
2. **Ship it.** The harness runner is packed *into* the sandbox image (`packages/sandbox/image/Dockerfile:156`), but `release-studio-sandbox.yaml` only triggered on `packages/sandbox/**` and only builds when `packages/sandbox/package.json`'s version is new — so a harness-runner-only fix shipped nothing. Added `packages/harness-runner/**` to the trigger paths and bumped sandbox 1.40.1 → 1.40.2 (chart `appVersion` + `image.tag`, chart 0.10.15).

On merge the workflow builds `studio-sandbox-go:1.40.2` and fires the `image-bump` dispatch to deco-apps-cd (stg + prod values). Running pods keep their image; only new claims pick it up.

## Testing

fmt + typecheck. Behavior verified against the stg pod logs above; no test encoded the old tool-count check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent harness runs from crashing when the Studio MCP is still connecting (`status=pending`). Ship the fix in sandbox 1.40.2 and ensure the sandbox image rebuilds on `packages/harness-runner/**` changes.

- **Bug Fixes**
  - In `packages/harness-runner/claude-code.ts`, only fail on `failed`/`needs-auth`/`disabled`; allow `pending` with zero tools and log the count.
  - Update `.github/workflows/release-studio-sandbox.yaml` to watch `packages/harness-runner/**`.

- **Dependencies**
  - Bump `@decocms/sandbox` to 1.40.2; Helm chart to 0.10.15; image tag/appVersion to 1.40.2.

<sup>Written for commit 999e2bf1d2d2970e288c70f3cf227fe5a79744fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

