### PR TITLE
fix(web): stop download-app-dialog crashing on clipboard write failure

### DIFF
--- a/apps/web/src/components/download-app-dialog.test.ts
+++ b/apps/web/src/components/download-app-dialog.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "bun:test";
+import { copyToClipboard } from "./download-app-dialog.tsx";
+
+describe("copyToClipboard", () => {
+  it("resolves true when writeText succeeds", async () => {
+    const ok = await copyToClipboard(
+      { writeText: () => Promise.resolve() },
+      "curl -fsSL https://example.com/install.sh | sh",
+    );
+    expect(ok).toBe(true);
+  });
+
+  it("resolves false instead of throwing when clipboard is undefined", async () => {
+    const ok = await copyToClipboard(undefined, "command");
+    expect(ok).toBe(false);
+  });
+
+  it("resolves false instead of rejecting when writeText is denied", async () => {
+    const ok = await copyToClipboard(
+      { writeText: () => Promise.reject(new Error("denied")) },
+      "command",
+    );
+    expect(ok).toBe(false);
+  });
+});

--- a/apps/web/src/components/download-app-dialog.tsx
+++ b/apps/web/src/components/download-app-dialog.tsx
@@ -33,6 +33,23 @@ interface DownloadAppDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
+// Clipboard write can reject or be entirely absent (denied permission, or a
+// non-HTTPS self-hosted origin — this dialog explicitly supports self-hosting).
+// Resolves to whether the copy actually happened, so callers never see an
+// unhandled rejection or a TypeError from calling into a missing API.
+export async function copyToClipboard(
+  clipboard: Pick<Clipboard, "writeText"> | undefined,
+  text: string,
+): Promise<boolean> {
+  if (!clipboard) return false;
+  try {
+    await clipboard.writeText(text);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export function DownloadAppDialog({
   open,
   onOpenChange,
@@ -57,7 +74,8 @@ export function DownloadAppDialog({
             type="button"
             className="w-full gap-2"
             onClick={() => {
-              navigator.clipboard.writeText(command).then(() => {
+              copyToClipboard(navigator.clipboard, command).then((ok) => {
+                if (!ok) return;
                 setCopied(true);
                 setTimeout(() => setCopied(false), 2000);
               });


### PR DESCRIPTION
Bug found while auditing `download-app-dialog.tsx` in this tick's focus area (download dialog polish).

The copy button called `navigator.clipboard.writeText(command).then(...)` with no guard and no `.catch()`. Two real failure paths:
- `navigator.clipboard` is `undefined` (non-HTTPS origin) — calling `.writeText` on it throws a synchronous `TypeError`, crashing the click handler. This dialog explicitly targets self-hosted instances (see the `installCommand()` comment), where HTTP-only setups are plausible.
- The write promise rejects (permission denied) — this produced an unhandled promise rejection and left the button silently stuck without ever showing the copied state, with no path to recover.

Extracted the copy logic into a small pure `copyToClipboard(clipboard, text)` helper that resolves to `true`/`false` instead of throwing/rejecting, and wired the button to it. On failure it now no-ops silently (the command text is still `select-all`-able in the `<code>` block above, so the user isn't stuck) instead of throwing.

Regression test: `apps/web/src/components/download-app-dialog.test.ts` covers success, missing `navigator.clipboard`, and a rejected `writeText` — all previously either threw or produced an unhandled rejection.

To verify: `bun test apps/web/src/components/download-app-dialog.test.ts`.

Locally ran: `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in the Download App dialog when clipboard writes fail on HTTP/self-hosted origins or when permission is denied. Adds a safe `copyToClipboard` helper so the button only shows “Copied” on success and silently no-ops on failure.

- **Bug Fixes**
  - Added `copyToClipboard(clipboard, text)` that returns `true/false` instead of throwing.
  - Updated click handler to use the helper; avoids unhandled rejections and TypeErrors.
  - Added tests for success, missing `navigator.clipboard`, and rejected `writeText`.

<sup>Written for commit 0fa214fa662c4fba8a1c9c758372555a0e345db5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

