### PR TITLE
fix(billing): a failed dispatch must not refund a run that already happened

### DIFF
--- a/apps/api/src/billing/task-quota.integration.test.ts
+++ b/apps/api/src/billing/task-quota.integration.test.ts
@@ -13,6 +13,7 @@ import {
   ensureTaskExecutionAllowed,
   hasTaskQuotaClaim,
   releaseTaskExecution,
+  rollbackTaskExecution,
   type TaskQuotaConfig,
 } from "./task-quota";
 
@@ -289,6 +290,53 @@ describe("task quota (integration)", () => {
     await expect(claimTaskExecution(ctxRl, task, CONFIG)).rejects.toThrow(
       /execution limit/,
     );
+  });
+
+  // The dispatch caller has to know whether the slot it charged is its own to
+  // undo: only a FRESH claim is. A "rerun" rides a slot an earlier run paid for
+  // (and may have shipped a PR from), so undoing it would refund real work.
+  it("reports whether the claim took a slot or rode an existing one", async () => {
+    const org = "org_claim_outcome";
+    await seedOrg(org, true);
+    const ctxO = ctxFor(org);
+    const task = await makeTask("system", org);
+
+    expect(await claimTaskExecution(ctxO, task, CONFIG)).toBe("claimed");
+    expect(await claimTaskExecution(ctxO, task, CONFIG)).toBe("rerun");
+    expect(
+      await claimTaskExecution(ctxO, await makeTask("user_1", org), CONFIG),
+    ).toBe("skipped");
+  });
+
+  it("rolling back a never-started dispatch frees the slot AND spends no run", async () => {
+    const org = "org_rollback";
+    await seedOrg(org, true);
+    const ctxRb = ctxFor(org);
+    const task = await makeTask("system", org);
+
+    await claimTaskExecution(ctxRb, task, CONFIG);
+    await rollbackTaskExecution(billing, org, task.id);
+    await rollbackTaskExecution(billing, org, task.id); // idempotent
+
+    expect(await billing.countTaskClaims(org, "trial")).toBe(0);
+    // Unlike a refund (the run happened, produced nothing): nothing ran here,
+    // so the per-task cap must be untouched or a task whose dispatch keeps
+    // failing dies at the cap with a quota error for runs that never existed.
+    expect(await runCountOf(task.id)).toBe(0);
+    await claimTaskExecution(ctxRb, task, CONFIG);
+    await claimTaskExecution(ctxRb, task, CONFIG);
+    expect(await runCountOf(task.id)).toBe(CONFIG.maxRunsPerTask);
+  });
+
+  it("a rollback is org-scoped — another org's id can't touch the claim", async () => {
+    const org = "org_rollback_scope";
+    await seedOrg(org, true);
+    const task = await makeTask("system", org);
+    await claimTaskExecution(ctxFor(org), task, CONFIG);
+
+    await rollbackTaskExecution(billing, "org_rollback_other", task.id);
+    expect(await stateOf(task.id)).toBe("held");
+    expect(await runCountOf(task.id)).toBe(1);
   });
 
   it("a refund is org-scoped — another org's id can't touch the claim", async () => {

--- a/apps/api/src/billing/task-quota.ts
+++ b/apps/api/src/billing/task-quota.ts
@@ -175,13 +175,18 @@ export async function ensureTaskExecutionAllowed(
  * review/conflict re-runs — funnels through it, for BOTH harnesses. The
  * claim is atomic per org (the storage transaction locks the billing row),
  * so a burst of concurrent dispatches consumes exactly the remaining slots.
+ *
+ * Returns what it did, because only the caller knows whether the dispatch it
+ * charged for actually started: `"claimed"` took a slot and is the ONLY
+ * outcome a failed dispatch may roll back. `"rerun"` rode an earlier run's
+ * slot — rolling that back would refund a run that really happened.
  */
 export async function claimTaskExecution(
   ctx: StudioContext,
   task: GatedTask,
   config: TaskQuotaConfig = taskQuotaConfig(),
-): Promise<void> {
-  if (!config.enforced || !isReportsTask(task)) return;
+): Promise<"claimed" | "rerun" | "skipped"> {
+  if (!config.enforced || !isReportsTask(task)) return "skipped";
   const billing = await ctx.storage.organizationBilling.getBilling(
     task.organizationId,
   );
@@ -195,6 +200,26 @@ export async function claimTaskExecution(
   );
   if (result === "exhausted") throw new TaskQuotaError(quota.exhaustedReason);
   if (result === "runs_exhausted") throw new TaskQuotaError("runs_exhausted");
+  return result;
+}
+
+/**
+ * Undo a charge whose dispatch never started — see `rollbackTaskClaim` for why
+ * this differs from a refund. Only valid for a `"claimed"` outcome.
+ *
+ * Errors are swallowed: the caller is already unwinding a dispatch failure and
+ * must re-throw THAT error, not this one.
+ */
+export async function rollbackTaskExecution(
+  billing: OrganizationBillingStorage,
+  organizationId: string,
+  taskBoardItemId: string,
+): Promise<void> {
+  await billing
+    .rollbackTaskClaim(organizationId, taskBoardItemId)
+    .catch((err) =>
+      console.error("[task-quota] rollback failed (stays charged)", err),
+    );
 }
 
 /** Whether this task holds a CHARGED claim — the server-side fact the

--- a/apps/api/src/storage/organization-billing.ts
+++ b/apps/api/src/storage/organization-billing.ts
@@ -248,4 +248,28 @@ export class OrganizationBillingStorage {
       .where("state", "=", "held")
       .execute();
   }
+
+  /**
+   * Undo a claim whose dispatch never started. Frees the slot AND rolls the run
+   * tally back — unlike a refund, where the run DID happen and only produced
+   * nothing, so its tally has to stand. Nothing ran here, so nothing may be
+   * spent: a task whose dispatch keeps failing (no model configured) would
+   * otherwise burn its per-task cap and die with a quota error for runs that
+   * never existed.
+   */
+  async rollbackTaskClaim(
+    organizationId: string,
+    taskBoardItemId: string,
+  ): Promise<void> {
+    await this.db
+      .updateTable("task_quota_claims")
+      .set((eb) => ({
+        state: "released",
+        run_count: eb("run_count", "-", 1),
+      }))
+      .where("organization_id", "=", organizationId)
+      .where("task_board_item_id", "=", taskBoardItemId)
+      .where("state", "=", "held")
+      .execute();
+  }
 }

--- a/apps/api/src/tools/task-board/enqueue-super-agent.ts
+++ b/apps/api/src/tools/task-board/enqueue-super-agent.ts
@@ -3,7 +3,7 @@ import type { TaskBoardItem } from "@/storage/types";
 import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
 import {
   claimTaskExecution,
-  releaseTaskExecution,
+  rollbackTaskExecution,
   TaskQuotaError,
 } from "../../billing/task-quota";
 import { enqueueAgentRunForTask } from "./enqueue-task-run";
@@ -140,7 +140,7 @@ export async function enqueueSuperAgentForTask(
   // throws [SUBSCRIPTION_REQUIRED] and nothing enqueues. The interactive
   // flip pre-checks in TASK_BOARD_ITEM_UPDATE so the user sees the paywall
   // BEFORE the write; here the claim is the enforcement.
-  await claimTaskExecution(ctx, task);
+  const claim = await claimTaskExecution(ctx, task);
 
   try {
     // Sandbox-hosted claude-code takes every task that has a repo it could work
@@ -177,11 +177,21 @@ export async function enqueueSuperAgentForTask(
     // here (e.g. no model configured — the exact case `enqueueAgentRunForTask`
     // can throw for) would leave the claim charged forever with no run to show
     // for it.
-    await releaseTaskExecution(
-      ctx.storage.organizationBilling,
-      task.organizationId,
-      task.id,
-    );
+    //
+    // ROLLBACK, not refund: no run happened, so the per-task tally must not be
+    // spent either — otherwise a task whose dispatch keeps failing dies at the
+    // run cap with a quota error for runs that never existed.
+    //
+    // Only a FRESH claim is ours to undo. A `"rerun"` rides a slot an earlier
+    // run already paid for (and may well have shipped a PR from) — undoing it
+    // here would refund a run that really happened.
+    if (claim === "claimed") {
+      await rollbackTaskExecution(
+        ctx.storage.organizationBilling,
+        task.organizationId,
+        task.id,
+      );
+    }
     throw err;
   }
 }


### PR DESCRIPTION
## Summary

#5717 closed the real leak (a dispatch that throws after `claimTaskExecution`
left the claim `held` forever, since the refund pass keys off a *finished
thread* and no thread exists). But it undoes the charge **unconditionally**,
and as a **refund**. Two things fall out of that:

1. **A failed re-dispatch refunds the original run's charge.** Every dispatch
   of an already-claimed task passes through the claim as a free `"rerun"`, so
   the row `releaseTaskClaim` matches is the one the *first* run paid for — a
   run that may already have shipped a PR. Fail a review-bounce dispatch and
   the org gets its slot back for work it received.
2. **A rollback is not a refund.** A refund deliberately keeps `run_count`, so
   it can never become a free reset of the per-task cap. Applied to a dispatch
   that never started, that spends the cap on runs that never existed: five
   failed dispatches and the task is dead with
   `[SUBSCRIPTION_REQUIRED] … reached its execution limit`, while the actual
   problem was (say) no model configured.

So the two undos are now distinct:

- `claimTaskExecution` reports what it did — `"claimed"` (took a slot),
  `"rerun"` (rode one an earlier run paid for), `"skipped"` (not gated). Only
  `"claimed"` is the dispatcher's to undo.
- `rollbackTaskClaim` frees the slot **and** decrements the tally, because no
  run happened. `releaseTaskClaim` — the genuine refund, where the run ran and
  produced nothing — is untouched.

## Testing

Real Postgres, in `task-quota.integration.test.ts`:

- the claim-outcome contract (`claimed` → `rerun` → `skipped`), which is what
  the dispatcher's guard reads;
- rollback frees the slot and spends no run, so the task can still use its full
  `maxRunsPerTask` afterwards; double-rollback is a no-op;
- rollback is org-scoped — another org's id can't touch the claim.

`bun test apps/api/src/billing apps/api/src/tools/task-board` → 195 pass.
`bun run check`, `bun run fmt`, `bun run lint` clean.

## Affected areas

Only the auto-task quota ledger. No migration, no wire/schema change. Dormant
for orgs where `STUDIO_TASK_QUOTA_ENFORCED` is off, and a no-op for
user-created tasks (never claimed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes quota accounting so a failed dispatch doesn’t refund a run that already happened by introducing a rollback that frees the slot and doesn’t spend the task’s run count.

- **Bug Fixes**
  - `claimTaskExecution` now returns `"claimed" | "rerun" | "skipped"`; only `"claimed"` can be undone.
  - Added `rollbackTaskExecution` and storage `rollbackTaskClaim` to free the slot and decrement `run_count`; idempotent and org-scoped.
  - Updated super-agent enqueue to rollback on dispatch failure instead of refunding, preventing refunds of past runs and avoiding run-cap burn on never-started runs.

<sup>Written for commit 32dac35fa8e2573892457f062985bb671aa6f81e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5761?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

