### PR TITLE
refactor(web): extract shared billing-checkout mutation hook

### DIFF
--- a/apps/web/src/components/chat/highlight/index.tsx
+++ b/apps/web/src/components/chat/highlight/index.tsx
@@ -22,7 +22,7 @@ import { CollapsibleHighlight } from "./collapsible-highlight";
 import { CreditsExhaustedBanner } from "../credits-exhausted-banner";
 import { SubscriptionLimitHighlight } from "./subscription-limit";
 import { useHighlightFlags } from "./use-highlight-count";
-import { useStudioTools } from "@/lib/studio-tools";
+import { useOpenBillingUrl } from "@/hooks/use-open-billing-url";
 import { parseErrorMessage } from "./parse-error-message";
 import type { UserAskToolPart } from "../types";
 
@@ -177,23 +177,11 @@ export function ChatHighlight() {
   const [preferences, setPreferences] = usePreferences();
   const { virtualMcpId, createTaskWithMessage } = useChatTask();
   const { chatMode, simpleModeTier } = useChatPrefs();
-  const studio = useStudioTools();
-
-  const handleSubscribe = async () => {
-    try {
-      const { url } = await studio.call(
-        "ORGANIZATION_BILLING_CHECKOUT_START",
-        {},
-      );
-      window.open(url, "_blank", "noopener,noreferrer");
-    } catch (err) {
-      toast.error(
-        t("taskBoard.subscriptionPaywall.checkoutError", {
-          message: err instanceof Error ? err.message : String(err),
-        }),
-      );
-    }
-  };
+  const { mutate: subscribe } = useOpenBillingUrl(
+    "ORGANIZATION_BILLING_CHECKOUT_START",
+    "taskBoard.subscriptionPaywall.checkoutError",
+  );
+  const handleSubscribe = () => subscribe();
 
   // Build a fresh RequestOptions at call time so tier/mode reflect the
   // user's current selection. `toolApprovalLevel` is passed in explicitly:

--- a/apps/web/src/hooks/use-open-billing-url.ts
+++ b/apps/web/src/hooks/use-open-billing-url.ts
@@ -1,0 +1,29 @@
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useStudioTools } from "@/lib/studio-tools";
+import { useT } from "@/i18n/use-t.ts";
+import type { TranslationKey } from "@/i18n/use-t.ts";
+
+/**
+ * Fetch a Stripe-hosted URL (checkout or billing portal) and open it in a
+ * new tab, like every other checkout in the app (`deco-credits-hero.tsx`).
+ * Shared by the billing settings page, the task-board subscription paywall,
+ * and the inline subscription-limit chat highlight.
+ */
+export function useOpenBillingUrl(
+  toolName:
+    | "ORGANIZATION_BILLING_CHECKOUT_START"
+    | "ORGANIZATION_BILLING_PORTAL",
+  errorKey: TranslationKey,
+) {
+  const studio = useStudioTools();
+  const t = useT();
+  return useMutation({
+    mutationFn: async () => {
+      const { url } = await studio.call(toolName, {});
+      return url;
+    },
+    onSuccess: (url) => window.open(url, "_blank", "noopener,noreferrer"),
+    onError: (err) => toast.error(t(errorKey, { message: err.message })),
+  });
+}

--- a/apps/web/src/layouts/task-board/subscription-paywall-dialog.tsx
+++ b/apps/web/src/layouts/task-board/subscription-paywall-dialog.tsx
@@ -12,8 +12,6 @@
  * are purely informational (quota renews on its own / make a new task), so
  * they stay a plain title + description.
  */
