### PR TITLE
fix(task-board): revert conflict-resolution bounce when dispatch fails

### DIFF
--- a/apps/api/src/tools/task-board/conflict-reaction.ts
+++ b/apps/api/src/tools/task-board/conflict-reaction.ts
@@ -120,9 +120,26 @@ export async function reactToApprovedPrConflict(
     data: { prNumber: pr.number },
   });
   emitTaskBoardUpdated(orgId, claimed);
-  await enqueueSuperAgentForTask(ctx, claimed, {
-    pr: { number: pr.number, url: pr.url },
-    resolveConflict: true,
-  });
+  try {
+    await enqueueSuperAgentForTask(ctx, claimed, {
+      pr: { number: pr.number, url: pr.url },
+      resolveConflict: true,
+    });
+  } catch (err) {
+    // Nothing was dispatched. Unlike a fresh delegation, this bounced the
+    // task's STATUS to In Progress as the dispatch fence — leaving it there
+    // strands the task forever: the guard above only fires on `in_review`,
+    // so no future poll or approval retries it. Bounce back so it does.
+    await ctx.storage.taskBoard
+      .update(claimed.id, orgId, { status: "in_review" }, "system")
+      .then((reverted) => emitTaskBoardUpdated(orgId, reverted))
+      .catch((revertErr) =>
+        console.error(
+          "[task-board] conflict-resolution status revert failed",
+          revertErr,
+        ),
+      );
+    throw err;
+  }
   return true;
 }


### PR DESCRIPTION
A bug found while auditing the task-board dispatch/claim machinery after recent hardening PRs (#5728, #5725).

`reactToApprovedPrConflict` atomically bounces an approved-but-conflicting task from In Review to In Progress as its dispatch fence, then calls `enqueueSuperAgentForTask` to resolve the conflict. If that enqueue throws (no model configured, a transient dispatch error), the bounce was never undone: the task is stuck In Progress forever, because every caller only re-triggers the reaction when `status === "in_review"` (`prs-get.ts`'s poll and `review-decision.ts`'s approval path) — no future poll or approval ever retries it, and the conflict-resolution attempt cap already counted this failed try.

This is the exact failure shape #5728 just fixed for `claimReviewer`'s slot (a dispatch failure must release what it claimed, or the retry path is permanently blocked). Here the "claim" is a status transition rather than a unique-constraint DB row, so the release is a revert back to `in_review` instead of a delete.

**Fix**: wrap the `enqueueSuperAgentForTask` call in try/catch; on failure, revert the item's status back to `in_review` (best-effort, logged if that write itself fails) and re-throw the original error unchanged. Both existing call sites already catch-and-log this as best-effort (and `review-decision.ts` already special-cases `TaskQuotaError` to propagate) — re-throwing unchanged preserves that behavior; only the stuck status is newly fixed.

**Reviewer check**: `apps/api/src/tools/task-board/conflict-reaction.ts` — confirm the revert only fires on enqueue failure and doesn't touch the success path.

**Verified locally**: `bun run fmt`, `apps/api && bunx tsc --noEmit` (clean), `bunx oxlint` on the touched file (0 warnings/errors), and the existing `conflict-reaction.test.ts` (pure cap-boundary logic, unaffected by this change) still passes. The reaction touches Postgres and has no integration test today (before or after this change) and no local Postgres is available here to add one confidently — CI's e2e/integration tier exercises it same as before.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug that left approved-but-conflicting tasks stuck In Progress when conflict-resolution dispatch failed.

- **Bug Fixes**
  - On `enqueueSuperAgentForTask` failure, revert the task back to `in_review` and emit an update.
  - Re-throw the original error so existing caller behavior stays the same; success path unchanged.
  - Log a warning if the revert write fails.

<sup>Written for commit 85da23e9e6d1e6c3b6a12e590bb8a855f98a6de6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

