### PR TITLE
docs: use `bunx decocms` on overview page

### DIFF
--- a/apps/docs/client/src/content/deco-studio/en/studio/overview.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/overview.mdx
@@ -71,7 +71,7 @@ Most teams use all three at once: the pilot for quick work, hand-built systems f
 
 | | |
 |---|---|
-| **Local** | `bunx -p decocms deco` — runs entirely on your machine, fully private |
+| **Local** | `bunx decocms` — runs entirely on your machine, fully private |
 | **Cloud** | [studio.decocms.com](https://studio.decocms.com) — manage everything from your browser |
 | **Team** | Shared connections, roles, and cost tracking across your organization |
 | **Self-hosted** | Deploy to your own infrastructure with Docker or Kubernetes |

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/overview.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/overview.mdx
@@ -71,7 +71,7 @@ A maioria dos times usa as três ao mesmo tempo: o pilot para tarefas rápidas, 
 
 | | |
 |---|---|
-| **Local** | `bunx -p decocms deco` — roda inteiramente na sua máquina, totalmente privado |
+| **Local** | `bunx decocms` — roda inteiramente na sua máquina, totalmente privado |
 | **Cloud** | [studio.decocms.com](https://studio.decocms.com) — gerencie tudo pelo navegador |
 | **Team** | Connections, roles e tracking de custos compartilhados em toda a organização |
 | **Self-hosted** | Faça deploy na sua própria infraestrutura com Docker ou Kubernetes |


### PR DESCRIPTION
## Summary
- Replace `bunx -p decocms deco` with `bunx decocms` in the docs Overview (homepage), in both English and Portuguese.

## Notes
The same command still appears on other docs pages (quickstart, ai-providers, self-hosting/quickstart). Happy to update those too if we want full consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the docs Overview pages (EN and PT-BR) to use the new `bunx decocms` command for local runs, replacing `bunx -p decocms deco`. This aligns the homepage instructions with the current CLI and reduces confusion.

<sup>Written for commit 56d95404f6edf9b891768739f3f82d43ba672f8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

