### PR TITLE
fix(native): allow arbitrary origins in preview iframe CSP

### DIFF
--- a/apps/native/crates/local-api/src/router.rs
+++ b/apps/native/crates/local-api/src/router.rs
@@ -817,7 +817,7 @@ mod tests {
         }
 
         fn content_security_policy(&self) -> String {
-            "default-src 'self'; connect-src 'self'; frame-src 'none'".into()
+            "default-src 'self'; connect-src 'self'; frame-src *".into()
         }
     }
 
@@ -890,7 +890,7 @@ mod tests {
             .to_str()
             .unwrap();
         assert!(csp.contains("connect-src 'self' http://localhost:61234 ws://localhost:61234"));
-        assert!(csp.contains("frame-src http://localhost:61234"));
+        assert!(csp.contains("frame-src *"));
 
         let asset = app
             .oneshot(request(Method::GET, "/assets/app.abc.js"))

--- a/apps/native/crates/local-api/src/ui.rs
+++ b/apps/native/crates/local-api/src/ui.rs
@@ -100,6 +100,12 @@ fn csp_error_response() -> Response {
         .unwrap_or_else(|_| Response::new(Body::empty()))
 }
 
+/// Adds the sandbox preview origin (and its `ws://` counterpart) to
+/// `connect-src` — that's same-page script talking to the local proxy, so it
+/// still needs a per-session allowlist. `frame-src` does not: it's `*` in the
+/// base policy (framed documents can't run script in or read state from this
+/// page's origin, so opening it to arbitrary org-owned preview domains — e.g.
+/// a published storefront — doesn't need per-session patching).
 fn patch_preview_origin(base: &str, preview_origin: &str) -> String {
     let mut directives = base
         .split(';')
@@ -117,7 +123,6 @@ fn patch_preview_origin(base: &str, preview_origin: &str) -> String {
             .as_deref()
             .map_or_else(|| vec![preview_origin], |ws| vec![preview_origin, ws]),
     );
-    add_csp_sources(&mut directives, "frame-src", vec![preview_origin]);
     format!("{};", directives.join("; "))
 }
 
@@ -160,21 +165,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn csp_adds_preview_to_existing_directives_and_replaces_none() {
+    fn csp_adds_preview_to_existing_connect_src() {
         let patched = patch_preview_origin(
-            "default-src 'self'; connect-src 'self'; frame-src 'none'",
+            "default-src 'self'; connect-src 'self'; frame-src *",
             "http://localhost:61234",
         );
         assert!(patched.contains("connect-src 'self' http://localhost:61234 ws://localhost:61234"));
-        assert!(patched.contains("frame-src http://localhost:61234"));
-        assert!(!patched.contains("frame-src 'none'"));
+        assert!(patched.contains("frame-src *"));
     }
 
     #[test]
-    fn csp_creates_missing_preview_directives() {
+    fn csp_creates_missing_connect_src_directive() {
         let patched = patch_preview_origin("default-src 'self'", "http://localhost:61234");
         assert!(patched.contains("connect-src 'self' http://localhost:61234 ws://localhost:61234"));
-        assert!(patched.contains("frame-src 'self' http://localhost:61234"));
     }
 
     #[test]

--- a/apps/native/src-tauri/tauri.conf.json5
+++ b/apps/native/src-tauri/tauri.conf.json5
@@ -91,11 +91,17 @@
       // same-origin (`/assets/*.woff2`), so the CSP spec's fallback to
       // `default-src 'self'` already covers them.
       //
-      // `frame-src 'self'` is the base for the sandbox preview iframe. The
-      // bundled index response adds its exact dedicated preview origin at
-      // runtime. That proxy forwards the sandbox application's Cookie and
-      // Authorization headers unchanged.
-      csp: "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost; img-src 'self' https: data: blob: asset: http://asset.localhost; style-src 'self' 'unsafe-inline'; script-src 'self'; frame-src 'self'",
+      // `frame-src *` is deliberately wide open: the preview surface embeds
+      // arbitrary org-owned domains (sandbox dev servers AND published
+      // storefronts like a customer's own `*.vtex.app`/custom domain), which
+      // can't be known at build time. Same reasoning as `img-src` above — a
+      // framed document can't execute script in or read state from this
+      // page's origin, so this doesn't widen the app's actual attack surface
+      // the way loosening `connect-src`/`script-src` would. The exact
+      // sandbox preview origin is still added to `connect-src` at runtime
+      // (see `src/csp.rs` / `src/ui_assets.rs`) since that traffic IS
+      // same-page script talking to the proxy.
+      csp: "default-src 'self'; connect-src 'self' ipc: http://ipc.localhost; img-src 'self' https: data: blob: asset: http://asset.localhost; style-src 'self' 'unsafe-inline'; script-src 'self'; frame-src *",
     },
   },
   // Self-update. Safe to commit: the plugin never auto-checks (updates run


### PR DESCRIPTION
## Summary
- The native app's Tauri webview CSP had `frame-src 'self'`, which blocks the sections editor's production preview mode from iframing a customer's live storefront domain (e.g. `fila.vtex.app`) — surfaced as `Refused to load ... because it does not appear in the frame-src directive`.
- Widened `frame-src` to `*`. Same reasoning already applied to `img-src` in this config: a framed document can't execute script in or read state from the parent page's origin, so this doesn't broaden the app's real attack surface the way loosening `connect-src`/`script-src` would.
- Removed the now-redundant per-session `frame-src` patching in `local-api`'s `patch_preview_origin` (it only added the sandbox preview origin, which is now already covered by `*`). `connect-src` patching for the sandbox preview proxy is untouched — that's same-page script talking to the local proxy, not iframing.

## Test plan
- [x] `cargo test --lib` in `apps/native/crates/local-api` — 802 passed, including updated CSP tests
- [x] `bun run fmt` / `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow the sections editor preview to iframe arbitrary domains by widening the webview CSP to `frame-src *`. This resolves CSP blocks when embedding customer storefronts in production, while keeping `connect-src` restrictions.

- **Bug Fixes**
  - Set `frame-src *` in `apps/native/src-tauri/tauri.conf.json5` to allow customer domains in the preview iframe.
  - Removed per-session `frame-src` patching in `apps/native/crates/local-api` (`patch_preview_origin`); kept runtime `connect-src` + `ws://` preview origin allowlist.
  - Updated CSP tests and inline comments.

<sup>Written for commit 59c6897fa878f865ca59fc24795a718bdc7e82fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

