### PR TITLE
fix(task-board): refund a task-quota claim when the dispatch itself never enqueues

### DIFF
--- a/apps/api/src/tools/task-board/enqueue-super-agent.ts
+++ b/apps/api/src/tools/task-board/enqueue-super-agent.ts
@@ -1,7 +1,11 @@
 import type { StudioContext } from "@/core/studio-context";
 import type { TaskBoardItem } from "@/storage/types";
 import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
-import { claimTaskExecution, TaskQuotaError } from "../../billing/task-quota";
+import {
+  claimTaskExecution,
+  releaseTaskExecution,
+  TaskQuotaError,
+} from "../../billing/task-quota";
 import { enqueueAgentRunForTask } from "./enqueue-task-run";
 import {
   buildClaudeCodeTaskPrompt,
@@ -138,32 +142,46 @@ export async function enqueueSuperAgentForTask(
   // BEFORE the write; here the claim is the enforcement.
   await claimTaskExecution(ctx, task);
 
-  // Sandbox-hosted claude-code takes every task that has a repo it could work
-  // in — bound before dispatch when there's exactly one, otherwise chosen
-  // mid-run with `TASK_ADD_REPO` (see `claude-code-task-run.ts`). An org with
-  // no repos imported runs Decopilot exactly as before.
-  const choice = await resolveTaskRepoChoice(ctx, task.organizationId);
+  try {
+    // Sandbox-hosted claude-code takes every task that has a repo it could work
+    // in — bound before dispatch when there's exactly one, otherwise chosen
+    // mid-run with `TASK_ADD_REPO` (see `claude-code-task-run.ts`). An org with
+    // no repos imported runs Decopilot exactly as before.
+    const choice = await resolveTaskRepoChoice(ctx, task.organizationId);
 
-  if (choice) {
-    const repo = "repo" in choice ? choice.repo : null;
+    if (choice) {
+      const repo = "repo" in choice ? choice.repo : null;
+      await enqueueAgentRunForTask(ctx, task, {
+        title: `Super Agent: ${task.title}`,
+        prompt: buildClaudeCodeTaskPrompt(task, repo, {
+          ...opts,
+          // Names the candidates in the prompt so the run doesn't spend its first
+          // step asking what exists.
+          ...("choices" in choice ? { repoChoices: choice.choices } : {}),
+        }),
+        temperature: 0.5,
+        harnessId: "claude-code",
+        ...(repo ? { repo } : {}),
+      });
+      return;
+    }
+
     await enqueueAgentRunForTask(ctx, task, {
       title: `Super Agent: ${task.title}`,
-      prompt: buildClaudeCodeTaskPrompt(task, repo, {
-        ...opts,
-        // Names the candidates in the prompt so the run doesn't spend its first
-        // step asking what exists.
-        ...("choices" in choice ? { repoChoices: choice.choices } : {}),
-      }),
+      prompt: buildSuperAgentTaskPrompt(task, opts),
       temperature: 0.5,
-      harnessId: "claude-code",
-      ...(repo ? { repo } : {}),
     });
-    return;
+  } catch (err) {
+    // Nothing was dispatched — no thread exists to ever trigger the
+    // thread-finish refund pass (run-reactions.ts). Without this, a failure
+    // here (e.g. no model configured — the exact case `enqueueAgentRunForTask`
+    // can throw for) would leave the claim charged forever with no run to show
+    // for it.
+    await releaseTaskExecution(
+      ctx.storage.organizationBilling,
+      task.organizationId,
+      task.id,
+    );
+    throw err;
   }
-
-  await enqueueAgentRunForTask(ctx, task, {
-    title: `Super Agent: ${task.title}`,
-    prompt: buildSuperAgentTaskPrompt(task, opts),
-    temperature: 0.5,
-  });
 }


### PR DESCRIPTION
Follows #5703 (refundable task-quota claims) and #5706 (claude-code dispatch by default).

**Bug**: `enqueueSuperAgentForTask` calls `claimTaskExecution` (charges the org's task-execution slot) BEFORE `resolveTaskRepoChoice`/`enqueueAgentRunForTask` run. `enqueueAgentRunForTask` can throw before ever creating a thread — the clearest case is `resolveTier(ctx, "smart")` failing with "no model configured", a failure mode `reactToSuperAgentDelegation`'s own comment calls out as expected ("a dispatch failure (e.g. no model configured) must never fail the write that delegated it"). When that happens, the claim stays charged forever: the only refund path (`refundUnproductiveTaskClaims` in run-reactions.ts) fires on thread-finish, keyed by `linkedTaskIds(threadId, ...)` — but no thread was ever created, so it's never eligible. The customer is billed an execution with zero output and zero recourse.

**Fix**: wrap the dispatch attempt in try/catch; on any failure, release the just-taken claim via `releaseTaskExecution` before rethrowing (the task-quota.ts header comment already documents this as the correct refund condition: "the run demonstrably produced nothing" — a dispatch that never enqueues is the most demonstrable case of that).

**Failure scenario**: an org with no model credential configured delegates a task to the Super Agent → `claimTaskExecution` charges a slot → `resolveTier` throws → the claim is permanently `held` with no thread, no PR, nothing for the existing refund pass to ever see.

**To confirm**: `cd apps/api && bunx tsc --noEmit` (green). No integration test added — this needs Postgres (unavailable in this sandbox) to exercise `claimTaskUnderLimit`/`releaseTaskClaim`; the existing `billing/task-quota.integration.test.ts` suite is the right place for a reviewer to add a case asserting the claim is released after a forced `enqueueAgentRunForTask` throw.

Checks run locally: `bun run fmt`, `bunx tsc --noEmit` (apps/api), `bunx oxlint` on the changed file (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refund task-quota claims when a Super Agent dispatch fails before a run is enqueued. Prevents charging orgs for runs that never start (e.g., no model configured).

- **Bug Fixes**
  - Wrap `enqueueSuperAgentForTask` dispatch in try/catch and call `releaseTaskExecution` on any pre-enqueue failure, then rethrow.
  - Handles errors from `resolveTaskRepoChoice` and `enqueueAgentRunForTask`, ensuring no orphaned claims when no thread is created.

<sup>Written for commit 72cd1f53641a4e01e8bbf34d771e757f8c4d9318. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

