### PR TITLE
feat(billing): per-org task-execution allowances, defaulting from the env

### DIFF
--- a/apps/api/migrations/164-per-org-task-quota.ts
+++ b/apps/api/migrations/164-per-org-task-quota.ts
@@ -1,0 +1,47 @@
+import { sql, type Kysely } from "kysely";
+
+/**
+ * Per-org task-execution allowances, overriding the deployment-wide
+ * `STUDIO_FREE_TASKS` / `STUDIO_MONTHLY_TASKS` for one tenant.
+ *
+ * The env knobs are global, so today the only way to give a client POC a
+ * bigger allowance is faking `organization_billing.status = 'active'` — which
+ * still caps at the global monthly number and breaks Checkout ("already has an
+ * active subscription") and the Customer Portal (no `stripe_customer_id`).
+ *
+ * COLUMNS, not `organization_settings.flags` entries: the flags bag is for
+ * booleans (see the repo guidelines), and these are numbers. They live on
+ * `organization_billing` because `claimTaskExecution` already loads that row
+ * to pick the period bucket, so a per-org limit costs no extra query.
+ *
+ * One column per existing knob rather than a single blended number, so nothing
+ * about the period buckets changes: an unsubscribed org still uses the lifetime
+ * `trial` bucket and a subscribed one still uses its Stripe cycle — only the
+ * ceiling differs.
+ *
+ * NULL = use the deployment default. The check constraints reject 0 and
+ * negatives: "block this org entirely" is not what an allowance means, and 0
+ * would be indistinguishable from unset to a careless reader.
+ *
+ * Deliberately NOT exposed through any MCP tool: an org admin must never be
+ * able to raise their own limit. Setting these is an operator action.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("organization_billing")
+    .addColumn("free_task_executions", "integer", (col) =>
+      col.check(sql`free_task_executions > 0`),
+    )
+    .addColumn("monthly_task_executions", "integer", (col) =>
+      col.check(sql`monthly_task_executions > 0`),
+    )
+    .execute();
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema
+    .alterTable("organization_billing")
+    .dropColumn("free_task_executions")
+    .dropColumn("monthly_task_executions")
+    .execute();
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -162,6 +162,7 @@ import * as migration160taskquotabilling from "./160-task-quota-billing.ts";
 import * as migration161taskquotaclaimstate from "./161-task-quota-claim-state.ts";
 import * as migration162claudesubscriptions from "./162-claude-subscriptions.ts";
 import * as migration163taskboarditemdismissed from "./163-task-board-item-dismissed.ts";
+import * as migration164perorgtaskquota from "./164-per-org-task-quota.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -351,6 +352,7 @@ const migrations: Record<string, Migration> = {
   "161-task-quota-claim-state": migration161taskquotaclaimstate,
   "162-claude-subscriptions": migration162claudesubscriptions,
   "163-task-board-item-dismissed": migration163taskboarditemdismissed,
+  "164-per-org-task-quota": migration164perorgtaskquota,
 };
 
 export default migrations;

--- a/apps/api/src/billing/task-quota.integration.test.ts
+++ b/apps/api/src/billing/task-quota.integration.test.ts
@@ -292,6 +292,73 @@ describe("task quota (integration)", () => {
     );
   });
 
+  // Per-org allowances (migration 164). Proven against real Postgres because
+  // the whole point is a COLUMN the claim path reads — an in-memory fake would
+  // happily accept one the update whitelist silently drops.
+  it("an org's own allowance beats the deployment default, same trial bucket", async () => {
+    const org = "org_own_allowance";
+    await seedOrg(org, true);
+    // CONFIG.freeTaskExecutions is 2; this tenant gets 5.
+    await database.db
+      .updateTable("organization_billing")
+      .set({ free_task_executions: 5 })
+      .where("organization_id", "=", org)
+      .execute();
+    const ctxA = ctxFor(org);
+    const tasks = await Promise.all(
+      Array.from({ length: 5 }, () => makeTask("system", org)),
+    );
+    for (const task of tasks) await claimTaskExecution(ctxA, task, CONFIG);
+
+    // Same bucket as any unsubscribed org — only the ceiling moved.
+    expect(await billing.countTaskClaims(org, "trial")).toBe(5);
+    // A bigger allowance is still an allowance: it runs out.
+    await expect(
+      claimTaskExecution(ctxA, await makeTask("system", org), CONFIG),
+    ).rejects.toThrow(/^\[SUBSCRIPTION_REQUIRED\].*free task executions/);
+  });
+
+  it("the monthly allowance is separate from the free one", async () => {
+    const org = "org_own_monthly";
+    await seedOrg(org, true);
+    const periodEnd = new Date("2026-12-01T00:00:00.000Z");
+    await billing.updateStripeState(org, {
+      status: "active",
+      currentPeriodEnd: periodEnd,
+    });
+    // Only the monthly column is set — CONFIG.monthlyTaskExecutions is 3.
+    await database.db
+      .updateTable("organization_billing")
+      .set({ monthly_task_executions: 4 })
+      .where("organization_id", "=", org)
+      .execute();
+    const ctxM = ctxFor(org);
+    const tasks = await Promise.all(
+      Array.from({ length: 4 }, () => makeTask("system", org)),
+    );
+    for (const task of tasks) await claimTaskExecution(ctxM, task, CONFIG);
+
+    expect(
+      await billing.countTaskClaims(org, `sub:${periodEnd.toISOString()}`),
+    ).toBe(4);
+    await expect(
+      claimTaskExecution(ctxM, await makeTask("system", org), CONFIG),
+    ).rejects.toThrow(/^\[SUBSCRIPTION_REQUIRED\].*monthly task executions/);
+  });
+
+  it("rejects a non-positive allowance at the database", async () => {
+    const org = "org_allowance_zero";
+    await seedOrg(org, true);
+    // 0 would read as "unset" to a careless caller while meaning "block them".
+    await expect(
+      database.db
+        .updateTable("organization_billing")
+        .set({ free_task_executions: 0 })
+        .where("organization_id", "=", org)
+        .execute(),
+    ).rejects.toThrow();
+  });
+
   // The dispatch caller has to know whether the slot it charged is its own to
   // undo: only a FRESH claim is. A "rerun" rides a slot an earlier run paid for
   // (and may have shipped a PR from), so undoing it would refund real work.

--- a/apps/api/src/billing/task-quota.test.ts
+++ b/apps/api/src/billing/task-quota.test.ts
@@ -79,6 +79,69 @@ describe("taskQuotaState", () => {
     });
   });
 
+  // Per-org allowances (migration 164): a different ceiling for one tenant,
+  // WITHOUT changing which bucket it lands in.
+  test("the org's own free allowance wins in the trial bucket", () => {
+    expect(
+      taskQuotaState(
+        { status: "none", currentPeriodEnd: null, freeTaskExecutions: 1000 },
+        LIMITS,
+      ),
+    ).toEqual({
+      periodKey: "trial",
+      limit: 1000,
+      exhaustedReason: "trial_exhausted",
+    });
+  });
+
+  test("the org's own monthly allowance wins in its billing cycle", () => {
+    expect(
+      taskQuotaState(
+        {
+          status: "active",
+          currentPeriodEnd: new Date("2026-09-01T00:00:00.000Z"),
+          monthlyTaskExecutions: 500,
+        },
+        LIMITS,
+      ),
+    ).toEqual({
+      periodKey: "sub:2026-09-01T00:00:00.000Z",
+      limit: 500,
+      exhaustedReason: "monthly_exhausted",
+    });
+  });
+
+  test("the two allowances are independent — one set doesn't move the other", () => {
+    // A tenant comped on the trial but on standard terms once it subscribes.
+    const billing = {
+      status: "none",
+      currentPeriodEnd: null,
+      freeTaskExecutions: 1000,
+      monthlyTaskExecutions: null,
+    };
+    expect(taskQuotaState(billing, LIMITS).limit).toBe(1000);
+    expect(taskQuotaState({ ...billing, status: "active" }, LIMITS).limit).toBe(
+      10,
+    );
+  });
+
+  test("null or absent falls back to the deployment default", () => {
+    const trial = {
+      periodKey: "trial",
+      limit: 3,
+      exhaustedReason: "trial_exhausted",
+    } as const;
+    expect(
+      taskQuotaState(
+        { status: "none", currentPeriodEnd: null, freeTaskExecutions: null },
+        LIMITS,
+      ),
+    ).toEqual(trial);
+    expect(
+      taskQuotaState({ status: "none", currentPeriodEnd: null }, LIMITS),
+    ).toEqual(trial);
+  });
+
   test("run-cap rejection has its own reason/message", () => {
     expect(new TaskQuotaError("runs_exhausted").message).toContain(
       "execution limit",

--- a/apps/api/src/billing/task-quota.ts
+++ b/apps/api/src/billing/task-quota.ts
@@ -24,6 +24,10 @@
  * is being paid, else the subscription's current period end, which
  * invoice.paid refreshes, minting a fresh bucket each cycle.
  *
+ * Both allowances default from the deployment env and are overridable per org
+ * (`organization_billing.free_task_executions` / `monthly_task_executions`,
+ * migration 164) for a tenant on different terms.
+ *
  * Dormant unless STUDIO_TASK_QUOTA_ENFORCED is set (self-hosted stays free).
  */
 
