### PR TITLE
refactor(shared): add JSDoc to registry-metadata export surface

### DIFF
--- a/packages/shared/src/tools/registry-metadata.ts
+++ b/packages/shared/src/tools/registry-metadata.ts
@@ -18,6 +18,9 @@
 // Types
 // ============================================================================
 
+/**
+ * High-level categories for grouping tools in the UI
+ */
 export type ToolCategory =
   | "Organizations"
   | "Connections"
@@ -240,6 +243,9 @@ const ALL_TOOL_NAMES = [
  */
 export type ToolName = (typeof ALL_TOOL_NAMES)[number];
 
+/**
+ * Metadata for a single MCP management tool — name, description, category, and danger flag.
+ */
 export interface ToolMetadata {
   name: ToolName;
   description: string;
@@ -1097,6 +1103,10 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
 // Permission Capabilities (high-level, user-facing permissions)
 // ============================================================================
 
+/**
+ * A gated permission capability — a user-facing feature grouping that maps to a set of MCP tools.
+ * Used for role editing and OAuth consent screens.
+ */
 export interface PermissionCapability {
   id: string;
   label: string;
@@ -1443,7 +1453,7 @@ const PERMISSION_CAPABILITIES: PermissionCapability[] = [
 ];
 
 /**
- * Tools every authenticated org member can use by default.
+ * Tools every authenticated org member can use by default, plus non-MCP resource keys.
  *
  * Granted at runtime by AccessControl (`checkResource`) to every member
  * regardless of role — NOT persisted into stored role permissions. To change
@@ -1494,6 +1504,10 @@ export const USER_ROLE_TOOLS: ReadonlySet<string> = new Set(
   ).flatMap((c) => c.tools),
 );
 
+/**
+ * Group gated capabilities by their UI section (e.g., "Organization", "Automations").
+ * Used to render the role editor's capability picker.
+ */
 export function getCapabilitySections(): Array<{
   section: string;
   capabilities: PermissionCapability[];
@@ -1511,6 +1525,9 @@ export function getCapabilitySections(): Array<{
   }));
 }
 
+/**
+ * Check whether all tools in a capability are granted.
+ */
 export function isCapabilityEnabled(
   cap: PermissionCapability,
   enabledTools: string[],
@@ -1520,6 +1537,9 @@ export function isCapabilityEnabled(
   return cap.tools.every((tool) => enabledTools.includes(tool));
 }
 
+/**
+ * Enable or disable all tools in a capability within a tool set.
+ */
 export function toggleCapabilityInTools(
   cap: PermissionCapability,
   currentTools: string[],


### PR DESCRIPTION
Add JSDoc documentation to 6 exported functions, types, and constants in `packages/shared/src/tools/registry-metadata.ts`:
- `ToolCategory` type
- `ToolMetadata` interface
- `PermissionCapability` interface
- `getCapabilitySections()` function
- `isCapabilityEnabled()` function
- `toggleCapabilityInTools()` function

The export surface was missing documentation that shared tooling consumers depend on; this reduces cognitive load for API consumers reading the type signatures and improves IDE autocomplete for these high-level abstractions.

**Changed lines:** -1 / +21 (purely additive JSDoc, no logic changes)

**Verification:** Ran `bun test apps/api/src/tools/registry-metadata.test.ts` (12 tests pass), `bunx tsc --noEmit` in packages/shared (green), `bunx oxlint` (0 errors).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add JSDoc to the exported API in `packages/shared/src/tools/registry-metadata.ts` to clarify capabilities and improve IDE autocomplete. Documents `ToolCategory`, `ToolMetadata`, `PermissionCapability`, `getCapabilitySections`, `isCapabilityEnabled`, and `toggleCapabilityInTools`; no logic or runtime changes.

<sup>Written for commit fdc15e910be8d99ca3e8477943d5da0634340a87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

