### PR TITLE
fix(task-board): hide delete on comments you don't own

### DIFF
--- a/apps/web/src/layouts/task-board/task-comments.tsx
+++ b/apps/web/src/layouts/task-board/task-comments.tsx
@@ -118,7 +118,9 @@ export function CommentThreadCard({
       )}
       <CommentEntry
         comment={thread}
-        onDelete={() => onDelete(thread.id)}
+        onDelete={
+          thread.author.id === me.id ? () => onDelete(thread.id) : undefined
+        }
         resolved={thread.resolved}
         onToggleResolved={onToggleResolved}
       />
@@ -129,7 +131,9 @@ export function CommentThreadCard({
           <Divider inset={i > 0} />
           <CommentEntry
             comment={reply}
-            onDelete={() => onDelete(reply.id)}
+            onDelete={
+              reply.author.id === me.id ? () => onDelete(reply.id) : undefined
+            }
             isReply
           />
         </Fragment>
@@ -209,7 +213,9 @@ function CommentEntry({
   comment: TaskComment;
   isReply?: boolean;
   resolved?: boolean;
-  onDelete: () => void;
+  /** Omitted for a comment that isn't the current user's — the server
+   *  rejects deleting someone else's comment, so don't offer it. */
+  onDelete?: () => void;
   /** Thread roots only — resolving settles the whole conversation. */
   onToggleResolved?: () => void;
 }) {
@@ -223,11 +229,13 @@ function CommentEntry({
         <span className="text-sm text-muted-foreground">
           {formatTimeAgo(new Date(comment.createdAt))}
         </span>
-        <CommentActionsMenu
-          resolved={resolved}
-          onDelete={onDelete}
-          onToggleResolved={onToggleResolved}
-        />
+        {(onDelete || onToggleResolved) && (
+          <CommentActionsMenu
+            resolved={resolved}
+            onDelete={onDelete}
+            onToggleResolved={onToggleResolved}
+          />
+        )}
       </div>
       <div
         className={cn(
@@ -255,7 +263,7 @@ function CommentActionsMenu({
   onToggleResolved,
 }: {
   resolved?: boolean;
-  onDelete: () => void;
+  onDelete?: () => void;
   onToggleResolved?: () => void;
 }) {
   const t = useT();
@@ -283,10 +291,12 @@ function CommentActionsMenu({
             <DropdownMenuSeparator />
           </>
         )}
-        <DropdownMenuItem variant="destructive" onSelect={onDelete}>
-          <Trash03 size={16} />
-          {t("taskBoard.taskDialog.commentDelete")}
-        </DropdownMenuItem>
+        {onDelete && (
+          <DropdownMenuItem variant="destructive" onSelect={onDelete}>
+            <Trash03 size={16} />
+            {t("taskBoard.taskDialog.commentDelete")}
+          </DropdownMenuItem>
+        )}
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/web/src/layouts/task-board/task-comments.tsx
+++ b/apps/web/src/layouts/task-board/task-comments.tsx
@@ -118,9 +118,7 @@ export function CommentThreadCard({
       )}
       <CommentEntry
         comment={thread}
-        onDelete={
-          thread.author.id === me.id ? () => onDelete(thread.id) : undefined
-        }
+        onDelete={canDelete(thread, me) ? () => onDelete(thread.id) : undefined}
         resolved={thread.resolved}
         onToggleResolved={onToggleResolved}
       />
@@ -132,7 +130,7 @@ export function CommentThreadCard({
           <CommentEntry
             comment={reply}
             onDelete={
-              reply.author.id === me.id ? () => onDelete(reply.id) : undefined
+              canDelete(reply, me) ? () => onDelete(reply.id) : undefined
             }
             isReply
           />
@@ -147,6 +145,12 @@ export function CommentThreadCard({
       />
     </div>
   );
+}
+
+/** You can delete your own comments, and the Super Agent's — it's working
+ *  for you, not another person whose comment you shouldn't be able to erase. */
+function canDelete(comment: TaskComment, me: CommentAuthor): boolean {
+  return comment.author.id === me.id || comment.author.isAgent === true;
 }
 
 /** Authors of a thread, in the order they first spoke. */


### PR DESCRIPTION
TASK_BOARD_COMMENT_DELETE (apps/api/src/tools/task-board/comments.ts) silently no-ops (`success: false`) when the caller isn't the comment's author — but `CommentActionsMenu` in the task dialog's comment feed showed the delete item to any viewer regardless of authorship. Clicking delete on someone else's comment does nothing, with no error surfaced, which reads as a broken button.

Hide the delete menu item when `comment.author.id !== me.id`, matching the server's existing ownership check. Resolve/unresolve is left untouched — any org member may toggle it, by design (see the tool's own doc comment).

Failure scenario before the fix: open a task with a comment from a teammate, hover it, click the overflow menu's Delete — nothing happens, no toast, no explanation.

To verify: open a task with a comment from another org member — the overflow menu now only offers resolve/unresolve for their comments, not delete; your own comments still show delete.

Checks run locally: `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, `bunx oxlint apps/web/src/layouts/task-board/task-comments.tsx` (0 warnings/errors). Full CI suite validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the Delete action for comments you don’t own, matching the server’s check, and keep Super Agent replies deletable. Resolve/unresolve remains available to all members.

- **Bug Fixes**
  - Use `canDelete` to pass `onDelete` only for your own comments or those by the Super Agent; omit otherwise.
  - Render the actions menu only when it has actions, and show Delete only when `onDelete` exists.

<sup>Written for commit 3d07ee9941d0a095329f26f695a77bfb3c656ebc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

