### PR TITLE
feat(task-board): auto-task subscription paywall UI + billing settings

### DIFF
--- a/apps/api/src/billing/task-quota.ts
+++ b/apps/api/src/billing/task-quota.ts
@@ -28,11 +28,14 @@
  */
 
 import type { StudioContext } from "@/core/studio-context";
+import { isReportsTask } from "@decocms/shared/task-board";
 import { getSettings } from "../settings";
 import type {
   OrganizationBillingRow,
   OrganizationBillingStorage,
 } from "../storage/organization-billing";
+
+export { isReportsTask };
 
 /**
  * The wire contract for the paywall UI — same convention as `[CREDITS]`
@@ -61,13 +64,6 @@ export class TaskQuotaError extends Error {
     super(`${SUBSCRIPTION_REQUIRED_PREFIX} ${QUOTA_MESSAGES[reason]}`);
     this.name = "TaskQuotaError";
   }
-}
-
-/** Only reports-pushed tasks are gated. The import route is the sole writer
- *  of created_by = "system" (routes/task-board-import.ts); every user- or
- *  agent-created task carries a real principal id. */
-export function isReportsTask(item: { createdBy: string }): boolean {
-  return item.createdBy === "system";
 }
 
 /** `past_due` counts — Stripe dunning grace. */
@@ -124,7 +120,7 @@ export interface TaskQuotaConfig {
   maxRunsPerTask: number;
 }
 
