### PR TITLE
fix(org-fs): 404 instead of 500 when a file's object is missing

### DIFF
--- a/apps/api/src/file-storage/org-fs.integration.test.ts
+++ b/apps/api/src/file-storage/org-fs.integration.test.ts
@@ -32,7 +32,12 @@ import { createBoundObjectStorage } from "../object-storage/bound-object-storage
 import { DevObjectStorage } from "../object-storage/dev-object-storage";
 import { S3Service } from "../object-storage/s3-service";
 import { OrgFsEntryStorage } from "../storage/org-fs";
-import { OrgFs, OrgFsQuotaError, OrgFsValidationError } from "./org-fs";
+import {
+  OrgFs,
+  OrgFsNotFoundError,
+  OrgFsQuotaError,
+  OrgFsValidationError,
+} from "./org-fs";
 import { verifySharePassword } from "./share-password";
 
 const ORG = "org_fs_svc";
@@ -84,6 +89,17 @@ describe("OrgFs service (integration)", () => {
 
     const stat = await fs.stat("skills", "hello.txt");
     expect(stat?.contentHash).toBe(entry.contentHash);
+  });
+
+  it("read() 404s (not 500s) when the manifest row outlives its object", async () => {
+    const storage = new DevObjectStorage(ORG, "http://test");
+    const drifted = new OrgFs(storage, new OrgFsEntryStorage(db.db), ORG);
+    await drifted.write("skills", "gone.txt", "bye", { actor: ACTOR });
+    // Manifest/bucket drift: the row stays, the bytes vanish.
+    await storage.delete("_fs/skills/gone.txt");
+    expect(drifted.read("skills", "gone.txt")).rejects.toBeInstanceOf(
+      OrgFsNotFoundError,
+    );
   });
 
   it("creates ancestor directories on nested write and lists the tree", async () => {

--- a/apps/api/src/file-storage/org-fs.ts
+++ b/apps/api/src/file-storage/org-fs.ts
@@ -67,6 +67,29 @@ export class OrgFsNotFoundError extends Error {
   }
 }
 
+/**
+ * True for an object-storage "the key isn't there" error: S3 `NoSuchKey`, a 404
+ * from a non-AWS gateway, or ENOENT from the dev filesystem backend. The
+ * manifest and the bucket can drift — a byte put that failed after the row
+ * landed, a bucket reset under an existing DB — and a missing object is a
+ * not-found, not a server fault.
+ */
+function isMissingObject(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const e = err as {
+    name?: string;
+    code?: string;
+    Code?: string;
+    $metadata?: { httpStatusCode?: number };
+  };
+  return (
+    e.name === "NoSuchKey" ||
+    e.Code === "NoSuchKey" ||
+    e.code === "ENOENT" ||
+    e.$metadata?.httpStatusCode === 404
+  );
+}
+
 function sha256(bytes: Uint8Array): string {
   return createHash("sha256").update(bytes).digest("hex");
 }
@@ -121,10 +144,20 @@ export class OrgFs {
     );
   }
 
