### PR TITLE
fix(task-board): allow deleting a Super Agent comment

### DIFF
--- a/apps/api/src/storage/task-board-comments.integration.test.ts
+++ b/apps/api/src/storage/task-board-comments.integration.test.ts
@@ -91,6 +91,25 @@ describe("TaskBoardStorage comments", () => {
     expect(ownDelete).toBe(true);
   });
 
+  it("lets any org member delete a Super Agent comment", async () => {
+    const comment = await storage.createComment({
+      taskBoardItemId: itemId,
+      organizationId: "org_test",
+      authorId: "super-agent",
+      body: "posted during a run",
+    });
+    expect(comment).not.toBeNull();
+
+    // Before fix: no caller's id ever equals "super-agent", so this comment
+    // could never be deleted by anyone.
+    const deleted = await storage.deleteComment(
+      comment!.id,
+      "org_test",
+      "user_123",
+    );
+    expect(deleted).toBe(true);
+  });
+
   it("rejects resolving a reply — resolved is a thread-root-only property", async () => {
     const root = await storage.createComment({
       taskBoardItemId: itemId,

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -945,14 +945,23 @@ export class TaskBoardStorage {
   }
 
   /** Delete a comment; a root takes its replies with it (FK cascade). False
-   *  when the comment isn't in this org, or isn't the caller's own. */
+   *  when the comment isn't in this org, or isn't the caller's own — except a
+   *  Super Agent comment, which nobody's `authorId` ever matches, so any org
+   *  member (already access-checked) may remove it; it's working for the org,
+   *  not a person whose comment they shouldn't be able to erase. */
   async deleteComment(
     id: string,
     organizationId: string,
     callerId: string,
   ): Promise<boolean> {
     const existing = await this.commentInOrg(id, organizationId);
-    if (!existing || existing.authorId !== callerId) return false;
+    if (!existing) return false;
+    if (
+      existing.authorId !== callerId &&
+      existing.authorId !== SUPER_AGENT_ASSIGNEE_ID
+    ) {
+      return false;
+    }
     await this.db
       .deleteFrom("task_board_comments")
       .where("id", "=", id)


### PR DESCRIPTION
Bug found while auditing `apps/api/src/tools/task-board/comments.ts` and its storage layer.

`TaskBoardStorage.deleteComment` requires `existing.authorId === callerId`. Comments posted during a task run are attributed to the Super Agent (`authorId = SUPER_AGENT_ASSIGNEE_ID`, see `comments.ts`'s `TASK_BOARD_COMMENT_CREATE` handler), but no real caller's id ever equals that constant — so once the agent posts a comment, it can never be deleted by anyone, an orphaned comment stuck in the thread forever.

Failure scenario: a task run posts a comment via the Super Agent identity; any org member opens the task and tries to delete it; `TASK_BOARD_COMMENT_DELETE` returns `{ success: false }` every time, no matter who calls it.

Fix: `deleteComment` now also allows the delete when the existing comment's `authorId` is the Super Agent sentinel — the caller is still access-checked by the tool (`ctx.access.check()`), just like the existing "anyone may resolve a thread" carve-out already does for `resolved`.

Added a regression test (`task-board-comments.integration.test.ts`) that creates a Super Agent comment and asserts a different org member can delete it — this needs the real-Postgres `Storage Integration` CI workflow to run (no Docker/Postgres available in this sandbox).

A reviewer can confirm with: `DATABASE_URL=... bun test apps/api/src/storage/task-board-comments.integration.test.ts` against a local Postgres.

Locally verified: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bunx oxlint` on both touched files — all clean. Full CI (including the storage-integration test) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where Super Agent–authored task board comments could not be deleted. Now any org member can delete those comments, with normal access checks enforced.

- **Bug Fixes**
  - Updated `TaskBoardStorage.deleteComment` to permit deletion when the comment’s `authorId` is the Super Agent sentinel, while keeping the caller check for all other comments.
  - Added an integration test to verify a different org member can delete a Super Agent comment.

<sup>Written for commit 5e41bb297fcab80d12c402801f444baa509abd29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