@@ -90,9 +94,24 @@ export interface TaskQuotaState {
  * period end, and the invoice.paid that carries one can arrive before the
  * bind (acked as "unknown subscription", never redelivered), so the window
  * can last a full cycle. Paywalling a customer who just paid is worse.
+ *
+ * `limits` are the DEPLOYMENT defaults; the org's own columns (migration 164)
+ * win when set, so one tenant can have a different ceiling without changing
+ * anything about which bucket it lands in.
  */
 export function taskQuotaState(
-  billing: Pick<OrganizationBillingRow, "status" | "currentPeriodEnd"> | null,
+  billing:
+    | (Pick<OrganizationBillingRow, "status" | "currentPeriodEnd"> &
+        // Optional so a caller that omits them falls back to the deployment
+        // default — the safe direction. Production passes the whole row, where
+        // both columns are always present.
+        Partial<
+          Pick<
+            OrganizationBillingRow,
+            "freeTaskExecutions" | "monthlyTaskExecutions"
+          >
+        >)
+    | null,
   limits: { freeTaskExecutions: number; monthlyTaskExecutions: number },
 ): TaskQuotaState {
   if (subscriptionInGoodStanding(billing)) {
@@ -100,13 +119,13 @@ export function taskQuotaState(
       periodKey: billing?.currentPeriodEnd
         ? `sub:${billing.currentPeriodEnd.toISOString()}`
         : "sub:pending",
-      limit: limits.monthlyTaskExecutions,
+      limit: billing?.monthlyTaskExecutions ?? limits.monthlyTaskExecutions,
       exhaustedReason: "monthly_exhausted",
     };
   }
   return {
     periodKey: "trial",
-    limit: limits.freeTaskExecutions,
+    limit: billing?.freeTaskExecutions ?? limits.freeTaskExecutions,
     exhaustedReason: "trial_exhausted",
   };
 }

--- a/apps/api/src/storage/organization-billing.ts
+++ b/apps/api/src/storage/organization-billing.ts
@@ -16,6 +16,8 @@ function toBillingRow(
     stripeSubscriptionId: row.stripe_subscription_id,
     currentPeriodEnd: row.current_period_end,
     lastStripeEventAt: row.last_stripe_event_at,
+    freeTaskExecutions: row.free_task_executions,
+    monthlyTaskExecutions: row.monthly_task_executions,
   };
 }
 