-  /** Raw bytes of a file. Throws if the path is not a live file. */
+  /**
+   * Raw bytes of a file. Throws OrgFsNotFoundError if the path is not a live
+   * file, or if the manifest row exists but its object is gone (drift).
+   */
   async read(volume: string, path: string): Promise<Uint8Array> {
     const entry = await this.requireFile(volume, path);
-    return this.storage.getBytes(fsObjectKey(volume, entry.path));
+    try {
+      return await this.storage.getBytes(fsObjectKey(volume, entry.path));
+    } catch (err) {
+      if (isMissingObject(err)) {
+        throw new OrgFsNotFoundError(`No such file: ${entry.path}`);
+      }
+      throw err;
+    }
   }
 
   /**

--- a/apps/api/src/harnesses/decopilot/build-agent-system-prompt.test.ts
+++ b/apps/api/src/harnesses/decopilot/build-agent-system-prompt.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { buildAgentSystemPrompt } from "./build-agent-system-prompt";
+import { OrgFsNotFoundError } from "@/file-storage/org-fs";
 
 const baseOpts = {
   ctx: {} as never,
@@ -212,7 +213,7 @@ describe("buildAgentSystemPrompt", () => {
       writes,
       read: async (volume: string, path: string) => {
         if (volume !== "home" || !(path in files)) {
-          throw new Error("not a live file");
+          throw new OrgFsNotFoundError(`No such file: ${path}`);
         }
         return new TextEncoder().encode(files[path]);
       },
@@ -316,8 +317,24 @@ describe("buildAgentSystemPrompt", () => {
       organization: { id: "org_test", slug: "acme" } as never,
       user: { id: "u1" },
     });
-    // stat still reports the org file as present → no clobbering write for it.
+    // Not a definitive not-found → no clobbering write for it.
     expect(fs.writes.map((w) => w.path)).not.toContain("MEMORY.md");
+  });
+
+  test("re-seeds when the manifest row exists but its object is gone", async () => {
+    const fs = fakeOrgFs({ "MEMORY.md": "Real memory." });
+    // Manifest/bucket drift: stat finds the row, read 404s on the bytes.
+    fs.read = async () => {
+      throw new OrgFsNotFoundError("No such file: MEMORY.md");
+    };
+    await buildAgentSystemPrompt({
+      ...baseOpts,
+      kind: "agent",
+      ctx: { orgFs: fs } as never,
+      organization: { id: "org_test", slug: "acme" } as never,
+      user: { id: "u1" },
+    });
+    expect(fs.writes.map((w) => w.path)).toContain("MEMORY.md");
   });
 
   test("kind: 'subagent' omits prompts block when passthroughClient is not provided", async () => {

--- a/apps/api/src/harnesses/decopilot/build-agent-system-prompt.ts
+++ b/apps/api/src/harnesses/decopilot/build-agent-system-prompt.ts
@@ -36,6 +36,7 @@ import { buildAgentsBlock } from "@/harnesses/lib/decopilot/agents-block";
 import { renderUserContextBlock } from "@/harnesses/lib/decopilot/user-context-block";
 import type { ConnectionsBlockTool } from "@/harnesses/lib/decopilot/connections-block";
 import type { HarnessUserContext } from "@/harnesses/lib/types";
+import { OrgFsNotFoundError } from "@/file-storage/org-fs";
 
 const SUBAGENT_IDENTITY_PROMPT = `You are a focused subtask agent delegated a specific task by a parent agent. You are NOT the parent agent.
 
@@ -281,19 +282,16 @@ async function loadMemoryBlock(
   try {
     const bytes = await ctx.orgFs.read("home", path);
     content = new TextDecoder().decode(bytes).trim();
-  } catch {
-    // Read failed. Seed a default template only when the file is genuinely
-    // absent — a `stat` guard so a transient read error never clobbers an
-    // existing file with the blank template. Best-effort; never throws.
-    if (actor) {
+  } catch (err) {
+    // Read failed. Seed a default template only on a definitive not-found —
+    // absent path, or a manifest row whose object is gone — so a transient read
+    // error never clobbers an existing file. Best-effort; never throws.
+    if (actor && err instanceof OrgFsNotFoundError) {
       try {
-        const existing = await ctx.orgFs.stat("home", path);
-        if (!existing) {
-          await ctx.orgFs.write("home", path, memoryTemplate(scope), {
-            actor,
-            contentType: "text/markdown",
-          });
-        }
+        await ctx.orgFs.write("home", path, memoryTemplate(scope), {
+          actor,
+          contentType: "text/markdown",
+        });
       } catch {
         // ignore — seeding is best-effort
       }


### PR DESCRIPTION
## Problem

`GET /api/:org/fs/home/read?path=MEMORY.md` was 500ing repeatedly in dev:

```
NoSuchKey: The specified key does not exist.
  Key: "<org>/_fs/home/MEMORY.md"
[5xx Response] GET /api/pedro-feijoada/fs/home/read - 500
```

The manifest row (`org_fs_entry`) exists but the object does not — drift, from a
byte put that failed after the row landed, or a bucket reset under an existing
DB. `OrgFs.read()` calls `requireFile()` (row found → passes), then
`storage.getBytes()`, and let the raw S3 error escape. `fsErrorResponse` only
knows the three `OrgFs*Error` types, so it rethrows → global handler → 500.

Worse, it never healed: `loadMemoryBlock` (agent system prompt) seeds a default
`MEMORY.md` only when `stat` says the file is absent — and a drifted row always
satisfies `stat`. So every dispatch re-read, re-failed, and re-500'd.

## Fix

- `OrgFs.read()` maps a missing object (`NoSuchKey`, a 404 from a non-AWS
  gateway, or `ENOENT` from the dev filesystem backend) to `OrgFsNotFoundError`
  → the route returns 404.
- `loadMemoryBlock` seeds on `OrgFsNotFoundError` instead of on a `stat` miss.
  A not-found is definitive, so the `stat` guard against clobbering on a
  *transient* error is redundant — and it was the thing blocking the re-seed.
  Net: less code, and drift self-heals on the next dispatch.

## Testing

- `apps/api/src/file-storage/org-fs.integration.test.ts` — new: write a file,
  delete its object out from under the manifest, assert `read()` rejects with
  `OrgFsNotFoundError`. Verified it fails without the fix.
- `build-agent-system-prompt.test.ts` — new: drifted row re-seeds; existing
  "does not overwrite on a transient read error" still holds (a plain `Error`
  is not a not-found).
- `bun run --cwd=apps/api check`, `bun run fmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 404 instead of 500 when an org file’s object is missing, and make `MEMORY.md` seeding self-heal when manifest/object drift occurs.

- **Bug Fixes**
  - Map S3 `NoSuchKey`, non-AWS 404, and dev `ENOENT` to `OrgFsNotFoundError` in `OrgFs.read`, so read routes return 404 on missing objects (manifest/object drift).
  - Seed `MEMORY.md` on `OrgFsNotFoundError` instead of relying on `stat`, preventing endless failures and avoiding clobbering on transient read errors.
  - Added tests for drift handling and seeding behavior.

<sup>Written for commit 9076dc0dbdfc4af0d0c86e9257882a0ed12246bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5757?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

