### PR TITLE
fix(settings): cap PORT at 65535

### DIFF
--- a/apps/api/src/settings/resolve-config.test.ts
+++ b/apps/api/src/settings/resolve-config.test.ts
@@ -185,6 +185,12 @@ describe("resolveConfig port", () => {
       );
     },
   );
+
+  it("throws for a PORT above 65535", () => {
+    expect(() => resolveConfig(flags, { PORT: "70000" })).toThrow(
+      "PORT must be at most 65535",
+    );
+  });
 });
 
 describe("resolveConfig clickhouse max memory usage", () => {

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -229,7 +229,15 @@ export function resolveConfig(
   const settings: Omit<Settings, "databaseUrl" | "natsUrls"> = {
     // Core
     nodeEnv,
-    port: toPositiveIntegerOrDefault("PORT", flags.port || envVars.PORT, 3000),
+    // Capped at 65535: TCP ports don't exist above that, and an out-of-range
+    // value would otherwise pass validation here and only fail confusingly
+    // once the HTTP server tries to bind it.
+    port: toPositiveIntegerOrDefault(
+      "PORT",
+      flags.port || envVars.PORT,
+      3000,
+      65535,
+    ),
     baseUrl: flags.baseUrl || envVars.BASE_URL,
     publicUrl: resolveAliasedEnv(
       envVars.STUDIO_PUBLIC_URL,


### PR DESCRIPTION
Reactive hardening in resolve-config.ts (this tick's focus area): `toPositiveIntegerOrDefault("PORT", ...)` validates that PORT is a positive integer but has no upper bound, unlike sibling numeric settings (e.g. `CLICKHOUSE_MAX_MEMORY_USAGE`, `STUDIO_TOPUP_FEE_PERCENT`) which already pass the existing `max` param.

Failure scenario: a fat-fingered PORT (e.g. `30000` typed as `300000`, or any value above 65535) sails through config validation and only fails later, confusingly, when the HTTP server tries to bind an invalid port — instead of failing fast at boot with a clear `PORT must be at most 65535` message.

Fix: pass `65535` as the existing `max` argument to `toPositiveIntegerOrDefault` for PORT. No new logic — `max` was already implemented and used elsewhere in this same file.

Reviewer check: `cd apps/api && bun test src/settings/resolve-config.test.ts` — includes a new regression test asserting PORT=70000 throws.

Locally ran: `bun run fmt`, `bun test apps/api/src/settings/resolve-config.test.ts` (94 pass), `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap `PORT` at 65535 in `resolve-config` validation to catch invalid ports early and avoid bind-time failures. Adds a regression test that asserts `PORT > 65535` throws with "PORT must be at most 65535".

<sup>Written for commit 1093317ed8e510434ec83a591e83183c0b98ba86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

