### PR TITLE
fix(decopilot): make automation model-permission failures permanent

### DIFF
--- a/apps/api/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/api/src/api/routes/decopilot/dispatch-run.ts
@@ -868,7 +868,10 @@ async function prepareRun(
         models.thinking.id,
       )
     ) {
-      throw new Error("Model not allowed for your role");
+      throw new PermanentRunError(
+        "model_not_allowed",
+        "Model not allowed for your role",
+      );
     }
     // NOTE: only image/deepResearch are filtered today — fast/smart must be
     // added here when they gain a producer.

--- a/apps/api/src/core/dispatch-errors.test.ts
+++ b/apps/api/src/core/dispatch-errors.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { isPermanentRunError, PermanentRunError } from "./dispatch-errors";
+
+describe("isPermanentRunError", () => {
+  test("recognizes a model_not_allowed PermanentRunError", () => {
+    const err = new PermanentRunError(
+      "model_not_allowed",
+      "Model not allowed for your role",
+    );
+    expect(isPermanentRunError(err)).toBe(true);
+  });
+
+  test("does not treat a plain Error as permanent", () => {
+    expect(isPermanentRunError(new Error("boom"))).toBe(false);
+  });
+});

--- a/apps/api/src/core/dispatch-errors.ts
+++ b/apps/api/src/core/dispatch-errors.ts
@@ -1,4 +1,7 @@
-export type PermanentRunErrorCode = "empty_request" | "agent_not_found";
+export type PermanentRunErrorCode =
+  | "empty_request"
+  | "agent_not_found"
+  | "model_not_allowed";
 
 export class PermanentRunError extends Error {
   /** Own-enumerable so it survives DBOS error (de)serialization. */


### PR DESCRIPTION
**Bug**: in `dispatchRunAndWait` (`apps/api/src/api/routes/decopilot/dispatch-run.ts`), the disallowed-model check throws a plain `Error("Model not allowed for your role")`. The sibling checks right above/below it in the same function (`taskId` missing, agent not found) throw `PermanentRunError` instead, specifically because `fireAutomationWorkflow` (`apps/api/src/automations/dbos-workflow.ts`) branches on `isPermanentRunError(err)`: a permanent error deactivates the automation with a clear reason, anything else just marks the run failed and leaves the automation active to fire (and fail identically) again next cycle.

**Failure scenario**: an org admin narrows a role's model permissions (or a model access grant is revoked) while an automation configured to use that model is still active. Every future cron fire hits the same `checkModelPermission` failure, which — because it's a plain `Error` — never trips the permanent-error branch. The automation silently fails forever instead of being deactivated once with a clear reason, the way `agent_not_found`/`empty_request` already are for equally unrecoverable-on-retry cases.

**Fix**: added a `model_not_allowed` code to `PermanentRunErrorCode` and switched the throw to `PermanentRunError`. `apps/api/src/core/dispatch-errors.test.ts` (new, small) is the regression proof: it exercises `isPermanentRunError` against a `model_not_allowed` instance to lock in the classification the automation-deactivation path depends on.

**Verify**: `cd apps/api && bunx tsc --noEmit` (green), `bun test apps/api/src/core/dispatch-errors.test.ts` (2 pass), `bunx oxlint` on the 3 touched files (0 warnings/errors) — all run locally. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make model-permission failures permanent in Decopilot automations. Misconfigured automations now deactivate with a clear reason instead of failing on every cron.

- **Bug Fixes**
  - Disallowed-model check now throws `PermanentRunError("model_not_allowed")` instead of a plain `Error`.
  - Added `"model_not_allowed"` to `PermanentRunErrorCode`.
  - Added a unit test to ensure `isPermanentRunError` recognizes this code.

<sup>Written for commit bc8ede4f5c6d79f592ce2c09f27b99747117070a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

