### PR TITLE
perf(task-board): shrink the create() sort_order race window

### DIFF
--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -5,7 +5,7 @@
  * many-to-many link between a task and the agent threads run for it.
  */
 
-import type { Kysely } from "kysely";
+import { sql, type Kysely } from "kysely";
 // Shared with the quota gate, which charges the same class of task.
 import { isReportsTask } from "../billing/task-quota";
 import type {
@@ -200,13 +200,11 @@ export class TaskBoardStorage {
 
     // New cards land at the top of their lane — one below the current lowest
     // sort_order (ascending order), matching the prior created_at-desc feel.
-    const { minOrder } = await this.db
-      .selectFrom("task_board_items")
-      .select((eb) => eb.fn.min("sort_order").as("minOrder"))
-      .where("organization_id", "=", params.organizationId)
-      .where("status", "=", status)
-      .executeTakeFirstOrThrow();
-
+    // Computed as a subquery inside the INSERT itself (rather than a separate
+    // SELECT beforehand plus an app-side -1) so two concurrent creates in the
+    // same lane race for, at most, a single round trip instead of two — the
+    // previous SELECT-then-INSERT left a full network round trip open for
+    // another create to land on the same sort_order.
     const row = await this.db
       .insertInto("task_board_items")
       .values({
@@ -220,7 +218,12 @@ export class TaskBoardStorage {
         assigned_by: params.assignedBy ?? null,
         due_date: params.dueDate ?? null,
         external_key: params.externalKey ?? null,
-        sort_order: (minOrder ?? 0) - 1,
+        sort_order: sql<number>`(
+          select coalesce(min(sort_order), 0) - 1
+          from task_board_items
+          where organization_id = ${params.organizationId}
+          and status = ${status}
+        )`,
         created_by: params.by,
         created_at: now,
         updated_by: params.by,


### PR DESCRIPTION
Reduction/optimization found while auditing `apps/api/src/storage/task-board.ts` for storage-layer races (no open issue/PR covers this).

`TaskBoardStorage.create()` computed the new card's `sort_order` with a separate `SELECT min(sort_order)` followed by an app-side `-1` and then an `INSERT` in a second round trip. Two concurrent `create()` calls landing cards in the same lane (status) could both read the same `min` before either commits, then both insert with the identical `sort_order` — a real race whenever two agents/users create cards in the same lane close together (e.g. a bulk import or two people dragging in new cards at once). Ties don't corrupt data, but they do leave two cards with an ambiguous relative order that the UI has to break arbitrarily.

This moves the `min(sort_order) - 1` computation into a subquery inside the `INSERT` itself, so it's one round trip instead of two — the race window shrinks from a full network round trip to a single statement. I'm not claiming this fully serializes concurrent creates (Postgres READ COMMITTED still lets two truly-simultaneous statements each snapshot before the other commits), just that it meaningfully narrows the window that's actually exploitable in practice.

Behavior-preserving: same formula (`coalesce(min(sort_order), 0) - 1`), same result for the single-writer case exercised by existing tests/tools — `bun run --cwd=apps/api migrate` unaffected, no schema change.

Reviewer check: `cd apps/api && bunx tsc --noEmit` (green) and `bunx oxlint src/storage/task-board.ts` (0 warnings/errors) — both run locally. No unit test added: this needs a real-Postgres concurrency test to observe (two parallel `create()` calls), which isn't cheaply verifiable in this environment per the testing tiers; full CI validates the rest.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shrink the sort_order race window in TaskBoardStorage.create() by computing min(sort_order) - 1 inside the INSERT. This reduces duplicate sort_order under concurrent creates and removes an extra round trip, with no behavior or schema changes.

- **Performance**
  - Use a single-statement INSERT with a subquery: coalesce(min(sort_order), 0) - 1 filtered by organization and status via `kysely` sql.
  - No API or schema changes; single-writer behavior remains the same.

<sup>Written for commit 2138a2929f0519bc1ee338d2874f39425866a54c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