-import { useMutation } from "@tanstack/react-query";
-import { toast } from "sonner";
 import { CheckCircle, Loading01 } from "@untitledui/icons";
 import { Button } from "@deco/ui/components/button.tsx";
 import {
@@ -24,7 +22,7 @@ import {
   DialogDescription,
   DialogFooter,
 } from "@deco/ui/components/dialog.tsx";
-import { useStudioTools } from "@/lib/studio-tools";
+import { useOpenBillingUrl } from "@/hooks/use-open-billing-url";
 import { useT } from "@/i18n/use-t.ts";
 import type { SubscriptionErrorKind } from "@/components/task-board/is-subscription-error";
 import { KANBAN_PREVIEW_SRC } from "./backlog-paywall";
@@ -43,28 +41,11 @@ export function SubscriptionPaywallDialog({
   onOpenChange: (open: boolean) => void;
 }) {
   const t = useT();
-  const studio = useStudioTools();
 
-  const { mutate: subscribe, isPending } = useMutation({
-    mutationFn: async () => {
-      const { url } = await studio.call(
-        "ORGANIZATION_BILLING_CHECKOUT_START",
-        {},
-      );
-      return url;
-    },
-    onSuccess: (url) => {
-      window.open(url, "_blank", "noopener,noreferrer");
-      onOpenChange(false);
-    },
-    onError: (err) => {
-      toast.error(
-        t("taskBoard.subscriptionPaywall.checkoutError", {
-          message: err.message,
-        }),
-      );
-    },
-  });
+  const { mutate: subscribe, isPending } = useOpenBillingUrl(
+    "ORGANIZATION_BILLING_CHECKOUT_START",
+    "taskBoard.subscriptionPaywall.checkoutError",
+  );
 
   if (kind === "trial_exhausted") {
     return (
@@ -121,7 +102,11 @@ export function SubscriptionPaywallDialog({
                 </Button>
                 <Button
                   disabled={isPending}
-                  onClick={() => subscribe()}
+                  onClick={() =>
+                    subscribe(undefined, {
+                      onSuccess: () => onOpenChange(false),
+                    })
+                  }
                   className="order-1 w-full gap-2 sm:order-none sm:w-auto"
                 >
                   {isPending && (

--- a/apps/web/src/views/settings/billing.tsx
+++ b/apps/web/src/views/settings/billing.tsx
@@ -6,8 +6,7 @@
  * checkout in the app (`deco-credits-hero.tsx`). Everything Stripe hosts
  * (card, invoices, cancellation) stays with Stripe — no custom billing UI.
  */
-import { useMutation, useQuery } from "@tanstack/react-query";
-import { toast } from "sonner";
+import { useQuery } from "@tanstack/react-query";
 import { CreditCard01, Loading01 } from "@untitledui/icons";
 import { cn } from "@deco/ui/lib/utils.ts";
 import { Button } from "@deco/ui/components/button.tsx";
@@ -23,26 +22,9 @@ import {
 } from "@/components/settings/settings-section";
 import { useProjectContext } from "@/sdk";
 import { useStudioTools } from "@/lib/studio-tools";
+import { useOpenBillingUrl } from "@/hooks/use-open-billing-url";
 import { KEYS } from "@/lib/query-keys";
 import { useT } from "@/i18n/use-t.ts";
-
-function useOpenBillingUrl(
-  toolName:
-    | "ORGANIZATION_BILLING_CHECKOUT_START"
-    | "ORGANIZATION_BILLING_PORTAL",
-  errorKey: "settings.billing.checkoutError" | "settings.billing.portalError",
-) {
-  const studio = useStudioTools();
-  const t = useT();
-  return useMutation({
-    mutationFn: async () => {
-      const { url } = await studio.call(toolName, {});
-      return url;
-    },
-    onSuccess: (url) => window.open(url, "_blank", "noopener,noreferrer"),
-    onError: (err) => toast.error(t(errorKey, { message: err.message })),
-  });
-}
 
 const PERIOD_END_FMT = new Intl.DateTimeFormat(undefined, {
   month: "short",


### PR DESCRIPTION
**Source:** reduction — three sites hand-rolled the identical "fetch a Stripe-hosted URL, open in a new tab, toast on error" mutation: `views/settings/billing.tsx`'s local `useOpenBillingUrl`, `layouts/task-board/subscription-paywall-dialog.tsx`'s inline `useMutation`, and `components/chat/highlight/index.tsx`'s `handleSubscribe` (a plain try/catch that also skipped the `isPending` guard the other two had).

**Payoff:** one canonical implementation instead of three drifting copies, and the chat highlight now gets the same pending-state protection (double-click guard) the settings page already had.

**Change:** moved `billing.tsx`'s `useOpenBillingUrl` to `apps/web/src/hooks/use-open-billing-url.ts` and pointed all three call sites at it. Net: -63/+18 lines. Behavior-preserving — same tool calls, same success/error handling, same translation keys per caller (only the paywall dialog now explicitly closes on success via `mutate`'s per-call `onSuccess` option, matching its prior behavior exactly).

**Verify:** `cd apps/web && bunx tsc --noEmit` (green) — the mutation isn't covered by an existing test, so this is a mechanical relocation, not new logic.

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/web), `bunx oxlint` on all 4 touched files (0 warnings/errors). Full CI covers the rest.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted a shared `useOpenBillingUrl` hook to centralize Stripe billing/checkout navigation and unify pending/error handling across settings, paywall dialog, and chat highlight. This removes duplication and adds the pending double-click guard to chat highlight.

- **Refactors**
  - Added `apps/web/src/hooks/use-open-billing-url.ts` and replaced local mutations in settings billing, subscription paywall dialog, and chat highlight.
  - Preserved dialog’s close-on-success via per-call `onSuccess`.
  - Kept existing tool calls and i18n keys; net -63/+18 lines.

<sup>Written for commit de9a73e68a6294a09550bd57d0b99a40309bbb8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

