### PR TITLE
fix(task-board): release a reviewer's claim if its dispatch failed

### DIFF
--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -890,6 +890,27 @@ export class TaskBoardStorage {
     return { claimed: false, token: existing?.token ?? token };
   }
 
+  /**
+   * Release a reviewer's claim on a cycle — the counterpart to `claimReviewer`
+   * for when the dispatch it was minted for never actually ran (e.g. the
+   * enqueue itself threw). Without this, a transient dispatch failure leaves
+   * the slot permanently claimed with no thread behind it: `claimReviewer`'s
+   * unique (task, reviewer, cycle) key would refuse every retry for the rest
+   * of that review cycle, so that reviewer would simply never run.
+   */
+  async releaseReviewerClaim(
+    taskBoardItemId: string,
+    reviewer: string,
+    cycleAt: Date,
+  ): Promise<void> {
+    await this.db
+      .deleteFrom("task_board_review_claims")
+      .where("task_board_item_id", "=", taskBoardItemId)
+      .where("reviewer", "=", reviewer)
+      .where("cycle_at", "=", cycleAt)
+      .execute();
+  }
+
   /** Resolve a review token to its claim (which reviewer, which cycle) for a
    *  task. Null when the token doesn't belong to this task — used to verify
    *  that a decision's caller really is the reviewer it claims to be. */

--- a/apps/api/src/tools/task-board/enqueue-reviewer.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.ts
@@ -136,9 +136,21 @@ export async function enqueueEnabledReviewers(
         return;
       }
       if (!claimed) return;
-      await enqueueReviewerForTask(ctx, task, kind, token).catch((err) => {
-        console.error(`[task-board] ${kind} reviewer enqueue failed`, err);
-      });
+      await enqueueReviewerForTask(ctx, task, kind, token).catch(
+        async (err) => {
+          console.error(`[task-board] ${kind} reviewer enqueue failed`, err);
+          // Nothing was dispatched — release the slot so the next poll/trigger
+          // can retry this reviewer instead of finding it permanently claimed.
+          await ctx.storage.taskBoard
+            .releaseReviewerClaim(task.id, kind, cycleAt)
+            .catch((releaseErr) =>
+              console.error(
+                `[task-board] ${kind} reviewer claim release failed`,
+                releaseErr,
+              ),
+            );
+        },
+      );
     }),
   );
 }


### PR DESCRIPTION
Bug found while auditing `apps/api/src/tools/task-board/enqueue-reviewer.ts` for stalled-run gaps.

`claimReviewer` takes a unique `(task, reviewer, cycle)` slot via an INSERT ... ON CONFLICT DO NOTHING before dispatching that reviewer's run. If `enqueueReviewerForTask` then throws — a transient dispatch failure such as no model configured, or a DB hiccup while creating/linking the run thread — the claim row is never released. Because the unique key is keyed on the review cycle (not the thread), every later trigger (the projector's run-finish hook, and the PRs-get modal's poll) sees the slot as already claimed and skips it for the rest of that cycle, even though no reviewer thread was ever created. That reviewer silently never runs on that PR, with no error surfaced anywhere — a mis-reported "reviewed" state on the board.

Fix: added `releaseReviewerClaim` (storage/task-board.ts) and call it from the `.catch` in `enqueueEnabledReviewers`, mirroring the existing `releaseTaskExecution` pattern in `enqueue-super-agent.ts`, which already handles the identical failure shape for the Super Agent's own dispatch.

How to verify: `cd apps/api && bunx tsc --noEmit` (green). No existing test exercised this path (it needs a real Postgres for `claimReviewer`/`releaseReviewerClaim`, out of scope for a local check) — CI's integration suite covers storage correctness. Ran `bun run fmt` and `bunx oxlint` on both changed files (clean).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release a reviewer's claim when dispatching their run fails, so the slot isn’t stuck for the rest of the review cycle. This allows retries and prevents the board from falsely showing the reviewer as completed.

- **Bug Fixes**
  - Added `releaseReviewerClaim(taskBoardItemId, reviewer, cycleAt)` to remove a stale (task, reviewer, cycle) claim when no run is created.
  - On `enqueueReviewerForTask` error inside `enqueueEnabledReviewers`, log and call `releaseReviewerClaim` (with a safe fallback log if release fails).

<sup>Written for commit 3f78ecb217403688153b5ceac1db81be026fca1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

