### PR TITLE
fix(decopilot): mark thread-ownership dispatch check as a permanent error

### DIFF
--- a/apps/api/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/api/src/api/routes/decopilot/dispatch-run.ts
@@ -972,7 +972,13 @@ async function prepareRun(
     rootSpan.setAttribute("decopilot.thread.id", mem.thread.id);
 
     if (mem.thread.created_by !== input.userId) {
-      throw new Error(
+      // Ownership never changes for a thread, so this is a permanent
+      // condition, not a transient dispatch failure — a retry (or, for
+      // automations, the next scheduled fire) will hit the exact same
+      // check forever. Marking it permanent lets fireAutomationWorkflow
+      // deactivate the automation instead of retrying it indefinitely.
+      throw new PermanentRunError(
+        "not_thread_owner",
         "You are not allowed to write to this thread because you are not the owner",
       );
     }

--- a/apps/api/src/core/dispatch-errors.ts
+++ b/apps/api/src/core/dispatch-errors.ts
@@ -1,7 +1,8 @@
 export type PermanentRunErrorCode =
   | "empty_request"
   | "agent_not_found"
-  | "model_not_allowed";
+  | "model_not_allowed"
+  | "not_thread_owner";
 
 export class PermanentRunError extends Error {
   /** Own-enumerable so it survives DBOS error (de)serialization. */


### PR DESCRIPTION
**Source:** bug found while hardening `apps/api/src/api/routes/decopilot/dispatch-run.ts`'s dispatch path.

**Payoff:** `prepareRun`'s "not the owner" guard threw a plain `Error` instead of `PermanentRunError`. `fireAutomationWorkflow` (apps/api/src/automations/dbos-workflow.ts) uses `isPermanentRunError(err)` to decide whether to deactivate a misconfigured automation or just log-and-retry-later. A thread's `created_by` never changes, so this condition is permanent by nature — same as the existing `empty_request`/`agent_not_found`/`model_not_allowed` codes — but it was falling into the generic "log an error, leave the automation active" branch, so an automation targeting a thread it doesn't own would silently fail on every future scheduled fire forever instead of self-deactivating with a clear reason.

**Fix:** added a `not_thread_owner` code to `PermanentRunErrorCode` and throw `PermanentRunError` instead of a plain `Error` at the ownership check in `prepareRun`.

**Verify:** `cd apps/api && bunx tsc --noEmit` (clean) and `bunx oxlint src/api/routes/decopilot/dispatch-run.ts src/core/dispatch-errors.ts` (0 warnings/errors). No existing unit test covers `prepareRun`'s ownership branch (it requires full DBOS/StudioContext integration, which is e2e territory, not unit) or `fireAutomationWorkflow`'s deactivation branch, so I did not add a mock-based unit test for either — full CI/e2e validates the rest.

Locally ran: `bun run fmt`, targeted `bunx tsc --noEmit` in apps/api, per-file `bunx oxlint`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark the thread ownership check in decopilot dispatch as a permanent error so misconfigured automations stop retrying and self-deactivate with a clear reason. Adds a `not_thread_owner` code and throws `PermanentRunError` in `prepareRun`.

- **Bug Fixes**
  - Added `not_thread_owner` to `PermanentRunErrorCode` in `apps/api/src/core/dispatch-errors.ts`.
  - In `apps/api/src/api/routes/decopilot/dispatch-run.ts`, throw `PermanentRunError('not_thread_owner', ...)` when `created_by !== userId`.
  - `fireAutomationWorkflow` now deactivates automations that target non-owned threads via `isPermanentRunError`.

<sup>Written for commit 0cd5bb9ef7d49f8093d5862066c89469f07e72ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

