### PR TITLE
fix(task-board): stop autonomous tasks parking forever before Done

### DIFF
--- a/apps/api/src/api/routes/decopilot/run-reactor.integration.test.ts
+++ b/apps/api/src/api/routes/decopilot/run-reactor.integration.test.ts
@@ -330,15 +330,20 @@ describe("reactAll (real Postgres)", () => {
           .select(["failure_reason", "failure_kind"])
           .where("id", "=", thread.id)
           .executeTakeFirstOrThrow();
-        if (reason === "reaped") {
-          expect(dbRow.failure_reason).toBe(
-            "Run stalled — no progress within the idle timeout window",
-          );
-          expect(dbRow.failure_kind).toBe("stall");
-        } else {
-          expect(dbRow.failure_reason).toBeNull();
-          expect(dbRow.failure_kind).toBeNull();
-        }
+        // Every non-ghost reason records one, through the real SQL path.
+        // Inverted: `error` and `cancelled` used to assert NULL here, which is
+        // what left a failed thread row unreadable — `status: failed` with no
+        // reason and no kind, so nothing could tell a cancel from a crash.
+        expect(dbRow.failure_reason).toBe(
+          {
+            reaped: "Run stalled — no progress within the idle timeout window",
+            cancelled: "Run cancelled before it finished",
+            error: "Run ended with an error — see the run's messages",
+          }[reason],
+        );
+        expect(dbRow.failure_kind).toBe(
+          { reaped: "stall", cancelled: "cancelled", error: "error" }[reason],
+        );
         expect(sseEvents).toHaveLength(2);
       }
     });

--- a/apps/api/src/api/routes/decopilot/run-reactor.test.ts
+++ b/apps/api/src/api/routes/decopilot/run-reactor.test.ts
@@ -102,7 +102,12 @@ describe("run reactor", () => {
     expect(updates[0]!.failure_kind).toBe("stall");
   });
 
