### PR TITLE
fix(task-board): reject deleting an id not in the caller's org

### DIFF
--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -297,15 +297,21 @@ export class TaskBoardStorage {
    *
    * User-created cards are deleted outright.
    */
-  async delete(id: string, organizationId: string, by: string): Promise<void> {
-    await this.inTransaction(async (trx) => {
+  /** Returns false when the id isn't in this org — a no-op, not a delete. */
+  async delete(
+    id: string,
+    organizationId: string,
+    by: string,
+  ): Promise<boolean> {
+    return this.inTransaction(async (trx) => {
       const row = await trx
         .selectFrom("task_board_items")
         .select(["created_by"])
         .where("id", "=", id)
         .where("organization_id", "=", organizationId)
         .executeTakeFirst();
-      if (row && isReportsTask({ createdBy: row.created_by })) {
+      if (!row) return false;
+      if (isReportsTask({ createdBy: row.created_by })) {
         await trx
           .updateTable("task_board_items")
           .set({ dismissed_at: new Date().toISOString(), updated_by: by })
@@ -314,7 +320,7 @@ export class TaskBoardStorage {
           // Already dismissed — keep the first dismissal's who/when.
           .where("dismissed_at", "is", null)
           .execute();
-        return;
+        return true;
       }
       await trx
         .deleteFrom("task_board_item_threads")
@@ -332,6 +338,7 @@ export class TaskBoardStorage {
         .where("id", "=", id)
         .where("organization_id", "=", organizationId)
         .execute();
+      return true;
     });
   }
 

--- a/apps/api/src/tools/task-board/delete.ts
+++ b/apps/api/src/tools/task-board/delete.ts
@@ -29,11 +29,14 @@ export const TASK_BOARD_ITEM_DELETE = defineTool({
     }
 
     // Storage dismisses a reports task instead of dropping the row.
-    await ctx.storage.taskBoard.delete(
+    const deleted = await ctx.storage.taskBoard.delete(
       input.id,
       organizationId,
       getUserId(ctx) ?? "system",
     );
+    if (!deleted) {
+      throw new Error(`Task board item not found: ${input.id}`);
+    }
     // Broadcast the removal so every open board drops the card live.
     emitTaskBoardDeleted(organizationId, input.id);
     return { success: true };

--- a/apps/api/src/tools/task-board/reports-task-guards.integration.test.ts
+++ b/apps/api/src/tools/task-board/reports-task-guards.integration.test.ts
@@ -186,6 +186,14 @@ describe("reports-task guards", () => {
     );
   });
 
+  it("rejects deleting an id that isn't in this org, instead of a silent no-op", async () => {
+    // Before fix: storage.delete() returned void, so a foreign/nonexistent id
+    // fell through as a false "success" and still broadcast the removal.
+    await expect(
+      TASK_BOARD_ITEM_DELETE.handler({ id: "task_does_not_exist" }, ctx),
+    ).rejects.toThrow("not found");
+  });
+
   it("restores a dismissed finding", async () => {
     const task = await taskBoard.create({
       organizationId: ORG,


### PR DESCRIPTION
**Source:** bug found while auditing `#5720` ("let report-generated tasks be deleted, and make it stick"), which had just fixed the exact same bug class for a different code path.

**The bug:** `TaskBoardStorage.delete()` returns `void` unconditionally. When the target id doesn't belong to the caller's org (or doesn't exist at all), the transaction's `SELECT ... WHERE id AND organization_id` finds nothing, and the function silently falls through having done nothing. `TASK_BOARD_ITEM_DELETE` still returns `{ success: true }` and broadcasts a live `emitTaskBoardDeleted` event for a card it never touched — a foreign/nonexistent id reads as a successful delete instead of failing. `#5720`'s own commit message calls out exactly this failure mode ("a refused delete read as a successful one") for the reports-task guard it fixed, but the not-found/cross-org case was left with the same shape.

**Failure scenario:** call `TASK_BOARD_ITEM_DELETE` with an id from another org, or one that's already gone — the tool resolves successfully and every open board for the caller's org drops a card by that id from its UI, even though nothing was deleted server-side.

**Fix:** `delete()` now returns whether the id existed in this org; the tool throws `"Task board item not found"` and skips the broadcast when it didn't — matching the existing behavior of `TASK_BOARD_ITEM_UPDATE`, which already throws the same message for the same condition.

**Regression test:** added to `reports-task-guards.integration.test.ts` — asserts `TASK_BOARD_ITEM_DELETE.handler` rejects with "not found" for an unknown id (uses real Postgres via the existing test harness in that file).

**To confirm:** `bun test apps/api/src/tools/task-board/reports-task-guards.integration.test.ts` (needs Postgres — not available in this sandbox).

**Locally verified:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bunx oxlint` on the 3 touched files — all clean. Full CI (including the Postgres-backed integration test) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject deleting task-board items that aren't in the caller's org or don't exist. Prevents false success responses and accidental live removals for foreign/nonexistent ids.

- **Bug Fixes**
  - `TaskBoardStorage.delete` now returns a boolean; false when the id isn’t in the org.
  - `TASK_BOARD_ITEM_DELETE` throws "Task board item not found" and skips `emitTaskBoardDeleted` when nothing was deleted.
  - Added a regression test in `reports-task-guards.integration.test.ts` to assert rejection on unknown ids.

<sup>Written for commit d09a34e381e23709c76ad4ea5a5795466e93a06f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

