### PR TITLE
refactor(task-board): dedupe claimConflictResolution/claimReviewChangesBounce

### DIFF
--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -620,28 +620,12 @@ export class TaskBoardStorage {
    * `status`/`assignee_id` against the first's committed row and matches
    * nothing.
    */
-  async claimConflictResolution(
+  claimConflictResolution(
     id: string,
     organizationId: string,
     by: string,
   ): Promise<TaskBoardItem | null> {
-    const row = await this.db
-      .updateTable("task_board_items")
-      .set({
-        status: "in_progress",
-        updated_by: by,
-        updated_at: new Date().toISOString(),
-      })
-      .where("id", "=", id)
-      .where("organization_id", "=", organizationId)
-      .where("status", "=", "in_review")
-      .where("assignee_id", "=", SUPER_AGENT_ASSIGNEE_ID)
-      .returningAll()
-      .executeTakeFirst();
-    if (!row) return null;
-    const item = this.itemFromDbRow(row);
-    await this.attachRefs([item], organizationId);
-    return item;
+    return this.claimInReviewSuperAgentSlot(id, organizationId, by);
   }
 
   /**
@@ -658,7 +642,23 @@ export class TaskBoardStorage {
    * Agent out from under the new owner. Same atomic-conditional-UPDATE pattern
    * as `claimConflictResolution`.
    */
-  async claimReviewChangesBounce(
+  claimReviewChangesBounce(
+    id: string,
+    organizationId: string,
+    by: string,
+  ): Promise<TaskBoardItem | null> {
+    return this.claimInReviewSuperAgentSlot(id, organizationId, by);
+  }
+
+  /**
+   * Shared fence behind both claim methods above: move a task from In Review
+   * to In Progress ONLY if it's still In Review AND still assigned to the
+   * Super Agent, returning the updated item to the single winner and null to
+   * everyone else. A single conditional UPDATE is atomic under READ
+   * COMMITTED — a second, concurrent caller re-checks `status`/`assignee_id`
+   * against the first's committed row and matches nothing.
+   */
+  private async claimInReviewSuperAgentSlot(
     id: string,
     organizationId: string,
     by: string,


### PR DESCRIPTION
**Source:** a code-reduction pass over `apps/api/src/storage/task-board.ts` — `claimConflictResolution` and `claimReviewChangesBounce` had byte-identical bodies (same conditional UPDATE, same WHERE fence on `status='in_review' AND assignee_id=SUPER_AGENT_ASSIGNEE_ID`, same attachRefs call), only the doc comment differed.

**Payoff:** one fence implementation instead of two silently-drifting copies — a future change to the claim semantics (e.g. widening the assignee check) previously had to be made in two places and could easily be made in only one.

**Change:** extracted the shared body into a private `claimInReviewSuperAgentSlot`, with both public methods now one-line delegations. Pure move, no behavior change — same SQL, same return semantics, same callers (`conflict-reaction.ts` and `review-decision.ts`, both owned by another worker's focus area this tick and untouched here).

**Verify:** `cd apps/api && bunx tsc --noEmit` (green) and `bunx oxlint apps/api/src/storage/task-board.ts` (0 warnings/errors) — no existing unit test directly exercises these two methods (their coverage lives in the tools that call them), so the typecheck + lint + manual diff review is the verification for this pure refactor. Full CI validates the rest.

**Reviewer command:** `cd apps/api && bunx tsc --noEmit`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduped `claimConflictResolution` and `claimReviewChangesBounce` by extracting their identical logic into a single private helper. No behavior change; both methods now delegate to the same atomic claim fence.

- **Refactors**
  - Added `claimInReviewSuperAgentSlot` to perform the conditional UPDATE (only if still `in_review` and assigned to the Super Agent) and return the updated item or null.
  - `claimConflictResolution` and `claimReviewChangesBounce` now call the helper with the same SQL and return semantics.

<sup>Written for commit f33590ce608fd162c4e26e15712e00f1df762af7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

