### PR TITLE
fix(i18n): stop task-board selectedCount always using plural in pt-br

### DIFF
--- a/apps/web/src/i18n/pt-br/task-board.ts
+++ b/apps/web/src/i18n/pt-br/task-board.ts
@@ -48,7 +48,7 @@ export const taskBoard = {
   "taskBoard.taskBoard.tasksTitle": "Tarefas",
   "taskBoard.taskBoard.laneMenuAriaLabel": "Mais ações para {lane}",
   "taskBoard.taskBoard.selectAllInLane": "Selecionar todos",
-  "taskBoard.taskBoard.selectedCount": "{count} selecionados",
+  "taskBoard.taskBoard.selectedCount": "{count} selecionado(s)",
   "taskBoard.taskBoard.clearSelectionButton": "Limpar",
   "taskBoard.taskBoard.actionsButton": "Ações",
   "taskBoard.taskBoard.moveToButton": "Mover para",


### PR DESCRIPTION
The pt-br task-board `selectedCount` string hardcodes plural ("{count} selecionados"), showing grammatically wrong text when exactly 1 item is selected (e.g. selecting a single task on the board shows "1 selecionados" instead of "1 selecionado").

Fixed to match the sibling key `orgs.connectionSelectionUi.selectedCount` and `registry.registryRequestsPage.selectedCount`, both already using the `"{count} selecionado(s)"` convention for the same count-of-selected-items meaning in this codebase.

Failure scenario: a pt-br user selects a single task on the task board (`apps/web/src/layouts/task-board/index.tsx:907`) and sees "1 selecionados" instead of the grammatically correct "1 selecionado(s)".

Reviewer check: `grep -n selectedCount apps/web/src/i18n/pt-br/task-board.ts apps/web/src/i18n/pt-br/orgs.ts apps/web/src/i18n/pt-br/registry.ts` — confirms the convention now matches across all three.

Local checks: `bun run fmt`, `bunx tsc --noEmit` in apps/web (clean, no type change), `bunx oxlint apps/web/src/i18n/pt-br/task-board.ts` (0 warnings/errors). No test needed — pure string content change. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the pt-BR task board selected count label to use "{count} selecionado(s)" instead of always plural. This shows the correct text for a single selection and aligns with other screens.

<sup>Written for commit a236c6ccd0af3d77d80a984197dd3207b0a9319c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

