### PR TITLE
fix(deco-import): upgrade legacy assets config instead of skipping it

### DIFF
--- a/apps/api/scripts/backfill-org-sites.ts
+++ b/apps/api/scripts/backfill-org-sites.ts
@@ -118,8 +118,15 @@ function emitSqlForSite(organizationId: string, slug: string): string {
     `VALUES (${s}, ${o}, 'deco-import', ${actor}, ${actor})`,
     `ON CONFLICT (slug) DO NOTHING;`,
     ``,
+    // Repoint storage too: a legacy row points at the OLD assets bucket, and
+    // the STS session policy only ever grants `<tenantBucket>/<slug>/*`.
+    // Flipping credential_type alone would leave a config that looks managed
+    // but whose minted credentials can't reach its own bucket.
     `UPDATE org_file_configs`,
     `   SET credential_type = 'managed', site_slug = ${s}, refresh_url = NULL,`,
+    `       bucket = ${sql(d.bucket)}, region = ${sql(d.region)}, endpoint = ${endpoint},`,
+    `       force_path_style = false, prefix = ${sql(d.prefix)},`,
+    `       public_url_base = ${sql(d.publicUrlBase)},`,
     `       updated_at = now(), updated_by = ${actor}`,
     ` WHERE organization_id = ${o}`,
     `   AND lower(name) = lower(${name})`,
@@ -290,6 +297,7 @@ async function main() {
 
       // 2. Ensure a managed file config for the slug.
       const configName = `${FILE_CONFIG_NAME_PREFIX}${site.name}`;
+      const descriptor = tenantStorageDescriptor(slug);
       const existing = await orgFileConfigs.list(organizationId);
       const match = existing.find(
         (c) => c.name.toLowerCase() === configName.toLowerCase(),
@@ -301,13 +309,22 @@ async function main() {
       }
 
       if (match) {
-        // Convert a legacy sts-session (admin bridge) config to managed.
+        // Convert a legacy sts-session (admin bridge) config to managed —
+        // storage fields included, since the legacy row points at the OLD
+        // assets bucket while the STS session policy only ever grants
+        // `<tenantBucket>/<slug>/*`.
         if (dryRun) {
           console.log(`  would convert config "${configName}" → managed`);
         } else {
           await orgFileConfigs.update({
             id: match.id,
             organizationId,
+            bucket: descriptor.bucket,
+            region: descriptor.region,
+            endpoint: descriptor.endpoint,
+            forcePathStyle: descriptor.forcePathStyle,
+            prefix: descriptor.prefix,
+            publicUrlBase: descriptor.publicUrlBase,
             siteSlug: slug,
             refreshUrl: null,
             credentials: { type: "managed" },
@@ -319,7 +336,6 @@ async function main() {
       }
 
       // No config yet — create one from the managed tenant descriptor.
-      const descriptor = tenantStorageDescriptor(slug);
       if (dryRun) {
         console.log(`  would create managed config "${configName}"`);
       } else {

--- a/apps/api/src/api/routes/deco-sites.test.ts
+++ b/apps/api/src/api/routes/deco-sites.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { isManagedConfigFor } from "./deco-sites";
+
+describe("isManagedConfigFor", () => {
+  test("already the managed config for the slug — nothing to do", () => {
+    expect(
+      isManagedConfigFor(
+        { credentialType: "managed", siteSlug: "als-storefront" },
+        "als-storefront",
+      ),
+    ).toBe(true);
+  });
+
+  test("legacy pre-tenancy config on the old bucket must be upgraded", () => {
+    expect(
+      isManagedConfigFor(
+        { credentialType: "sts-session", siteSlug: null },
+        "als-storefront",
+      ),
+    ).toBe(false);
+    expect(
+      isManagedConfigFor(
+        { credentialType: "static", siteSlug: null },
+        "als-storefront",
+      ),
+    ).toBe(false);
+  });
+
+  test("managed but pointing at another slug must be re-pointed", () => {
+    expect(
+      isManagedConfigFor(
+        { credentialType: "managed", siteSlug: "other-site" },
+        "als-storefront",
+      ),
+    ).toBe(false);
+  });
+
+  test("siteSlug casing does not force a pointless rewrite", () => {
+    expect(
+      isManagedConfigFor(
+        { credentialType: "managed", siteSlug: "ALS-Storefront" },
+        "als-storefront",
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/api/src/api/routes/deco-sites.ts
+++ b/apps/api/src/api/routes/deco-sites.ts
@@ -329,11 +329,30 @@ const ADMIN_MCP = "https://sites-admin-mcp.deco.site/api/mcp";
 const FILE_CONFIG_NAME_PREFIX = "deco-assets-";
 
 /**
+ * True when a config already IS the managed config for `slug` — the only case
+ * where re-importing has nothing to do. A same-named config that isn't (the
+ * legacy pre-tenancy import created `deco-assets-<site>` pointing at the old
+ * assets bucket with vended credentials) must be upgraded in place: the
+ * `(organization_id, lower(name))` unique index makes creating a second row
+ * impossible, so skipping would strand the org on the legacy bucket forever.
+ */
+export function isManagedConfigFor(
+  config: { credentialType: string; siteSlug: string | null },
+  slug: string,
+): boolean {
+  return (
+    config.credentialType === "managed" &&
+    config.siteSlug?.toLowerCase() === slug
+  );
+}
+
+/**
  * Claim the site slug for this org in studio's own tenancy table and create a
  * `managed` FILE_CONFIG for it. Studio mints prefix-scoped STS credentials
  * in-process at upload/list time (see file-storage/tenant-credentials.ts) — no
  * service-account key, no live call to admin to vend credentials. Idempotent:
- * re-importing the same site re-claims (same org) and skips an existing config.
+ * re-importing the same site re-claims (same org) and, when the config already
+ * points at the managed tenant bucket, changes nothing.
  * Best-effort: any failure is logged and swallowed by the caller.
  */
 async function provisionManagedAssetsConfig(params: {
@@ -370,25 +389,46 @@ async function provisionManagedAssetsConfig(params: {
   }
 
   const configName = `${FILE_CONFIG_NAME_PREFIX}${siteName}`;
-  const existing = await ctx.storage.orgFileConfigs.list(orgId);
-  if (existing.some((c) => c.name.toLowerCase() === configName.toLowerCase())) {
+  const existing = (await ctx.storage.orgFileConfigs.list(orgId)).find(
+    (c) => c.name.toLowerCase() === configName.toLowerCase(),
+  );
+  if (existing && isManagedConfigFor(existing, slug)) {
     return;
   }
 
   const descriptor = tenantStorageDescriptor(slug);
-  await ctx.storage.orgFileConfigs.create({
-    organizationId: orgId,
-    name: configName,
-    description: `Managed deco-assets storage for site "${siteName}".`,
+  const storage = {
     bucket: descriptor.bucket,
     region: descriptor.region,
     endpoint: descriptor.endpoint,
     forcePathStyle: descriptor.forcePathStyle,
     prefix: descriptor.prefix,
     publicUrlBase: descriptor.publicUrlBase,
+    // The legacy config carried an sts-session refreshUrl; managed mints
+    // in-process, so clear it or the S3 client would still call out to admin.
     refreshUrl: null,
     siteSlug: slug,
-    credentials: { type: "managed" },
+    credentials: { type: "managed" as const },
+  };
+
+  if (existing) {
+    await ctx.storage.orgFileConfigs.update({
+      id: existing.id,
+      organizationId: orgId,
+      ...storage,
+      updatedBy: userId,
+    });
+    console.log(
+      `[deco-sites] legacy file-config "${configName}" upgraded to managed for org=${orgId}`,
+    );
+    return;
+  }
+
+  await ctx.storage.orgFileConfigs.create({
+    organizationId: orgId,
+    name: configName,
+    description: `Managed deco-assets storage for site "${siteName}".`,
+    ...storage,
     createdBy: userId,
   });
   console.log(


### PR DESCRIPTION
## Problem

The deco.cx import skipped provisioning the managed assets config whenever **any**
file config named `deco-assets-<site>` already existed — regardless of which bucket
it pointed at:

```ts
const existing = await ctx.storage.orgFileConfigs.list(orgId);
if (existing.some((c) => c.name.toLowerCase() === configName.toLowerCase())) return;
```

Orgs that imported a site **before** the managed tenancy shipped (#4058) carry a
config with exactly that name pointing at the **legacy** assets bucket with vended
credentials. For them the skip is permanent: re-importing is a silent no-op, so the
org stays on the old bucket forever. The only escape is deleting the config by hand
and re-importing — and only if the delete lands before the next attempt.

Creating a second row alongside the legacy one is not possible: `org_file_configs`
has a unique index on `(organization_id, lower(name))` (migration 094).

## Fix

Upgrade the same-named config in place instead of skipping it — repoint
bucket/region/endpoint/prefix/publicUrlBase at the tenant descriptor, set
`site_slug`, switch credentials to `managed`, and clear the stale `sts-session`
`refreshUrl` (otherwise the S3 client would still call out to admin for
credentials it no longer needs).

Re-import stays a no-op **only** when the config already IS the managed config for
that slug — that check is `isManagedConfigFor`, exported so it can be unit-tested
without the deco Supabase dependency the route needs.

## Production evidence

Org `als` (`studio.decocms.com/als`), site `als-storefront`, imported 2026-06-11
on the legacy bucket:

| 2026-08-05 (UTC) | result |
|---|---|
| 15:54 | connection + `org_sites` claim, **no file config** |
| 15:57 | connection + claim, **no file config** |
| 16:04 | legacy row manually deleted first → correct managed config created |

Two re-imports produced nothing at all — exactly the early-return path. Also
confirmed the managed bucket is the right target: `als-storefront/` objects
resolve in the tenant bucket, and assets uploaded after the bucket migration
exist **only** there.

Other orgs still carrying legacy same-named rows (e.g. `guilherme-samba-cloud`
with `deco-assets-farmrio` / `-lojastorra-2` / `-demo-linkedin`) get fixed on
their next import instead of needing manual surgery.

## Testing

- `bun test apps/api/src/api/routes/deco-sites.test.ts` — 4 pass (already-managed,
  legacy `sts-session`, legacy `static`, managed-but-wrong-slug, slug casing)
- `bun run --cwd=apps/api check`, `bun run lint` (0 errors), `bun run fmt` clean

E2E is not viable for this route — it needs live deco Supabase credentials — so
the decision is factored into a pure predicate and unit-tested there.

## Follow-ups (not in this PR)

1. Projects imported before #4058 have no `metadata.siteSlug`, so the
   sections-editor picker can't lock onto the managed config
   (`sections-editor.tsx:183` → `matchSiteSlugConfig`). Needs a backfill.
2. The import currently fails after the connection step for `als-storefront` —
   no project/virtual MCP was created in any of the three attempts, and the
   rollback swallows every error (`.catch(() => {})` in
   `import-from-deco-dialog.tsx`), leaving orphan connections behind.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make deco.cx imports and the backfill upgrade legacy `deco-assets-<site>` configs to the managed tenancy instead of skipping them, so orgs move off the old bucket on re-import or backfill. Re-import stays a no-op only when the config is already managed for that slug.

- **Bug Fixes**
  - Upgrade same-named legacy configs in place for both import and backfill: repoint storage fields (bucket/region/endpoint/prefix/publicUrlBase), set `siteSlug`, and switch credentials to `managed`.
  - Use `isManagedConfigFor` to skip only when already managed for the slug (case-insensitive); otherwise update the existing row.
  - Clear stale `sts-session` `refreshUrl` and add unit tests for legacy/static, managed-wrong-slug, and casing.

<sup>Written for commit 43ec24c66f0274bf7284e664aa320361218112f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

