### PR TITLE
feat(task-board): auto-merge when no reviewers are enabled

### DIFF
--- a/apps/api/src/tools/task-board/auto-merge.ts
+++ b/apps/api/src/tools/task-board/auto-merge.ts
@@ -1,0 +1,73 @@
+import type { StudioContext } from "@/core/studio-context";
+import type { TaskBoardItem } from "@/storage/types";
+import { recordTaskActivity } from "./activity";
+import { emitTaskBoardUpdated } from "./run-reactions";
+import { mergeLinkedPr } from "./merge-pr";
+import { fetchPrConflict } from "./prs-get";
+import { reactToApprovedPrConflict } from "./conflict-reaction";
+
+/** What `finalizeAutoMerge` did with the task's PR. `merged` → the PR merged and
+ *  the task advanced to Done; `resolving` → the merge was blocked by a base-branch
+ *  conflict and the PR was handed back to the Super Agent to resolve. Both false
+ *  means nothing changed (auto-merge off, CI not ready, no PR, or a transient
+ *  failure) and the task stays In Review. */
+export type AutoMergeOutcome = { merged: boolean; resolving: boolean };
+
+/**
+ * The tail of the auto-merge flow, shared by the two ways an approved PR reaches
+ * it: the reviewer decision (every enabled reviewer approved) and the
+ * no-reviewer path (auto-merge on with QA Agent + Code Reviewer both off, driven
+ * from `enqueueEnabledReviewers`). Callers must have already checked the
+ * auto-merge gate is satisfied and the org's `auto_merge` flag is on — this
+ * function just executes the merge.
+ *
+ * Tries to merge the task's open PR (`mergeLinkedPr` itself refuses to ship on
+ * red/pending CI). On success it moves the task to Done, logs the status change,
+ * and broadcasts the update. If the merge was blocked by a conflict with the
+ * base branch specifically, it hands the PR back to the Super Agent to resolve
+ * (the conflict fetch is a GitHub round-trip, so only pay it when a merge was
+ * actually attempted). Returns what happened so the caller can report status.
+ *
+ * Emits on the terminal transitions it owns (Done, or the conflict bounce via
+ * `reactToApprovedPrConflict`) but NOT on the no-op case — a caller that changed
+ * other state (e.g. recorded an approval) is responsible for its own emit.
+ */
+export async function finalizeAutoMerge(
+  ctx: StudioContext,
+  orgId: string,
+  task: TaskBoardItem,
+): Promise<AutoMergeOutcome> {
+  const merged = await mergeLinkedPr(ctx, orgId, task.id);
+  if (merged) {
+    const done = await ctx.storage.taskBoard.update(
+      task.id,
+      orgId,
+      { status: "done" },
+      task.updatedBy,
+    );
+    await recordTaskActivity(ctx, {
+      taskBoardItemId: task.id,
+      action: "status_changed",
+      actorId: null,
+      data: { from: task.status, to: "done" },
+    });
+    emitTaskBoardUpdated(orgId, done);
+    return { merged: true, resolving: false };
+  }
+
+  // No merge — when it was a base-branch conflict, hand the PR back to the Super
+  // Agent to resolve. Act on the newest linked PR (the one `mergeLinkedPr` just
+  // tried). Best-effort: a dispatch failure must never surface as a merge error.
+  const prs = await ctx.storage.taskBoard.listPrs(task.id, orgId);
+  const pr = prs[0];
+  const resolving = pr
+    ? await reactToApprovedPrConflict(ctx, orgId, task, {
+        pr: { number: pr.number, url: pr.url },
+        conflict: await fetchPrConflict(ctx, orgId, pr),
+      }).catch((err) => {
+        console.error("[task-board] conflict auto-resolve failed", err);
+        return false;
+      })
+    : false;
+  return { merged: false, resolving };
+}

