### PR TITLE
fix(chat): bound message-queue-store's per-thread tracking maps

### DIFF
--- a/apps/web/src/components/chat/message-queue-store.test.ts
+++ b/apps/web/src/components/chat/message-queue-store.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import {
+  enqueueMessage,
+  markQueueDirty,
+  isQueueDirty,
+  messageQueueStore,
+  stashPendingBody,
+  takePendingBody,
+} from "./message-queue-store";
+
+const item = (messageId: string) => ({
+  workflowId: `thread-run:t:${messageId}`,
+  messageId,
+  status: "queued" as const,
+  enqueuedAt: 0,
+  text: "hi",
+});
+
+describe("messageQueueStore eviction", () => {
+  test("evicts the oldest thread once past the tracked cap, dropping its dirty flag and pending body", () => {
+    const evictedThreadId = "evict-me";
+    messageQueueStore(evictedThreadId);
+    markQueueDirty(evictedThreadId);
+    stashPendingBody(evictedThreadId, {
+      id: "m1",
+      role: "user",
+      parts: [],
+    } as never);
+    enqueueMessage(evictedThreadId, item("m1"));
+
+    // Push the tracked-thread count well past the cap so the LRU thread
+    // (the one touched first, above) gets evicted.
+    for (let i = 0; i < 250; i++) {
+      messageQueueStore(`filler-${i}`);
+    }
+
+    expect(isQueueDirty(evictedThreadId)).toBe(false);
+    expect(takePendingBody(evictedThreadId, "m1")).toBeUndefined();
+    // A fresh lookup after eviction starts a clean, empty store.
+    expect(messageQueueStore(evictedThreadId).get()).toEqual([]);
+  });
+});

--- a/apps/web/src/components/chat/message-queue-store.ts
+++ b/apps/web/src/components/chat/message-queue-store.ts
@@ -17,6 +17,27 @@ import { Store } from "./store/store-primitive";
 const stores = new Map<string, Store<QueueItemDTO[]>>();
 
 /**
+ * Cap on distinct threads tracked at once. Nothing ever calls a "thread
+ * closed" cleanup here (there's no such lifecycle event), so a long-lived tab
+ * that visits many threads over a session would otherwise grow `stores`,
+ * `dirtyThreads`, and `pendingBodies` without bound. Evicting the
+ * least-recently-touched thread once the map is over the cap keeps memory
+ * bounded without needing that missing lifecycle hook.
+ */
+const MAX_TRACKED_THREADS = 200;
+
+function touchThread(threadId: string): void {
+  if (stores.size < MAX_TRACKED_THREADS || stores.has(threadId)) return;
+  const oldest = stores.keys().next().value;
+  if (oldest === undefined) return;
+  stores.delete(oldest);
+  dirtyThreads.delete(oldest);
+  for (const key of pendingBodies.keys()) {
+    if (key.startsWith(`${oldest}:`)) pendingBodies.delete(key);
+  }
+}
+
+/**
  * Threads that have queued a message behind a running turn since their live
  * body was last known to be in sync. While a thread is "dirty", each run
  * terminal must reconcile the chat body against the server (`reconcileFrom
@@ -43,6 +64,7 @@ export function clearQueueDirty(threadId: string): void {
 export function messageQueueStore(threadId: string): Store<QueueItemDTO[]> {
   let store = stores.get(threadId);
   if (!store) {
+    touchThread(threadId);
     store = new Store<QueueItemDTO[]>([]);
     stores.set(threadId, store);
   }


### PR DESCRIPTION
**Bug**: `message-queue-store.ts` keeps three module-scoped collections (`stores`, `dirtyThreads`, `pendingBodies`) keyed by thread id, seeded the first time a thread's message queue is read/written. Nothing anywhere calls a "thread closed" cleanup for these — there's no such lifecycle event in the chat UI — so a long-lived tab that visits many threads over a session (normal for task-board-heavy users) grows all three without bound for the page's lifetime.

**Fix**: cap tracked threads at 200 and evict the least-recently-touched thread (oldest `Map` key, since insertion order is preserved and re-touching an existing key doesn't reorder it) once over the cap — clearing its dirty flag and any stashed pending body along with its queue store.

**Why a maintainer wants this**: it's a real, unbounded memory leak in a component every chat session touches, with zero behavior change for the common case (well under 200 threads visited per tab lifetime).

**Verification**: added `message-queue-store.test.ts` — seeds one thread's store/dirty-flag/pending-body, pushes 250 more threads through `messageQueueStore()`, and asserts the original thread's dirty flag, pending body, and queue contents are all cleared (fresh empty store) after eviction.

**Commands to confirm**: `bun test apps/web/src/components/chat/message-queue-store.test.ts`; `cd apps/web && bunx tsc --noEmit`; `bunx oxlint apps/web/src/components/chat/message-queue-store.ts apps/web/src/components/chat/message-queue-store.test.ts`.

Ran `bun run fmt`, the targeted test, a workspace typecheck, and per-file oxlint locally — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the per-thread maps in `message-queue-store` to prevent unbounded memory growth in long-lived tabs. We cap tracked threads at 200 and evict the least-recently-touched thread, clearing its queue, dirty flag, and pending bodies.

- **Bug Fixes**
  - Added `MAX_TRACKED_THREADS = 200` and eviction of the oldest thread when over cap.
  - On eviction, remove its store, clear `dirtyThreads`, and delete any `${threadId}:messageId` entries in `pendingBodies`.
  - Added `message-queue-store.test.ts` to verify eviction clears the evicted thread’s state.

<sup>Written for commit ad11f60a1be4c5b022d8cba5aef31066b6b57157. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

