### PR TITLE
feat(commerce-onboarding): gate Shopify card behind ?shopify search param

### DIFF
--- a/apps/web/src/routes/commerce-onboarding/use-commerce-companions.ts
+++ b/apps/web/src/routes/commerce-onboarding/use-commerce-companions.ts
@@ -7,6 +7,7 @@ import {
   useSuspenseQueries,
   useSuspenseQuery,
 } from "@tanstack/react-query";
+import { useSearch } from "@tanstack/react-router";
 import { PROVIDER_BY_BINDING_TYPE } from "./companion-forms/sa-binding-copy.ts";
 import { COMMERCE_COMPANION_MCPS } from "./companions.ts";
 import {
@@ -84,10 +85,16 @@ export function useCommerceCompanions({
     : null;
   // Live schema wins; fall back to the known companion set while it loads or
   // when it's unreachable, so the section is never empty due to a CD proxy 401.
-  const requirements =
+  // Shopify is gated behind an explicit `?shopify` search param while it's
+  // being rolled out; without it the card never renders.
+  const { shopify: shopifyParam } = useSearch({ strict: false }) as {
+    shopify?: unknown;
+  };
+  const requirements = (
     schemaRequirements && schemaRequirements.length > 0
       ? schemaRequirements
-      : FALLBACK_COMPANION_REQUIREMENTS;
+      : FALLBACK_COMPANION_REQUIREMENTS
+  ).filter((r) => r.bindingType !== "shopify" || shopifyParam != null);
   const bindingTypes = requirements.map((r) => r.bindingType);
   const registryAppIds = requirements
     .map((r) => COMMERCE_COMPANION_MCPS[r.bindingType]?.registryAppId)


### PR DESCRIPTION
## Summary
Hide the Shopify companion card in commerce onboarding (both the blocking connect modal and the `/commerce-onboarding` route) unless the URL contains a `shopify` search param (any value: `?shopify`, `?shopify=1`, …).

The filter lives in `useCommerceCompanions`, the single point both surfaces build cards from. Filtering the binding requirements up front also means the registry never fetches the Shopify app when the param is absent.

## Notes
- Without the param, an already-linked Shopify connection is also hidden (visual only — the connection itself is untouched).
- `bun run fmt` and `tsc --noEmit` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate the Shopify companion card in commerce onboarding behind a `?shopify` search param. The card won’t render or fetch from the registry unless the param is present.

- Use `useSearch` from `@tanstack/react-router` to show Shopify only when `?shopify` is in the URL.
- Filter companion requirements to skip Shopify when absent, so the registry app isn’t fetched; existing Shopify links remain but are hidden visually.

<sup>Written for commit 503eeca8560e4f19b871dce66fd1cd7aeb699023. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