-function taskQuotaConfig(): TaskQuotaConfig {
+export function taskQuotaConfig(): TaskQuotaConfig {
   const settings = getSettings();
   return {
     enforced: settings.taskQuotaEnforced,

--- a/apps/api/src/tools/index.ts
+++ b/apps/api/src/tools/index.ts
@@ -85,6 +85,7 @@ export const CORE_TOOLS = [
   OrganizationTools.ORGANIZATION_MEMBER_UPDATE_ROLE,
   OrganizationTools.ORGANIZATION_BILLING_CHECKOUT_START,
   OrganizationTools.ORGANIZATION_BILLING_PORTAL,
+  OrganizationTools.ORGANIZATION_TASK_QUOTA_GET,
 
   // Connection collection tools
   ConnectionTools.COLLECTION_CONNECTIONS_CREATE,

--- a/apps/api/src/tools/organization/index.ts
+++ b/apps/api/src/tools/organization/index.ts
@@ -45,3 +45,4 @@ export { ORGANIZATION_MEMBER_UPDATE_ROLE } from "./member-update-role";
 // Billing (per-org subscription)
 export { ORGANIZATION_BILLING_CHECKOUT_START } from "./billing-checkout";
 export { ORGANIZATION_BILLING_PORTAL } from "./billing-portal";
+export { ORGANIZATION_TASK_QUOTA_GET } from "./task-quota-get";

--- a/apps/api/src/tools/organization/task-quota-get.ts
+++ b/apps/api/src/tools/organization/task-quota-get.ts
@@ -1,0 +1,73 @@
+/**
+ * ORGANIZATION_TASK_QUOTA_GET — read-only view of the org's auto-task quota,
+ * for the billing settings page (and, eventually, a pre-emptive "2 of 3 used"
+ * indicator on the board — see `task-quota.ts`'s module doc). Composes the
+ * same pure helpers the gate itself uses (`taskQuotaState`,
+ * `countTaskClaims`), so this can never drift from what actually blocks a
+ * delegation.
+ */
+
+import { z } from "zod";
+import { defineTool } from "../../core/define-tool";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
+import {
+  subscriptionInGoodStanding,
+  taskQuotaConfig,
+  taskQuotaState,
+} from "../../billing/task-quota";
+
+export const ORGANIZATION_TASK_QUOTA_GET = defineTool({
+  name: "ORGANIZATION_TASK_QUOTA_GET",
+  description:
+    "Get the organization's auto-task quota: how many runs are used in the current period, the limit, and the subscription's billing status.",
+  annotations: {
+    title: "Get Task Quota",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  inputSchema: z.object({}),
+  outputSchema: z.object({
+    /** Dormant unless STUDIO_TASK_QUOTA_ENFORCED — self-hosted deployments
+     *  never gate, so the frontend should hide quota UI entirely. */
+    enforced: z.boolean(),
+    /** Raw Stripe-mirrored status ("none" when the org never subscribed). */
+    billingStatus: z.string(),
+    /** Whether `billingStatus` counts as paying (active or past_due — Stripe
+     *  dunning grace still counts). */
+    subscribed: z.boolean(),
+    /** Whether `ORGANIZATION_BILLING_PORTAL` has something to open. */
+    hasBillingAccount: z.boolean(),
+    /** Runs used in the current period (trial or billing cycle). */
+    used: z.number(),
+    /** Runs allowed in the current period. */
+    limit: z.number(),
+    /** ISO end of the current billing cycle — null during the trial. */
+    currentPeriodEnd: z.string().datetime().nullable(),
+  }),
+
+  handler: async (_input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const org = requireOrganization(ctx);
+
+    const config = taskQuotaConfig();
+    const billing = await ctx.storage.organizationBilling.getBilling(org.id);
+    const quota = taskQuotaState(billing, config);
+    const used = await ctx.storage.organizationBilling.countTaskClaims(
+      org.id,
+      quota.periodKey,
+    );
+
+    return {
+      enforced: config.enforced,
+      billingStatus: billing?.status ?? "none",
+      subscribed: subscriptionInGoodStanding(billing),
+      hasBillingAccount: !!billing?.stripeCustomerId,
+      used,
+      limit: quota.limit,
+      currentPeriodEnd: billing?.currentPeriodEnd?.toISOString() ?? null,
+    };
+  },
+});

--- a/apps/web/src/components/chat/highlight/index.tsx
+++ b/apps/web/src/components/chat/highlight/index.tsx
@@ -20,7 +20,9 @@ import { UserAskQuestionHighlight } from "./user-ask-question";
 import { TodosHighlight } from "./todos";
 import { CollapsibleHighlight } from "./collapsible-highlight";
 import { CreditsExhaustedBanner } from "../credits-exhausted-banner";
+import { SubscriptionLimitHighlight } from "./subscription-limit";
 import { useHighlightFlags } from "./use-highlight-count";
+import { useStudioTools } from "@/lib/studio-tools";
 import { parseErrorMessage } from "./parse-error-message";
 import type { UserAskToolPart } from "../types";
 
@@ -175,6 +177,23 @@ export function ChatHighlight() {
   const [preferences, setPreferences] = usePreferences();
   const { virtualMcpId, createTaskWithMessage } = useChatTask();
   const { chatMode, simpleModeTier } = useChatPrefs();
+  const studio = useStudioTools();
+
+  const handleSubscribe = async () => {
+    try {
+      const { url } = await studio.call(
+        "ORGANIZATION_BILLING_CHECKOUT_START",
+        {},
+      );
+      window.open(url, "_blank", "noopener,noreferrer");
+    } catch (err) {
+      toast.error(
+        t("taskBoard.subscriptionPaywall.checkoutError", {
+          message: err instanceof Error ? err.message : String(err),
+        }),
+      );
+    }
+  };
 
   // Build a fresh RequestOptions at call time so tier/mode reflect the
   // user's current selection. `toolApprovalLevel` is passed in explicitly:
@@ -308,6 +327,13 @@ export function ChatHighlight() {
   return (
     <div className="absolute bottom-full left-0 right-0">
       <TodosHighlight todos={flags.todos} />
+      {flags.subscriptionErrorKind && (
+        <SubscriptionLimitHighlight
+          kind={flags.subscriptionErrorKind}
+          onDismiss={clearError}
+          onSubscribe={handleSubscribe}
+        />
+      )}
       {showError && (
         <StatusHighlight
           variant="error"

--- a/apps/web/src/components/chat/highlight/subscription-limit.tsx
+++ b/apps/web/src/components/chat/highlight/subscription-limit.tsx
@@ -1,0 +1,64 @@
+/**
+ * Inline card for a `[SUBSCRIPTION_REQUIRED]` run error — e.g. a reviewer
+ * thread's `TASK_BOARD_REVIEW_DECISION` bounce-back to the Super Agent hit
+ * the org's or the task's auto-task quota. Deliberately NOT the sales
+ * paywall modal (`SubscriptionPaywallDialog`) used for a user-initiated
+ * delegation: this is an automated review flow, so it stays a quiet inline
+ * card. Only the trial-exhausted case gets a "Subscribe" action — the other
+ * two are informational (it resolves on its own next cycle, or needs a new
+ * task).
+ */
+import { Lightning01 } from "@untitledui/icons";
+import { Button } from "@deco/ui/components/button.tsx";
+import { useT } from "@/i18n/use-t.ts";
+import type { SubscriptionErrorKind } from "@/components/task-board/is-subscription-error";
+import { CollapsibleHighlight } from "./collapsible-highlight";
+
+const COPY_KEYS = {
+  trial_exhausted: {
+    label: "chat.subscriptionLimit.trialLabel",
+    title: "chat.subscriptionLimit.trialTitle",
+  },
+  monthly_exhausted: {
+    label: "chat.subscriptionLimit.monthlyLabel",
+    title: "chat.subscriptionLimit.monthlyTitle",
+  },
+  runs_exhausted: {
+    label: "chat.subscriptionLimit.runsLabel",
+    title: "chat.subscriptionLimit.runsTitle",
+  },
+} as const satisfies Record<
+  SubscriptionErrorKind,
+  { label: string; title: string }
+>;
+
+export function SubscriptionLimitHighlight({
+  kind,
+  onDismiss,
+  onSubscribe,
+}: {
+  kind: SubscriptionErrorKind;
+  onDismiss: () => void;
+  onSubscribe: () => void;
+}) {
+  const t = useT();
+  const { label, title } = COPY_KEYS[kind];
+
+  return (
+    <CollapsibleHighlight
+      icon={<Lightning01 size={14} />}
+      label={t(label)}
+      title={t(title)}
+      defaultExpanded={true}
+      variant="warning"
+      onClose={onDismiss}
+      footerRight={
+        kind === "trial_exhausted" ? (
+          <Button size="sm" onClick={onSubscribe} className="h-7 text-xs">
+            {t("chat.subscriptionLimit.subscribeButton")}
+          </Button>
+        ) : undefined
+      }
+    />
+  );
+}

--- a/apps/web/src/components/chat/highlight/use-highlight-count.test.ts
+++ b/apps/web/src/components/chat/highlight/use-highlight-count.test.ts
@@ -7,6 +7,7 @@ import {
 
 const noFlags: HighlightFlags = {
   isCreditExhausted: false,
+  subscriptionErrorKind: null,
   hasTodos: false,
   showError: false,
   showWarning: false,
@@ -57,6 +58,18 @@ describe("deriveHighlightFlags", () => {
         error: err,
       }),
     ).toEqual({ ...noFlags, isCreditExhausted: true });
+  });
+
+  test("subscription-quota error → subscriptionErrorKind set, showError suppressed", () => {
+    const err = new Error(
+      "[SUBSCRIPTION_REQUIRED] this task reached its execution limit — create a new task to keep going",
+    );
+    expect(
+      deriveHighlightFlags({
+        ...baseInput,
+        error: err,
+      }),
+    ).toEqual({ ...noFlags, subscriptionErrorKind: "runs_exhausted" });
   });
 
   test("finishReason 'length' (not streaming, no error) → showWarning true", () => {

--- a/apps/web/src/components/chat/highlight/use-highlight-count.ts
+++ b/apps/web/src/components/chat/highlight/use-highlight-count.ts
@@ -17,10 +17,17 @@ import { deriveCurrentTodos } from "./derive-current-todos";
 import { extractPendingApprovals } from "./extract-pending-approvals";
 import { extractPendingPlans } from "./extract-pending-plans";
 import { isCreditError } from "../is-credit-error";
+import { subscriptionErrorKind } from "@/components/task-board/is-subscription-error";
 import { useChatStream } from "../context";
 
 export interface HighlightFlags {
   isCreditExhausted: boolean;
+  /** Non-null when the run errored on the org's auto-task quota — e.g. a
+   *  reviewer thread bouncing the task back to the Super Agent hit the
+   *  org/task's execution limit. Renders inline, not as a sales paywall (this
+   *  is an automated review flow, not a user-initiated purchase moment) —
+   *  see `SubscriptionLimitHighlight`. */
+  subscriptionErrorKind: ReturnType<typeof subscriptionErrorKind>;
   hasTodos: boolean;
   showError: boolean;
   showWarning: boolean;
@@ -42,6 +49,7 @@ export interface DeriveHighlightFlagsInput {
 
 const EMPTY_FLAGS: HighlightFlags = {
   isCreditExhausted: false,
+  subscriptionErrorKind: null,
   hasTodos: false,
   showError: false,
   showWarning: false,
@@ -89,7 +97,11 @@ export function deriveHighlightFlags(
 
   const todos = deriveCurrentTodos(messages);
 
-  const showError = !isStreaming && !!error;
+  // A subscription-quota error renders as its own inline card (with tailored
+  // copy, no CTA — see SubscriptionLimitHighlight), not the generic raw-message
+  // error card.
+  const subKind = !isStreaming ? subscriptionErrorKind(error) : null;
+  const showError = !isStreaming && !!error && !subKind;
   const hasApprovals =
     pendingApprovals.length > 0 || (isStreaming && isWaitingForApprovals);
   const hasPlans = pendingPlans.length > 0;
@@ -110,6 +122,7 @@ export function deriveHighlightFlags(
 
   return {
     isCreditExhausted: false,
+    subscriptionErrorKind: subKind,
     hasTodos: todos.length > 0,
     showError,
     showWarning,
@@ -151,6 +164,7 @@ export function useHighlightCount(): number {
   return (
     Number(flags.hasTodos) +
     Number(flags.showError) +
+    Number(!!flags.subscriptionErrorKind) +
     Number(flags.showWarning) +
     Number(flags.hasApprovals) +
     Number(flags.hasPlans) +

--- a/apps/web/src/components/markdown-editor/index.tsx
+++ b/apps/web/src/components/markdown-editor/index.tsx
@@ -80,10 +80,14 @@ export function MarkdownEditor({
   defaultValue,
   onChange,
   placeholder,
+  editable = true,
 }: {
   defaultValue: string;
   onChange: (markdown: string) => void;
   placeholder?: string;
+  /** Read at creation time only — remount (via `key`) to change it, same as
+   *  `defaultValue`. */
+  editable?: boolean;
 }) {
   const t = useT();
   const { uploadFile, pending } = useEditorFileUpload();
@@ -123,6 +127,7 @@ export function MarkdownEditor({
     extensions: markdownEditorExtensions(placeholder),
     content: defaultValue,
     contentType: "markdown",
+    editable,
     editorProps: {
       attributes: {
         class: cn(CONTENT_CLASS, PLACEHOLDER_CLASS),
@@ -160,18 +165,21 @@ export function MarkdownEditor({
       <BubbleToolbar editor={editor} />
       <EditorContent editor={editor} className="text-[15px] text-foreground" />
       {/* Sits clear of the description body so it reads as a control on the
-          editor, not as the last line of the text. */}
+          editor, not as the last line of the text. Hidden when read-only —
+          nothing here would do anything. */}
       <div className="mt-4 flex items-center gap-2 text-xs text-muted-foreground">
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          // Icon-only, so the label has to live on the control itself.
-          aria-label={t("markdownEditor.attachFile")}
-          onClick={() => fileInputRef.current?.click()}
-        >
-          <Attachment01 size={14} />
-        </Button>
+        {editable && (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            // Icon-only, so the label has to live on the control itself.
+            aria-label={t("markdownEditor.attachFile")}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <Attachment01 size={14} />
+          </Button>
+        )}
         {pending > 0 && (
           <span
             className="inline-flex items-center gap-1.5"

--- a/apps/web/src/components/task-board/is-subscription-error.ts
+++ b/apps/web/src/components/task-board/is-subscription-error.ts
@@ -1,0 +1,36 @@
+/**
+ * Detect auto-task quota/subscription errors.
+ * The backend prefixes these with `[SUBSCRIPTION_REQUIRED]` (same convention
+ * as `[CREDITS]`, see `../chat/is-credit-error.ts`) and distinguishes the
+ * three cases in the text after the prefix — see `apps/api/src/billing/
+ * task-quota.ts`'s `QUOTA_MESSAGES`.
+ *
+ * Extracted as a pure .ts module so it can be tested without dragging in
+ * @deco/ui transitively.
+ */
+const SUBSCRIPTION_REQUIRED_PREFIX = "[SUBSCRIPTION_REQUIRED]";
+
+export type SubscriptionErrorKind =
+  /** The org's 3 lifetime free auto-task runs are used up — sell the
+   *  subscription. */
+  | "trial_exhausted"
+  /** A paying org used its 10-per-cycle quota — no CTA, it renews on its own. */
+  | "monthly_exhausted"
+  /** THIS task hit its 5 re-run cap — no CTA, the fix is a new task. */
+  | "runs_exhausted";
+
+export function subscriptionErrorKind(
+  error: Error | null | undefined,
+): SubscriptionErrorKind | null {
+  if (!error?.message.startsWith(SUBSCRIPTION_REQUIRED_PREFIX)) return null;
+  if (error.message.includes("used its free task executions")) {
+    return "trial_exhausted";
+  }
+  if (error.message.includes("used its monthly task executions")) {
+    return "monthly_exhausted";
+  }
+  if (error.message.includes("reached its execution limit")) {
+    return "runs_exhausted";
+  }
+  return null;
+}

--- a/apps/web/src/i18n/en/chat.ts
+++ b/apps/web/src/i18n/en/chat.ts
@@ -505,4 +505,14 @@ export const chat = {
   "chat.todoStatus.completed": "completed",
   "chat.todoStatus.inProgress": "in progress",
   "chat.todoStatus.pending": "pending",
+  "chat.subscriptionLimit.trialLabel": "Subscription required",
+  "chat.subscriptionLimit.trialTitle":
+    "This organization used its 3 free auto-task runs. Subscribe to keep going.",
+  "chat.subscriptionLimit.monthlyLabel": "Auto-task quota used up",
+  "chat.subscriptionLimit.monthlyTitle":
+    "This organization used its auto-task runs for this billing cycle. More become available next cycle.",
+  "chat.subscriptionLimit.runsLabel": "Task limit reached",
+  "chat.subscriptionLimit.runsTitle":
+    "This task reached its re-run limit. Create a new task to keep going.",
+  "chat.subscriptionLimit.subscribeButton": "Subscribe",
 } as const;

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -653,22 +653,18 @@ export const settings = {
   "settings.aiProviders.moreProvidersSingular": "{count} more provider",
   "settings.aiProviders.moreProvidersPlural": "{count} more providers",
   "settings.billing.title": "Billing",
-  "settings.billing.description":
-    "Manage the organization's auto-task subscription.",
   "settings.billing.autoTasksTitle": "Auto tasks",
   "settings.billing.unlimitedDescription":
     "Auto-task runs are unlimited on this deployment. Tasks you create yourself are never limited either.",
   "settings.billing.autoTasksDescriptionTrial":
-    "3 free lifetime runs, then $50/month for 10 runs per billing cycle. Tasks you create yourself are never limited.",
+    "3 free lifetime runs, then $50/month for 10 runs per billing cycle.",
   "settings.billing.autoTasksDescriptionSubscribed":
     "10 auto-task runs per billing cycle. Tasks you create yourself are never limited.",
   "settings.billing.statusTrial": "Free trial",
   "settings.billing.statusActive": "Active",
   "settings.billing.statusPastDue": "Payment issue",
-  "settings.billing.usageLabel": "{used} of {limit} runs used",
+  "settings.billing.runsUsedLabel": "runs used",
   "settings.billing.renewsOn": "Renews {date}",
-  "settings.billing.cancelHint":
-    "Manage billing opens Stripe's portal — update your card, see invoices, or cancel anytime.",
   "settings.billing.subscribeButton": "Subscribe",
   "settings.billing.manageButton": "Manage billing",
   "settings.billing.checkoutError": "Couldn't start checkout: {message}",

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -5,6 +5,7 @@ export const settings = {
   "settings.nav.brandContext": "Brand Context",
   "settings.nav.aiProviders": "AI Providers",
   "settings.nav.secrets": "Secrets",
+  "settings.nav.billing": "Billing",
   "settings.nav.buckets": "Buckets",
   "settings.nav.build": "Build",
   "settings.nav.connections": "Connections",
@@ -651,4 +652,25 @@ export const settings = {
     "Bring your own model server (advanced)",
   "settings.aiProviders.moreProvidersSingular": "{count} more provider",
   "settings.aiProviders.moreProvidersPlural": "{count} more providers",
+  "settings.billing.title": "Billing",
+  "settings.billing.description":
+    "Manage the organization's auto-task subscription.",
+  "settings.billing.autoTasksTitle": "Auto tasks",
+  "settings.billing.unlimitedDescription":
+    "Auto-task runs are unlimited on this deployment. Tasks you create yourself are never limited either.",
+  "settings.billing.autoTasksDescriptionTrial":
+    "3 free lifetime runs, then $50/month for 10 runs per billing cycle. Tasks you create yourself are never limited.",
+  "settings.billing.autoTasksDescriptionSubscribed":
+    "10 auto-task runs per billing cycle. Tasks you create yourself are never limited.",
+  "settings.billing.statusTrial": "Free trial",
+  "settings.billing.statusActive": "Active",
+  "settings.billing.statusPastDue": "Payment issue",
+  "settings.billing.usageLabel": "{used} of {limit} runs used",
+  "settings.billing.renewsOn": "Renews {date}",
+  "settings.billing.cancelHint":
+    "Manage billing opens Stripe's portal — update your card, see invoices, or cancel anytime.",
+  "settings.billing.subscribeButton": "Subscribe",
+  "settings.billing.manageButton": "Manage billing",
+  "settings.billing.checkoutError": "Couldn't start checkout: {message}",
+  "settings.billing.portalError": "Couldn't open billing portal: {message}",
 } as const;

--- a/apps/web/src/i18n/en/task-board.ts
+++ b/apps/web/src/i18n/en/task-board.ts
@@ -135,6 +135,8 @@ export const taskBoard = {
   "taskBoard.taskDialog.shipSuccess": "Merged and shipped to production",
   "taskBoard.taskDialog.shipError": "Couldn't merge the pull request",
   "taskBoard.taskDialog.propertiesLabel": "Properties",
+  "taskBoard.taskDialog.reportsContentLocked":
+    "Generated from your report — title, description, and priority are managed automatically",
   "taskBoard.taskDialog.saveButton": "Save",
   "taskBoard.taskDialog.setPriorityButton": "Set priority",
   "taskBoard.taskDialog.someoneLabel": "someone",
@@ -171,4 +173,25 @@ export const taskBoard = {
   "taskBoard.taskFilters.filterDrawerTitle": "Filters",
   "taskBoard.taskFilters.priorityAnyPriority": "Any priority",
   "taskBoard.taskFilters.priorityLabel": "Priority",
+  "taskBoard.subscriptionPaywall.trialTitle": "Subscribe to keep auto-fixing",
+  "taskBoard.subscriptionPaywall.trialBenefitRuns":
+    "10 auto-task runs every billing cycle",
+  "taskBoard.subscriptionPaywall.trialBenefitBacklog":
+    "The agent keeps clearing your backlog while you review the PRs",
+  "taskBoard.subscriptionPaywall.trialBenefitReruns":
+    "Re-runs on the same task stay free, up to 5 each",
+  "taskBoard.subscriptionPaywall.trialPrice": "$50",
+  "taskBoard.subscriptionPaywall.trialPricePeriod": "/month",
+  "taskBoard.subscriptionPaywall.previewAlt": "Preview of your task board",
+  "taskBoard.subscriptionPaywall.monthlyTitle": "Auto-task quota used up",
+  "taskBoard.subscriptionPaywall.monthlyDescription":
+    "This organization used its auto-task runs for this billing cycle. More become available at the start of the next one.",
+  "taskBoard.subscriptionPaywall.runsTitle": "This task reached its limit",
+  "taskBoard.subscriptionPaywall.runsDescription":
+    "This task has been re-run as many times as allowed. Create a new task to keep going.",
+  "taskBoard.subscriptionPaywall.subscribeButton": "Subscribe",
+  "taskBoard.subscriptionPaywall.notNowButton": "Not now",
+  "taskBoard.subscriptionPaywall.dismissButton": "Close",
+  "taskBoard.subscriptionPaywall.checkoutError":
+    "Couldn't start checkout: {message}",
 } as const;

--- a/apps/web/src/i18n/en/task-board.ts
+++ b/apps/web/src/i18n/en/task-board.ts
@@ -174,12 +174,8 @@ export const taskBoard = {
   "taskBoard.taskFilters.priorityAnyPriority": "Any priority",
   "taskBoard.taskFilters.priorityLabel": "Priority",
   "taskBoard.subscriptionPaywall.trialTitle": "Subscribe to keep auto-fixing",
-  "taskBoard.subscriptionPaywall.trialBenefitRuns":
-    "10 auto-task runs every billing cycle",
-  "taskBoard.subscriptionPaywall.trialBenefitBacklog":
-    "The agent keeps clearing your backlog while you review the PRs",
-  "taskBoard.subscriptionPaywall.trialBenefitReruns":
-    "Re-runs on the same task stay free, up to 5 each",
+  "taskBoard.subscriptionPaywall.trialBenefitMonitoring":
+    "Continuous monitoring of your site, catching new issues automatically",
   "taskBoard.subscriptionPaywall.trialPrice": "$50",
   "taskBoard.subscriptionPaywall.trialPricePeriod": "/month",
   "taskBoard.subscriptionPaywall.previewAlt": "Preview of your task board",

--- a/apps/web/src/i18n/en/task-board.ts
+++ b/apps/web/src/i18n/en/task-board.ts
@@ -176,6 +176,10 @@ export const taskBoard = {
   "taskBoard.subscriptionPaywall.trialTitle": "Subscribe to keep auto-fixing",
   "taskBoard.subscriptionPaywall.trialBenefitMonitoring":
     "Continuous monitoring of your site, catching new issues automatically",
+  "taskBoard.subscriptionPaywall.trialBenefitAutoFix":
+    "The agent fixes what it finds and opens a pull request for your review",
+  "taskBoard.subscriptionPaywall.trialBenefitRuns":
+    "10 auto-task runs every billing cycle",
   "taskBoard.subscriptionPaywall.trialPrice": "$50",
   "taskBoard.subscriptionPaywall.trialPricePeriod": "/month",
   "taskBoard.subscriptionPaywall.previewAlt": "Preview of your task board",

--- a/apps/web/src/i18n/pt-br/chat.ts
+++ b/apps/web/src/i18n/pt-br/chat.ts
@@ -520,4 +520,14 @@ export const chat = {
   "chat.todoStatus.completed": "concluído",
   "chat.todoStatus.inProgress": "em progresso",
   "chat.todoStatus.pending": "pendente",
+  "chat.subscriptionLimit.trialLabel": "Assinatura necessária",
+  "chat.subscriptionLimit.trialTitle":
+    "Esta organização usou as 3 execuções grátis de auto tasks. Assine para continuar.",
+  "chat.subscriptionLimit.monthlyLabel": "Cota de auto tasks esgotada",
+  "chat.subscriptionLimit.monthlyTitle":
+    "Esta organização usou suas execuções de auto tasks deste ciclo de cobrança. Mais ficam disponíveis no próximo ciclo.",
+  "chat.subscriptionLimit.runsLabel": "Limite da task atingido",
+  "chat.subscriptionLimit.runsTitle":
+    "Esta task atingiu o limite de re-execuções. Crie uma nova task para continuar.",
+  "chat.subscriptionLimit.subscribeButton": "Assinar",
 } satisfies Record<keyof typeof chatEn, string>;

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -7,6 +7,7 @@ export const settings = {
   "settings.nav.brandContext": "Contexto da marca",
   "settings.nav.aiProviders": "Provedores de IA",
   "settings.nav.secrets": "Segredos",
+  "settings.nav.billing": "Cobrança",
   "settings.nav.buckets": "Buckets",
   "settings.nav.build": "Criação",
   "settings.nav.connections": "Conexões",
@@ -691,4 +692,27 @@ export const settings = {
     "Traga seu pr\u00f3prio servidor de modelos (avan\u00e7ado)",
   "settings.aiProviders.moreProvidersSingular": "{count} provedor adicional",
   "settings.aiProviders.moreProvidersPlural": "{count} provedores adicionais",
+  "settings.billing.title": "Cobrança",
+  "settings.billing.description":
+    "Gerencie a assinatura de auto tasks da organização.",
+  "settings.billing.autoTasksTitle": "Auto tasks",
+  "settings.billing.unlimitedDescription":
+    "As execuções de auto tasks são ilimitadas neste deployment. Tasks criadas por você também nunca têm limite.",
+  "settings.billing.autoTasksDescriptionTrial":
+    "3 execuções grátis vitalícias, depois R$ 250/mês para 10 execuções por ciclo de cobrança. Tasks criadas por você nunca têm limite.",
+  "settings.billing.autoTasksDescriptionSubscribed":
+    "10 execuções de auto tasks por ciclo de cobrança. Tasks criadas por você nunca têm limite.",
+  "settings.billing.statusTrial": "Teste grátis",
+  "settings.billing.statusActive": "Ativa",
+  "settings.billing.statusPastDue": "Problema no pagamento",
+  "settings.billing.usageLabel": "{used} de {limit} execuções usadas",
+  "settings.billing.renewsOn": "Renova em {date}",
+  "settings.billing.cancelHint":
+    "Gerenciar cobrança abre o portal da Stripe — atualize seu cartão, veja faturas ou cancele quando quiser.",
+  "settings.billing.subscribeButton": "Assinar",
+  "settings.billing.manageButton": "Gerenciar cobrança",
+  "settings.billing.checkoutError":
+    "Não foi possível iniciar o checkout: {message}",
+  "settings.billing.portalError":
+    "Não foi possível abrir o portal de cobrança: {message}",
 } satisfies Record<keyof typeof settingsEn, string>;

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -693,22 +693,18 @@ export const settings = {
   "settings.aiProviders.moreProvidersSingular": "{count} provedor adicional",
   "settings.aiProviders.moreProvidersPlural": "{count} provedores adicionais",
   "settings.billing.title": "Cobrança",
-  "settings.billing.description":
-    "Gerencie a assinatura de auto tasks da organização.",
   "settings.billing.autoTasksTitle": "Auto tasks",
   "settings.billing.unlimitedDescription":
     "As execuções de auto tasks são ilimitadas neste deployment. Tasks criadas por você também nunca têm limite.",
   "settings.billing.autoTasksDescriptionTrial":
-    "3 execuções grátis vitalícias, depois R$ 250/mês para 10 execuções por ciclo de cobrança. Tasks criadas por você nunca têm limite.",
+    "3 execuções grátis vitalícias, depois R$ 250/mês para 10 execuções por ciclo de cobrança.",
   "settings.billing.autoTasksDescriptionSubscribed":
     "10 execuções de auto tasks por ciclo de cobrança. Tasks criadas por você nunca têm limite.",
   "settings.billing.statusTrial": "Teste grátis",
   "settings.billing.statusActive": "Ativa",
   "settings.billing.statusPastDue": "Problema no pagamento",
-  "settings.billing.usageLabel": "{used} de {limit} execuções usadas",
+  "settings.billing.runsUsedLabel": "execuções usadas",
   "settings.billing.renewsOn": "Renova em {date}",
-  "settings.billing.cancelHint":
-    "Gerenciar cobrança abre o portal da Stripe — atualize seu cartão, veja faturas ou cancele quando quiser.",
   "settings.billing.subscribeButton": "Assinar",
   "settings.billing.manageButton": "Gerenciar cobrança",
   "settings.billing.checkoutError":

--- a/apps/web/src/i18n/pt-br/task-board.ts
+++ b/apps/web/src/i18n/pt-br/task-board.ts
@@ -184,6 +184,10 @@ export const taskBoard = {
     "Assine para continuar com o auto-fix",
   "taskBoard.subscriptionPaywall.trialBenefitMonitoring":
     "Monitoramento contínuo do seu site, detectando novos problemas automaticamente",
+  "taskBoard.subscriptionPaywall.trialBenefitAutoFix":
+    "O agente corrige o que encontra e abre um pull request para sua revisão",
+  "taskBoard.subscriptionPaywall.trialBenefitRuns":
+    "10 execuções de auto tasks por ciclo de cobrança",
   "taskBoard.subscriptionPaywall.trialPrice": "R$ 250",
   "taskBoard.subscriptionPaywall.trialPricePeriod": "/mês",
   "taskBoard.subscriptionPaywall.previewAlt": "Prévia do seu quadro de tarefas",

--- a/apps/web/src/i18n/pt-br/task-board.ts
+++ b/apps/web/src/i18n/pt-br/task-board.ts
@@ -182,12 +182,8 @@ export const taskBoard = {
   "taskBoard.taskFilters.priorityLabel": "Prioridade",
   "taskBoard.subscriptionPaywall.trialTitle":
     "Assine para continuar com o auto-fix",
-  "taskBoard.subscriptionPaywall.trialBenefitRuns":
-    "10 execuções de auto tasks por ciclo de cobrança",
-  "taskBoard.subscriptionPaywall.trialBenefitBacklog":
-    "O agente continua limpando seu backlog enquanto você revisa os PRs",
-  "taskBoard.subscriptionPaywall.trialBenefitReruns":
-    "Re-execuções na mesma task continuam grátis, até 5 cada",
+  "taskBoard.subscriptionPaywall.trialBenefitMonitoring":
+    "Monitoramento contínuo do seu site, detectando novos problemas automaticamente",
   "taskBoard.subscriptionPaywall.trialPrice": "R$ 250",
   "taskBoard.subscriptionPaywall.trialPricePeriod": "/mês",
   "taskBoard.subscriptionPaywall.previewAlt": "Prévia do seu quadro de tarefas",

--- a/apps/web/src/i18n/pt-br/task-board.ts
+++ b/apps/web/src/i18n/pt-br/task-board.ts
@@ -142,6 +142,8 @@ export const taskBoard = {
   "taskBoard.taskDialog.shipSuccess": "Mesclado e enviado para produção",
   "taskBoard.taskDialog.shipError": "Não foi possível mesclar o pull request",
   "taskBoard.taskDialog.propertiesLabel": "Propriedades",
+  "taskBoard.taskDialog.reportsContentLocked":
+    "Gerado pelo seu relatório — título, descrição e prioridade são gerenciados automaticamente",
   "taskBoard.taskDialog.saveButton": "Salvar",
   "taskBoard.taskDialog.setPriorityButton": "Definir prioridade",
   "taskBoard.taskDialog.someoneLabel": "alguém",
@@ -178,4 +180,26 @@ export const taskBoard = {
   "taskBoard.taskFilters.filterDrawerTitle": "Filtros",
   "taskBoard.taskFilters.priorityAnyPriority": "Qualquer prioridade",
   "taskBoard.taskFilters.priorityLabel": "Prioridade",
+  "taskBoard.subscriptionPaywall.trialTitle":
+    "Assine para continuar com o auto-fix",
+  "taskBoard.subscriptionPaywall.trialBenefitRuns":
+    "10 execuções de auto tasks por ciclo de cobrança",
+  "taskBoard.subscriptionPaywall.trialBenefitBacklog":
+    "O agente continua limpando seu backlog enquanto você revisa os PRs",
+  "taskBoard.subscriptionPaywall.trialBenefitReruns":
+    "Re-execuções na mesma task continuam grátis, até 5 cada",
+  "taskBoard.subscriptionPaywall.trialPrice": "R$ 250",
+  "taskBoard.subscriptionPaywall.trialPricePeriod": "/mês",
+  "taskBoard.subscriptionPaywall.previewAlt": "Prévia do seu quadro de tarefas",
+  "taskBoard.subscriptionPaywall.monthlyTitle": "Cota de auto tasks esgotada",
+  "taskBoard.subscriptionPaywall.monthlyDescription":
+    "Esta organização usou suas execuções de auto tasks deste ciclo de cobrança. Mais execuções ficam disponíveis no início do próximo ciclo.",
+  "taskBoard.subscriptionPaywall.runsTitle": "Esta task atingiu o limite",
+  "taskBoard.subscriptionPaywall.runsDescription":
+    "Esta task já foi re-executada o máximo de vezes permitido. Crie uma nova task para continuar.",
+  "taskBoard.subscriptionPaywall.subscribeButton": "Assinar",
+  "taskBoard.subscriptionPaywall.notNowButton": "Agora não",
+  "taskBoard.subscriptionPaywall.dismissButton": "Fechar",
+  "taskBoard.subscriptionPaywall.checkoutError":
+    "Não foi possível iniciar o checkout: {message}",
 } satisfies Record<keyof typeof taskBoardEn, string>;

--- a/apps/web/src/layouts/settings-layout.tsx
+++ b/apps/web/src/layouts/settings-layout.tsx
@@ -37,6 +37,7 @@ import {
   Building02,
   ZapSquare,
   CpuChip01,
+  CreditCard01,
   Loading01,
   Lock01,
   LogOut01,
@@ -122,6 +123,16 @@ function useSettingsSidebarGroups(): SettingsNavGroup[] {
           icon: <CpuChip01 size={14} />,
           to: "/$org/settings/ai-providers",
           requires: "ai-providers:manage",
+        },
+        {
+          key: "billing",
+          label: t("settings.nav.billing"),
+          icon: <CreditCard01 size={14} />,
+          to: "/$org/settings/billing",
+          // Same tools + gate as the members page's seat billing (both are
+          // the one org subscription, see registry-metadata.ts's
+          // `members:manage` group).
+          requires: "members:manage",
         },
         {
           key: "secrets",

--- a/apps/web/src/layouts/task-board/backlog-paywall.tsx
+++ b/apps/web/src/layouts/task-board/backlog-paywall.tsx
@@ -36,8 +36,9 @@ import { track } from "@/lib/posthog-client";
 import { useT } from "@/i18n/use-t.ts";
 
 /** A preview of the unlocked board (carries the brand-lime edge), used as the
- *  modal hero — hosted on the deco CDN. */
-const KANBAN_PREVIEW_SRC =
+ *  modal hero — hosted on the deco CDN. Shared with `subscription-paywall-
+ *  dialog.tsx` so the board has one hero image across its paywalls, not two. */
+export const KANBAN_PREVIEW_SRC =
   "https://decoims.com/image?src=decocms%2F7263a67f-fb83-410b-a5f2-e54e87deaaac%2Freport-kanban.png&quality=original&fit=cover";
 
 /** What the unlock buys — kept true to what the paid product delivers. */

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -104,6 +104,9 @@ import {
 import { useTags } from "@/hooks/use-tags";
 import { TaskBoardItemDialog, toEndOfDayIso } from "./task-dialog";
 import { AssigneePickerContent } from "./assignee-picker";
+import { SubscriptionPaywallDialog } from "./subscription-paywall-dialog";
+import { subscriptionErrorKind } from "@/components/task-board/is-subscription-error";
+import { isReportsTask } from "@decocms/shared/task-board";
 import { useFlipLanes } from "./use-flip-lanes";
 import { Calendar as DayPickerCalendar } from "@deco/ui/components/calendar.tsx";
 import { buildTaskChatContext } from "./build-task-chat-context";
@@ -333,6 +336,16 @@ export function TaskBoardPage() {
       return true;
     }
     return false;
+  };
+  // Set when delegating to the Super Agent (dialog submit or the lane/card
+  // assignee picker) is rejected with a `[SUBSCRIPTION_REQUIRED]` error — see
+  // `subscriptionErrorKind`'s 3 cases. Both delegation paths funnel through
+  // `actions.update`, so a single per-call `onError` here covers both.
+  const [subscriptionPaywall, setSubscriptionPaywall] =
+    useState<ReturnType<typeof subscriptionErrorKind>>(null);
+  const onDelegateError = (err: Error) => {
+    const kind = subscriptionErrorKind(err);
+    if (kind) setSubscriptionPaywall(kind);
   };
   const { data: membersData } = useMembers();
   const members = (membersData?.data?.members ?? []) as Member[];
@@ -608,17 +621,23 @@ export function TaskBoardPage() {
             // unassign since TASK_BOARD_ITEM_UPDATE treats undefined as
             // unchanged. `assigneeId` is nullable in the update schema, so
             // pass `userId` through as-is.
-            actions.update.mutate({ id, assigneeId: userId });
+            actions.update.mutate(
+              { id, assigneeId: userId },
+              { onError: onDelegateError },
+            );
           }}
           onAutoFix={
             reportsOnly
               ? (item) => {
                   if (blockSuperAgentWithoutGithub(SUPER_AGENT_ASSIGNEE_ID))
                     return;
-                  actions.update.mutate({
-                    id: item.id,
-                    assigneeId: SUPER_AGENT_ASSIGNEE_ID,
-                  });
+                  actions.update.mutate(
+                    {
+                      id: item.id,
+                      assigneeId: SUPER_AGENT_ASSIGNEE_ID,
+                    },
+                    { onError: onDelegateError },
+                  );
                 }
               : undefined
           }
@@ -664,7 +683,20 @@ export function TaskBoardPage() {
             return;
           }
           if (activeItem) {
-            actions.update.mutate({ id: activeItem.id, ...input });
+            // Reports-generated tasks reject a write touching title/
+            // description/priority (their content is owned by the reports
+            // sync) — the dialog locks those fields, but still round-trips
+            // their unchanged values here, so drop them instead of sending a
+            // payload the server would 500 on. Board interactions
+            // (status/assignee/dueDate/tagIds) always go through.
+            const { title, description, priority, ...boardFields } = input;
+            const contentFields = isReportsTask(activeItem)
+              ? {}
+              : { title, description, priority };
+            actions.update.mutate(
+              { id: activeItem.id, ...boardFields, ...contentFields },
+              { onError: onDelegateError },
+            );
           } else {
             actions.create.mutate(input);
           }
@@ -701,6 +733,11 @@ export function TaskBoardPage() {
         onOpenChange={setRepoPickerOpen}
       />
 
+      <SubscriptionPaywallDialog
+        kind={subscriptionPaywall}
+        onOpenChange={(open) => !open && setSubscriptionPaywall(null)}
+      />
+
       {selectedIds.size > 0 && (
         <SelectionBar
           count={selectedIds.size}
@@ -727,7 +764,10 @@ export function TaskBoardPage() {
           onAssign={(userId) => {
             if (blockSuperAgentWithoutGithub(userId)) return;
             for (const id of selectedIds)
-              actions.update.mutate({ id, assigneeId: userId });
+              actions.update.mutate(
+                { id, assigneeId: userId },
+                { onError: onDelegateError },
+              );
             clearSelection();
           }}
           onSetDueDate={(date) => {
@@ -750,10 +790,10 @@ export function TaskBoardPage() {
                   if (blockSuperAgentWithoutGithub(SUPER_AGENT_ASSIGNEE_ID))
                     return;
                   for (const id of selectedIds)
-                    actions.update.mutate({
-                      id,
-                      assigneeId: SUPER_AGENT_ASSIGNEE_ID,
-                    });
+                    actions.update.mutate(
+                      { id, assigneeId: SUPER_AGENT_ASSIGNEE_ID },
+                      { onError: onDelegateError },
+                    );
                   clearSelection();
                 }
               : undefined

--- a/apps/web/src/layouts/task-board/subscription-paywall-dialog.tsx
+++ b/apps/web/src/layouts/task-board/subscription-paywall-dialog.tsx
@@ -1,0 +1,153 @@
+/**
+ * Shown when delegating a task to the Super Agent (task dialog submit, or the
+ * lane/card assignee picker) is rejected with a `[SUBSCRIPTION_REQUIRED]`
+ * error — see `is-subscription-error.ts` for the 3 cases this distinguishes.
+ * Billing itself is never built here: `ORGANIZATION_BILLING_CHECKOUT_START`
+ * returns Stripe's hosted checkout URL, opened in a new tab like every other
+ * checkout in the app (`deco-credits-hero.tsx`).
+ *
+ * `trial_exhausted` is the only case with something to sell — it gets the
+ * richer benefits/price layout (same shell as `backlog-paywall.tsx`'s modal,
+ * per the "only one visual paywall pattern on the board" rule). The other two
+ * are purely informational (quota renews on its own / make a new task), so
+ * they stay a plain title + description.
+ */
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { CheckCircle, Loading01 } from "@untitledui/icons";
+import { Button } from "@deco/ui/components/button.tsx";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@deco/ui/components/dialog.tsx";
+import { useStudioTools } from "@/lib/studio-tools";
+import { useT } from "@/i18n/use-t.ts";
+import type { SubscriptionErrorKind } from "@/components/task-board/is-subscription-error";
+import { KANBAN_PREVIEW_SRC } from "./backlog-paywall";
+
+const BENEFIT_KEYS = [
+  "taskBoard.subscriptionPaywall.trialBenefitRuns",
+  "taskBoard.subscriptionPaywall.trialBenefitBacklog",
+  "taskBoard.subscriptionPaywall.trialBenefitReruns",
+] as const;
+
+export function SubscriptionPaywallDialog({
+  kind,
+  onOpenChange,
+}: {
+  kind: SubscriptionErrorKind | null;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const t = useT();
+  const studio = useStudioTools();
+
+  const { mutate: subscribe, isPending } = useMutation({
+    mutationFn: async () => {
+      const { url } = await studio.call(
+        "ORGANIZATION_BILLING_CHECKOUT_START",
+        {},
+      );
+      return url;
+    },
+    onSuccess: (url) => {
+      window.open(url, "_blank", "noopener,noreferrer");
+      onOpenChange(false);
+    },
+    onError: (err) => {
+      toast.error(
+        t("taskBoard.subscriptionPaywall.checkoutError", {
+          message: err.message,
+        }),
+      );
+    },
+  });
+
+  if (kind === "trial_exhausted") {
+    return (
+      <Dialog open onOpenChange={onOpenChange}>
+        <DialogContent
+          className="gap-0 p-3 sm:max-w-[440px]"
+          closeButtonClassName="z-10 rounded-full bg-background/70 p-1 text-foreground backdrop-blur transition-colors hover:bg-background"
+        >
+          {/* Same hero as backlog-paywall.tsx's modal — one board-preview
+              image, not a second asset. */}
+          <div className="overflow-hidden rounded-xl bg-muted">
+            <img
+              src={KANBAN_PREVIEW_SRC}
+              alt={t("taskBoard.subscriptionPaywall.previewAlt")}
+              className="h-[160px] w-full object-cover object-left-top"
+            />
+          </div>
+
+          <div className="flex flex-col gap-6 px-3 pb-3 pt-7">
+            <DialogTitle className="text-xl font-semibold text-foreground">
+              {t("taskBoard.subscriptionPaywall.trialTitle")}
+            </DialogTitle>
+            <ul className="flex flex-col gap-3">
+              {BENEFIT_KEYS.map((key) => (
+                <li key={key} className="flex items-start gap-3 text-sm">
+                  <CheckCircle
+                    size={18}
+                    className="mt-0.5 shrink-0 text-success"
+                    aria-hidden
+                  />
+                  <span className="leading-snug text-foreground">{t(key)}</span>
+                </li>
+              ))}
+            </ul>
+            <div className="flex items-baseline gap-1.5">
+              <span className="text-2xl font-semibold text-foreground">
+                {t("taskBoard.subscriptionPaywall.trialPrice")}
+              </span>
+              <span className="text-sm text-muted-foreground">
+                {t("taskBoard.subscriptionPaywall.trialPricePeriod")}
+              </span>
+            </div>
+            <DialogFooter>
+              <Button variant="ghost" onClick={() => onOpenChange(false)}>
+                {t("taskBoard.subscriptionPaywall.notNowButton")}
+              </Button>
+              <Button disabled={isPending} onClick={() => subscribe()}>
+                {isPending && <Loading01 size={16} className="animate-spin" />}
+                {t("taskBoard.subscriptionPaywall.subscribeButton")}
+              </Button>
+            </DialogFooter>
+          </div>
+        </DialogContent>
+      </Dialog>
+    );
+  }
+
+  const copy = kind
+    ? {
+        monthly_exhausted: {
+          title: t("taskBoard.subscriptionPaywall.monthlyTitle"),
+          description: t("taskBoard.subscriptionPaywall.monthlyDescription"),
+        },
+        runs_exhausted: {
+          title: t("taskBoard.subscriptionPaywall.runsTitle"),
+          description: t("taskBoard.subscriptionPaywall.runsDescription"),
+        },
+      }[kind]
+    : null;
+
+  return (
+    <Dialog open={!!kind} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[440px]">
+        <DialogHeader>
+          <DialogTitle>{copy?.title}</DialogTitle>
+          <DialogDescription>{copy?.description}</DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            {t("taskBoard.subscriptionPaywall.dismissButton")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/layouts/task-board/subscription-paywall-dialog.tsx
+++ b/apps/web/src/layouts/task-board/subscription-paywall-dialog.tsx
@@ -31,6 +31,8 @@ import { KANBAN_PREVIEW_SRC } from "./backlog-paywall";
 
 const BENEFIT_KEYS = [
   "taskBoard.subscriptionPaywall.trialBenefitMonitoring",
+  "taskBoard.subscriptionPaywall.trialBenefitAutoFix",
+  "taskBoard.subscriptionPaywall.trialBenefitRuns",
 ] as const;
 
 export function SubscriptionPaywallDialog({

--- a/apps/web/src/layouts/task-board/subscription-paywall-dialog.tsx
+++ b/apps/web/src/layouts/task-board/subscription-paywall-dialog.tsx
@@ -30,9 +30,7 @@ import type { SubscriptionErrorKind } from "@/components/task-board/is-subscript
 import { KANBAN_PREVIEW_SRC } from "./backlog-paywall";
 
 const BENEFIT_KEYS = [
-  "taskBoard.subscriptionPaywall.trialBenefitRuns",
-  "taskBoard.subscriptionPaywall.trialBenefitBacklog",
-  "taskBoard.subscriptionPaywall.trialBenefitReruns",
+  "taskBoard.subscriptionPaywall.trialBenefitMonitoring",
 ] as const;
 
 export function SubscriptionPaywallDialog({

--- a/apps/web/src/layouts/task-board/subscription-paywall-dialog.tsx
+++ b/apps/web/src/layouts/task-board/subscription-paywall-dialog.tsx
@@ -99,23 +99,38 @@ export function SubscriptionPaywallDialog({
                 </li>
               ))}
             </ul>
-            <div className="flex items-baseline gap-1.5">
-              <span className="text-2xl font-semibold text-foreground">
-                {t("taskBoard.subscriptionPaywall.trialPrice")}
-              </span>
-              <span className="text-sm text-muted-foreground">
-                {t("taskBoard.subscriptionPaywall.trialPricePeriod")}
-              </span>
+            {/* Price + actions — stacked full-width on mobile, price-left /
+                buttons-right on sm+ (matches backlog-paywall.tsx's modal). */}
+            <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+              <div className="flex items-baseline gap-1.5">
+                <span className="text-2xl font-semibold text-foreground">
+                  {t("taskBoard.subscriptionPaywall.trialPrice")}
+                </span>
+                <span className="text-sm text-muted-foreground">
+                  {t("taskBoard.subscriptionPaywall.trialPricePeriod")}
+                </span>
+              </div>
+              <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
+                <Button
+                  variant="ghost"
+                  onClick={() => onOpenChange(false)}
+                  disabled={isPending}
+                  className="order-2 w-full sm:order-none sm:w-auto"
+                >
+                  {t("taskBoard.subscriptionPaywall.notNowButton")}
+                </Button>
+                <Button
+                  disabled={isPending}
+                  onClick={() => subscribe()}
+                  className="order-1 w-full gap-2 sm:order-none sm:w-auto"
+                >
+                  {isPending && (
+                    <Loading01 size={16} className="animate-spin" />
+                  )}
+                  {t("taskBoard.subscriptionPaywall.subscribeButton")}
+                </Button>
+              </div>
             </div>
-            <DialogFooter>
-              <Button variant="ghost" onClick={() => onOpenChange(false)}>
-                {t("taskBoard.subscriptionPaywall.notNowButton")}
-              </Button>
-              <Button disabled={isPending} onClick={() => subscribe()}>
-                {isPending && <Loading01 size={16} className="animate-spin" />}
-                {t("taskBoard.subscriptionPaywall.subscribeButton")}
-              </Button>
-            </DialogFooter>
           </div>
         </DialogContent>
       </Dialog>

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -36,6 +36,7 @@ import {
   HelpCircle,
   LinkExternal01,
   Loading02,
+  Lock01,
   Plus,
   Tag01,
   Trash03,
@@ -46,7 +47,10 @@ import { SuperAgentIcon } from "@/components/super-agent-icon";
 import { QaAgentIcon } from "@/components/qa-agent-icon";
 import { CodeReviewerIcon } from "@/components/code-reviewer-icon";
 import { MemoizedMarkdown } from "@/components/chat/markdown";
-import { isReviewerThreadTitle } from "@decocms/shared/task-board";
+import {
+  isReportsTask,
+  isReviewerThreadTitle,
+} from "@decocms/shared/task-board";
 import { MarkdownEditor } from "@/components/markdown-editor";
 import { useMembers } from "@/hooks/use-members";
 import { useCreateTag, useDeleteTag, useTags } from "@/hooks/use-tags";
@@ -233,6 +237,11 @@ export function TaskBoardItemDialog({
     ? members.find((m) => m.userId === item.assignedBy)
     : undefined;
   const StatusIcon = STATUS_CONFIG[status].icon;
+  // Reports-generated tasks: content (title/description/priority) is owned by
+  // the reports sync, which refreshes it on open items — TASK_BOARD_ITEM_UPDATE
+  // rejects a write that touches any of those fields. Board interactions
+  // (status/drag, assignee/delegating, due date, tags) stay free.
+  const contentLocked = !!item && isReportsTask(item);
 
   return (
     <Dialog open={open} onOpenChange={(next) => !next && close()}>
@@ -270,6 +279,7 @@ export function TaskBoardItemDialog({
                 }}
                 value={title}
                 onChange={(e) => {
+                  if (contentLocked) return;
                   setTitle(e.target.value);
                   e.target.style.height = "auto";
                   e.target.style.height = `${e.target.scrollHeight}px`;
@@ -280,8 +290,18 @@ export function TaskBoardItemDialog({
                 placeholder={t("taskBoard.taskDialog.taskTitlePlaceholder")}
                 autoFocus
                 rows={1}
-                className="w-full resize-none overflow-hidden border-0 bg-transparent text-xl font-medium leading-snug text-foreground outline-none placeholder:text-foreground/30"
+                readOnly={contentLocked}
+                className={cn(
+                  "w-full resize-none overflow-hidden border-0 bg-transparent text-xl font-medium leading-snug text-foreground outline-none placeholder:text-foreground/30",
+                  contentLocked && "cursor-default",
+                )}
               />
+              {contentLocked && (
+                <p className="mb-3 mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+                  <Lock01 size={12} />
+                  {t("taskBoard.taskDialog.reportsContentLocked")}
+                </p>
+              )}
             </div>
 
             <div className="flex flex-col gap-6 p-6 pt-6 sm:p-8 sm:pt-6">
@@ -294,6 +314,7 @@ export function TaskBoardItemDialog({
                   defaultValue={description}
                   onChange={setDescription}
                   placeholder={t("taskBoard.taskDialog.descriptionPlaceholder")}
+                  editable={!contentLocked}
                 />
                 {description && (
                   <Button
@@ -380,9 +401,16 @@ export function TaskBoardItemDialog({
                 <DropdownMenuTrigger asChild>
                   <button
                     type="button"
+                    disabled={contentLocked}
+                    title={
+                      contentLocked
+                        ? t("taskBoard.taskDialog.reportsContentLocked")
+                        : undefined
+                    }
                     className={cn(
                       PROPERTY_BUTTON,
                       priority === "none" && "text-muted-foreground",
+                      contentLocked && "cursor-default opacity-60",
                     )}
                   >
                     {priority === "none" ? (

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -199,6 +199,9 @@ export const KEYS = {
   organizationSettings: (organizationId: string) =>
     ["organization-settings", organizationId] as const,
 
+  organizationTaskQuota: (organizationId: string) =>
+    ["organization-task-quota", organizationId] as const,
+
   userModelPreferences: (organizationId: string) =>
     ["user-model-preferences", organizationId] as const,
 

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -485,6 +485,14 @@ const settingsAiProvidersRoute = createRoute({
   ),
 });
 
+const settingsBillingRoute = createRoute({
+  getParentRoute: () => settingsLayout,
+  path: "/billing",
+  component: lazyRouteComponent(
+    () => import("./routes/orgs/settings/billing.tsx"),
+  ),
+});
+
 const settingsSecretsRoute = createRoute({
   getParentRoute: () => settingsLayout,
   path: "/secrets",
@@ -595,6 +603,7 @@ const settingsWithChildren = settingsLayout.addChildren([
   settingsConnectRoute,
   settingsBrandContextRoute,
   settingsAiProvidersRoute,
+  settingsBillingRoute,
   settingsSecretsRoute,
   settingsBucketsRoute,
   settingsMembersRoute,

--- a/apps/web/src/routes/orgs/settings/billing.tsx
+++ b/apps/web/src/routes/orgs/settings/billing.tsx
@@ -1,0 +1,10 @@
+import { OrgBillingPage } from "@/views/settings/billing";
+import { RequireCapability } from "@/components/require-capability";
+
+export default function BillingRoute() {
+  return (
+    <RequireCapability capability="members:manage" area="billing">
+      <OrgBillingPage />
+    </RequireCapability>
+  );
+}

--- a/apps/web/src/views/settings/billing.tsx
+++ b/apps/web/src/views/settings/billing.tsx
@@ -1,0 +1,222 @@
+/**
+ * Settings > Billing — the org's auto-task subscription. `ORGANIZATION_
+ * TASK_QUOTA_GET` is the read side (usage, limit, billing status);
+ * `ORGANIZATION_BILLING_CHECKOUT_START` / `_PORTAL` are the only writes —
+ * both return Stripe-hosted URLs, opened in a new tab like every other
+ * checkout in the app (`deco-credits-hero.tsx`). Everything Stripe hosts
+ * (card, invoices, cancellation) stays with Stripe — no custom billing UI.
+ */
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { CreditCard01, Loading01 } from "@untitledui/icons";
+import { cn } from "@deco/ui/lib/utils.ts";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Badge } from "@deco/ui/components/badge.tsx";
+import { Progress } from "@deco/ui/components/progress.tsx";
+import { Skeleton } from "@deco/ui/components/skeleton.tsx";
+import { Page } from "@/components/page";
+import {
+  SettingsCard,
+  SettingsCardItem,
+  SettingsPage,
+  SettingsSection,
+} from "@/components/settings/settings-section";
+import { useProjectContext } from "@/sdk";
+import { useStudioTools } from "@/lib/studio-tools";
+import { KEYS } from "@/lib/query-keys";
+import { useT } from "@/i18n/use-t.ts";
+
+function useOpenBillingUrl(
+  toolName:
+    | "ORGANIZATION_BILLING_CHECKOUT_START"
+    | "ORGANIZATION_BILLING_PORTAL",
+  errorKey: "settings.billing.checkoutError" | "settings.billing.portalError",
+) {
+  const studio = useStudioTools();
+  const t = useT();
+  return useMutation({
+    mutationFn: async () => {
+      const { url } = await studio.call(toolName, {});
+      return url;
+    },
+    onSuccess: (url) => window.open(url, "_blank", "noopener,noreferrer"),
+    onError: (err) => toast.error(t(errorKey, { message: err.message })),
+  });
+}
+
+const PERIOD_END_FMT = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+});
+
+/** Status pill: paying (good standing) / payment issue (Stripe dunning) /
+ *  free trial (never subscribed, or a canceled subscription). */
+function StatusBadge({
+  billingStatus,
+  subscribed,
+  t,
+}: {
+  billingStatus: string;
+  subscribed: boolean;
+  t: ReturnType<typeof useT>;
+}) {
+  if (subscribed && billingStatus === "past_due") {
+    return (
+      <Badge variant="warning">{t("settings.billing.statusPastDue")}</Badge>
+    );
+  }
+  if (subscribed) {
+    return (
+      <Badge variant="success">{t("settings.billing.statusActive")}</Badge>
+    );
+  }
+  return <Badge variant="secondary">{t("settings.billing.statusTrial")}</Badge>;
+}
+
+function AutoTasksCard() {
+  const t = useT();
+  const { org } = useProjectContext();
+  const studio = useStudioTools();
+  const checkout = useOpenBillingUrl(
+    "ORGANIZATION_BILLING_CHECKOUT_START",
+    "settings.billing.checkoutError",
+  );
+  const portal = useOpenBillingUrl(
+    "ORGANIZATION_BILLING_PORTAL",
+    "settings.billing.portalError",
+  );
+
+  const { data, isLoading } = useQuery({
+    queryKey: KEYS.organizationTaskQuota(org.id),
+    queryFn: () => studio.call("ORGANIZATION_TASK_QUOTA_GET", {}),
+  });
+
+  if (isLoading) {
+    return (
+      <SettingsCard>
+        <div className="flex flex-col gap-3 px-4 py-4">
+          <Skeleton className="h-4 w-40" />
+          <Skeleton className="h-2 w-full" />
+        </div>
+      </SettingsCard>
+    );
+  }
+
+  // Dormant unless STUDIO_TASK_QUOTA_ENFORCED — self-hosted deployments never
+  // gate auto-tasks, so there's nothing to subscribe to or manage.
+  if (!data || !data.enforced) {
+    return (
+      <SettingsCard>
+        <SettingsCardItem
+          icon={<CreditCard01 size={16} />}
+          title={t("settings.billing.autoTasksTitle")}
+          description={t("settings.billing.unlimitedDescription")}
+        />
+      </SettingsCard>
+    );
+  }
+
+  const { billingStatus, subscribed, hasBillingAccount, used, limit } = data;
+  const usedPct = limit > 0 ? Math.min(100, (used / limit) * 100) : 0;
+  const nearLimit = used >= limit;
+
+  return (
+    <SettingsCard>
+      <div className="flex flex-col gap-4 px-4 py-4">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex flex-col gap-1">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium text-foreground">
+                {t("settings.billing.autoTasksTitle")}
+              </span>
+              <StatusBadge
+                billingStatus={billingStatus}
+                subscribed={subscribed}
+                t={t}
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {subscribed
+                ? t("settings.billing.autoTasksDescriptionSubscribed")
+                : t("settings.billing.autoTasksDescriptionTrial")}
+            </p>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            {hasBillingAccount && (
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={portal.isPending}
+                onClick={() => portal.mutate()}
+              >
+                {portal.isPending && (
+                  <Loading01 size={14} className="animate-spin" />
+                )}
+                {t("settings.billing.manageButton")}
+              </Button>
+            )}
+            {!subscribed && (
+              <Button
+                size="sm"
+                disabled={checkout.isPending}
+                onClick={() => checkout.mutate()}
+              >
+                {checkout.isPending && (
+                  <Loading01 size={14} className="animate-spin" />
+                )}
+                {t("settings.billing.subscribeButton")}
+              </Button>
+            )}
+          </div>
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-baseline justify-between gap-2">
+            <span
+              className={cn(
+                "text-sm font-medium",
+                nearLimit ? "text-warning" : "text-foreground",
+              )}
+            >
+              {t("settings.billing.usageLabel", {
+                used: String(used),
+                limit: String(limit),
+              })}
+            </span>
+            {subscribed && data.currentPeriodEnd && (
+              <span className="text-xs text-muted-foreground">
+                {t("settings.billing.renewsOn", {
+                  date: PERIOD_END_FMT.format(new Date(data.currentPeriodEnd)),
+                })}
+              </span>
+            )}
+          </div>
+          <Progress value={usedPct} className="h-1.5" />
+        </div>
+
+        <p className="text-xs text-muted-foreground/80">
+          {t("settings.billing.cancelHint")}
+        </p>
+      </div>
+    </SettingsCard>
+  );
+}
+
+export function OrgBillingPage() {
+  const t = useT();
+  return (
+    <Page>
+      <Page.Content>
+        <Page.Body>
+          <SettingsPage>
+            <Page.Title>{t("settings.billing.title")}</Page.Title>
+            <SettingsSection description={t("settings.billing.description")}>
+              <AutoTasksCard />
+            </SettingsSection>
+          </SettingsPage>
+        </Page.Body>
+      </Page.Content>
+    </Page>
+  );
+}

--- a/apps/web/src/views/settings/billing.tsx
+++ b/apps/web/src/views/settings/billing.tsx
@@ -205,10 +205,6 @@ function AutoTasksCard() {
           </p>
           <Progress value={usedPct} className="h-1.5" />
         </div>
-
-        <p className="text-xs text-muted-foreground/80 pt-4 border-t border-border/60">
-          {t("settings.billing.cancelHint")}
-        </p>
       </div>
     </SettingsCard>
   );
@@ -222,7 +218,7 @@ export function OrgBillingPage() {
         <Page.Body>
           <SettingsPage>
             <Page.Title>{t("settings.billing.title")}</Page.Title>
-            <SettingsSection description={t("settings.billing.description")}>
+            <SettingsSection>
               <AutoTasksCard />
             </SettingsSection>
           </SettingsPage>

--- a/apps/web/src/views/settings/billing.tsx
+++ b/apps/web/src/views/settings/billing.tsx
@@ -123,24 +123,30 @@ function AutoTasksCard() {
 
   return (
     <SettingsCard>
-      <div className="flex flex-col gap-4 px-4 py-4">
-        <div className="flex items-start justify-between gap-3">
-          <div className="flex flex-col gap-1">
-            <div className="flex items-center gap-2">
-              <span className="text-sm font-medium text-foreground">
-                {t("settings.billing.autoTasksTitle")}
-              </span>
-              <StatusBadge
-                billingStatus={billingStatus}
-                subscribed={subscribed}
-                t={t}
-              />
+      <div className="flex flex-col gap-5 px-5 py-5">
+        {/* Provider info and actions */}
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <div className="size-9 shrink-0 rounded-lg bg-muted/60 flex items-center justify-center text-muted-foreground">
+              <CreditCard01 size={16} />
             </div>
-            <p className="text-xs text-muted-foreground">
-              {subscribed
-                ? t("settings.billing.autoTasksDescriptionSubscribed")
-                : t("settings.billing.autoTasksDescriptionTrial")}
-            </p>
+            <div className="flex flex-col gap-1">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-medium text-foreground">
+                  {t("settings.billing.autoTasksTitle")}
+                </span>
+                <StatusBadge
+                  billingStatus={billingStatus}
+                  subscribed={subscribed}
+                  t={t}
+                />
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {subscribed
+                  ? t("settings.billing.autoTasksDescriptionSubscribed")
+                  : t("settings.billing.autoTasksDescriptionTrial")}
+              </p>
+            </div>
           </div>
           <div className="flex shrink-0 items-center gap-2">
             {hasBillingAccount && (
@@ -171,18 +177,20 @@ function AutoTasksCard() {
           </div>
         </div>
 
-        <div className="flex flex-col gap-1.5">
+        {/* Usage */}
+        <div className="flex flex-col gap-2.5 pt-4 border-t border-border/60">
           <div className="flex items-baseline justify-between gap-2">
             <span
               className={cn(
-                "text-sm font-medium",
+                "text-2xl font-semibold tabular-nums tracking-tight",
                 nearLimit ? "text-warning" : "text-foreground",
               )}
             >
-              {t("settings.billing.usageLabel", {
-                used: String(used),
-                limit: String(limit),
-              })}
+              {used}
+              <span className="text-sm font-normal text-muted-foreground">
+                {" "}
+                / {limit}
+              </span>
             </span>
             {subscribed && data.currentPeriodEnd && (
               <span className="text-xs text-muted-foreground">
@@ -192,10 +200,13 @@ function AutoTasksCard() {
               </span>
             )}
           </div>
+          <p className="text-xs text-muted-foreground">
+            {t("settings.billing.runsUsedLabel")}
+          </p>
           <Progress value={usedPct} className="h-1.5" />
         </div>
 
-        <p className="text-xs text-muted-foreground/80">
+        <p className="text-xs text-muted-foreground/80 pt-4 border-t border-border/60">
           {t("settings.billing.cancelHint")}
         </p>
       </div>

--- a/packages/shared/src/task-board.ts
+++ b/packages/shared/src/task-board.ts
@@ -7,6 +7,19 @@
 export const SUPER_AGENT_ASSIGNEE_ID = "super-agent";
 
 /**
+ * True for a task pushed by the Reports import route (`created_by = "system"`,
+ * the sentinel for non-user principals — see `apps/api/src/api/routes/
+ * task-board-import.ts`). Its CONTENT (title/description/priority) is owned by
+ * the reports sync, which refreshes it on open items, so both the write guard
+ * (`TASK_BOARD_ITEM_UPDATE`) and the board UI (locking those fields) key off
+ * this. Board interactions — status/drag, assignee (delegating IS how a run
+ * starts), due date, tags — stay free.
+ */
+export function isReportsTask(item: { createdBy: string }): boolean {
+  return item.createdBy === "system";
+}
+
+/**
  * The org's automated reviewers. Both are derived identities over the org's
  * agent runtime (never seeded), enabled per-org via `qa_agent_enabled` /
  * `code_reviewer_enabled` flags. When a Super Agent task reaches In Review with

--- a/packages/shared/src/tools/registry-metadata.ts
+++ b/packages/shared/src/tools/registry-metadata.ts
@@ -72,6 +72,7 @@ const ALL_TOOL_NAMES = [
   "ORGANIZATION_MEMBER_UPDATE_ROLE",
   "ORGANIZATION_BILLING_CHECKOUT_START",
   "ORGANIZATION_BILLING_PORTAL",
+  "ORGANIZATION_TASK_QUOTA_GET",
   // Connection tools
   "COLLECTION_CONNECTIONS_CREATE",
   "COLLECTION_CONNECTIONS_LIST",
@@ -406,6 +407,11 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
   {
     name: "ORGANIZATION_BILLING_PORTAL",
     description: "Open the Stripe billing portal",
+    category: "Organizations",
+  },
+  {
+    name: "ORGANIZATION_TASK_QUOTA_GET",
+    description: "Get the org's auto-task quota usage",
     category: "Organizations",
   },
   // Connection tools
@@ -1236,6 +1242,7 @@ const PERMISSION_CAPABILITIES: PermissionCapability[] = [
       // preview are the money half of the same surface.
       "ORGANIZATION_BILLING_CHECKOUT_START",
       "ORGANIZATION_BILLING_PORTAL",
+      "ORGANIZATION_TASK_QUOTA_GET",
       // Approving/denying join requests adds members, and the UI lives on the
       // members page — keep it under members:manage.
       "ORGANIZATION_JOIN_REQUEST_LIST",

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -1030,6 +1030,18 @@ export interface StudioToolIO {
     input: { [x: string]: never };
     output: { url: string };
   };
+  ORGANIZATION_TASK_QUOTA_GET: {
+    input: { [x: string]: never };
+    output: {
+      enforced: boolean;
+      billingStatus: string;
+      subscribed: boolean;
+      hasBillingAccount: boolean;
+      used: number;
+      limit: number;
+      currentPeriodEnd: string | null;
+    };
+  };
   COLLECTION_CONNECTIONS_CREATE: {
     input: {
       data: {


### PR DESCRIPTION
## Summary
Frontend for the auto-task monetization backend (task-quota gate already shipped, backend untouched aside from a small read tool):

- **Delegation paywall** — assigning a task to the Super Agent (task dialog, card/lane assignee picker, bulk selection) now catches `[SUBSCRIPTION_REQUIRED]` and shows `SubscriptionPaywallDialog`: rich benefits+price+Subscribe layout for the trial-exhausted case, plain informational dialogs for monthly-exhausted / task-run-limit.
- **Review-flow inline card** — the same error surfacing from the automated reviewer's own thread (e.g. a review bounce hitting the task's re-run cap) renders as a quiet inline `SubscriptionLimitHighlight` in chat, not a sales paywall.
- **PR polling** — already silent both server- and client-side; verified, no change needed.
- **Settings > Billing** — new page (usage, status badge, renewal date, Subscribe / Manage billing via Stripe-hosted checkout/portal).
- **New tool**: `ORGANIZATION_TASK_QUOTA_GET` (read-only; composes the same `taskQuotaState`/`countTaskClaims` helpers the gate itself uses) so the billing page shows real usage instead of guessing.
- **Bugfix found during testing**: reports-generated tasks (`created_by = "system"`) already reject title/description/priority edits server-side — the task dialog now locks those fields (readOnly title, non-editable description, disabled priority picker) instead of letting the user edit-then-silently-fail on save.

All copy is threaded through `t()` (en + pt-br).

## Test plan
- [x] `bun run fmt`, `bun run check` (full workspace), `bun run lint` (0 errors, pre-existing warnings only), `bun run knip` (clean)
- [x] `bun test apps/web/src` — no regressions (same 103 pre-existing failures on `main`, all in unrelated files)
- [x] Manually verified end-to-end against a local dev server with `STUDIO_TASK_QUOTA_ENFORCED=true`: seeded reports-style tasks, exhausted the trial slot, confirmed the paywall dialog fires pre-write (nothing dispatched), confirmed the billing page renders real usage from the new tool, confirmed reports-task content locking
- [ ] Screenshots — none attached (manual verification was via local screenshots shared in chat, not saved to the branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an auto‑task subscription paywall and org billing settings. Delegating to the Super Agent now honors org quota with a Stripe checkout/portal to subscribe or manage billing, and report‑generated task content is locked to match backend rules.

- **New Features**
  - Paywall on Super Agent delegation when `[SUBSCRIPTION_REQUIRED]`: rich subscribe dialog for trial‑exhausted with 3 benefits (continuous monitoring, auto‑fix PRs, 10 runs/cycle); simple info for monthly/task‑run limits.
  - Inline chat card for quota errors in automated review threads; “Subscribe” only for trial‑exhausted.
  - Settings > Billing page: shows usage, limit, billing status, and renewal date; opens Stripe via `ORGANIZATION_BILLING_CHECKOUT_START` and `ORGANIZATION_BILLING_PORTAL`; shows “unlimited” when enforcement is off. Restyled to match the credits card (icon avatar, larger usage stat, simplified copy). New route and nav item added.
  - New tool `ORGANIZATION_TASK_QUOTA_GET` to return quota usage/status; wired into UI with a new query key. Copy localized (en, pt‑BR).

- **Bug Fixes**
  - Report‑generated tasks: title, description, and priority are read‑only in the dialog (editor controls hidden); updates drop these fields to avoid server rejection.
  - Paywall dialog layout: price moved to the same row as action buttons (stacks on mobile).

<sup>Written for commit d367ef033c87588ad096d9735d046ece0dd930a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

