### PR TITLE
refactor(sandbox): remove unnecessary type casts from sandbox-map

### DIFF
--- a/apps/api/src/tools/sandbox/sandbox-map.ts
+++ b/apps/api/src/tools/sandbox/sandbox-map.ts
@@ -55,14 +55,15 @@ export function mergeSandboxMapEntry(
   entry: SandboxRecord,
 ): SandboxMap {
   const currentBranchMap = parseBranchMap(current[targetUserId]?.[branch]);
+  const nextBranchMap = {
+    ...currentBranchMap,
+    [sandboxProviderKind]: entry,
+  };
   return {
     ...current,
     [targetUserId]: {
       ...(current[targetUserId] ?? {}),
-      [branch]: {
-        ...currentBranchMap,
-        [sandboxProviderKind]: entry,
-      } as SandboxMap[string][string],
+      [branch]: nextBranchMap,
     },
   };
 }
@@ -124,7 +125,7 @@ export function deleteSandboxMapEntry(
   if (Object.keys(nextBranchMap).length === 0) {
     delete userMap[branch];
   } else {
-    userMap[branch] = nextBranchMap as SandboxMap[string][string];
+    userMap[branch] = nextBranchMap;
   }
 
   const next: SandboxMap = { ...current };


### PR DESCRIPTION
Remove unnecessary `as SandboxMap[string][string]` type casts from `mergeSandboxMapEntry` and `deleteSandboxMapEntry` functions. TypeScript's type inference already correctly types the objects being assigned, so the explicit casts are redundant.

**Rationale:** Type casts hide intent and obscure the actual types at play. When TypeScript can infer types correctly without them (as in this case), relying on inference is clearer and maintains safety while reducing visual clutter.

**Changes:**
- Simplify `mergeSandboxMapEntry`: extract `nextBranchMap` as an intermediate variable to avoid the cast
- Simplify `deleteSandboxMapEntry`: remove the cast from the assignment to `userMap[branch]`
- Both functions maintain identical behavior and pass all tests

**Verification:**
- `bun test ./packages/sandbox/server/provider/agent-sandbox/runner.test.ts` — 9 pass
- `bun test apps/api/src/tools/sandbox/sandbox-map.test.ts` — 21 pass  
- `bunx tsc --noEmit` in apps/api — no type errors
- `bun run fmt` — no formatting changes needed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed unnecessary `as SandboxMap[string][string]` casts in `mergeSandboxMapEntry` and `deleteSandboxMapEntry` to rely on TypeScript inference and reduce noise. No behavior change; the sandbox map stays type-safe.

- **Refactors**
  - `mergeSandboxMapEntry`: extracted `nextBranchMap` and returned it without a cast.
  - `deleteSandboxMapEntry`: assigned `nextBranchMap` directly instead of casting.

<sup>Written for commit 0c86eccf13d31c802f2c671a0cbb175ff0c83fb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

