### PR TITLE
fix(reports): fold empty scan state into loading tracker

### DIFF
--- a/apps/web/src/routes/reports/scan-gate.tsx
+++ b/apps/web/src/routes/reports/scan-gate.tsx
@@ -105,6 +105,7 @@ type StageState = "done" | "active" | "pending";
 function stagesFor(phase: ScanPhase): StageState[] {
   if (phase === "scanning") return ["done", "active", "pending", "pending"];
   if (phase === "pending") return ["done", "done", "active", "pending"];
+  if (phase === "empty") return ["done", "done", "done", "active"];
   return ["done", "done", "done", "pending"];
 }
 
@@ -120,17 +121,16 @@ function ScanScreen({
   email: string;
 }) {
   const t = useT();
-  const isActive = phase === "scanning" || phase === "pending";
+  const isActive =
+    phase === "scanning" || phase === "pending" || phase === "empty";
   const stages = stagesFor(phase);
 
   const errorMessage =
     phase === "blocked"
       ? t("reports.scanGate.errorBlocked")
-      : phase === "empty"
-        ? t("reports.scanGate.errorEmpty")
-        : phase === "error"
-          ? t("reports.scanGate.errorFailed")
-          : null;
+      : phase === "error"
+        ? t("reports.scanGate.errorFailed")
+        : null;
 
   return (
     <div
@@ -286,7 +286,19 @@ function ScanScreen({
               })}
             </div>
 
-            <ReportSocialProof />
+            {phase === "empty" ? (
+              <p
+                className="mt-5 sm:mt-7 text-[12px] leading-4"
+                style={{ color: DECK.faint }}
+              >
+                {t("reports.scanGate.errorEmpty")}{" "}
+                <a href="https://decocms.com/diagnostico" className="underline">
+                  {t("reports.scanGate.tryAnother")}
+                </a>
+              </p>
+            ) : (
+              <ReportSocialProof />
+            )}
           </div>
         )}
 


### PR DESCRIPTION
## What is this contribution about?
When a diagnostic scan's run reaches a terminal engine status before the report is actually queryable, `ScanGate` showed a jarring dead-end error card ("Try another store"), even though this is usually just a transient race rather than a real failure. This PR keeps the `empty` phase inside the loading tracker (last step shown as active) with a soft inline note and a quiet fallback link, reserving the hard red error card for genuine `blocked`/`error` failures.

## How did you verify your code works?
Ran `bun run --cwd=apps/web check` (no new type errors) and `bun run fmt` (no changes needed). Manual review of the phase transitions in `orchestrate-scan.ts` against the updated `stagesFor`/`isActive`/`errorMessage` logic in `scan-gate.tsx`; no new automated test added since this is a pure presentational branch change with no new logic to unit test.

## Screenshots/Demonstration
Before: the `empty` phase rendered the full red-alert error card with only a "Try another store" CTA.
After: the `empty` phase stays on the same loading card, with the last tracker step marked active and a small note ("...still being assembled. Check back soon.") plus an inline "Try another store" link.

## How to Test
1. Trigger a diagnostic scan whose run status reaches a terminal state (`complete`/`errored`/`terminated`/`unknown`) before the report has slides.
2. Observe the scan screen: it should stay on the loading tracker (not switch to the red error card), with the last step active and the soft note visible.
3. Trigger a `blocked` or hard `error` phase and confirm the red error card still appears as before.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the `empty` scan phase inside the loading tracker with the last step active and a small note, instead of showing the error card. This avoids false dead-ends when the run finishes before the report is ready.

- **Bug Fixes**
  - Treat `empty` as loading: show a soft inline note and "Try another store" link.
  - Reserve the error card for `blocked` and `error`; update `stagesFor`, `isActive`, and render logic in `scan-gate.tsx`.

<sup>Written for commit 0ec741691e404649b8aac93a8a0ed0fcc8a9f551. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

