### PR TITLE
fix(web): give review-settings switches an accessible name

### DIFF
--- a/apps/web/src/components/settings/review-settings.tsx
+++ b/apps/web/src/components/settings/review-settings.tsx
@@ -82,6 +82,7 @@ function FlagToggle({
         <Switch
           checked={enabled}
           disabled={setFlag.isPending}
+          aria-label={t(titleKey)}
           onCheckedChange={(next) =>
             setFlag.mutate(flag, next, {
               onError: () => toast.error(t("settings.review.updateError")),


### PR DESCRIPTION
The four org-level review-setting toggles (QA Agent, Code Reviewer, Auto-merge, auto-assign report tasks) render as bare `<Switch>` controls with no `aria-label` and no associated `<label>` — the title/description are plain text next to the control, not wired to it. A screen reader announces each as an unnamed "switch", giving no way to tell them apart.

**Fix**: pass `aria-label={t(titleKey)}` through to the `Switch` in `FlagToggle`, reusing the same translated title already shown visually, so each toggle gets a distinct accessible name in both locales.

A reviewer can confirm by inspecting the accessibility tree for `apps/web/src/components/settings/review-settings.tsx` (e.g. via the browser's Accessibility panel) — each switch now reports its title as its name instead of "switch".

Locally verified: `bun run fmt`, `bunx oxlint apps/web/src/components/settings/review-settings.tsx` (0 errors), `bunx tsc --noEmit` in `apps/web` (clean). No test added — this is a one-line prop addition with no branching logic to regress; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add accessible names to the four org-level review-setting switches so screen readers can tell them apart instead of announcing a generic “switch.” The underlying Switch now receives `aria-label={t(titleKey)}`, reusing the translated title.

<sup>Written for commit 29510fa2e8b090eeb2526a61ddf8ce1fa75e8296. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

