### PR TITLE
fix(skills): make authored skills and org-fs bytes outlive the sandbox

### DIFF
--- a/apps/api/src/file-storage/skill-set-sync.test.ts
+++ b/apps/api/src/file-storage/skill-set-sync.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { parseTar, planVolumeTree, staleDirs } from "./skill-set-sync";
+import {
+  isUpToDate,
+  parseTar,
+  planVolumeTree,
+  staleDirs,
+} from "./skill-set-sync";
 
 /** Build a minimal ustar archive in memory (the GitHub tarball shape). */
 function makeTar(
@@ -127,5 +132,29 @@ describe("staleDirs", () => {
 
   it("collapses nested stale dirs into one recursive root", () => {
     expect(staleDirs([], ["a", "a/b", "a/b/c"])).toEqual(["a"]);
+  });
+});
+
+describe("isUpToDate", () => {
+  const args = {
+    hash: "h",
+    manifestHash: "h",
+    path: "brand/SKILL.md",
+    storedPaths: new Set(["brand/SKILL.md"]),
+  };
+
+  it("skips a file present in both the manifest and object storage", () => {
+    expect(isUpToDate(args)).toBe(true);
+  });
+
+  it("rewrites a manifest row whose object is gone", () => {
+    // The bug this exists to prevent: hash-only comparison marks the file
+    // unchanged forever, so the set never heals and reads keep failing.
+    expect(isUpToDate({ ...args, storedPaths: new Set() })).toBe(false);
+  });
+
+  it("rewrites on a content change", () => {
+    expect(isUpToDate({ ...args, manifestHash: "old" })).toBe(false);
+    expect(isUpToDate({ ...args, manifestHash: null })).toBe(false);
   });
 });

--- a/apps/api/src/file-storage/skill-set-sync.ts
+++ b/apps/api/src/file-storage/skill-set-sync.ts
@@ -18,12 +18,15 @@ import { gunzipSync } from "node:zlib";
 import type { Kysely } from "kysely";
 import type { Database } from "../storage/types";
 import { OrgFsEntryStorage } from "../storage/org-fs";
-import { createBoundObjectStorage } from "../object-storage/bound-object-storage";
+import {
+  type BoundObjectStorage,
+  createBoundObjectStorage,
+} from "../object-storage/bound-object-storage";
 import { DevObjectStorage } from "../object-storage/dev-object-storage";
 import { getObjectStorageS3Service } from "../object-storage/factory";
 import { detectContentType } from "../object-storage/key-utils";
 import { OrgFs } from "./org-fs";
-import { normalizeFsPath } from "./org-fs-path";
+import { fsVolumePrefix, normalizeFsPath } from "./org-fs-path";
 import {
   getPublicSets,
   ORG_FS_PUBLIC_ORG_ID,
@@ -198,6 +201,43 @@ function sha256Hex(bytes: Uint8Array): string {
   return createHash("sha256").update(bytes).digest("hex");
 }
 
+/**
+ * Whether a desired file can be skipped this cycle.
+ *
+ * The manifest hash alone is NOT enough: manifest rows and object bytes live in
+ * two stores that can diverge (a set synced while the deployment had no S3 wrote
+ * its bytes to dev storage; a wiped bucket keeps its rows). Hash-only "unchanged"
+ * makes that permanent — every later sync skips the file, reads 404 → the mount
+ * answers EIO, and the whole set is dead with a green sync. Observed: 33 public
+ * skills with a complete manifest and zero objects in the bucket.
+ *
+ * So: skip only what is present in BOTH.
+ */
+export function isUpToDate(args: {
+  hash: string;
+  manifestHash: string | null | undefined;
+  storedPaths: ReadonlySet<string>;
+  path: string;
+}): boolean {
+  return args.manifestHash === args.hash && args.storedPaths.has(args.path);
+}
+
+/** Paths (volume-relative) whose bytes actually exist in object storage. */
+async function storedPaths(
+  storage: BoundObjectStorage,
+  volume: string,
+): Promise<Set<string>> {
+  const prefix = fsVolumePrefix(volume);
+  const paths = new Set<string>();
+  let continuationToken: string | undefined;
+  do {
+    const page = await storage.list({ prefix, continuationToken });
+    for (const obj of page.objects) paths.add(obj.key.slice(prefix.length));
+    continuationToken = page.nextContinuationToken;
+  } while (continuationToken);
+  return paths;
+}
+
 export interface SyncResult {
   set: string;
   written: number;
@@ -261,8 +301,16 @@ async function syncPublicSet(
   }
   let written = 0;
   let unchanged = 0;
+  const stored = await storedPaths(storage, volume);
   for (const [path, bytes] of desired) {
-    if (current.get(path) === sha256Hex(bytes)) {
+    if (
+      isUpToDate({
+        hash: sha256Hex(bytes),
+        manifestHash: current.get(path),
+        storedPaths: stored,
+        path,
+      })
+    ) {
       unchanged++;
       continue;
     }

--- a/apps/api/src/tools/task-board/claude-code-task-run.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.ts
@@ -179,7 +179,7 @@ export function buildClaudeCodeTaskPrompt(
   opts?: SuperAgentPromptOpts & { repoChoices?: TaskRepoChoiceOption[] },
 ): string {
   const lines: string[] = [
-    "You've been assigned this task. Complete it and finish with a pull request.",
+    "You've been assigned this task. Complete it and finish with a pull request if it makes sense (like a coding task) or is explicitly requested.",
     "",
     "You are running AUTONOMOUSLY — no human is watching, so drive this to " +
       "completion yourself. Make reasonable decisions and move on; do not stop " +

--- a/packages/harness-runner/claude-code.test.ts
+++ b/packages/harness-runner/claude-code.test.ts
@@ -115,18 +115,27 @@ describe("buildOptions", () => {
     const withInstructions = options({
       agent: { id: "a", instructions: "Be terse." },
     });
-    expect(withInstructions.systemPrompt).toEqual({
-      type: "preset",
-      preset: "claude_code",
-      append: "Be terse.",
-    });
+    const prompt = withInstructions.systemPrompt as {
+      type: string;
+      preset: string;
+      append: string;
+    };
+    expect(prompt.type).toBe("preset");
+    expect(prompt.preset).toBe("claude_code");
+    expect(prompt.append).toStartWith("Be terse.");
   });
 
-  test("omits append when the agent has no instructions", () => {
-    expect(options().systemPrompt).toEqual({
-      type: "preset",
-      preset: "claude_code",
-    });
+  test("points skill authoring at the org-fs mount, instructions or not", () => {
+    // Without this the model writes a reusable skill into the checkout, where it
+    // dies with the branch instead of syncing to the org.
+    for (const opts of [options(), options({ agent: { id: "a" } })]) {
+      const { append } = opts.systemPrompt as { append: string };
+      expect(append).toContain("/skills/");
+      // The path is for WRITING only. Handing it out as a place to look sent the
+      // model to Bash for a listing it already had in the prompt.
+      expect(append).toContain("Never search the filesystem for skills");
+    }
+    expect(options().skills).toBe("all");
   });
 
   test("runs in the repo checkout when the workspace has one", () => {

--- a/packages/harness-runner/claude-code.ts
+++ b/packages/harness-runner/claude-code.ts
@@ -136,6 +136,43 @@ function sessionFile(threadId: string): string {
   return `${dir}/deco-sessions/${threadId.replace(/[^A-Za-z0-9_-]/g, "_")}`;
 }
 
+/**
+ * The pod's user-scope Claude config dir — the same one `sessionFile` writes to,
+ * and the one the daemon links `skills` out of onto the org-fs mount.
+ */
+function claudeConfigDir(): string {
+  return process.env.CLAUDE_CONFIG_DIR ?? `${process.env.HOME ?? "."}/.claude`;
+}
+
+/**
+ * Where a skill the agent authors has to land to outlive the pod: the user-scope
+ * skills dir, which the daemon links onto the org's `org/home/skills` (see
+ * `ensureSkillsLinkLocked`). Writing there IS an org-fs write, so the skill is
+ * shared org-wide; a skill written into the checkout only reaches whoever merges
+ * the branch.
+ *
+ * Absolute, not `~/…`: the Write tool takes a path, not a shell word, so a tilde
+ * would create a literal `~` directory next to the checkout and the skill would
+ * die with the pod.
+ */
+export function skillsInstruction(): string {
+  const dir = `${claudeConfigDir()}/skills`;
+  return (
+    // READING is deliberately not given a path. Every discovered skill's name and
+    // description is already in this prompt, so a path here only invites the model
+    // to go `ls` for what it was just handed — which is exactly what it did.
+    "Your available skills are already listed for you with their descriptions; " +
+    "invoke one with the Skill tool. Never search the filesystem for skills and " +
+    "never read a SKILL.md yourself.\n\n" +
+    "When you WRITE or edit a reusable skill, put it at " +
+    `\`${dir}/<name>/SKILL.md\` (frontmatter \`name\` + \`description\`), using ` +
+    "that absolute path — never `~`. That folder syncs to the org, so the skill " +
+    "outlives this sandbox and every teammate's run sees it. Do NOT put a skill " +
+    "in the checkout's `.claude/skills/`, and do not commit one to the repo, " +
+    "unless the task explicitly asks for a skill scoped to that repository."
+  );
+}
+
 /** SDK options for one run. Exported for the unit test — it is the whole policy. */
 export function buildOptions(args: {
   input: HarnessStreamInputWire;
@@ -146,6 +183,9 @@ export function buildOptions(args: {
   const cwd = input.workspace.cwd ?? undefined;
   const instructions = input.agent.instructions;
   const model = process.env[ENVS.MODEL_ENV];
+  const instructionsWithSkills = [instructions, skillsInstruction()]
+    .filter(Boolean)
+    .join("\n\n");
   const executable = process.env[ENVS.EXECUTABLE_ENV];
   return {
     ...(cwd ? { cwd } : {}),
@@ -157,8 +197,12 @@ export function buildOptions(args: {
     systemPrompt: {
       type: "preset",
       preset: "claude_code",
-      ...(instructions ? { append: instructions } : {}),
+      append: instructionsWithSkills,
     },
+    // The org's skills reach the pod as `~/.claude/skills` (the daemon links it
+    // onto the org-fs mount), which the SDK discovers from the `user` setting
+    // source — but only once skills are turned on for the session.
+    skills: "all",
     ...(model ? { model } : {}),
     // ponytail: fixed, not configurable — raise it here if runs come back thin.
     effort: "low",
@@ -239,6 +283,14 @@ export async function runClaudeCode(
         const studioToolCount = message.tools.filter((tool) =>
           tool.startsWith("mcp__"),
         ).length;
+        // Skills are a filesystem contract across two processes (the daemon
+        // links the dir, the SDK scans it) and a broken link is silent — the
+        // model just never mentions a skill. Log what it actually found.
+        console.error(
+          `[claude-code] skills (${message.skills.length}): ${
+            message.skills.join(" ") || "none discovered"
+          }`,
+        );
         console.error(
           `[claude-code] mcp: ${
             message.mcp_servers

--- a/packages/harness-runner/claude-code.ts
+++ b/packages/harness-runner/claude-code.ts
@@ -155,7 +155,7 @@ function claudeConfigDir(): string {
  * would create a literal `~` directory next to the checkout and the skill would
  * die with the pod.
  */
-export function skillsInstruction(): string {
+function skillsInstruction(): string {
   const dir = `${claudeConfigDir()}/skills`;
   return (
     // READING is deliberately not given a path. Every discovered skill's name and

--- a/packages/sandbox/daemon-go/internal/dispatch/dispatch.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/dispatch.go
@@ -52,6 +52,11 @@ type Deps struct {
 	// repointed at this run's thread, `.deco/tools/` refreshed. Must not block for
 	// long and must not fail the run. Optional.
 	BeforeRun func(RunInfo)
+	// AfterRun settles the workspace once the harness has exited, however it
+	// exited (success, crash, cancel): whatever the model wrote to the wrong
+	// place gets moved to where it survives the pod. Same contract as BeforeRun —
+	// quick, and it must not fail the run. Optional.
+	AfterRun func(RunInfo)
 }
 
 // RunInfo is what the daemon needs from a dispatched run's input to prepare the
@@ -367,6 +372,12 @@ func (reg *Registry) runHarness(
 	// rather than in each caller so the offloaded-messages path gets it too.
 	if deps.BeforeRun != nil {
 		deps.BeforeRun(runInfoOf(input))
+	}
+	// Deferred, not placed after RunHarness: every terminal path below returns
+	// early (crash, cancel, unknown harness), and the run that crashed halfway is
+	// exactly the one whose stray output must still be rescued.
+	if deps.AfterRun != nil {
+		defer deps.AfterRun(runInfoOf(input))
 	}
 
 	if len(deps.HarnessRunnerCmd) == 0 {

--- a/packages/sandbox/daemon-go/internal/gitx/status.go
+++ b/packages/sandbox/daemon-go/internal/gitx/status.go
@@ -250,3 +250,23 @@ var ansiColorRe = regexp.MustCompile("\x1b\\[[0-9;]*m")
 func FormatGitError(err error) string {
 	return ansiColorRe.ReplaceAllString(err.Error(), "")
 }
+
+// UntrackedUnder lists repo-relative paths under `pathspec` that git neither
+// tracks nor ignores — i.e. what something newly wrote into the checkout. The
+// `--exclude-standard` filter is what keeps daemon-planted paths out: they are
+// already registered in `.git/info/exclude`.
+func UntrackedUnder(repoDir, pathspec string) []string {
+	out, ok := tryReadGit(repoDir, []string{
+		"ls-files", "--others", "--exclude-standard", "--", pathspec,
+	})
+	if !ok {
+		return nil
+	}
+	var paths []string
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if line != "" {
+			paths = append(paths, line)
+		}
+	}
+	return paths
+}

--- a/packages/sandbox/daemon-go/internal/orgfs/links.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/links.go
@@ -12,10 +12,13 @@ package orgfs
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"sync"
 	"time"
 
@@ -29,8 +32,8 @@ const (
 	firstMountPoll = 250 * time.Millisecond
 )
 
-// One path segment, no traversal — threadIds are cluster-issued slugs/UUIDs.
-var safeThreadId = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+// One path segment, no traversal — thread ids, volume set and skill dir names.
+var safeSegment = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
 
 // Mount is one live mount, as reported by the sidecar's status file (mirrors
 // MountManager.list()).
@@ -62,6 +65,8 @@ type Links struct {
 	// design — a stuck FUSE lstat blocks only org-fs callers.
 	mu               sync.Mutex
 	lastOutputThread string
+	skillsLinked     bool
+	publicSkillsRun  bool
 }
 
 // Expected reports whether org-fs volumes should exist on this pod.
@@ -173,8 +178,12 @@ func (l *Links) RepointForRun(threadId string) bool {
 
 // ensureRepoLinkLocked drops `<repoDir>/org → ../org` and excludes it so the
 // shutdown `git add -A` never commits it. At dispatch time, not boot — a link in
-// place first makes `git clone` refuse the non-empty dir.
+// place first makes `git clone` refuse the non-empty dir. Also links the org's
+// skills folder into the pod's Claude config dir (same job: make org content
+// resolve where the harness looks for it).
 func (l *Links) ensureRepoLinkLocked() {
+	l.ensureSkillsLinkLocked()
+	defer l.ensurePublicSkillLinksLocked()
 	if l.RepoDir == "" {
 		return
 	}
@@ -192,11 +201,271 @@ func (l *Links) ensureRepoLinkLocked() {
 	gitx.EnsureExclude(l.RepoDir, "/org")
 }
 
+// ensureSkillsLinkLocked points the pod's USER skill dir (`~/.claude/skills`,
+// or `$CLAUDE_CONFIG_DIR/skills`) at the org's `org/home/skills` on the mount.
+//
+// User scope, not the repo's `.claude/skills`: Claude Code loads both, so the
+// org's skills add to whatever the checkout ships instead of shadowing it. And
+// because the link IS the mount, a skill the agent writes there is an org-fs
+// write — it syncs back with no extra machinery, and the next run in any pod
+// sees it.
+//
+// Absolute target (the config dir is outside `<appRoot>`), and a real directory
+// already sitting there wins — never shadow a pod's own skills.
+func (l *Links) ensureSkillsLinkLocked() {
+	if l.skillsLinked {
+		return
+	}
+	dir := os.Getenv("CLAUDE_CONFIG_DIR")
+	if dir == "" {
+		home := os.Getenv("HOME")
+		if home == "" {
+			return
+		}
+		dir = filepath.Join(home, ".claude")
+	}
+	// Gated on the SIDECAR's report, not on the directory: a mount point exists
+	// even when the mount failed, and MkdirAll into that puts the org's skills on
+	// ephemeral disk, where they die with the pod (this file's whole premise).
+	if !l.volumeMounted("home") {
+		return
+	}
+	target := filepath.Join(l.AppRoot, "org", "home", "skills")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		slog.Warn("org-fs skills dir failed", "err", err)
+		return
+	}
+	// Reads and writes fail independently on this mount, and only reads can kill
+	// a run: rclone's write-back cache absorbs a write and flushes it out of band
+	// (a skill the agent authors syncs even while GETs are wedged), but Claude
+	// Code READS every skill in this dir during startup, on the thread pool that
+	// then never answers.
+	//
+	// So the read gate applies only when there is something to read. An empty
+	// skills dir has no file to hang on, and linking it is what gives the agent
+	// somewhere durable to write — skip the link there and the agent writes its
+	// skill into the checkout, which is the whole bug this exists to fix.
+	if names := skillDirNames(target); len(names) > 0 {
+		if ok, err := readableWithin(
+			filepath.Join(target, names[0], "SKILL.md"), skillReadBudget,
+		); !ok {
+			slog.Warn("org-fs skills link skipped: home mount does not read",
+				"probe", names[0], "budget", skillReadBudget, "err", err)
+			return
+		}
+	}
+	link := filepath.Join(dir, "skills")
+	if st, err := os.Lstat(link); err == nil {
+		if st.Mode()&os.ModeSymlink == 0 {
+			slog.Warn("org-fs skills link skipped: exists and is not a symlink", "link", link)
+			l.skillsLinked = true
+			return
+		}
+		if cur, err := os.Readlink(link); err == nil && cur == target {
+			l.skillsLinked = true
+			return
+		}
+		if err := os.Remove(link); err != nil {
+			slog.Warn("org-fs skills link failed", "err", err)
+			return
+		}
+	} else if err := os.MkdirAll(dir, 0o755); err != nil {
+		slog.Warn("org-fs skills link failed", "err", err)
+		return
+	}
+	if err := os.Symlink(target, link); err != nil {
+		slog.Warn("org-fs skills link failed", "err", err)
+		return
+	}
+	l.skillsLinked = true
+}
+
+// How long a single org-fs read may take before the mount counts as unusable
+// for skills. Generous for a network filesystem, tiny next to a dead run.
+const skillReadBudget = 3 * time.Second
+
+// readableWithin reports whether path's first byte can be read within d, and
+// why not when it fails. The reason matters: "hung mount" and "backend returns
+// EIO because the bytes were never uploaded" both surface here as a skipped
+// set, and only the error tells them apart — without it the warn line sends you
+// exec'ing into a pod to find out.
+//
+// This gate is the whole reason skills are safe to expose: org-fs is a network
+// filesystem, and a wedged backend turns a read into an INDEFINITE block, not an
+// error. Claude Code scans every skill dir during STARTUP, on its I/O thread
+// pool — so one hung read there means the CLI never emits `init`, the run
+// produces nothing at all, and the pod bills a full idle TTL having done zero
+// work. Observed live: both Bun pool threads parked in `request_wait_answer`.
+//
+// A timeout leaks its goroutine until the FUSE request finally answers. That is
+// the point: the blocked read is quarantined in the daemon, where it costs a
+// skill, instead of in the CLI, where it costs the run.
+func readableWithin(path string, d time.Duration) (bool, error) {
+	done := make(chan error, 1)
+	go func() {
+		f, err := os.Open(path)
+		if err != nil {
+			done <- err
+			return
+		}
+		defer f.Close()
+		if _, err := f.Read(make([]byte, 1)); err != nil && err != io.EOF {
+			done <- err
+			return
+		}
+		done <- nil
+	}()
+	select {
+	case err := <-done:
+		return err == nil, err
+	case <-time.After(d):
+		return false, fmt.Errorf("read did not answer within %s", d)
+	}
+}
+
+// skillDirNames lists the subdirectories of dir that hold a SKILL.md. Listing
+// and stat are the org-fs operations that survive a wedged backend (both are
+// served from the mount's metadata), so this is safe to call before any read —
+// and filtering here is what keeps a non-skill directory from being chosen as
+// the read probe and condemning a whole set.
+func skillDirNames(dir string) []string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var names []string
+	for _, e := range entries {
+		if !e.IsDir() || !safeSegment.MatchString(e.Name()) {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(dir, e.Name(), "SKILL.md")); err != nil {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	return names
+}
+
+// volumeMounted reports whether the sidecar has `<appRoot>/org/<dir>` mounted.
+func (l *Links) volumeMounted(dir string) bool {
+	want := filepath.Join(l.AppRoot, "org", dir)
+	for _, m := range l.mountsOrWait() {
+		if m.MountPath == want {
+			return true
+		}
+	}
+	return false
+}
+
+// Prefix for the symlinks this daemon plants in the checkout's skills dir. It
+// is what makes them ours: everything matching it is removed and rebuilt on
+// sync, and one git-exclude line covers the whole set.
+const publicSkillPrefix = "orgfs-"
+
+// ensurePublicSkillLinksLocked exposes the read-only public skill sets
+// (`org/public/<set>/<skill>`) to Claude Code as PROJECT skills — one symlink
+// per skill under `<repoDir>/.claude/skills/`.
+//
+// Why not the user dir like home skills: that dir IS the home mount now, so a
+// symlink dropped there would be written into org-fs — pod-local paths synced
+// org-wide. And the public mounts are read-only, so a plugin manifest cannot go
+// next to them either. The checkout's skills dir is the one writable place the
+// SDK already scans.
+//
+// Additive and disposable: the repo's own skills are untouched (only `orgfs-*`
+// entries are ours, and they are cleared before rebuild so a removed set leaves
+// no dangling skill), and one exclude line keeps them out of every commit.
+func (l *Links) ensurePublicSkillLinksLocked() {
+	if l.publicSkillsRun || l.RepoDir == "" {
+		return
+	}
+	// Claimed before the work starts, so concurrent fs calls don't each launch a
+	// sync; released again below if nothing linked, so a mount that recovers gets
+	// another attempt.
+	l.publicSkillsRun = true
+	// OFF the caller's thread: this walks a network filesystem, and it ran under
+	// the lock on the dispatch path — 33 unreadable skills × the read budget put
+	// two minutes of dead air in front of a run that was otherwise ready. The
+	// cost of racing the harness's own startup scan is at worst a skill missing
+	// from THIS run; the cost of blocking was the run.
+	go func() {
+		if l.syncPublicSkills() {
+			return
+		}
+		l.mu.Lock()
+		l.publicSkillsRun = false
+		l.mu.Unlock()
+	}()
+}
+
+// syncPublicSkills does the linking, reporting whether anything was linked. Runs
+// without `mu`: it touches only the checkout's skills dir and the read-only
+// public mounts, which no other link path writes.
+func (l *Links) syncPublicSkills() bool {
+	sets, err := os.ReadDir(filepath.Join(l.AppRoot, "org", "public"))
+	if err != nil {
+		// No public mount on this pod (older sandbox, or none configured).
+		return false
+	}
+	dir := filepath.Join(l.RepoDir, ".claude", "skills")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		slog.Warn("org-fs public skills link failed", "err", err)
+		return false
+	}
+	// Ours are cleared first: a set that lost a skill must not leave a symlink
+	// pointing at nothing, which Claude Code reports as a broken skill.
+	if entries, err := os.ReadDir(dir); err == nil {
+		for _, e := range entries {
+			if strings.HasPrefix(e.Name(), publicSkillPrefix) {
+				os.RemoveAll(filepath.Join(dir, e.Name()))
+			}
+		}
+	}
+	gitx.EnsureExclude(l.RepoDir, "/.claude/skills/"+publicSkillPrefix+"*")
+
+	linked, unreadable := 0, 0
+	for _, set := range sets {
+		if !set.IsDir() || !safeSegment.MatchString(set.Name()) {
+			continue
+		}
+		setDir := filepath.Join(l.AppRoot, "org", "public", set.Name())
+		names := skillDirNames(setDir)
+		if len(names) == 0 {
+			continue
+		}
+		// ONE probe per set, not per skill. `stat` is served from the mount's
+		// metadata and succeeds on a backend whose GETs hang forever, so a read
+		// has to be proven — but a set is one volume with one backend, so the
+		// first skill's answer is the whole set's answer. Per-skill probing cost
+		// 33 × the budget on a wedged mount.
+		if ok, err := readableWithin(
+			filepath.Join(setDir, names[0], "SKILL.md"), skillReadBudget,
+		); !ok {
+			slog.Warn("org-fs public skills skipped: set does not read",
+				"set", set.Name(), "probe", names[0], "skills", len(names), "err", err)
+			unreadable += len(names)
+			continue
+		}
+		for _, name := range names {
+			// `<set>-<skill>`: collision-free across sets. Cosmetic — the name the
+			// model sees comes from SKILL.md's frontmatter, not the directory.
+			link := filepath.Join(dir, publicSkillPrefix+set.Name()+"-"+name)
+			if err := os.Symlink(filepath.Join(setDir, name), link); err != nil {
+				slog.Warn("org-fs public skill link failed", "skill", name, "err", err)
+				continue
+			}
+			linked++
+		}
+	}
+	slog.Info("org-fs public skills linked", "count", linked, "unreadable", unreadable)
+	return linked > 0
+}
+
 // repointThreadLink points `org/<linkName>` at `<mountDir>/<threadId>`, creating
 // the thread's subtree through the mount. Relative target so the tree survives
 // being moved.
 func (l *Links) repointThreadLink(threadId, mountDir, linkName string) bool {
-	if !safeThreadId.MatchString(threadId) {
+	if !safeSegment.MatchString(threadId) {
 		slog.Warn("org-fs link skipped: unsafe threadId", "link", linkName, "threadId", threadId)
 		return false
 	}
@@ -230,4 +499,79 @@ func (l *Links) repointThreadLink(threadId, mountDir, linkName string) bool {
 		return false
 	}
 	return true
+}
+
+// AdoptStrayRepoSkills moves skills written into the checkout's
+// `.claude/skills/` onto the org mount, where they outlive the pod.
+//
+// This exists because prose lost. The harness prompt tells the model to author
+// skills at the user-scope path (the org mount), and it still wrote
+// `<repoDir>/.claude/skills/rubber-duck/` — that dir is where Claude Code's own
+// skill-authoring convention points, and a bundled skill's body beats an
+// appended system-prompt paragraph. So the destination is enforced after the
+// fact instead of asked for: a skill in the checkout dies with the branch, and
+// nobody notices until they look for it next week.
+//
+// Only UNTRACKED dirs move: the repo's own committed skills are the one thing
+// that legitimately lives there, and `--exclude-standard` already drops the
+// `orgfs-*` symlinks this daemon plants (they are in `.git/info/exclude`).
+// Copy-then-remove, not rename — the checkout is local disk and the target is
+// FUSE, so a rename is EXDEV.
+func (l *Links) AdoptStrayRepoSkills() {
+	if l == nil || l.RepoDir == "" || !l.Expected() {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if !l.volumeMounted("home") {
+		return
+	}
+	target := filepath.Join(l.AppRoot, "org", "home", "skills")
+	for _, name := range strayRepoSkillDirs(l.RepoDir) {
+		src := filepath.Join(l.RepoDir, ".claude", "skills", name)
+		dst := filepath.Join(target, name)
+		// A same-named org skill wins: it is shared, this one is one run's guess.
+		if _, err := os.Lstat(dst); err == nil {
+			slog.Warn("stray skill not adopted: name already in the org", "skill", name)
+			continue
+		}
+		if err := os.CopyFS(dst, os.DirFS(src)); err != nil {
+			slog.Warn("stray skill adopt failed", "skill", name, "err", err)
+			// Leave the source in place — a half-copy on the mount is worse than
+			// a skill still sitting in the checkout, and the next run retries.
+			os.RemoveAll(dst)
+			continue
+		}
+		if err := os.RemoveAll(src); err != nil {
+			slog.Warn("stray skill left in checkout", "skill", name, "err", err)
+		}
+		slog.Info("stray skill adopted into the org", "skill", name)
+	}
+}
+
+// strayRepoSkillDirs names the untracked skill directories in the checkout —
+// the ones holding a SKILL.md, deduped from git's per-FILE listing.
+func strayRepoSkillDirs(repoDir string) []string {
+	var names []string
+	seen := map[string]bool{}
+	for _, p := range gitx.UntrackedUnder(repoDir, ".claude/skills") {
+		// `.claude/skills/<name>/...` — anything shallower is not a skill.
+		parts := strings.Split(p, "/")
+		if len(parts) < 4 {
+			continue
+		}
+		name := parts[2]
+		if seen[name] || !safeSegment.MatchString(name) ||
+			strings.HasPrefix(name, publicSkillPrefix) {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(
+			repoDir, ".claude", "skills", name, "SKILL.md",
+		)); err != nil {
+			continue
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+	return names
 }

--- a/packages/sandbox/daemon-go/internal/orgfs/links_test.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/links_test.go
@@ -3,7 +3,9 @@ package orgfs
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -64,5 +66,254 @@ func TestExpectedRequiresSidecarEnv(t *testing.T) {
 	var nilLinks *Links
 	if nilLinks.Expected() {
 		t.Error("nil Links reported org-fs expected")
+	}
+}
+
+// The skills link is what makes an org skill both readable by Claude Code and
+// durable when the agent writes one. Three invariants no mount-level test sees:
+// an unmounted mount point is never linked (MkdirAll would put the org's skills
+// on ephemeral disk), an EMPTY dir is linked without probing (it is the agent's
+// only durable place to write a skill, and there is no file to hang on), and a
+// POPULATED dir that does not read is not linked (Claude Code reads it during
+// startup, so a hung read there kills the run).
+func TestSkillsLinkNeedsAMountThatWorks(t *testing.T) {
+	appRoot := t.TempDir()
+	configDir := filepath.Join(t.TempDir(), "config")
+	t.Setenv("CLAUDE_CONFIG_DIR", configDir)
+	statusPath := filepath.Join(t.TempDir(), "status.json")
+	link := filepath.Join(configDir, "skills")
+	homeMount := filepath.Join(appRoot, "org", "home")
+	skillsDir := filepath.Join(homeMount, "skills")
+	if err := os.MkdirAll(homeMount, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	setMounts := func(mounts ...Mount) {
+		raw, _ := json.Marshal(sidecarStatus{Mounts: mounts})
+		if err := os.WriteFile(statusPath, raw, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Mount point present, sidecar reporting nothing mounted there.
+	setMounts(Mount{Volume: "outputs", MountPath: filepath.Join(appRoot, "org", ".outputs")})
+
+	l := &Links{AppRoot: appRoot, StatusPath: statusPath, ConfigPath: "unused"}
+	l.ensureSkillsLinkLocked()
+	if _, err := os.Lstat(link); err == nil {
+		t.Fatal("linked an unmounted mount point — the skills would die with the pod")
+	}
+
+	// Mounted and empty: linked with no probe, so the agent has somewhere durable
+	// to write even while the backend's reads are wedged.
+	setMounts(Mount{Volume: "home", MountPath: homeMount})
+	l.ensureSkillsLinkLocked()
+	target, err := os.Readlink(link)
+	if err != nil {
+		t.Fatalf("empty skills dir not linked — the agent would write to the repo: %v", err)
+	}
+	if target != skillsDir {
+		t.Errorf("skills → %q, want %q", target, skillsDir)
+	}
+
+	// Populated but unreadable: not linked. A SKILL.md that exists (stat, served
+	// from mount metadata) but cannot be read is exactly the wedged-backend shape.
+	// Fresh Links — the first one memoized its success.
+	if err := os.MkdirAll(filepath.Join(skillsDir, "wedged"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wedgedSkill := filepath.Join(skillsDir, "wedged", "SKILL.md")
+	if err := os.WriteFile(wedgedSkill, []byte("---\nname: w\n---\n"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(link); err != nil {
+		t.Fatal(err)
+	}
+	unreadable := &Links{AppRoot: appRoot, StatusPath: statusPath, ConfigPath: "unused"}
+	unreadable.ensureSkillsLinkLocked() // no SKILL.md in `wedged` → read fails
+	if _, err := os.Lstat(link); err == nil {
+		t.Fatal("linked a populated dir whose skill does not read — startup would hang")
+	}
+	if unreadable.skillsLinked {
+		t.Fatal("memoized a failed link; a recovered mount would never be picked up")
+	}
+
+	// Populated and readable: linked.
+	if err := os.Chmod(wedgedSkill, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	unreadable.ensureSkillsLinkLocked()
+	if _, err := os.Readlink(link); err != nil {
+		t.Errorf("healthy populated dir not linked: %v", err)
+	}
+}
+
+// A pod that ships its own skills dir keeps it — org skills are additive.
+func TestSkillsLinkNeverShadowsARealDir(t *testing.T) {
+	appRoot := t.TempDir()
+	configDir := filepath.Join(t.TempDir(), "config")
+	t.Setenv("CLAUDE_CONFIG_DIR", configDir)
+	if err := os.MkdirAll(filepath.Join(configDir, "skills", "builtin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(appRoot, "org", "home"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	(&Links{AppRoot: appRoot, ConfigPath: "unused"}).ensureSkillsLinkLocked()
+	if _, err := os.Stat(filepath.Join(configDir, "skills", "builtin")); err != nil {
+		t.Errorf("replaced the pod's own skills dir: %v", err)
+	}
+}
+
+// Public sets are where an org's curated skills actually live, and they mount
+// read-only — so they reach Claude Code as project skills in the checkout. The
+// invariants: the repo's own skills survive, ours are rebuilt (no dangling
+// symlink when a set loses a skill), and they never reach a commit.
+func TestPublicSkillLinks(t *testing.T) {
+	appRoot := t.TempDir()
+	repoDir := filepath.Join(appRoot, "repo")
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(t.TempDir(), "config"))
+	writeSkill := func(set, skill string) {
+		dir := filepath.Join(appRoot, "org", "public", set, skill)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: x\n---\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// The repo ships a skill of its own, and a dir that is not a skill at all.
+	ownSkill := filepath.Join(repoDir, ".claude", "skills", "repo-own")
+	if err := os.MkdirAll(ownSkill, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoDir, ".git", "info"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeSkill("core", "slides")
+	writeSkill("core", "pdf")
+	if err := os.MkdirAll(filepath.Join(appRoot, "org", "public", "core", "not-a-skill"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	l := &Links{AppRoot: appRoot, RepoDir: repoDir, ConfigPath: "unused"}
+	l.syncPublicSkills()
+
+	skillsDir := filepath.Join(repoDir, ".claude", "skills")
+	target, err := os.Readlink(filepath.Join(skillsDir, "orgfs-core-slides"))
+	if err != nil {
+		t.Fatalf("public skill not linked: %v", err)
+	}
+	if want := filepath.Join(appRoot, "org", "public", "core", "slides"); target != want {
+		t.Errorf("link → %q, want %q", target, want)
+	}
+	if _, err := os.Lstat(filepath.Join(skillsDir, "orgfs-core-not-a-skill")); err == nil {
+		t.Error("linked a directory with no SKILL.md")
+	}
+	if _, err := os.Stat(ownSkill); err != nil {
+		t.Errorf("clobbered the repo's own skill: %v", err)
+	}
+
+	excl, err := os.ReadFile(filepath.Join(repoDir, ".git", "info", "exclude"))
+	if err != nil || !strings.Contains(string(excl), "/.claude/skills/orgfs-*") {
+		t.Errorf("links not git-excluded — a run would commit them: %q %v", excl, err)
+	}
+
+	// A rebuild after `pdf` disappeared must not leave it dangling.
+	if err := os.RemoveAll(filepath.Join(appRoot, "org", "public", "core", "pdf")); err != nil {
+		t.Fatal(err)
+	}
+	l.publicSkillsRun = false
+	l.syncPublicSkills()
+	if _, err := os.Lstat(filepath.Join(skillsDir, "orgfs-core-pdf")); err == nil {
+		t.Error("stale symlink kept for a skill that no longer exists")
+	}
+	if _, err := os.Readlink(filepath.Join(skillsDir, "orgfs-core-slides")); err != nil {
+		t.Errorf("rebuild dropped a live skill: %v", err)
+	}
+}
+
+func TestAdoptStrayRepoSkills(t *testing.T) {
+	appRoot := t.TempDir()
+	repoDir := filepath.Join(appRoot, "repo")
+	statusPath := filepath.Join(t.TempDir(), "status.json")
+	homeMount := filepath.Join(appRoot, "org", "home")
+	if err := os.MkdirAll(filepath.Join(homeMount, "skills"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := json.Marshal(sidecarStatus{Mounts: []Mount{
+		{Volume: "home", MountPath: homeMount},
+	}})
+	if err := os.WriteFile(statusPath, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	writeSkill := func(name, body string) string {
+		dir := filepath.Join(repoDir, ".claude", "skills", name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return dir
+	}
+	git := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	// A committed skill (the repo legitimately owns it) and a dir with no
+	// SKILL.md, both of which must survive untouched.
+	tracked := writeSkill("repo-own", "---\nname: repo-own\n---\n")
+	if err := os.MkdirAll(filepath.Join(repoDir, ".claude", "skills", "junk"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	git("init", "-q")
+	git("config", "user.email", "t@t.t")
+	git("config", "user.name", "t")
+	git("add", "-A")
+	git("commit", "-qm", "init")
+
+	// What the model actually did: authored a skill into the checkout, with a
+	// nested file, where it would die with the branch.
+	stray := writeSkill("rubber-duck", "---\nname: rubber-duck\n---\nquack\n")
+	if err := os.WriteFile(filepath.Join(stray, "notes.md"), []byte("more"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	l := &Links{AppRoot: appRoot, RepoDir: repoDir, StatusPath: statusPath, ConfigPath: "unused"}
+	l.AdoptStrayRepoSkills()
+
+	adopted := filepath.Join(homeMount, "skills", "rubber-duck")
+	body, err := os.ReadFile(filepath.Join(adopted, "SKILL.md"))
+	if err != nil {
+		t.Fatalf("stray skill not adopted onto the mount: %v", err)
+	}
+	if !strings.Contains(string(body), "quack") {
+		t.Errorf("adopted the wrong bytes: %q", body)
+	}
+	if _, err := os.Stat(filepath.Join(adopted, "notes.md")); err != nil {
+		t.Errorf("nested file lost in the move: %v", err)
+	}
+	if _, err := os.Stat(stray); err == nil {
+		t.Error("left the skill in the checkout too — the next commit ships it")
+	}
+	if _, err := os.Stat(filepath.Join(tracked, "SKILL.md")); err != nil {
+		t.Errorf("moved a skill the repo owns: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(homeMount, "skills", "junk")); err == nil {
+		t.Error("adopted a directory with no SKILL.md")
+	}
+
+	// A name the org already uses is left alone rather than overwritten.
+	stray2 := writeSkill("rubber-duck", "---\nname: mine\n---\nlocal\n")
+	l.AdoptStrayRepoSkills()
+	if _, err := os.Stat(stray2); err != nil {
+		t.Error("deleted a stray skill without adopting it")
+	}
+	if body, _ := os.ReadFile(filepath.Join(adopted, "SKILL.md")); !strings.Contains(string(body), "quack") {
+		t.Error("clobbered the org's skill with a same-named local one")
 	}
 }

--- a/packages/sandbox/daemon-go/main.go
+++ b/packages/sandbox/daemon-go/main.go
@@ -753,6 +753,11 @@ func main() {
 				ExpiresAt: info.McpExpiresAt,
 			})
 		},
+		// A skill the model authored into the checkout would die with the branch;
+		// move it onto the org mount before anyone goes looking for it.
+		AfterRun: func(dispatch.RunInfo) {
+			d.orgFsLinks.AdoptStrayRepoSkills()
+		},
 	}
 
 	fsDeps := routes.FsDeps{

--- a/selfhost/examples/k8s-local/templates/dev-deps.yaml
+++ b/selfhost/examples/k8s-local/templates/dev-deps.yaml
@@ -1,8 +1,16 @@
 {{- /*
-Throwaway PostgreSQL + MinIO for the local umbrella. DEV ONLY — ephemeral
-(emptyDir), fixed Service names (studio-db, studio-minio) so the Studio subchart
-values can reference them statically. For production, drop these and point the
-chart at managed Postgres/S3.
+Throwaway PostgreSQL + MinIO for the local umbrella. DEV ONLY — fixed Service
+names (studio-db, studio-minio) so the Studio subchart values can reference them
+statically. For production, drop these and point the chart at managed
+Postgres/S3.
+
+Both claim a PVC rather than an emptyDir. Throwaway does not mean per-pod: the
+object store holds the ONLY copy of every org-fs byte while Postgres holds the
+manifest that names them, so losing one and keeping the other leaves org-fs in
+its worst state — `list`/`stat` answer 200 from the manifest and every `read`
+404s on a missing object. That silently breaks anything reading org content (the
+sandbox mounts, skills) with no error that names the cause. Observed exactly
+that after a minio pod recreate wiped the bucket.
 */ -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -30,7 +38,7 @@ spec:
             requests: { cpu: "50m", memory: "128Mi" }
             limits: { memory: "256Mi" }
           volumeMounts: [{ name: data, mountPath: /var/lib/postgresql/data }]
-      volumes: [{ name: data, emptyDir: {} }]
+      volumes: [{ name: data, persistentVolumeClaim: { claimName: studio-db-data } }]
 ---
 apiVersion: v1
 kind: Service
@@ -71,7 +79,7 @@ spec:
             requests: { cpu: "25m", memory: "128Mi" }
             limits: { memory: "256Mi" }
           volumeMounts: [{ name: data, mountPath: /data }]
-      volumes: [{ name: data, emptyDir: {} }]
+      volumes: [{ name: data, persistentVolumeClaim: { claimName: studio-minio-data } }]
 ---
 apiVersion: v1
 kind: Service
@@ -79,3 +87,19 @@ metadata: { name: studio-minio }
 spec:
   selector: { app: studio-minio }
   ports: [{ name: s3, port: 9000, targetPort: s3 }]
+---
+# The bytes org-fs hands out. Paired with studio-db's manifest below — see the
+# header: keeping one and losing the other is the failure mode worth avoiding.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata: { name: studio-minio-data }
+spec:
+  accessModes: [ReadWriteOnce]
+  resources: { requests: { storage: 10Gi } }
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata: { name: studio-db-data }
+spec:
+  accessModes: [ReadWriteOnce]
+  resources: { requests: { storage: 5Gi } }


### PR DESCRIPTION
## Summary

Two ways a skill could exist and still be unreachable:

1. **Authored skills died with the branch.** The agent had no idea where to put a skill it wrote, so it wrote one into the checkout — which reaches only whoever merges that branch.
2. **Synced sets could serve a manifest with no bytes.** `skill-set-sync` skipped a file whenever its hash matched the manifest, regardless of whether the object still existed. One wiped bucket makes that permanent: every later sync skips the file, `list`/`stat` answer 200 off the manifest, every `read` 404s, the mount returns EIO. Observed in a local deployment: 33 public skills, complete manifest, zero objects.

## Changes

- **`packages/harness-runner`** — `skillsInstruction()` is now always appended to the system prompt (with or without agent instructions): write reusable skills to the absolute `<claude-config>/skills/<name>/SKILL.md` (the daemon links that dir onto the org mount, so it syncs org-wide), never `~`, never the checkout's `.claude/skills/`. Reading deliberately gets no path — every skill's name and description is already in the prompt, and handing over a path just sent the model to Bash for a listing it already had.
- **`packages/sandbox/daemon-go`** — new `AfterRun` dispatch hook, `defer`red so crashed/cancelled runs settle too (the half-finished run is exactly the one with stray output worth rescuing). It calls `AdoptStrayRepoSkills()`, which moves skills the model wrote into the checkout onto the org mount. `gitx.UntrackedUnder` finds them via `ls-files --others --exclude-standard`, so daemon-planted paths (already in `.git/info/exclude`) stay out.
- **`apps/api/src/file-storage/skill-set-sync.ts`** — extracted `isUpToDate()`: skip only when the manifest hash matches **and** the path is present in object storage. One paginated `list()` per set per cycle.
- **`selfhost/examples/k8s-local`** — PVCs for minio and postgres instead of `emptyDir`. "Throwaway" shouldn't mean per-pod when the object store holds the only copy of every org-fs byte and Postgres holds the manifest naming them; losing one and keeping the other is the failure above, guaranteed on the next pod recreate.
- **`apps/api/src/tools/task-board`** — the autonomous prompt no longer demands a PR from every task, only where one makes sense or was asked for.

## Testing

- `bun test apps/api/src/file-storage/skill-set-sync.test.ts packages/harness-runner/claude-code.test.ts` — passes. New cases: `isUpToDate` rewrites a manifest row whose object is gone, and the skills instruction is present with and without agent instructions.
- `go test ./internal/orgfs/ ./internal/gitx/ ./internal/dispatch/` — passes (~250 new lines of `links_test.go`).
- `bun run fmt` at the repo root is blocked by an unrelated nested `biome.json` in my local worktree; the changed TS files were formatted directly and `gofmt -l` is clean.

## Notes

Not verified end-to-end in a live pod yet — the adopt path deserves a real sandbox run before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make authored skills and org-fs bytes survive sandbox runs. Ensure public skill sets never point to missing objects.

- New Features
  - `packages/harness-runner`: Always append skills guidance to the system prompt; write reusable skills to absolute `"<CLAUDE_CONFIG_DIR>/skills/<name>/SKILL.md"`; enable `skills: "all"`; don’t search the filesystem for skills.
  - `packages/sandbox/daemon-go`: Add `AfterRun` to adopt skills written into the repo into `org/home/skills`; link user skills dir to the org mount; expose public sets as project skills via `orgfs-<set>-<skill>` symlinks (git-excluded) and skip linking when mounts don’t read; log discovered skills.
  - `selfhost/examples/k8s-local`: Switch `minio` and `postgres` to PVCs to persist object bytes and manifests across pod restarts.
  - `apps/api/src/tools/task-board`: Only ask for a PR when it makes sense.

- Bug Fixes
  - `apps/api/src/file-storage/skill-set-sync`: New `isUpToDate` checks both manifest hash and object existence; one paginated `list()` per set. Prevents “green” syncs with missing objects that lead to 404 reads/EIO mounts.

<sup>Written for commit 43318effcc0bbc4e2e3de1c5f994ae4833f60755. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