@@ -28,6 +30,10 @@ export interface OrganizationBillingRow {
   /** Newest applied Stripe event's `created` time — the webhook skips
    *  deliveries older than this so out-of-order events can't regress state. */
   lastStripeEventAt: Date | null;
+  /** Operator-set per-org allowances replacing the deployment defaults
+   *  (migration 164). null = use the default. */
+  freeTaskExecutions: number | null;
+  monthlyTaskExecutions: number | null;
 }
 
 export class OrganizationBillingStorage {

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -1264,6 +1264,20 @@ export interface OrganizationBillingTable {
     Date | string | null | undefined,
     Date | string | null
   >;
+  /** Per-org allowances (migration 164) overriding the deployment-wide
+   *  `STUDIO_FREE_TASKS` / `STUDIO_MONTHLY_TASKS`. NULL = use the default.
+   *  Operator-set only — never writable through a tool, or an org admin could
+   *  raise its own limit. */
+  free_task_executions: ColumnType<
+    number | null,
+    number | null | undefined,
+    number | null
+  >;
+  monthly_task_executions: ColumnType<
+    number | null,
+    number | null | undefined,
+    number | null
+  >;
   created_at: ColumnType<Date, Date | string | undefined, never>;
   updated_at: ColumnType<Date, Date | string | undefined, Date | string>;
 }


### PR DESCRIPTION
## Summary

The auto-task quota is a deployment-wide pair of env knobs, so a tenant on
different terms has no lever. Makes both numbers per-org and nullable, with the
env as the default:

```sql
update organization_billing set free_task_executions = 1000
where organization_id = '<org-id>';
```

| | before | after |
|---|---|---|
| free (trial) allowance | `STUDIO_FREE_TASKS`, global | `organization_billing.free_task_executions` ?? env |
| monthly allowance | `STUDIO_MONTHLY_TASKS`, global | `organization_billing.monthly_task_executions` ?? env |

Today the only way to comp an org is faking `status = 'active'`, which still
caps at the global monthly number **and** breaks Checkout (`already has an
active subscription`) and the Customer Portal (no `stripe_customer_id`).

## Why this shape

- **Columns, not `organization_settings.flags`** — the flags bag is for
  booleans, per the repo guidelines. These are numbers.
- **On `organization_billing`** — `claimTaskExecution` already loads that row to
  pick the period bucket, so a per-org ceiling costs no extra query.
- **One column per existing knob, not one blended number** — so *nothing* about
  the period buckets changes. An unsubscribed org still uses the lifetime
  `trial` bucket; a subscribed one still uses its Stripe cycle; only the ceiling
  differs. That also makes setting one reversible: drop it and the org is
  exactly where it was, with its claim history intact.
- **No tool exposure.** An org admin must never be able to raise its own limit,
  so this is an operator action (SQL / the admin surface). `defineTool` would be
  the wrong home for it.
- Check constraints reject 0 and negatives — "block this org entirely" is not
  what an allowance means, and 0 reads as unset to a careless caller.

`ORGANIZATION_TASK_QUOTA_GET` needs no change: it composes `taskQuotaState`, so
it reports the org's real ceiling for free, and the paywall UI's counter follows.

## Testing

Unit (`task-quota.test.ts`) — each allowance winning in its own bucket, the two
being independent (comped on the trial, standard once subscribed), and
null/absent falling back to the deployment default.

Real Postgres (`task-quota.integration.test.ts`) — the claim path actually
honoring the columns (an in-memory fake would happily accept a column the
`update()` whitelist silently drops), the bigger allowance still running out,
and the check constraint rejecting 0. Migration `down`/`up` roundtrip verified
by hand.

`bun test apps/api/src/billing apps/api/src/storage apps/api/src/tools/task-board apps/api/src/tools/organization apps/api/migrations` → 287 pass.
`bun run check`, `fmt`, `lint` clean.

## Deploy note

One migration (`164-per-org-task-quota`), additive and nullable — no backfill,
no behavior change until a column is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
