### PR TITLE
fix(local-mode): self-heal stale JWKS so already-broken installs recover

### DIFF
--- a/apps/api/src/auth/local-mode.integration.test.ts
+++ b/apps/api/src/auth/local-mode.integration.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Real-Postgres coverage for pruneUndecryptableJwks() — the local-mode
+ * self-heal that recovers pre-fix installs whose JWKS was encrypted under a
+ * now-lost random secret (see local-mode.ts / settings/local-secret.ts).
+ *
+ * These assert the exact wire/storage contract Better Auth uses: privateKey is
+ * stored as a JSON-encoded hex ciphertext keyed by the auth secret, so the
+ * probe must delete only rows that fail to decrypt under the current secret and
+ * leave valid ones untouched.
+ */
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "bun:test";
+import { symmetricEncrypt } from "better-auth/crypto";
+import { sql } from "kysely";
+import { pruneUndecryptableJwks } from "./local-mode";
+import type { StudioDatabase } from "../database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+} from "../database/test-db-pg";
+
+const SECRET = "current-persisted-secret";
+const OTHER_SECRET = "lost-per-process-secret";
+
+/** Encode a private key the way Better Auth stores it: JSON-wrapped hex cipher. */
+async function encodePrivateKey(secret: string, plaintext: string) {
+  return JSON.stringify(
+    await symmetricEncrypt({ key: secret, data: plaintext }),
+  );
+}
+
+async function insertJwk(
+  db: StudioDatabase["db"],
+  id: string,
+  privateKey: string,
+) {
+  await sql`
+    insert into jwks (id, "publicKey", "privateKey", "createdAt")
+    values (${id}, ${'{"pub":true}'}, ${privateKey}, now())
+  `.execute(db);
+}
+
+async function jwkIds(db: StudioDatabase["db"]): Promise<string[]> {
+  const { rows } = await sql<{ id: string }>`
+    select id from jwks order by id
+  `.execute(db);
+  return rows.map((r) => r.id);
+}
+
+describe("pruneUndecryptableJwks", () => {
+  let database: StudioDatabase;
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    // Self-contained: Better Auth owns this table via its own migrations, which
+    // the Kysely-only test harness does not run.
+    await sql`
+      create table if not exists jwks (
+        id text primary key,
+        "publicKey" text not null,
+        "privateKey" text not null,
+        "createdAt" timestamptz not null default now()
+      )
+    `.execute(database.db);
+  });
+
+  afterAll(async () => {
+    await sql`delete from jwks`.execute(database.db);
+    await closeTestPgDatabase(database);
+  });
+
+  beforeEach(async () => {
+    await sql`delete from jwks`.execute(database.db);
+  });
+
+  it("deletes keys that no longer decrypt and keeps the ones that do", async () => {
+    await insertJwk(
+      database.db,
+      "good",
+      await encodePrivateKey(SECRET, "k-good"),
+    );
+    await insertJwk(
+      database.db,
+      "wrong-secret",
+      await encodePrivateKey(OTHER_SECRET, "k-stale"),
+    );
+    await insertJwk(database.db, "corrupt", "not-valid-json{");
+
+    const removed = await pruneUndecryptableJwks(database.db, SECRET);
+
+    expect(removed).toBe(2);
+    expect(await jwkIds(database.db)).toEqual(["good"]);
+  });
+
+  it("is a no-op when every key decrypts (idempotent across restarts)", async () => {
+    await insertJwk(database.db, "a", await encodePrivateKey(SECRET, "k-a"));
+    await insertJwk(database.db, "b", await encodePrivateKey(SECRET, "k-b"));
+
+    expect(await pruneUndecryptableJwks(database.db, SECRET)).toBe(0);
+    // Second boot: still clean, still a no-op.
+    expect(await pruneUndecryptableJwks(database.db, SECRET)).toBe(0);
+    expect(await jwkIds(database.db)).toEqual(["a", "b"]);
+  });
+
+  it("removes every key when the secret rotated out from under all of them", async () => {
+    await insertJwk(
+      database.db,
+      "x",
+      await encodePrivateKey(OTHER_SECRET, "k-x"),
+    );
+    await insertJwk(
+      database.db,
+      "y",
+      await encodePrivateKey(OTHER_SECRET, "k-y"),
+    );
+
+    expect(await pruneUndecryptableJwks(database.db, SECRET)).toBe(2);
+    expect(await jwkIds(database.db)).toEqual([]);
+  });
+});

--- a/apps/api/src/auth/local-mode.integration.test.ts
+++ b/apps/api/src/auth/local-mode.integration.test.ts
@@ -3,10 +3,14 @@
  * self-heal that recovers pre-fix installs whose JWKS was encrypted under a
  * now-lost random secret (see local-mode.ts / settings/local-secret.ts).
  *
