### PR TITLE
fix(task-board): make hover-only buttons reachable by keyboard focus

### DIFF
--- a/apps/web/src/layouts/task-board/tag-picker.tsx
+++ b/apps/web/src/layouts/task-board/tag-picker.tsx
@@ -106,7 +106,7 @@ export function TagPickerContent({
                   aria-label={t("taskBoard.taskDialog.deleteTagAriaLabel", {
                     name: tag.name,
                   })}
-                  className="flex size-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground opacity-0 hover:bg-background hover:text-destructive group-hover:opacity-100"
+                  className="flex size-5 shrink-0 items-center justify-center rounded-sm text-muted-foreground opacity-0 hover:bg-background hover:text-destructive focus-visible:opacity-100 group-hover:opacity-100"
                   onClick={(e) => {
                     e.stopPropagation();
                     onDelete(tag.id);

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -372,7 +372,7 @@ export function TaskBoardItemDialog({
                     aria-label={t(
                       "taskBoard.taskDialog.copyDescriptionAriaLabel",
                     )}
-                    className="absolute right-0 top-0 size-7 rounded-md border border-border bg-card text-muted-foreground opacity-0 shadow-sm transition-opacity hover:text-foreground group-hover:opacity-100"
+                    className="absolute right-0 top-0 size-7 rounded-md border border-border bg-card text-muted-foreground opacity-0 shadow-sm transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
                     onClick={() => handleCopy(description)}
                   >
                     {copied ? <Check size={14} /> : <Copy01 size={14} />}


### PR DESCRIPTION
Two hover-revealed icon buttons in the task-board dialogs were invisible to keyboard users: the tag delete button in the tag picker (`tag-picker.tsx`) and the "copy description" button in the task dialog (`task-dialog.tsx`) both used `opacity-0 ... group-hover:opacity-100` with no focus counterpart, so tabbing to them left the button fully invisible while still focused and clickable — a sighted keyboard user has no way to see what they're about to activate.

The repo already has the fix for this exact pattern one file over: `task-comments.tsx`'s comment-actions trigger uses `opacity-0 ... focus-visible:opacity-100 group-hover:opacity-100`. This PR applies the same `focus-visible:opacity-100` class to the other two hover-only buttons in the same directory, matching the established convention.

Why a maintainer wants it: keyboard-only users (and screen-magnifier users tabbing through) currently can't see the tag-delete or copy-description controls before activating them — a real, if small, a11y gap on interactive elements that are otherwise fully functional.

No behavior change for mouse users; this only adds a `:focus-visible` variant alongside the existing `:hover`/`group-hover` ones. Pure CSS-class addition, no logic touched.

To verify: open a task in the task dialog, tab to the description's copy button — it's now visible while focused (previously invisible). Same for the tag picker's per-tag delete button opened from the tag popover.

Checks run locally: `bun run fmt`, `bunx oxlint` on both touched files (0 warnings/errors). No type changes, so `tsc --noEmit` was skipped — full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make hover-only icon buttons in task-board dialogs visible on keyboard focus. Previously they stayed fully transparent while focused; now they appear on focus-visible with no change for mouse users.

- **Details**
  - Tag delete button in `apps/web/src/layouts/task-board/tag-picker.tsx`: add `focus-visible:opacity-100`.
  - Description copy button in `apps/web/src/layouts/task-board/task-dialog.tsx`: add `focus-visible:opacity-100`.

<sup>Written for commit 6e246748c2186f2fbd09ed76f86bf5a824c373af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5727?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