--- a/apps/api/src/tools/task-board/conflict-reaction.ts
+++ b/apps/api/src/tools/task-board/conflict-reaction.ts
@@ -1,7 +1,7 @@
 import type { StudioContext } from "@/core/studio-context";
 import type { TaskBoardItem } from "@/storage/types";
 import {
-  allReviewersApproved,
+  readyForAutoMerge,
   REVIEWER_FLAG,
   REVIEWER_KINDS,
   type ReviewCycleActivity,
@@ -45,10 +45,11 @@ export function conflictResolutionCapReached(
  * which pulls a task back to In Progress the moment a run starts on it.
  *
  * Gated on the org's `auto_merge` flag — conflict resolution is an extension of
- * auto-merge (the only thing standing between an approved PR and an automatic
+ * auto-merge (the only thing standing between a mergeable PR and an automatic
  * merge is the conflict), so it rides the same opt-in rather than its own knob.
- * Also gated on the SAME verified all-approved check the auto-merge uses (a
- * self-asserted approval must not trigger it) and a per-task cap so a conflict
+ * Also gated on the SAME `readyForAutoMerge` check the auto-merge uses — every
+ * enabled reviewer token-verified-approved, or no reviewer enabled (a
+ * self-asserted approval must not trigger it) — and a per-task cap so a conflict
  * the agent can't resolve doesn't loop forever.
  *
  * `opts.pr` is the PR the caller detected the conflict on — the reaction acts on
@@ -79,15 +80,15 @@ export async function reactToApprovedPrConflict(
   const flags = settings?.flags ?? {};
   if (flags.auto_merge !== true) return false;
 
-  // Same gate as the auto-merge: EVERY enabled reviewer must have a
-  // token-verified approval in the current cycle. With no reviewer enabled
-  // `allReviewersApproved` is false, so a conflict never auto-resolves without
-  // an approval standing behind it.
+  // Same gate as the auto-merge: the PR must be ready to merge — every enabled
+  // reviewer token-verified-approved in the current cycle, OR no reviewer
+  // enabled (auto-merge with both off, so there's nothing to wait on). Without
+  // this, a conflicting PR under a no-reviewer auto-merge org would sit forever.
   const enabled = REVIEWER_KINDS.filter(
     (k) => flags[REVIEWER_FLAG[k]] === true,
   );
   const activity = await ctx.storage.taskBoard.listActivity(item.id, orgId);
-  if (!allReviewersApproved(activity, enabled, { verifiedOnly: true })) {
+  if (!readyForAutoMerge(activity, enabled, { verifiedOnly: true })) {
     return false;
   }
 

--- a/apps/api/src/tools/task-board/enqueue-reviewer.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.ts
@@ -14,6 +14,7 @@ import {
 import { recordTaskActivity } from "./activity";
 import { emitTaskBoardUpdated } from "./run-reactions";
 import { enqueueAgentRunForTask } from "./enqueue-task-run";
+import { finalizeAutoMerge } from "./auto-merge";
 
 /**
  * A Super Agent run finished — if it left a task In Review with an open PR,
@@ -102,7 +103,24 @@ export async function enqueueEnabledReviewers(
   const enabled = REVIEWER_KINDS.filter(
     (k) => flags[REVIEWER_FLAG[k]] === true,
   );
-  if (enabled.length === 0) return;
+  if (enabled.length === 0) {
+    // No reviewer enabled — there's nothing to dispatch, but auto-merge still
+    // applies: with QA Agent and Code Reviewer both off, the reviewer gate is
+    // vacuously satisfied (same convention as the manual ship button), so an In
+    // Review Super Agent PR ships as soon as its checks are green (or absent).
+    // `finalizeAutoMerge` refuses to ship on red/pending CI and resolves a
+    // base-branch conflict, so this is safe on either trigger (the poll path
+    // gates on ready checks; the run-finish path relies on that guard). Both
+    // callers reach here idempotently — a merged PR moves the task off In
+    // Review, so the next poll's assignee/status guard skips it. Off without
+    // auto-merge: leave it In Review for a human. Best-effort.
+    if (flags.auto_merge === true) {
+      await finalizeAutoMerge(ctx, task.organizationId, task).catch((err) => {
+        console.error("[task-board] no-reviewer auto-merge failed", err);
+      });
+    }
+    return;
+  }
 
   // A reviewer belongs to the current cycle if its thread is still live, or was
   // created since the task last entered In Review — either way don't re-enqueue.

--- a/apps/api/src/tools/task-board/review-decision.ts
+++ b/apps/api/src/tools/task-board/review-decision.ts
@@ -12,9 +12,7 @@ import { TaskBoardItemStatusSchema } from "./schema";
 import { recordTaskActivity } from "./activity";
 import { emitTaskBoardUpdated } from "./run-reactions";
 import { enqueueSuperAgentForTask } from "./enqueue-super-agent";
-import { mergeLinkedPr } from "./merge-pr";
-import { fetchPrConflict } from "./prs-get";
-import { reactToApprovedPrConflict } from "./conflict-reaction";
+import { finalizeAutoMerge } from "./auto-merge";
 
 /**
  * True when EVERY enabled reviewer has a token-VERIFIED `approve` as its latest
@@ -207,71 +205,24 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
 
     const settings = await ctx.storage.organizationSettings.get(organizationId);
     const autoMerge = settings?.flags?.auto_merge === true;
-    const merged = autoMerge
-      ? await mergeLinkedPr(ctx, organizationId, taskBoardItemId)
-      : false;
 
-    // A merge ships the task → Done.
-    if (merged) {
-      const done = await ctx.storage.taskBoard.update(
-        taskBoardItemId,
-        organizationId,
-        { status: "done" },
-        item.updatedBy,
-      );
-      await recordTaskActivity(ctx, {
-        taskBoardItemId,
-        action: "status_changed",
-        actorId: null,
-        data: { from: item.status, to: "done" },
-      });
-      emitTaskBoardUpdated(organizationId, done);
-      return { status: done.status, merged: true };
-    }
+    // With auto-merge on, run the shared finalize: merge the PR (→ Done), or, if
+    // a base-branch conflict blocks it, hand the PR back to the Super Agent to
+    // resolve — the same tail the no-reviewer auto-merge path uses. It emits on
+    // the transitions it owns (Done, or the conflict bounce). With auto-merge
+    // off the task stays In Review for a human to ship.
+    const outcome = autoMerge
+      ? await finalizeAutoMerge(ctx, organizationId, item)
+      : { merged: false, resolving: false };
 
-    // No merge — the task is still In Review (we only move it on a merge). When
-    // auto-merge is on and the merge was blocked by a conflict specifically (not
-    // pending CI, not a transient failure), hand the PR back to the Super Agent
-    // to resolve it — the headless counterpart to the poll path in `prs-get`.
-    // The conflict fetch is a GitHub round-trip, so only pay it when auto-merge
-    // is on. Otherwise leave it In Review for a human.
     const current =
       (await ctx.storage.taskBoard.getById(taskBoardItemId, organizationId)) ??
       item;
-    if (autoMerge) {
-      const prs = await ctx.storage.taskBoard.listPrs(
-        taskBoardItemId,
-        organizationId,
-      );
-      // The newest linked PR is the one under review (the same one
-      // `mergeLinkedPr` just tried to merge) — detect and act on it.
-      const pr = prs[0];
-      // Best-effort, like the poll path in `prs-get` — a dispatch failure (no
-      // model configured, queue error) must never fail this decision: the
-      // approval + bounce-to-in_progress + activity write already committed,
-      // so surfacing an error here would report failure on an otherwise-
-      // successful reviewer decision while burning a conflict-resolution
-      // attempt with no run enqueued.
-      const resolving = pr
-        ? await reactToApprovedPrConflict(ctx, organizationId, current, {
-            pr: { number: pr.number, url: pr.url },
-            conflict: await fetchPrConflict(ctx, organizationId, pr),
-          }).catch((err) => {
-            console.error("[task-board] conflict auto-resolve failed", err);
-            return false;
-          })
-        : false;
-      if (resolving) {
-        const bounced =
-          (await ctx.storage.taskBoard.getById(
-            taskBoardItemId,
-            organizationId,
-          )) ?? current;
-        // `reactToApprovedPrConflict` already emitted the update.
-        return { status: bounced.status, merged: false };
-      }
+    // Nothing terminal happened — this handler still recorded the approval, so
+    // emit the refreshed card so clients see the new verdict.
+    if (!outcome.merged && !outcome.resolving) {
+      emitTaskBoardUpdated(organizationId, current);
     }
-    emitTaskBoardUpdated(organizationId, current);
-    return { status: current.status, merged: false };
+    return { status: current.status, merged: outcome.merged };
   },
 });

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -382,7 +382,7 @@ export const settings = {
     "Reviews the code using the repository's stack-appropriate review skills.",
   "settings.review.autoMergeTitle": "Enable Auto-merge",
   "settings.review.autoMergeDescription":
-    "When every enabled reviewer approves, merge the pull request automatically instead of waiting for a human. If a conflict blocks the merge, the Super Agent resolves it first.",
+    "When every enabled reviewer approves, merge the pull request automatically instead of waiting for a human — with no reviewers enabled, it merges as soon as checks pass. If a conflict blocks the merge, the Super Agent resolves it first.",
   "settings.review.updateError": "Couldn't update the setting",
   "settings.agentRuntime.title": "Agent runtime",
   "settings.agentRuntime.description":

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -398,7 +398,7 @@ export const settings = {
     "Revisa o c\u00f3digo usando as skills de review apropriadas \u00e0 stack do reposit\u00f3rio.",
   "settings.review.autoMergeTitle": "Ativar Auto-merge",
   "settings.review.autoMergeDescription":
-    "Quando todos os revisores habilitados aprovam, mescla o pull request automaticamente em vez de esperar por uma pessoa. Se um conflito bloquear o merge, o Super Agent resolve antes.",
+    "Quando todos os revisores habilitados aprovam, mescla o pull request automaticamente em vez de esperar por uma pessoa — sem nenhum revisor habilitado, mescla assim que os checks passam. Se um conflito bloquear o merge, o Super Agent resolve antes.",
   "settings.review.updateError":
     "N\u00e3o foi poss\u00edvel atualizar a configura\u00e7\u00e3o",
   "settings.agentRuntime.title": "Runtime do agente",

--- a/packages/shared/src/organization/schema.ts
+++ b/packages/shared/src/organization/schema.ts
@@ -153,7 +153,7 @@ export const OrgFlagsSchema = z.object({
     .boolean()
     .optional()
     .describe(
-      "When every enabled reviewer (QA Agent / Code Reviewer) approves a task's pull request, merge it automatically instead of leaving the merge to a human. If the merge is blocked by a conflict with the base branch, hand the PR back to the Super Agent to resolve the conflict (check out the branch, merge the base, push) so it can then merge.",
+      "When every enabled reviewer (QA Agent / Code Reviewer) approves a task's pull request, merge it automatically instead of leaving the merge to a human. With no reviewer enabled, the PR merges as soon as its checks pass (or it has none). If the merge is blocked by a conflict with the base branch, hand the PR back to the Super Agent to resolve the conflict (check out the branch, merge the base, push) so it can then merge.",
     ),
   claude_code_sandbox_enabled: z
     .boolean()

--- a/packages/shared/src/task-board.test.ts
+++ b/packages/shared/src/task-board.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
   allReviewersApproved,
   isReviewerThreadTitle,
+  readyForAutoMerge,
   reviewCycleStart,
   reviewCycleVerdicts,
   type ReviewCycleActivity,
@@ -144,5 +145,43 @@ describe("allReviewersApproved", () => {
     ).toBe(false);
     // The human ship button (no verifiedOnly) still sees both as approved.
     expect(allReviewersApproved(forged, ["qa", "code_review"])).toBe(true);
+  });
+});
+
+describe("readyForAutoMerge", () => {
+  const qaApproved = [
+    IN_REVIEW_1,
+    at(
+      "review_approved",
+      { reviewer: "qa", verified: true },
+      "2026-01-01T10:05:00Z",
+    ),
+  ];
+
+  it("no reviewers enabled → ready (auto-merge with QA + Code Reviewer both off)", () => {
+    // The gap this closes: with an empty enabled set, `allReviewersApproved` is
+    // false, but auto-merge must still ship — nothing is standing in the way.
+    expect(readyForAutoMerge([], [])).toBe(true);
+    expect(readyForAutoMerge(qaApproved, [])).toBe(true);
+  });
+
+  it("with reviewers enabled, gates exactly like allReviewersApproved", () => {
+    expect(readyForAutoMerge(qaApproved, ["qa"])).toBe(true);
+    expect(readyForAutoMerge(qaApproved, ["qa", "code_review"])).toBe(false);
+  });
+
+  it("passes verifiedOnly through — an unverified approval doesn't count", () => {
+    const forged = [
+      IN_REVIEW_1,
+      at(
+        "review_approved",
+        { reviewer: "qa", verified: false },
+        "2026-01-01T10:05:00Z",
+      ),
+    ];
+    expect(readyForAutoMerge(forged, ["qa"], { verifiedOnly: true })).toBe(
+      false,
+    );
+    expect(readyForAutoMerge(forged, ["qa"])).toBe(true);
   });
 });

--- a/packages/shared/src/task-board.ts
+++ b/packages/shared/src/task-board.ts
@@ -113,6 +113,22 @@ export function allReviewersApproved(
   return enabled.every((k) => verdicts.get(k) === "approved");
 }
 
+/** True when a task's PR may auto-merge: either NO reviewer is enabled (nothing
+ *  to wait on — the org opted into auto-merge with QA Agent and Code Reviewer
+ *  both off, so the reviewer gate is vacuously satisfied) or every enabled
+ *  reviewer approved in the current cycle. This is the same convention the
+ *  manual ship button uses (`isReadyToShip`), so the two ways an approved PR
+ *  reaches production agree on "no reviewers ⇒ ready". `verifiedOnly` requires
+ *  token-verified approvals — the automatic merge/conflict paths pass it so a
+ *  self-asserted approval can't ship; the manual button does not. */
+export function readyForAutoMerge(
+  activity: ReviewCycleActivity[],
+  enabled: ReviewerKind[],
+  opts?: { verifiedOnly?: boolean },
+): boolean {
+  return enabled.length === 0 || allReviewersApproved(activity, enabled, opts);
+}
+
 /**
  * Org-scoped SSE event pushed on `sseHub` whenever a Super Agent run advances a
  * task board item's status (enqueued→todo, executing→in_progress, PR→in_review).

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -559,6 +559,17 @@ export interface StudioToolIO {
     input: { id: string };
     output: { success: boolean };
   };
+  TASK_ADD_REPO: {
+    input: { connectionId?: string | undefined };
+    output: {
+      success: boolean;
+      message: string;
+      repositories?: { connectionId: string; repo: string }[] | undefined;
+      repo?: string | undefined;
+      cloned?: boolean | undefined;
+      files?: string | undefined;
+    };
+  };
   BRAND_CONTEXT_LIST: {
     input: { includeArchived?: boolean | undefined };
     output: {
@@ -3508,6 +3519,7 @@ export interface StudioToolIO {
                     expandedAt: string;
                   }[]
                 | undefined;
+              read_only?: boolean | undefined;
             }
           | undefined;
         run_config?: Record<string, unknown> | null | undefined;
@@ -3574,6 +3586,7 @@ export interface StudioToolIO {
                     expandedAt: string;
                   }[]
                 | undefined;
+              read_only?: boolean | undefined;
             }
           | undefined;
         run_config?: Record<string, unknown> | null | undefined;
@@ -3617,6 +3630,7 @@ export interface StudioToolIO {
                     expandedAt: string;
                   }[]
                 | undefined;
+              read_only?: boolean | undefined;
             }
           | undefined;
         run_config?: Record<string, unknown> | null | undefined;
@@ -3647,6 +3661,7 @@ export interface StudioToolIO {
                     expandedAt: string;
                   }[]
                 | undefined;
+              read_only?: boolean | undefined;
             }
           | undefined;
         branch?: string | null | undefined;
@@ -3686,6 +3701,7 @@ export interface StudioToolIO {
                     expandedAt: string;
                   }[]
                 | undefined;
+              read_only?: boolean | undefined;
             }
           | undefined;
         run_config?: Record<string, unknown> | null | undefined;
@@ -3727,6 +3743,7 @@ export interface StudioToolIO {
                     expandedAt: string;
                   }[]
                 | undefined;
+              read_only?: boolean | undefined;
             }
           | undefined;
         run_config?: Record<string, unknown> | null | undefined;


### PR DESCRIPTION
## Summary

With **QA Agent** and **Code Reviewer** both disabled, an In Review Super Agent PR now **merges automatically** once its checks pass (or it has none), instead of sitting In Review waiting for a human.

Before this, auto-merge was effectively coupled to having at least one reviewer enabled — for two independent reasons:
1. `allReviewersApproved([])` returned `false` (an empty enabled set is not vacuously "all approved"), and
2. no reviewer run was ever dispatched, so `TASK_BOARD_REVIEW_DECISION` — the only path that reached the merge — was never called.

This aligns auto-merge with the **manual "Ship to production" button**, which already treats "no reviewers enabled" as ready (`isReadyToShip` → `enabled.length === 0 || …`).

## Changes

- **`readyForAutoMerge` (shared)** — new predicate: *no reviewer enabled* **OR** *every enabled reviewer approved*. Same convention as the ship button; `verifiedOnly` still required on the automatic paths so a self-asserted approval can't ship.
- **`finalizeAutoMerge` (new `auto-merge.ts`)** — the merge tail (merge → Done + activity + emit; on a base-branch conflict, hand the PR back to the Super Agent) extracted and shared by the reviewer-decision path and the new no-reviewer path, removing the duplicated block in `review-decision.ts`.
- **`enqueueEnabledReviewers`** — when no reviewer is enabled and `auto_merge` is on, it now runs `finalizeAutoMerge` directly. Fires from **both** existing triggers: the board's poll (`TASK_BOARD_ITEM_PRS_GET`, gated on green checks) and the headless run-finish hook. `mergeLinkedPr` still refuses to ship on red/pending CI, so both are safe.
- **Conflict auto-resolution** now rides the same `readyForAutoMerge` gate, so a no-reviewer org's conflicting PR isn't stranded.
- **Copy**: clarified the `auto_merge` flag description + en/pt-br toggle text ("with no reviewers enabled, it merges as soon as checks pass"); regenerated tool contracts.

## Testing

- `packages/shared` unit tests: added 3 cases for `readyForAutoMerge` (no-reviewers→ready, gates like `allReviewersApproved` when reviewers exist, `verifiedOnly` passthrough). `bun test packages/shared/src/task-board.test.ts` → 11 pass.
- `bun run check` on `apps/api`, `apps/web`, `packages/shared` — clean.
- `bun run lint` (0 errors) and `bun run knip` (no dead code).
- Task-board unit tests pass (the one failing test is a Postgres integration test needing a live DB).

## Known limitation (follow-up)

The headless run-finish trigger fires the moment the Super Agent completes — usually **before CI finishes** — so `mergeLinkedPr` is blocked by pending checks and the merge only re-attempts on the next board poll (reconcile-on-view). This is a **pre-existing** systemic gap in the auto-merge design (it affects the reviewer flow too, just more rarely); with no reviewers it becomes the common case. Proper fix is a headless retry — recommended approach is a **DBOS scheduled sweep** (mirroring `automationsGcWorkflow`) that periodically re-runs `finalizeAutoMerge` for `in_review` auto-merge tasks. Tracked as follow-up, not included here.

> Note: this branch is behind `main`; a rebase may be needed before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-merge now works when QA Agent and Code Reviewer are both disabled: In Review PRs merge automatically once checks pass, matching the “Ship to production” button. This prevents PRs from sitting In Review without reviewers.

- **New Features**
  - Auto-merge with no reviewers enabled, triggered by both the board poll and the headless run-finish hook; still blocked on failing/pending checks.
  - Conflict auto-resolution uses the same gate and hands the PR back to the Super Agent when a base-branch conflict blocks merge.
  - Updated `auto_merge` setting copy in EN/PT-BR to explain the no-reviewer behavior.

- **Refactors**
  - Added `readyForAutoMerge` (no reviewers OR all enabled reviewers approved, with optional verified-only).
  - Extracted `finalizeAutoMerge` to unify merge → Done and conflict bounce; used by reviewer-decision and no-reviewer paths.
  - Simplified reviewer decision flow and switched conflict reaction to `readyForAutoMerge`.

<sup>Written for commit 0c24cb16340db2b418edc0272269fc4dd085ff9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