- * These assert the exact wire/storage contract Better Auth uses: privateKey is
- * stored as a JSON-encoded hex ciphertext keyed by the auth secret, so the
- * probe must delete only rows that fail to decrypt under the current secret and
- * leave valid ones untouched.
+ * These assert the load-bearing part of the storage contract Better Auth uses:
+ * privateKey is stored as a JSON-encoded hex ciphertext keyed by the auth
+ * secret, so the probe must delete only rows that fail to decrypt under the
+ * current secret and leave valid ones untouched. (The real better-auth table
+ * carries an extra nullable `expiresAt` the probe never reads; omitted here.)
+ *
+ * NOTE: this suite issues an unconditional `delete from jwks` — point
+ * DATABASE_URL at a throwaway/test DB, never a dev DB with real signing keys.
  */
 import {
   afterAll,
@@ -106,6 +110,27 @@ describe("pruneUndecryptableJwks", () => {
     // Second boot: still clean, still a no-op.
     expect(await pruneUndecryptableJwks(database.db, SECRET)).toBe(0);
     expect(await jwkIds(database.db)).toEqual(["a", "b"]);
+  });
+
+  it("is a no-op on an empty table", async () => {
+    expect(await pruneUndecryptableJwks(database.db, SECRET)).toBe(0);
+  });
+
+  it("returns 0 when the jwks table does not exist yet (fresh DB)", async () => {
+    await sql`drop table jwks`.execute(database.db);
+    try {
+      expect(await pruneUndecryptableJwks(database.db, SECRET)).toBe(0);
+    } finally {
+      // Restore the table so beforeEach/afterAll (and any later test) still work.
+      await sql`
+        create table if not exists jwks (
+          id text primary key,
+          "publicKey" text not null,
+          "privateKey" text not null,
+          "createdAt" timestamptz not null default now()
+        )
+      `.execute(database.db);
+    }
   });
 
   it("removes every key when the secret rotated out from under all of them", async () => {

--- a/apps/api/src/auth/local-mode.ts
+++ b/apps/api/src/auth/local-mode.ts
@@ -7,13 +7,82 @@
  * Only runs when DECOCMS_LOCAL_MODE=true (set by CLI).
  */
 
-import { getDb } from "@/database";
+import { getDb, type StudioDatabase } from "@/database";
+import { symmetricDecrypt } from "better-auth/crypto";
+import { sql } from "kysely";
 import { getSettings } from "../settings";
 import { userInfo } from "os";
 import { auth } from "./index";
 
 const LOCAL_EMAIL_DOMAIN = "localhost.studio";
 const LEGACY_LOCAL_EMAIL_DOMAIN = "localhost.mesh";
+
+/**
+ * Self-heal stale JWKS keys left by a pre-fix local install.
+ *
+ * Before local mode persisted a stable secret (see settings/local-secret.ts),
+ * Better Auth minted a fresh random secret every process start and encrypted
+ * the JWKS private key with it. On the next boot the now-different secret could
+ * not decrypt that key — `GET /api/auth/get-session` 500s and the user is
+ * trapped in an unbreakable login loop. Persisting the secret stops NEW installs
+ * from ever reaching that state, but a DB seeded by a pre-fix version still
+ * carries a JWKS row encrypted under a secret that no longer exists, so those
+ * users stay stuck until the row is cleared.
+ *
+ * So on every local-mode boot, probe each JWKS row with the current secret and
+ * drop any that no longer decrypt. Better Auth transparently regenerates a fresh
+ * key (encrypted with the persisted secret) on the next sign, so `bunx decocms`
+ * self-recovers with no manual DB surgery. Local mode is loopback-only, so
+ * discarding a signing key only invalidates local sessions the broken boot had
+ * already invalidated anyway.
+ *
+ * Returns the number of undecryptable keys removed.
+ */
+export async function healLocalJwks(): Promise<number> {
+  const { betterAuthSecret } = getSettings();
+  // No secret resolved => Better Auth is on its random-per-process path; there
+  // is no stable key to probe against, so healing would be meaningless.
+  if (!betterAuthSecret) return 0;
+  return pruneUndecryptableJwks(getDb().db, betterAuthSecret);
+}
+
+/**
+ * Core of {@link healLocalJwks}, decoupled from the Settings/DB singletons so it
+ * can be exercised against a real Postgres in tests. Probes every JWKS row with
+ * `secret` and deletes the ones that no longer decrypt. Returns the count removed.
+ */
+export async function pruneUndecryptableJwks(
+  db: StudioDatabase["db"],
+  secret: string,
+): Promise<number> {
+  let rows: readonly { id: string; privateKey: string }[];
+  try {
+    const result = await sql<{ id: string; privateKey: string }>`
+      select id, "privateKey" from jwks
+    `.execute(db);
+    rows = result.rows;
+  } catch {
+    // jwks table not created yet (fresh DB, before Better Auth mints the first
+    // key) — nothing to heal.
+    return 0;
+  }
+
+  let removed = 0;
+  for (const row of rows) {
+    try {
+      // Mirror Better Auth's own decrypt path (plugins/jwt/sign): the stored
+      // privateKey is a JSON-encoded encrypted payload keyed by the secret.
+      await symmetricDecrypt({
+        key: secret,
+        data: JSON.parse(row.privateKey),
+      });
+    } catch {
+      await sql`delete from jwks where id = ${row.id}`.execute(db);
+      removed++;
+    }
+  }
+  return removed;
+}
 
 /**
  * Get the local admin password.

--- a/apps/api/src/auth/local-mode.ts
+++ b/apps/api/src/auth/local-mode.ts
@@ -39,11 +39,16 @@ const LEGACY_LOCAL_EMAIL_DOMAIN = "localhost.mesh";
  * Returns the number of undecryptable keys removed.
  */
 export async function healLocalJwks(): Promise<number> {
-  const { betterAuthSecret } = getSettings();
+  const settings = getSettings();
+  // Defense in depth: this DELETEs signing keys, so it must never run outside
+  // local mode even if a future caller forgets the gate. `betterAuthSecret` is
+  // truthy in production too, so it alone is not a safe guard — a server
+  // recovers via its explicit shared BETTER_AUTH_SECRET, never by dropping keys.
+  if (!settings.localMode) return 0;
   // No secret resolved => Better Auth is on its random-per-process path; there
   // is no stable key to probe against, so healing would be meaningless.
-  if (!betterAuthSecret) return 0;
-  return pruneUndecryptableJwks(getDb().db, betterAuthSecret);
+  if (!settings.betterAuthSecret) return 0;
+  return pruneUndecryptableJwks(getDb().db, settings.betterAuthSecret);
 }
 
 /**
@@ -61,24 +66,40 @@ export async function pruneUndecryptableJwks(
       select id, "privateKey" from jwks
     `.execute(db);
     rows = result.rows;
-  } catch {
-    // jwks table not created yet (fresh DB, before Better Auth mints the first
-    // key) — nothing to heal.
+  } catch (err) {
+    // Postgres 42P01 = undefined_table: a fresh DB hasn't had Better Auth mint
+    // its first key yet, so there is genuinely nothing to heal.
+    if ((err as { code?: string } | undefined)?.code === "42P01") return 0;
+    // Anything else (DB down, permissions, a column renamed by a Better Auth
+    // upgrade) must be surfaced — silently returning 0 would leave a genuinely
+    // broken install stuck in the login loop with no diagnostic.
+    console.warn("[local-mode] JWKS heal skipped — could not read jwks:", err);
     return 0;
   }
 
   let removed = 0;
   for (const row of rows) {
+    // Mirror Better Auth's own decrypt path (plugins/jwt/sign, verified against
+    // better-auth@1.4.22): the stored privateKey is a JSON-encoded encrypted
+    // payload keyed by the secret. Re-verify this contract on any upgrade.
+    let decryptable = true;
     try {
-      // Mirror Better Auth's own decrypt path (plugins/jwt/sign): the stored
-      // privateKey is a JSON-encoded encrypted payload keyed by the secret.
-      await symmetricDecrypt({
-        key: secret,
-        data: JSON.parse(row.privateKey),
-      });
+      await symmetricDecrypt({ key: secret, data: JSON.parse(row.privateKey) });
     } catch {
+      decryptable = false;
+    }
+    if (decryptable) continue;
+
+    try {
       await sql`delete from jwks where id = ${row.id}`.execute(db);
       removed++;
+    } catch (err) {
+      // A transient delete failure must not abort the rest of boot (seeding
+      // runs after this); the next clean boot will retry the heal.
+      console.warn(
+        `[local-mode] JWKS heal could not delete stale key ${row.id}:`,
+        err,
+      );
     }
   }
   return removed;

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -281,8 +281,17 @@ const stopProfiling = startProfiling();
 // from the self MCP endpoint (http://localhost:PORT/mcp/self).
 if (settings.localMode) {
   import("./auth/local-mode")
-    .then(async ({ seedLocalMode, markSeedComplete }) => {
+    .then(async ({ seedLocalMode, markSeedComplete, healLocalJwks }) => {
       try {
+        // Recover pre-fix installs whose JWKS was encrypted under a now-lost
+        // random secret; runs before the seed gate opens so the first login
+        // never races a stale key. See healLocalJwks() for the full rationale.
+        const healed = await healLocalJwks();
+        if (healed > 0) {
+          console.log(
+            `[local-mode] cleared ${healed} undecryptable JWKS key(s); Better Auth will generate a fresh one`,
+          );
+        }
         const seeded = await seedLocalMode();
         void seeded;
       } catch (error) {

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -284,8 +284,10 @@ if (settings.localMode) {
     .then(async ({ seedLocalMode, markSeedComplete, healLocalJwks }) => {
       try {
         // Recover pre-fix installs whose JWKS was encrypted under a now-lost
-        // random secret; runs before the seed gate opens so the first login
-        // never races a stale key. See healLocalJwks() for the full rationale.
+        // random secret; runs before the seed gate opens so the auto-login
+        // (/local-session) path never races a stale key. A direct get-session
+        // probe can still 500 once in the brief pre-heal window, exactly as it
+        // did before this fix. See healLocalJwks() for the full rationale.
         const healed = await healLocalJwks();
         if (healed > 0) {
           console.log(


### PR DESCRIPTION
## Summary

Follow-up to #5733. That PR persists a stable local-mode auth secret **going forward**, but does nothing for a DB seeded by a **pre-fix** version. Such a DB carries a JWKS row whose private key was encrypted under a random per-process secret that no longer exists — so `GET /api/auth/get-session` **still 500s** and the user stays trapped in the login loop even after upgrading to `bunx decocms@latest`:

```
BetterAuthError: Failed to decrypt private key. Make sure the secret currently
in use is the same as the one used to encrypt the private key.
[5xx Response] GET /api/auth/get-session - 500
```

The goal: a user who already hit the error just runs `bunx decocms@latest` and it works — no manual DB surgery.

## Fix

On every local-mode boot, probe each `jwks` row with the current persisted secret (via Better Auth's own `symmetricDecrypt`, mirroring `plugins/jwt/sign`) and **delete the ones that no longer decrypt**. Better Auth transparently regenerates a fresh key — encrypted with the stable secret — on the next sign, so an already-broken install self-recovers.

- `auth/local-mode.ts` — new `healLocalJwks()` (reads the Settings/DB singletons) delegating to a decoupled, testable core `pruneUndecryptableJwks(db, secret)`.
- `index.ts` — runs the heal in the local-mode boot block **before the seed gate opens**, so the first login never races a stale key.

Local mode is loopback-only auto-login, so discarding a signing key only invalidates sessions the broken boot had already invalidated. Valid keys (and non-local deployments) are untouched — the probe deletes only rows that fail to decrypt under the current secret.

## Testing

- **New real-Postgres integration test** `auth/local-mode.integration.test.ts` (3 cases): deletes undecryptable rows while keeping valid ones, is a no-op/idempotent when every key decrypts, and clears all keys when the secret rotated out from under them — passing.
- **Manual end-to-end** against `bunx decocms` embedded Postgres: simulated a pre-fix broken install by rotating the persisted secret so the existing JWKS became undecryptable, then booted this build →
  - log: `[local-mode] cleared 1 undecryptable JWKS key(s); Better Auth will generate a fresh one`
  - `GET /api/auth/get-session` → **200** (was 500), auto-login OK, **zero** `BetterAuthError`
  - restart with a clean DB → heal reports **0** (idempotent), 200.
- `bun run --cwd apps/api check` (typecheck), `bun run fmt`, `bun run lint` — clean.

## Affected areas

`bunx decocms` / CLI local mode (`DECOCMS_LOCAL_MODE=true`) only. Server deployments (explicit `BETTER_AUTH_SECRET`) never resolve a persisted secret and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically heals stale JWKS in local mode so broken installs recover from login loops. Fixes 500s on `/api/auth/get-session` with no manual DB steps.

- **Bug Fixes**
  - On local-mode boot, `healLocalJwks()` probes each `jwks` row using `symmetricDecrypt` from `better-auth/crypto` and deletes keys that fail to decrypt; non-42P01 read errors are logged, and per-row delete failures no longer abort boot. Better Auth regenerates a fresh key on next sign.
  - Runs before the seed gate so `/local-session` doesn’t race a stale key. Executes only when `DECOCMS_LOCAL_MODE=true` and a persisted secret exists; server deployments are unaffected.
  - Adds `pruneUndecryptableJwks(db, secret)` and real Postgres tests, including empty-table and missing-table cases. Logs the number of cleared keys.

<sup>Written for commit ba17c7607f9cabdabb1bea79e5fa58d0cba1a22f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

