### PR TITLE
fix(task-board): broadcast the paywall un-delegate on report import

### DIFF
--- a/apps/api/src/api/routes/task-board-import.ts
+++ b/apps/api/src/api/routes/task-board-import.ts
@@ -274,6 +274,7 @@ export const createTaskBoardImportRoutes = () => {
         quotaBlocked++;
         await new TaskBoardStorage(ctx.db)
           .update(row.id, organizationId, { assigneeId: null }, "system")
+          .then((updated) => emitTaskBoardUpdated(organizationId, updated))
           .catch((undoErr: unknown) => {
             console.error("[task-board-import] un-delegate failed", undoErr);
           });


### PR DESCRIPTION
Bug found while reading the task-board-import route (recently touched by #5731's paywall work).

When a reports-import batch delegates a card to the Super Agent but the org is over its task quota, the route correctly un-assigns the card (`assigneeId: null`) so the user isn't left with a card that looks delegated with no run behind it. But that un-assign update was never broadcast over SSE — only the earlier "touched" batch (which still had the Super Agent assignee) was emitted. Any board open at import time keeps showing the card as assigned to the Super Agent until the user manually refreshes, contradicting the comment right above the code ("the user sees the paywall when they delegate it themselves") which assumes the UI reflects the un-assign live.

Failure scenario: org is at its task quota, a diagnostic report import tries to auto-delegate a finding to the Super Agent, quota check throws `TaskQuotaError`, the route un-assigns the row in storage but the open task board (SSE-subscribed) never gets the update event, so the card visually stays "delegated" until a manual reload.

Fix: emit `emitTaskBoardUpdated` with the updated (un-assigned) row right after the successful un-delegate update, mirroring how every other mutation in this route already broadcasts.

Reviewer check: `bunx tsc --noEmit` in apps/api stays green; `bunx oxlint apps/api/src/api/routes/task-board-import.ts` is clean. A DB-backed regression test would need the integration harness (Postgres) to exercise the transaction + quota path, which isn't available in this environment — the change itself is a one-line addition mirroring the existing broadcast pattern used everywhere else in the same handler.

Locally verified: `bun run fmt`, `bunx tsc --noEmit` (apps/api), `bunx oxlint` on the touched file. Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the task board staying out of sync during report imports when an org is over its task quota. We now broadcast the un-assign (assigneeId: null) over SSE immediately, so open boards stop showing the card as delegated to the Super Agent without needing a refresh.

<sup>Written for commit d2db837289e8360501187328f9aa679ac99d32d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