-  test("RUN_FAILED reason 'error' does NOT set failure_reason (unchanged)", async () => {
+  // Inverted: this used to assert 'error' left both columns unset, on the
+  // theory that its reason "is surfaced elsewhere". It was surfaced only as an
+  // error PART, so every reader of the thread ROW — the board card, the task
+  // list, a support query — saw `failed` with `failure_reason: ''` and
+  // `failure_kind: null` and could not tell a crash from a cancel.
+  test("RUN_FAILED reason 'error' records a legible reason and kind", async () => {
     const updates: Record<string, unknown>[] = [];
     const deps: RunReactorDeps = {
       storage: {
@@ -132,6 +137,96 @@ describe("run reactor", () => {
             taskId: "run_1",
             orgId: "org_1",
             reason: "error",
+          },
+          state: undefined,
+        },
+      ],
+      deps,
+    );
+
+    expect(updates[0]!.failure_reason).toBe(
+      "Run ended with an error — see the run's messages",
+    );
+    expect(updates[0]!.failure_kind).toBe("error");
+  });
+
+  // The failure this investigation started from: a takeover / client hangup
+  // surfaced as `cancelled: run cancelled` in an error part, while the thread
+  // row carried no reason at all.
+  test("RUN_FAILED reason 'cancelled' records a cancelled kind, not a bare write", async () => {
+    const updates: Record<string, unknown>[] = [];
+    const deps: RunReactorDeps = {
+      storage: {
+        update: async (
+          _id: string,
+          _orgId: string,
+          data: Record<string, unknown>,
+        ) => {
+          updates.push(data);
+          return null;
+        },
+        get: async () => ({
+          id: "run_1",
+          organization_id: "org_1",
+          status: "failed",
+        }),
+        forceFailIfInProgress: async () => true,
+      } as unknown as ThreadStoragePort,
+      sseHub: { emit: () => {} },
+    };
+
+    await reactAll(
+      [
+        {
+          event: {
+            type: "RUN_FAILED",
+            taskId: "run_1",
+            orgId: "org_1",
+            reason: "cancelled",
+          },
+          state: undefined,
+        },
+      ],
+      deps,
+    );
+
+    expect(updates[0]!.failure_kind).toBe("cancelled");
+    expect(updates[0]!.failure_reason).toBe("Run cancelled before it finished");
+  });
+
+  // `ghost` keeps its bare write: it force-fails a row whose run never existed
+  // on this pod, and stamping a reason there would overwrite the real one a
+  // concurrent terminal writer just set.
+  test("RUN_FAILED reason 'ghost' still records no reason", async () => {
+    const updates: Record<string, unknown>[] = [];
+    const deps: RunReactorDeps = {
+      storage: {
+        update: async (
+          _id: string,
+          _orgId: string,
+          data: Record<string, unknown>,
+        ) => {
+          updates.push(data);
+          return null;
+        },
+        get: async () => ({
+          id: "run_1",
+          organization_id: "org_1",
+          status: "failed",
+        }),
+        forceFailIfInProgress: async () => true,
+      } as unknown as ThreadStoragePort,
+      sseHub: { emit: () => {} },
+    };
+
+    await reactAll(
+      [
+        {
+          event: {
+            type: "RUN_FAILED",
+            taskId: "run_1",
+            orgId: "org_1",
+            reason: "ghost",
           },
           state: undefined,
         },

--- a/apps/api/src/api/routes/decopilot/run-reactor.ts
+++ b/apps/api/src/api/routes/decopilot/run-reactor.ts
@@ -17,11 +17,37 @@ import {
   createDecopilotStepEvent,
   createDecopilotThreadStatusEvent,
 } from "@decocms/shared/sdk";
-import type { RunEvent, RunTransition } from "./run-state";
+import type { RunEvent, RunFailedReason, RunTransition } from "./run-state";
 
 /** Recorded on a run the idle reaper force-fails for lack of progress. */
 const STALL_FAILURE_REASON =
   "Run stalled — no progress within the idle timeout window";
+
+/**
+ * What to persist on `threads` for each way a run can fail.
+ *
+ * Every reason gets one. It used to be `reaped` only, on the theory that the
+ * others "are surfaced elsewhere" — they are surfaced only as an error PART, so
+ * anything reading the thread row (the board card, the task list, a support
+ * query) saw `status: failed` with `failure_reason: ''` and `failure_kind: null`
+ * and could not tell a cancel from a crash. `ghost` keeps its bare write: it
+ * force-fails a row whose run never existed on this pod, and stamping a reason
+ * there would overwrite the real one a concurrent terminal writer just set.
+ */
+const RUN_FAILURE_RECORD: Record<
+  Exclude<RunFailedReason, "ghost">,
+  { failure_reason: string; failure_kind: string }
+> = {
+  reaped: { failure_reason: STALL_FAILURE_REASON, failure_kind: "stall" },
+  cancelled: {
+    failure_reason: "Run cancelled before it finished",
+    failure_kind: "cancelled",
+  },
+  error: {
+    failure_reason: "Run ended with an error — see the run's messages",
+    failure_kind: "error",
+  },
+};
 
 // ============================================================================
 // Errors
@@ -197,12 +223,7 @@ async function react(event: RunEvent, deps: RunReactorDeps): Promise<void> {
         await storage.update(event.taskId, event.orgId, {
           run_config: null,
           run_started_at: null,
-          // A reaped run stalled (no progress within the idle window); record a
-          // legible reason. Other reasons ("error"/"cancelled") keep their bare
-          // terminal write — their reason is surfaced elsewhere.
-          ...(event.reason === "reaped"
-            ? { failure_reason: STALL_FAILURE_REASON, failure_kind: "stall" }
-            : {}),
+          ...RUN_FAILURE_RECORD[event.reason],
         });
       }
       // Deliberately NO JetStream purge here. The consume step projects every

--- a/apps/api/src/api/routes/task-run-mcp.ts
+++ b/apps/api/src/api/routes/task-run-mcp.ts
@@ -17,7 +17,7 @@ import { Hono } from "hono";
 import type { StudioContext } from "../../core/studio-context";
 import { managementContextStore, toolSubsetMCP } from "../../tools";
 import {
-  TASK_RUN_TOOL_NAMES,
+  resolveReviewRunToolNames,
   taskRunContextStore,
 } from "../../tools/task-board/task-run-context";
 import { serveMcpRequest } from "../utils/serve-mcp";
@@ -30,7 +30,17 @@ export const createTaskRunMcpRoutes = () => {
   app.all("/:threadId", async (c) => {
     const ctx = c.get("studioContext");
     const threadId = c.req.param("threadId");
-    const server = toolSubsetMCP("mcp-task-run", TASK_RUN_TOOL_NAMES);
+    // A reviewer's run gets one extra tool (`TASK_BOARD_REVIEW_DECISION`) — the
+    // one it is instructed to finish with. Derived from the run thread itself,
+    // not from a request argument, for the same reason the threadId is in the
+    // path: the per-run key is minted with full access, so anything the caller
+    // could assert it could also forge. The lookup is org-scoped by
+    // `resolveOrgFromPath`, so a foreign thread reads as null → narrow list.
+    const thread = await ctx.storage.threads.get(threadId);
+    const server = toolSubsetMCP(
+      "mcp-task-run",
+      resolveReviewRunToolNames(thread?.title),
+    );
     const transport = new WebStandardStreamableHTTPServerTransport({
       enableJsonResponse:
         c.req.raw.headers.get("Accept")?.includes("application/json") ?? false,

--- a/apps/api/src/tools/task-board/claude-code-task-run.test.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.test.ts
@@ -48,6 +48,20 @@ describe("buildClaudeCodeTaskPrompt", () => {
     expect(buildClaudeCodeTaskPrompt(task, repo)).toContain("AUTONOMOUSLY");
   });
 
+  // Inverted: this used to say "move it to review anyway so a human can close
+  // it out". In Review is the reviewers' lane and reviewers are only enqueued
+  // for a task that HAS a PR, so a no-PR task parked there had nobody to pick
+  // it up — in prod every single In Review card was one of these, with zero
+  // PRs and zero reviewer claims between them.
+  test("a task needing no code change goes to done, not in_review", () => {
+    const prompt = buildClaudeCodeTaskPrompt(task, repo);
+    expect(prompt).toContain("no code change");
+    expect(prompt).toContain('move it to "done" instead of "in_review"');
+    expect(prompt).not.toContain("move it to review anyway");
+    // And it has to leave the reason where a human will read it.
+    expect(prompt).toContain("mcp__studio__TASK_BOARD_COMMENT_CREATE");
+  });
+
   test("reviewer feedback leads, and updates the existing PR", () => {
     const prompt = buildClaudeCodeTaskPrompt(task, repo, {
       feedback: "Missing a test.",

--- a/apps/api/src/tools/task-board/claude-code-task-run.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.ts
@@ -242,7 +242,13 @@ export function buildClaudeCodeTaskPrompt(
         : "."),
     "- Change only what the task needs. Don't refactor around it.",
     `- Then move this task to review on the board: call \`mcp__studio__TASK_BOARD_ITEM_UPDATE\` with id "${task.id}" and status "in_review". Pass ONLY the fields you are changing.`,
-    "- If the task turns out to need no code change, say why in your final message and move it to review anyway so a human can close it out.",
+    // NOT "move it to review anyway": In Review is the reviewers' lane, and
+    // reviewers are only enqueued for a task that has a PR
+    // (`enqueueReviewersOnThreadFinish`). A no-PR task parked there had no
+    // reviewer to pick it up and no signal that a human should — every such
+    // card sat In Review untouched. Done is the terminal lane, and the comment
+    // is what a human reads to disagree and reopen it.
+    `- If the task turns out to need no code change, do NOT open a PR: explain why in a comment on the task (\`mcp__studio__TASK_BOARD_COMMENT_CREATE\`) and move it to "done" instead of "in_review". There is nothing for a reviewer to review, so In Review would strand it.`,
     // The board is where a human reads this task, so anything a reviewer needs
     // to know belongs there too — a final message they never open is not a
     // report. Optional: a comment per run, not per step.

--- a/apps/api/src/tools/task-board/enqueue-reviewer.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.ts
@@ -14,6 +14,7 @@ import {
 import { recordTaskActivity } from "./activity";
 import { emitTaskBoardUpdated } from "./run-reactions";
 import { enqueueAgentRunForTask } from "./enqueue-task-run";
+import { resolveTaskRepoChoice } from "./claude-code-task-run";
 
 /**
  * A Super Agent run finished — if it left a task In Review with an open PR,
@@ -46,9 +47,19 @@ export async function enqueueReviewersOnThreadFinish(args: {
       // titled "Super Agent: …"; a reviewer's finishing run (also linked) is not.
       const finishing = item.threads.find((thr) => thr.threadId === threadId);
       if (!finishing?.title?.startsWith("Super Agent:")) continue;
-      // Nothing to review without a PR (research/answer tasks reach In Review too).
+      // Nothing to review without a PR (research/answer tasks reach In Review
+      // too). Logged, not silent: this is a terminal park — no reviewer will
+      // ever claim the card and nothing else moves it, so "why is this task
+      // stuck In Review?" has to be answerable from the logs. The task prompt
+      // steers no-code-change tasks to Done for exactly this reason.
       const prs = await taskBoard.listPrs(taskId, orgId);
-      if (prs.length === 0) continue;
+      if (prs.length === 0) {
+        console.warn(
+          `[task-board] ${taskId} reached In Review with no PR — no reviewer ` +
+            `enqueued; the card stays In Review until a human moves it`,
+        );
+        continue;
+      }
       const ctx = await contextFactory(
         orgId,
         item.assignedBy ?? item.createdBy,
@@ -199,6 +210,27 @@ async function enqueueReviewerForTask(
 ): Promise<void> {
   const organizationId = task.organizationId;
 
+  // Same harness the Super Agent runs on, for the same reason: a review needs
+  // real `git`/`gh` on a checkout, and — the blocking one — only a
+  // sandbox-hosted run is handed the task-run MCP surface that carries
+  // `TASK_BOARD_ITEM_PRS_GET` and `TASK_BOARD_REVIEW_DECISION`. On Decopilot
+  // (the previous default) both came back `not_found` from `enable_tool`, so a
+  // reviewer could reach its verdict and never record it. Falls back to
+  // Decopilot when the org has no importable repo, exactly as the Super Agent
+  // does — with no repo there is no checkout to review anyway.
+  const choice = await resolveTaskRepoChoice(ctx, organizationId);
+  const repo = choice && "repo" in choice ? choice.repo : null;
+  const sandboxed = choice !== null;
+  // Over the sandbox's MCP client the task-run tools are namespaced; hosted
+  // Decopilot calls them bare. Naming them wrong is not cosmetic — it is what
+  // the model retries `enable_tool` against before giving up.
+  const prsGetTool = sandboxed
+    ? "mcp__studio__TASK_BOARD_ITEM_PRS_GET"
+    : "TASK_BOARD_ITEM_PRS_GET";
+  const decisionTool = sandboxed
+    ? "mcp__studio__TASK_BOARD_REVIEW_DECISION"
+    : "TASK_BOARD_REVIEW_DECISION";
+
   const prompt = [
     REVIEWER_FOCUS[kind],
     "",
@@ -214,13 +246,19 @@ async function enqueueReviewerForTask(
     `Task title: ${task.title}`,
     task.description ? `\nTask description:\n${task.description}\n` : "",
     "How to work:",
-    "- Call `TASK_BOARD_ITEM_PRS_GET` with the task id below to find the pull request under review, then load its repository to inspect / exercise the change.",
+    `- Call \`${prsGetTool}\` with the task id below to find the pull request under review.`,
+    repo
+      ? `- The repository ${repo.owner}/${repo.name} is already cloned at your working directory and \`git\` and \`gh\` are authenticated — check the PR's branch out there to inspect / exercise the change.`
+      : sandboxed
+        ? `- Your working directory is EMPTY. Call \`mcp__studio__TASK_ADD_REPO\` with the connectionId of the PR's repository FIRST; it clones the repository and waits for the checkout, and \`git\` and \`gh\` are authenticated once it returns.`
+        : "- Load the PR's repository to inspect / exercise the change.",
     "- Do NOT push commits or change the code yourself. You are reviewing, not implementing.",
-    "- End the run by calling `TASK_BOARD_REVIEW_DECISION` exactly once with the task id, " +
+    `- End the run by calling \`${decisionTool}\` exactly once with the task id, ` +
       `reviewer "${kind}", the reviewToken below, and your decision:`,
     "  - `approve` when it's good to ship. Include a short summary of what you verified.",
     "  - `request_changes` when something is wrong or missing. Include specific, actionable notes — the task goes back to the Super Agent with your notes.",
     "- The reviewToken proves you are this reviewer — pass it through EXACTLY as given. Without it your approval won't count toward an automatic merge.",
+    `- \`${decisionTool}\` is how the verdict is recorded. A review that ends without it is thrown away and the task stays stuck In Review, so call it even when your notes are short.`,
     "",
     `(task id: ${task.id})`,
     `(reviewToken: ${reviewToken})`,
@@ -231,6 +269,8 @@ async function enqueueReviewerForTask(
     title: `${REVIEWER_LABEL[kind]}: ${task.title}`,
     prompt,
     temperature: 0.3,
+    ...(sandboxed ? { harnessId: "claude-code" as const } : {}),
+    ...(repo ? { repo } : {}),
   });
 
   // Timeline: "Super Agent delegated to <reviewer>" (machine actor → null), and

--- a/apps/api/src/tools/task-board/stall-recovery.test.ts
+++ b/apps/api/src/tools/task-board/stall-recovery.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { shouldAdvanceToReview } from "@/storage/task-board";
-import { decideStallAction } from "./stall-recovery";
+import { decideStallAction, isNeverStartedRun } from "./stall-recovery";
 
 /** A used thread — `shouldAdvanceToReview` filters out message-less ones. */
 const thread = (status: string | null, hasMessages = true) => ({
@@ -128,6 +128,68 @@ describe("shouldAdvanceToReview gates the sweep", () => {
       expect(
         shouldAdvanceToReview({ status, threads: [thread("completed")] }),
       ).toBe(false);
+    }
+  });
+});
+
+describe("isNeverStartedRun", () => {
+  const HOUR = 60 * 60 * 1000;
+  const now = 1_700_000_000_000;
+
+  /** A thread row as the reaper reads it. */
+  const row = (
+    overrides: Partial<{
+      status: string;
+      run_started_at: string | null;
+      last_progress_at: string | null;
+      updated_at: string;
+    }> = {},
+  ) =>
+    ({
+      status: "in_progress",
+      run_started_at: null,
+      last_progress_at: null,
+      updated_at: new Date(now - HOUR).toISOString(),
+      ...overrides,
+    }) as Parameters<typeof isNeverStartedRun>[0];
+
+  // The exact prod shape: threads written `in_progress` whose run never reached
+  // RUN_STARTED, so they are invisible to the in-memory idle reaper on every
+  // pod — and one of them freezes its whole card's advance gate.
+  test("an in_progress thread that never started and is past the window is reaped", () => {
+    expect(isNeverStartedRun(row(), now)).toBe(true);
+  });
+
+  test("a run that DID start is left to the idle reaper / DBOS recovery", () => {
+    expect(
+      isNeverStartedRun(
+        row({ run_started_at: new Date(now - HOUR).toISOString() }),
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  test("a freshly enqueued run is not reaped — it may still be picked up", () => {
+    expect(
+      isNeverStartedRun(
+        row({ updated_at: new Date(now - 60_000).toISOString() }),
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  test("a streaming run keeps itself alive via last_progress_at", () => {
+    expect(
+      isNeverStartedRun(
+        row({ last_progress_at: new Date(now - 60_000).toISOString() }),
+        now,
+      ),
+    ).toBe(false);
+  });
+
+  test("only in_progress threads are reaped", () => {
+    for (const status of ["completed", "failed", "requires_action"]) {
+      expect(isNeverStartedRun(row({ status }), now)).toBe(false);
     }
   });
 });

--- a/apps/api/src/tools/task-board/stall-recovery.ts
+++ b/apps/api/src/tools/task-board/stall-recovery.ts
@@ -16,6 +16,15 @@
  *     on a `user_ask` (a human owns it), the second is either live or the stall
  *     reaper's to fail — and once it does, the next board open nudges it.
  *
+ * With ONE exception, added because "the stall reaper's to fail" was not true of
+ * every `in_progress` thread: a run that never STARTED (see
+ * `failNeverStartedThreads`) has no entry in any pod's `RunRegistry`, so the
+ * in-memory idle reaper cannot see it and no DB sweep exists. Those threads sat
+ * `in_progress` with zero parts indefinitely, and because
+ * `shouldAdvanceToReview` requires every thread terminal, one of them froze its
+ * whole card — no advance, no nudge, forever. We fail them here first, which
+ * both unblocks the gate below and gives the card a legible reason.
+ *
  * "Used" is `shouldAdvanceToReview`'s filter: threads with no messages don't
  * count, because a never-typed-in chat is born `completed`.
  *
@@ -30,9 +39,14 @@ import type { StudioContext } from "@/core/studio-context";
 import { enqueueThreadRun } from "@/dispatch-queue";
 import { isHostedDecopilotRuntime } from "@/harnesses/decopilot/hosted-runtime";
 import { shouldAdvanceToReview } from "@/storage/task-board";
-import type { TaskBoardItem, TaskBoardItemThreadRef } from "@/storage/types";
+import type {
+  TaskBoardItem,
+  TaskBoardItemThreadRef,
+  Thread,
+} from "@/storage/types";
 import { getDecopilotId } from "@decocms/shared/sdk";
 import { advanceTasksToReviewOnThreadFinish } from "./run-reactions";
+import { isThreadRunStale } from "@/tools/thread/helpers";
 
 export type StallAction = "none" | "advance" | "nudge";
 
@@ -150,6 +164,68 @@ async function resolveStallAction(
   });
 }
 
+/** Recorded on a thread whose run never reported progress and can no longer be
+ *  owned by any pod. Distinct from `"stall"` (a run that started, streamed, then
+ *  went quiet — the in-memory idle reaper's case) so the two are tellable apart
+ *  in the DB. */
+const ABANDONED_FAILURE_REASON =
+  "Run never started — no pod picked it up before the idle window elapsed";
+
+/**
+ * True for a thread whose run NEVER STARTED and is now too old to ever start.
+ *
+ * The in-memory idle reaper only sees runs present in a pod's `RunRegistry`,
+ * i.e. runs that reached `RUN_STARTED`. A thread whose dispatch never got that
+ * far — the enqueue landed, the row was written `in_progress`, and nothing ever
+ * ran — is invisible to it on every pod, and no DB sweep exists.
+ *
+ * `run_started_at` is the discriminator: set means a run really did begin, and
+ * that one belongs to the idle reaper / DBOS recovery, which can still resume
+ * it. Staleness is the shared `isThreadRunStale` test (the same one that renders
+ * "expired" in thread responses), so a live run is never touched.
+ *
+ * Pure — unit-tested.
+ */
+export function isNeverStartedRun(
+  thread: Pick<Thread, "status" | "run_started_at" | "updated_at"> &
+    Pick<Thread, "last_progress_at">,
+  now: number = Date.now(),
+): boolean {
+  if (thread.status !== "in_progress") return false;
+  if (thread.run_started_at) return false;
+  return isThreadRunStale(thread, now);
+}
+
+/**
+ * Fail the card's `in_progress` threads that no run can still be behind.
+ *
+ * Returns the ids it failed, so the caller can skip a card it just changed and
+ * let the next board open act on fresh data rather than a stale in-memory list.
+ */
+async function failNeverStartedThreads(
+  ctx: StudioContext,
+  item: TaskBoardItem,
+): Promise<string[]> {
+  const failed: string[] = [];
+  for (const ref of item.threads) {
+    if (ref.status !== "in_progress") continue;
+    const thread = await ctx.storage.threads.get(ref.threadId);
+    if (!thread || !isNeverStartedRun(thread)) continue;
+    const marked = await ctx.storage.threads.markRunFailed(
+      ref.threadId,
+      ABANDONED_FAILURE_REASON,
+      "abandoned",
+    );
+    if (marked) {
+      failed.push(ref.threadId);
+      console.warn(
+        `[task-board] failed never-started thread ${ref.threadId} on ${item.id}`,
+      );
+    }
+  }
+  return failed;
+}
+
 /**
  * Recover every stalled card in a freshly-read board. Takes the items the read
  * already loaded, so detection costs nothing. Best-effort per task: one card's
@@ -163,6 +239,24 @@ export async function recoverStalledTasks(
   if (!organizationId) return;
 
   for (const item of items) {
+    // First clear any never-started thread blocking this card's gate below.
+    // Skipped for a card that isn't parked In Progress: In Review / Done cards
+    // are not waiting on a run, and a card a human is actively working has no
+    // stuck agent thread to reap.
+    if (item.status === "in_progress") {
+      try {
+        const reaped = await failNeverStartedThreads(ctx, item);
+        // `item.threads` is now stale for this card — the statuses the gate
+        // reads were loaded before the writes above. Let the next board open
+        // (or the finish hook) act on it rather than reasoning off stale rows.
+        if (reaped.length > 0) continue;
+      } catch (err) {
+        console.error(
+          `[task-board] reaping threads for ${item.id} failed`,
+          err,
+        );
+      }
+    }
     // Narrow off the already-loaded list first, so a board with nothing stuck
     // costs zero queries. Threads are newest-first (`attachThreads` orders by
     // `link.created_at desc`), so the newest *used* one is the last run to have

--- a/apps/api/src/tools/task-board/task-run-context.test.ts
+++ b/apps/api/src/tools/task-board/task-run-context.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Which task-board tools a run's MCP endpoint serves, by run thread title.
+ *
+ * The bug this encodes: reviewer runs were told to finish by calling
+ * `TASK_BOARD_REVIEW_DECISION` and never had it — reviews reached a verdict and
+ * threw it away, leaving the task stuck In Review. The narrow surface must stay
+ * narrow for a WORKER run (an agent must not approve its own work), so the two
+ * lists are distinguished by the thread title the board itself assigned.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  REVIEW_RUN_TOOL_NAMES,
+  resolveReviewRunToolNames,
+  TASK_RUN_TOOL_NAMES,
+} from "./task-run-context";
+
+describe("resolveReviewRunToolNames", () => {
+  test("a QA Agent run can record its decision", () => {
+    expect(resolveReviewRunToolNames("QA Agent: Add an H1")).toContain(
+      "TASK_BOARD_REVIEW_DECISION",
+    );
+  });
+
+  test("a Code Reviewer run can record its decision", () => {
+    expect(resolveReviewRunToolNames("Code Reviewer: Add an H1")).toContain(
+      "TASK_BOARD_REVIEW_DECISION",
+    );
+  });
+
+  // The invariant the narrow list exists for: the worker must not be able to
+  // approve or bounce its own work.
+  test("a Super Agent run cannot record a review decision", () => {
+    expect(resolveReviewRunToolNames("Super Agent: Add an H1")).toEqual(
+      TASK_RUN_TOOL_NAMES,
+    );
+  });
+
+  test("an unknown or missing title falls back to the narrow surface", () => {
+    for (const title of [null, undefined, "", "Some chat"]) {
+      expect(resolveReviewRunToolNames(title)).toEqual(TASK_RUN_TOOL_NAMES);
+    }
+  });
+
+  // A reviewer needs to FIND the PR as well as rule on it: `enable_tool` came
+  // back `not_found` for this one too, in every observed review.
+  test("both surfaces can look up the task's PR", () => {
+    for (const list of [TASK_RUN_TOOL_NAMES, REVIEW_RUN_TOOL_NAMES]) {
+      expect(list).toContain("TASK_BOARD_ITEM_PRS_GET");
+    }
+  });
+
+  test("the review surface only ADDS to the narrow one", () => {
+    for (const name of TASK_RUN_TOOL_NAMES) {
+      expect(REVIEW_RUN_TOOL_NAMES).toContain(name);
+    }
+    expect(REVIEW_RUN_TOOL_NAMES).toHaveLength(TASK_RUN_TOOL_NAMES.length + 1);
+  });
+});

--- a/apps/api/src/tools/task-board/task-run-context.ts
+++ b/apps/api/src/tools/task-board/task-run-context.ts
@@ -10,6 +10,10 @@
 
 import { AsyncLocalStorage } from "node:async_hooks";
 import type { ToolName } from "@decocms/shared/tools/registry-metadata";
+import {
+  isReviewerThreadTitle,
+  REVIEWER_KINDS,
+} from "@decocms/shared/task-board";
 
 export interface TaskRunContext {
   /** The run thread this MCP session belongs to. */
@@ -37,7 +41,8 @@ export function requireTaskRunContext(): TaskRunContext {
  *
  * Deliberately absent: creating and deleting tasks, `TASK_BOARD_REVIEW_DECISION`
  * and `TASK_BOARD_PROMOTE_TO_PRODUCTION` — an agent must not approve or merge
- * its own work.
+ * its own work. A REVIEWER's run is a different run on a different thread, and
+ * gets `REVIEW_RUN_TOOL_NAMES` below.
  */
 export const TASK_RUN_TOOL_NAMES: readonly ToolName[] = [
   "TASK_ADD_REPO",
@@ -49,3 +54,40 @@ export const TASK_RUN_TOOL_NAMES: readonly ToolName[] = [
   "TASK_BOARD_COMMENT_CREATE",
   "TASK_BOARD_COMMENT_UPDATE",
 ];
+
+/**
+ * The same surface plus `TASK_BOARD_REVIEW_DECISION`, for a REVIEWER's run.
+ *
+ * A reviewer is told "end the run by calling `TASK_BOARD_REVIEW_DECISION`" — it
+ * has to actually have it. It didn't: reviewer runs went out on Decopilot, which
+ * aggregates no connections, so every review ended with `enable_tool` answering
+ * `not_found` for both this and `TASK_BOARD_ITEM_PRS_GET`. Reviewers did the
+ * whole review, reached a verdict, and had no way to record it — the task then
+ * sat In Review forever.
+ *
+ * Still keyed to the run: `resolveReviewRunToolNames` hands this list out only
+ * for a thread the board created as a reviewer thread, so the invariant above
+ * ("an agent must not approve its own work") holds — a Super Agent run's own
+ * endpoint never serves it.
+ */
+export const REVIEW_RUN_TOOL_NAMES: readonly ToolName[] = [
+  ...TASK_RUN_TOOL_NAMES,
+  "TASK_BOARD_REVIEW_DECISION",
+];
+
+/**
+ * Which tool surface a task-run MCP session gets, from the run thread's title.
+ *
+ * The title is how the rest of the board already tells a reviewer thread from a
+ * Super Agent one (`isReviewerThreadTitle`, `"Super Agent:"` in
+ * `enqueueReviewersOnThreadFinish`) — reusing it keeps one discriminator rather
+ * than adding a column. A missing thread falls back to the narrow list.
+ */
+export function resolveReviewRunToolNames(
+  title: string | null | undefined,
+): readonly ToolName[] {
+  const isReviewer = REVIEWER_KINDS.some((kind) =>
+    isReviewerThreadTitle(title, kind),
+  );
+  return isReviewer ? REVIEW_RUN_TOOL_NAMES : TASK_RUN_TOOL_NAMES;
+}

--- a/apps/api/src/tools/thread/helpers.ts
+++ b/apps/api/src/tools/thread/helpers.ts
@@ -41,33 +41,47 @@ export type ThreadStatusForResponse = ThreadStatus | "expired";
  * (context_start_message_id, run_owner_pod, run_started_at) are stripped so
  * MCP clients validating structuredContent with Ajv don't reject the response.
  */
+/**
+ * True when an `in_progress` thread has shown no sign of life for longer than
+ * `THREAD_EXPIRY_MS` — the single definition of "this run is not coming back".
+ *
+ * Liveness = the most recent of `updated_at` (bumped by terminal writers) and
+ * `last_progress_at` (bumped per streamed chunk, throttled). A still-streaming
+ * run keeps `last_progress_at` fresh even though `updated_at` stays stale for
+ * the whole turn, so keying only off `updated_at` would falsely flip an
+ * actively-streaming thread to "expired" after 30 min. Use the same heartbeat
+ * the reaper trusts.
+ *
+ * Says nothing about `status`: callers check that themselves, because the two
+ * uses differ. The response normalizer renders a virtual "expired" (never
+ * stored, so the thread can resume if the stream reconnects); board stall
+ * recovery persists a failure, and only for a run no pod can still own.
+ */
+export function isThreadRunStale(
+  thread: Pick<Thread, "updated_at" | "last_progress_at">,
+  now: number = Date.now(),
+): boolean {
+  const updatedAtMs = new Date(thread.updated_at).getTime();
+  const progressAtMs = thread.last_progress_at
+    ? new Date(thread.last_progress_at).getTime()
+    : Number.NaN;
+  const lastActiveMs = Math.max(
+    Number.isFinite(updatedAtMs) ? updatedAtMs : Number.NEGATIVE_INFINITY,
+    Number.isFinite(progressAtMs) ? progressAtMs : Number.NEGATIVE_INFINITY,
+  );
+  return (
+    !Number.isFinite(lastActiveMs) || now - lastActiveMs > THREAD_EXPIRY_MS
+  );
+}
+
 export function normalizeThreadForResponse(
   thread: Thread,
   now: number = Date.now(),
 ): ThreadEntity {
   let status: ThreadStatusForResponse = thread.status;
 
-  if (status === "in_progress") {
-    // Liveness = the most recent of `updated_at` (bumped by terminal writers)
-    // and `last_progress_at` (bumped per streamed chunk, throttled). A
-    // still-streaming run keeps `last_progress_at` fresh even though
-    // `updated_at` stays stale for the whole turn, so keying only off
-    // `updated_at` would falsely flip an actively-streaming thread to
-    // "expired" after 30 min. Use the same heartbeat the reaper trusts.
-    const updatedAtMs = new Date(thread.updated_at).getTime();
-    const progressAtMs = thread.last_progress_at
-      ? new Date(thread.last_progress_at).getTime()
-      : Number.NaN;
-    const lastActiveMs = Math.max(
-      Number.isFinite(updatedAtMs) ? updatedAtMs : Number.NEGATIVE_INFINITY,
-      Number.isFinite(progressAtMs) ? progressAtMs : Number.NEGATIVE_INFINITY,
-    );
-    if (
-      !Number.isFinite(lastActiveMs) ||
-      now - lastActiveMs > THREAD_EXPIRY_MS
-    ) {
-      status = "expired";
-    }
+  if (status === "in_progress" && isThreadRunStale(thread, now)) {
+    status = "expired";
   }
 
   return {


### PR DESCRIPTION
## Why

Audited the `demo-storefront` board in prod after its tasks were manually moved back to backlog. 61 items, 114 agent threads, **6 ever reached Done.**

| item status | has PR | count |
|---|---|---|
| done | yes | 6 |
| **in_review** | **no** | **9** |
| in_progress | no | 2 |
| triage | mixed | 46 |

Nothing reaches Done without a `task_board_item_prs` row. All 9 In Review items had zero PRs *and* zero rows in `task_board_review_claims` — no reviewer was ever dispatched for any of them. Four independent bugs, compounding.

## What was broken

**1. Reviewers were told to call tools they did not have.** Reviewer runs dispatched with no `harnessId` → hosted Decopilot, which aggregates no connections. Every review thread opens identically:

```
tool-enable_tool {tools:["TASK_BOARD_ITEM_PRS_GET","TASK_BOARD_REVIEW_DECISION"]}
→ {enabled: [], not_found: ["TASK_BOARD_ITEM_PRS_GET","TASK_BOARD_REVIEW_DECISION"]}
```

The prompt says *"Making the approve / request-changes call IS your job"* — with no tool to make it. `thrd_m9Qn6asuBEwM0RvUv2-4-` reviewed thoroughly across 104 parts, concluded *"This is a solid, well-verified fix. I'll approve."*, ended `requires_action`, verdict discarded. Four complete reviews thrown away this way.

**2. In Review with no PR was a dead end, and the prompt aimed at it.** The task prompt said *"if the task needs no code change, move it to review anyway so a human can close it out"* — but `enqueueReviewersOnThreadFinish` skips a task with no PR, so nothing picks the card up and nothing signals a human should. `thrd_f3XItWFcNHgYZodrzhn_f` did exactly this correctly (the H1 was already merged in main), then parked forever.

**3. Threads written `in_progress` whose run never started were never reaped.** 8 threads with 2 parts (prompt + finish), `run_started_at`/`last_progress_at` NULL, oldest ~20h. The idle reaper only sees runs in a pod's in-memory `RunRegistry` — i.e. runs that reached `RUN_STARTED` — and there is no DB sweep. Since `shouldAdvanceToReview` requires every thread terminal, one such thread froze its whole card.

**4. Failed threads recorded no reason.** All 4 had `failure_reason = ''`, `failure_kind = NULL`. Only `reaped` wrote them; `cancelled`/`error` got a bare write because their reason "is surfaced elsewhere" — elsewhere being an error *part*. The real cause was `cancelled: run cancelled` (a dispatch takeover), invisible to anything reading the row.

## What this changes

- Reviewers run on the sandbox-hosted `claude-code` harness (the one handed the task-run MCP surface), falling back to Decopilot when the org has no importable repo. `TASK_BOARD_REVIEW_DECISION` is served on that surface **for a reviewer thread only**, keyed off the title the board assigned — a worker run's endpoint still cannot approve its own work. Prompt tool names namespaced to match what the sandbox client exposes.
- No-code-change tasks go to **Done** with an explanatory comment, not In Review. The no-PR reviewer skip now logs.
- Board stall recovery fails never-started threads, reusing the existing `isThreadRunStale` heartbeat (extracted from `normalizeThreadForResponse`, which already renders these as "expired") so a live streaming run is never touched.
- Every `RunFailedReason` records a reason + kind. `ghost` deliberately still does not — it force-fails a row whose run never existed on this pod, and a reason there would overwrite one a concurrent terminal writer just set.

## Testing

- `bun run --cwd=apps/api check` clean; `bun run lint` 0 errors; knip clean on the changed symbols.
- 70 unit tests pass across the 6 affected files (new: `task-run-context.test.ts`, `isNeverStartedRun` suite, `cancelled`/`ghost` reactor cases, the no-code-change prompt).
- **Two tests inverted** rather than appended, per the repo's rule: `RUN_FAILED reason 'error' does NOT set failure_reason (unchanged)` and the prompt's `in_review` expectation both encoded the bug.
- The 11–12 remaining `*.integration.test.ts` failures are pre-existing on the base commit (local Postgres missing the `dismissed_at` migration), verified by stashing.

## Risk

Reviewer dispatch changing harness is a dispatch-path change. It is already gated per-org by the existing `qa_agent_enabled` / `code_reviewer_enabled` flags — the flags for exactly this feature, not a neighbor's — so no new flag was added.

## Not fixed here

The deploy preview is unreachable from the sandbox: dozens of `Browserless function call failed (400): Navigation timeout of 30000 ms exceeded` and `content fetch failed (500)` against `envs-demo-storefront--*.decocdn.com`, with one scrape returning the literal `<title>Deploy Preview - Starting up</title>` holding page and a 15s meta-refresh. QA agents burn 5–10 turns retrying a cold-booting preview then give up. That is where most of the wasted effort actually went, and it needs its own fix. Two smaller ones also observed: `gh pr checkout N` fails in the sandbox (`cannot set up tracking information; 'origin/fix/…' is not a branch`), and the GitHub MCP `pull_request_read` rejected `pullNumber` as a string 4 calls in a row.

The 9 already-stuck In Review items need a manual move; this PR stops new ones being created.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops task-board items getting stuck before Done by fixing reviewer tool access, handling no‑code tasks, and reaping never‑started runs. Also records clear failure reasons so failed threads are readable.

- **Bug Fixes**
  - Reviewer runs use sandbox `claude-code` (fallback to Decopilot when no repo) and get `TASK_BOARD_REVIEW_DECISION` only on reviewer threads; MCP tool surface is resolved from the thread title and tool names are correctly namespaced.
  - Tasks needing no code change go straight to Done with a comment; reviewer enqueue logs and skips when In Review has no PR.
  - Stall recovery fails never‑started `in_progress` threads using the shared heartbeat and records `failure_kind: "abandoned"`, unblocking cards without touching live runs.
  - Failed runs persist clear `failure_reason`/`failure_kind` for `error` and `cancelled`; `ghost` remains bare.

<sup>Written for commit 41bb69b3cbb4aaace3aee434247ce4e111432646. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

