### PR TITLE
docs: use bunx decocms across studio quickstart pages

### DIFF
--- a/apps/docs/client/src/content/deco-studio/en/studio/ai-providers.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/ai-providers.mdx
@@ -62,7 +62,7 @@ The **OpenAI-compatible** provider has branded presets for common deployments â€
 
 ### Local-only providers
 
-When Studio runs locally (via `bunx -p decocms deco`), two extra providers light up that delegate to a CLI installed on your machine:
+When Studio runs locally (via `bunx decocms`), two extra providers light up that delegate to a CLI installed on your machine:
 
 | Provider | Notes |
 |---|---|

--- a/apps/docs/client/src/content/deco-studio/en/studio/quickstart.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/quickstart.mdx
@@ -21,10 +21,10 @@ Sign up at [studio.decocms.com](https://studio.decocms.com) and you're ready to 
 ### Option B — Run locally
 
 ```bash
-bunx -p decocms deco
+bunx decocms
 ```
 
-This spins up a local instance with embedded PostgreSQL. Fully private — everything stays on your machine. The package is published as `decocms`; the binary it ships is `deco`. Or clone and run from source:
+This spins up a local instance with embedded PostgreSQL. Fully private — everything stays on your machine. Or clone and run from source:
 
 ```bash
 git clone https://github.com/decocms/studio.git

--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/quickstart.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/quickstart.mdx
@@ -15,7 +15,7 @@ folder has ready-made scripts, example values, and the full dependency map.
 
 | Tier | How | Dependencies |
 |------|-----|--------------|
-| **Local — CLI** | `bunx -p decocms deco` | embedded, on your machine |
+| **Local — CLI** | `bunx decocms` | embedded, on your machine |
 | **Local — Compose** | `docker compose -f deploy/docker-compose/docker-compose.postgres.yml up` | all bundled (Postgres + NATS + MinIO) |
 | **Local — Kubernetes** | one `helm install` of the umbrella `selfhost/examples/k8s-local` | all bundled (dev Postgres + MinIO + NATS + sandbox) |
 | **Production — Kubernetes** | `helm install` [the chart](/en/studio/self-hosting/deploy/kubernetes) | external/managed Postgres + S3 + NATS + ClickHouse |
@@ -33,7 +33,7 @@ curl -fsSL https://raw.githubusercontent.com/decocms/studio/main/selfhost/skills
 ### Option A: one-command local (CLI)
 
 ```bash
-bunx -p decocms deco
+bunx decocms
 ```
 
 Local instance with an embedded PostgreSQL — fully private. The package is

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/ai-providers.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/ai-providers.mdx
@@ -62,7 +62,7 @@ O provider **OpenAI-compatible** tem presets com marca para deployments comuns �
 
 ### Providers somente locais
 
-Quando o Studio roda localmente (via `bunx -p decocms deco`), dois providers extras aparecem, delegando a um CLI instalado na sua máquina:
+Quando o Studio roda localmente (via `bunx decocms`), dois providers extras aparecem, delegando a um CLI instalado na sua máquina:
 
 | Provider | Observações |
 |---|---|

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/quickstart.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/quickstart.mdx
@@ -21,10 +21,10 @@ Cadastre-se em [studio.decocms.com](https://studio.decocms.com) e está tudo pro
 ### Opção B — Rodar localmente
 
 ```bash
-bunx -p decocms deco
+bunx decocms
 ```
 
-Isso sobe uma instância local com PostgreSQL embutido. Totalmente privado — tudo fica na sua máquina. O pacote é publicado como `decocms`; o binário que ele entrega é `deco`. Ou clone e rode a partir do código-fonte:
+Isso sobe uma instância local com PostgreSQL embutido. Totalmente privado — tudo fica na sua máquina. Ou clone e rode a partir do código-fonte:
 
 ```bash
 git clone https://github.com/decocms/studio.git

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/quickstart.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/quickstart.mdx
@@ -15,7 +15,7 @@ do repositório tem scripts prontos, values de exemplo e o mapa completo de depe
 
 | Tier | Como | Dependências |
 |------|------|--------------|
-| **Local — CLI** | `bunx -p decocms deco` | embutido, na sua máquina |
+| **Local — CLI** | `bunx decocms` | embutido, na sua máquina |
 | **Local — Compose** | `docker compose -f deploy/docker-compose/docker-compose.postgres.yml up` | tudo embutido (Postgres + NATS + MinIO) |
 | **Local — Kubernetes** | um `helm install` do umbrella `selfhost/examples/k8s-local` | tudo embutido (Postgres + MinIO de dev + NATS + sandbox) |
 | **Produção — Kubernetes** | `helm install` [o chart](/pt-br/studio/self-hosting/deploy/kubernetes) | Postgres + S3 + NATS + ClickHouse externos/gerenciados |
@@ -33,7 +33,7 @@ curl -fsSL https://raw.githubusercontent.com/decocms/studio/main/selfhost/skills
 ### Opção A: local com um comando (CLI)
 
 ```bash
-bunx -p decocms deco
+bunx decocms
 ```
 
 Instância local com PostgreSQL embutido — totalmente privada. O pacote é


### PR DESCRIPTION
## Summary

Replaces `bunx -p decocms deco` with the simpler `bunx decocms` across the remaining Studio docs pages (EN + PT-BR), matching the change already made to the overview page in #5735.

- **quickstart.mdx** (Option B — Run locally): command updated; dropped the now-obsolete note about the package being `decocms` and the shipped binary being `deco`.
- **self-hosting/quickstart.mdx**: CLI table row and code block.
- **ai-providers.mdx**: inline "runs locally (via …)" reference.

No remaining `bunx -p decocms deco` references in `apps/docs/`.

## Testing

Docs-only change (MDX copy). No code paths affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes Studio docs to use `bunx decocms` instead of `bunx -p decocms deco` across EN and PT-BR quickstart, self-hosting, and AI providers pages. Removes the outdated note about the `decocms` package/binary naming; no functional changes.

<sup>Written for commit 0d413d90b9f0111c0e451c24fdc3227efb1ecfc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

