### PR TITLE
fix(native): preview iframe blocked by navigation policy (dynamic origin allowlist)

### DIFF
--- a/apps/native/src-tauri/build.rs
+++ b/apps/native/src-tauri/build.rs
@@ -6,6 +6,7 @@ fn main() {
         "auth_logout",
         "auth_complete_session",
         "selftest_report",
+        "register_preview_origin",
     ];
 
     tauri_build::try_build(

--- a/apps/native/src-tauri/capabilities/default.json
+++ b/apps/native/src-tauri/capabilities/default.json
@@ -21,6 +21,7 @@
     "allow-auth-logout",
     "allow-auth-complete-session",
     "allow-selftest-report",
+    "allow-register-preview-origin",
     {
       "identifier": "opener:allow-open-url",
       "comment": "Loopback HTTP covers sandbox previews and local development servers. https://* is required by MCP OAuth and by every external link in the app, both of which reach the OS because window.open returns null in a webview: an authorize URL belongs to whatever authorization server a connection's MCP server advertises, so the set is open-ended and cannot be enumerated ahead of time. vscode/cursor back the Open in editor buttons. Plaintext http beyond loopback stays denied \u2014 an authorize URL served over it would be a downgrade.",

--- a/apps/native/src-tauri/permissions/autogenerated/register_preview_origin.toml
+++ b/apps/native/src-tauri/permissions/autogenerated/register_preview_origin.toml
@@ -1,0 +1,11 @@
+# Automatically generated - DO NOT EDIT!
+
+[[permission]]
+identifier = "allow-register-preview-origin"
+description = "Enables the register_preview_origin command without any pre-configured scope."
+commands.allow = ["register_preview_origin"]
+
+[[permission]]
+identifier = "deny-register-preview-origin"
+description = "Denies the register_preview_origin command without any pre-configured scope."
+commands.deny = ["register_preview_origin"]

--- a/apps/native/src-tauri/src/commands.rs
+++ b/apps/native/src-tauri/src/commands.rs
@@ -33,7 +33,7 @@ use serde::Serialize;
 use tauri::State;
 
 use crate::auth::{AuthResultWire, AuthStatusWire};
-use crate::state::LocalApiState;
+use crate::state::{LocalApiState, PreviewOriginState};
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -139,6 +139,46 @@ pub async fn auth_complete_session(
     result.map(AuthResultWire::from).map_err(|e| e.to_string())
 }
 
+/// Registers `origin` as a currently-legitimate preview iframe target — see
+/// `state::PreviewOriginState`'s doc comment for why this exists. Called by
+/// the frontend (`apps/web/src/lib/desktop/tauri-bridge.ts`'s
+/// `registerPreviewOrigin`) immediately before setting a preview iframe's
+/// `src` to an external (non-sandbox-proxy) origin, and MUST be awaited
+/// first: `setup::is_allowed_webview_navigation` denies anything not already
+/// registered, and a denied iframe navigation fires neither `load` nor
+/// `error` (WKWebView cancels it outright), so a caller that raced ahead of
+/// registration would see a permanently blank frame with no recovery signal.
+///
+/// Parses and re-serializes rather than trusting the raw string: normalizes
+/// to exactly what `url.origin().ascii_serialization()` produces at the
+/// `on_navigation` check site, and rejects non-http(s) input.
+#[tauri::command]
+pub fn register_preview_origin(
+    origin: String,
+    state: State<'_, PreviewOriginState>,
+) -> Result<(), String> {
+    state.register(normalize_preview_origin(&origin)?);
+    Ok(())
+}
+
+/// Parses and re-serializes rather than trusting the raw string: normalizes
+/// to exactly what `url.origin().ascii_serialization()` produces at the
+/// `setup::is_allowed_webview_navigation` check site, and rejects non-http(s)
+/// input. Pure logic, split out from the command itself so it's unit-testable
+/// — `tauri::State` has no public constructor for a plain unit test to use.
+fn normalize_preview_origin(origin: &str) -> Result<String, String> {
+    let parsed: tauri::Url = origin
+        .parse()
+        .map_err(|error| format!("invalid origin {origin:?}: {error}"))?;
+    if parsed.scheme() != "https" && parsed.scheme() != "http" {
+        return Err(format!(
+            "only http(s) origins may be registered, got scheme {:?}",
+            parsed.scheme()
+        ));
+    }
+    Ok(parsed.origin().ascii_serialization())
+}
+
 /// Self-test-mode-only (see `selftest.rs`). A real frontend build never
 /// calls this — the self-test JS bundle is the only caller, and it's only
 /// ever `eval()`'d when `DESKTOP_SELFTEST=1`. Harmless if invoked outside
@@ -166,5 +206,24 @@ mod tests {
         assert_eq!(value["previewPort"], 61_234);
         assert_eq!(value["upstreamUrl"], "https://studio.decocms.com");
         assert_eq!(value["token"], "bootstrap");
+    }
+
+    #[test]
+    fn normalize_preview_origin_strips_path_and_query() {
+        assert_eq!(
+            normalize_preview_origin("https://fila.vtex.app/?__draft=abc&deviceHint=desktop")
+                .unwrap(),
+            "https://fila.vtex.app"
+        );
+    }
+
+    #[test]
+    fn normalize_preview_origin_rejects_non_http_schemes() {
+        for bad in ["file:///etc/passwd", "javascript:alert(1)", "not a url"] {
+            assert!(
+                normalize_preview_origin(bad).is_err(),
+                "{bad} must be rejected"
+            );
+        }
     }
 }

--- a/apps/native/src-tauri/src/lib.rs
+++ b/apps/native/src-tauri/src/lib.rs
@@ -59,6 +59,7 @@ pub fn run() {
             commands::auth_logout,
             commands::auth_complete_session,
             commands::selftest_report,
+            commands::register_preview_origin,
         ])
         .setup(|app| {
             let handle = app.handle().clone();

--- a/apps/native/src-tauri/src/setup.rs
+++ b/apps/native/src-tauri/src/setup.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 use tauri::{Emitter, Manager, WebviewUrl, WebviewWindowBuilder};
 
-use crate::state::LocalApiState;
+use crate::state::{LocalApiState, PreviewOriginState};
 use crate::{control_origin, selftest};
 
 const AUTH_STATUS_CHANGED_EVENT: &str = "auth-status-changed";
@@ -54,10 +54,12 @@ fn is_allowed_webview_navigation(
     url: &tauri::Url,
     control_origin: &str,
     preview_port: u16,
+    preview_origins: &PreviewOriginState,
 ) -> bool {
     url.as_str() == "about:blank"
         || url.origin().ascii_serialization() == control_origin
         || is_sandbox_preview_url(url, preview_port)
+        || preview_origins.contains(&url.origin().ascii_serialization())
 }
 
 /// Whether `url` is a sandbox preview.
@@ -326,13 +328,32 @@ pub async fn run(app: &tauri::AppHandle) -> Result<(), SetupError> {
             .map_err(|error| SetupError::ControlUrl(error.to_string()))?,
     );
     let navigation_control_origin = browser_origin.clone();
+    // Managed here (not read via `State` inside the closure below): the
+    // closure is built and moved into `WebviewWindowBuilder` before the
+    // window — and therefore command-invocation machinery — exists, so it
+    // captures its own clone directly, the same way `navigation_control_origin`
+    // and `preview_port` already do just above.
+    let preview_origins = PreviewOriginState::default();
+    app.manage(preview_origins.clone());
+    let navigation_preview_origins = preview_origins;
     let mut builder = WebviewWindowBuilder::new(app, "main", webview_url)
         .title("Studio")
         .inner_size(1080.0, 720.0)
         // Wry reports child-frame navigations here too, so rejected URLs must
         // not cause side effects. Only explicit UI actions open the browser.
+        // External preview domains (a customer's live site, embedded as an
+        // iframe by the CMS preview pane) are allowed via
+        // `navigation_preview_origins`, a session-scoped set the frontend
+        // populates through `register_preview_origin` immediately before
+        // setting such an iframe's `src` — see `PreviewOriginState`'s doc
+        // comment for why a static allowlist can't cover this instead.
         .on_navigation(move |url| {
-            is_allowed_webview_navigation(url, &navigation_control_origin, preview_port)
+            is_allowed_webview_navigation(
+                url,
+                &navigation_control_origin,
+                preview_port,
+                &navigation_preview_origins,
+            )
         })
         .on_new_window(move |_url, _features| new_window_policy());
     if selftest_mode {
@@ -421,13 +442,19 @@ mod tests {
     fn webview_navigation_is_limited_to_control_and_preview_origins() {
         let control = "https://local.studio.decocms.com:43120";
         let preview_port = 61_234;
+        let preview_origins = PreviewOriginState::default();
         for allowed in [
             "https://local.studio.decocms.com:43120/fila",
             "https://h1-abc.local.studio.decocms.com:61234/products",
             "about:blank",
         ] {
             assert!(
-                is_allowed_webview_navigation(&allowed.parse().unwrap(), control, preview_port),
+                is_allowed_webview_navigation(
+                    &allowed.parse().unwrap(),
+                    control,
+                    preview_port,
+                    &preview_origins
+                ),
                 "{allowed} should be allowed"
             );
         }
@@ -446,10 +473,49 @@ mod tests {
             "http://evil.localhost:61234/",
         ] {
             assert!(
-                !is_allowed_webview_navigation(&blocked.parse().unwrap(), control, preview_port),
+                !is_allowed_webview_navigation(
+                    &blocked.parse().unwrap(),
+                    control,
+                    preview_port,
+                    &preview_origins
+                ),
                 "{blocked} should be blocked"
             );
         }
+    }
+
+    #[test]
+    fn webview_navigation_allows_a_registered_preview_origin_but_nothing_else_external() {
+        let control = "https://local.studio.decocms.com:43120";
+        let preview_port = 61_234;
+        let preview_origins = PreviewOriginState::default();
+        let registered: tauri::Url = "https://fila.vtex.app/?__draft=abc".parse().unwrap();
+        let unregistered: tauri::Url = "https://evil.example.com/".parse().unwrap();
+
+        assert!(
+            !is_allowed_webview_navigation(&registered, control, preview_port, &preview_origins),
+            "must stay blocked before registration"
+        );
+
+        preview_origins.register(registered.origin().ascii_serialization());
+
+        assert!(
+            is_allowed_webview_navigation(&registered, control, preview_port, &preview_origins),
+            "registered origin must be allowed, including a different path/query on it"
+        );
+        assert!(
+            is_allowed_webview_navigation(
+                &"https://fila.vtex.app/other-page".parse().unwrap(),
+                control,
+                preview_port,
+                &preview_origins
+            ),
+            "same origin, different path, must also be allowed"
+        );
+        assert!(
+            !is_allowed_webview_navigation(&unregistered, control, preview_port, &preview_origins),
+            "an unrelated external origin must still be blocked"
+        );
     }
 
     #[test]

--- a/apps/native/src-tauri/src/state.rs
+++ b/apps/native/src-tauri/src/state.rs
@@ -1,12 +1,14 @@
-//! Managed Tauri state: the running local-api server handle. Registered
-//! via `app.manage(..)` in `setup.rs` and read by `commands.rs`.
+//! Managed Tauri state: the running local-api server handle, and the
+//! dynamic preview-origin allowlist. Registered via `app.manage(..)` in
+//! `setup.rs` and read by `commands.rs`.
 //!
 //! There is no `AuthState` here — `auth_status`/`auth_login`/
 //! `auth_logout` call `upstream::global()` directly (see `auth.rs`'s
 //! module doc); that crate's own process-wide singleton IS its Tauri
 //! integration seam, so no local wrapper is needed.
 
-use std::sync::{Arc, Mutex};
+use std::collections::HashSet;
+use std::sync::{Arc, Mutex, PoisonError};
 
 /// Wraps the local-api [`local_api::ServerHandle`] so it can be `app.manage()`d.
 /// `Option` because [`LocalApiState::take`] removes it exactly once, on
@@ -49,5 +51,39 @@ impl LocalApiState {
     /// return `None`.
     pub fn take(&self) -> Option<local_api::ServerHandle> {
         self.0.lock().ok().and_then(|mut guard| guard.take())
+    }
+}
+
+/// Origins the FRONTEND has told us it's about to legitimately embed as a
+/// preview iframe (e.g. a customer's live storefront domain), checked by
+/// `setup::is_allowed_webview_navigation` alongside its fixed allowlist.
+///
+/// Exists because Tauri's `on_navigation` hook fires for iframe navigations
+/// exactly the same as top-level ones (no way to tell them apart from the
+/// URL alone — see `setup.rs`'s doc comment on that closure), and the set of
+/// legitimate external preview domains is unbounded (any org's own site),
+/// so a static allowlist can't cover it. The frontend already knows exactly
+/// which origin it's about to preview — see
+/// `apps/web/src/lib/desktop/tauri-bridge.ts`'s `registerPreviewOrigin`.
+///
+/// Session-scoped only: never persisted, cleared on app restart. No
+/// eviction — cardinality is bounded by the distinct preview domains a user
+/// visits in one session, which stays small.
+#[derive(Default, Clone)]
+pub struct PreviewOriginState(Arc<Mutex<HashSet<String>>>);
+
+impl PreviewOriginState {
+    pub fn register(&self, origin: String) {
+        self.0
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .insert(origin);
+    }
+
+    pub fn contains(&self, origin: &str) -> bool {
+        self.0
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .contains(origin)
     }
 }

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -90,7 +90,10 @@ import { useCreatePage } from "@/components/sections-editor/use-create-page";
 import { CreatePageModal } from "@/components/sections-editor/create-page-modal";
 import { toast } from "sonner";
 import { useIsDesktopApp } from "@/hooks/use-is-desktop-app";
-import { openExternalUrlInSystemBrowser } from "@/lib/desktop/tauri-bridge";
+import {
+  openExternalUrlInSystemBrowser,
+  registerPreviewOrigin,
+} from "@/lib/desktop/tauri-bridge";
 import {
   VISUAL_EDITOR_SCRIPT,
   VisualEditorPayloadSchema,
@@ -260,6 +263,12 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   >(null);
   const previewIframeRef = useRef<HTMLIFrameElement>(null);
   const blocksPanelRef = useRef<PanelImperativeHandle>(null);
+  /** Origin most recently confirmed registered with the native shell via
+   *  `registerPreviewOrigin` — see the effect below that sets it. `null`
+   *  until the very first desktop-app production-mode registration lands. */
+  const [registeredPreviewOrigin, setRegisteredPreviewOrigin] = useState<
+    string | null
+  >(null);
 
   // Pages dropdown in URL bar
   const [pagesOpen, setPagesOpen] = useState(false);
@@ -536,6 +545,25 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   });
   const previewSurfaceActive = display.mode !== "none";
 
+  // Origin of the "production" mode's base — an external, org-owned domain
+  // (the published site), unlike "sandbox" mode's `iframeBase`, which is
+  // always this app's own local sandbox-preview-proxy origin (already
+  // allowed natively, no registration needed). `null` outside production
+  // mode, or once no `iframeBase` is available yet.
+  const productionOrigin =
+    display.mode === "production" && display.iframeBase
+      ? new URL(display.iframeBase).origin
+      : null;
+  // In the desktop app, an external production origin must be registered
+  // with the native shell's navigation policy BEFORE the iframe below is
+  // allowed to navigate there — see `registerPreviewOrigin`'s doc comment
+  // for why this can't be fire-and-forget. Plain browser tabs have no such
+  // gate, so this is a no-op there.
+  const productionOriginReady =
+    !isDesktopApp ||
+    !productionOrigin ||
+    registeredPreviewOrigin === productionOrigin;
+
   const iframeSrc =
     display.mode === "sandbox"
       ? withVariantMatcherOverride(
@@ -545,7 +573,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
           ),
           workspace.state.variantOverride ?? [],
         )
-      : display.mode === "production"
+      : display.mode === "production" && productionOriginReady
         ? // The published site is the base for both modes while the sandbox
           // provisions; Fast Preview swaps in the same page carrying a
           // `?__draft=` pointer the moment one exists. Same origin either way,
@@ -555,6 +583,29 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
             previewDeviceSize,
           )
         : null;
+
+  // Registers `productionOrigin` with the native shell before the iframe
+  // above is allowed to navigate there (see `productionOriginReady`).
+  // oxlint-disable-next-line ban-use-effect/ban-use-effect -- imperative native-shell IPC gate before cross-origin iframe navigation, mirrors the draft-URL effect just below
+  useEffect(() => {
+    if (!isDesktopApp || !productionOrigin) return;
+    if (registeredPreviewOrigin === productionOrigin) return;
+    let cancelled = false;
+    registerPreviewOrigin(productionOrigin)
+      .then(() => {
+        if (!cancelled) setRegisteredPreviewOrigin(productionOrigin);
+      })
+      .catch((error) => {
+        console.error(
+          "Failed to register preview origin",
+          productionOrigin,
+          error,
+        );
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isDesktopApp, productionOrigin, registeredPreviewOrigin]);
 
   // "Open outside the preview pane". In a browser that's a new tab; inside the
   // Tauri webview there is no tab strip to open into, so `window.open` cannot

--- a/apps/web/src/lib/desktop/tauri-bridge.ts
+++ b/apps/web/src/lib/desktop/tauri-bridge.ts
@@ -144,6 +144,24 @@ export async function performAuthCompleteSession(): Promise<void> {
 }
 
 /**
+ * `invoke('register_preview_origin')` — tells the native shell's navigation
+ * policy that `origin` (scheme+host+port; path/query are ignored server-side)
+ * is a currently-legitimate preview iframe target, e.g. an org's own live
+ * storefront domain. Required before setting a preview iframe's `src` to
+ * anything outside the app's own control/sandbox-proxy origins: Tauri's
+ * `on_navigation` hook (`apps/native/src-tauri/src/setup.rs`) fires for
+ * iframe navigations exactly like top-level ones and denies anything not on
+ * its allowlist, and WKWebView fires neither `load` nor `error` for a denied
+ * navigation — so this MUST be awaited before the iframe's `src` is set, or
+ * the very first paint races the registration and the frame stays silently
+ * blank with nothing to trigger a retry.
+ */
+export async function registerPreviewOrigin(origin: string): Promise<void> {
+  assertDesktopEnvironment("register_preview_origin");
+  await invoke<void>("register_preview_origin", { origin });
+}
+
+/**
  * Open an external URL in the operating system's default browser.
  *
  * `window.open` cannot serve the desktop app's "open the preview outside the


### PR DESCRIPTION
## Summary
- The CMS preview pane's `<iframe src="https://<org-live-domain>/...">` (VTEX's live-preview mechanism) rendered permanently blank in the native app while working fine in a browser tab.
- Root cause, confirmed live via the Tauri MCP devtools: Tauri's `on_navigation` hook fires for iframe navigations exactly like top-level window navigations (no way to distinguish them from the URL alone), and the native shell's fixed allowlist only permits the app's own control origin + the local sandbox-preview-proxy origin. WKWebView cancels a denied navigation without firing `load` or `error`, so the frame just stays blank with no recovery signal.
- Fix: the frontend now tells the Rust backend, via a new `register_preview_origin` Tauri command, which external origin it's about to legitimately preview — **awaited** before the iframe's `src` is set (a fire-and-forget call would race the first navigation attempt). Rust checks a small session-scoped dynamic allowlist alongside the existing fixed origins. Pure cross-platform logic, no unsafe/platform-specific code, so it carries over to Windows/Linux for free once those backends exist.
- New Tauri commands need two things beyond `generate_handler!` or they silently fail at invoke time ("not allowed. Command not found"): an entry in `build.rs`'s own `COMMANDS` list (drives the auto-generated permission stub) and an explicit `allow-<command>` grant in `capabilities/default.json`.

Note: this branch previously also carried the git clone/worktree simplification work from PR #5763, which was merged separately (squash) while this iframe fix was still in progress — this PR is rebased cleanly on top of that merge and contains only the iframe-navigation fix.

## Test plan
- [x] `cargo test -p local-api --lib` — 803 passed
- [x] `cargo test -p deco --lib` — 32 passed, including two new tests (`webview_navigation_allows_a_registered_preview_origin_but_nothing_else_external`, `normalize_preview_origin_*`)
- [x] `cargo clippy` / `cargo fmt --check` — clean
- [x] `bun run --cwd=apps/web check` (tsc) / `bun run lint` (oxlint) / `bun run fmt:check` — clean
- [x] Verified live against the running dev build via the Tauri MCP devtools:
  - a fresh iframe to a *registered* origin now fires `load`
  - a fresh iframe to a *never-registered* external origin still fires neither `load` nor `error` (denied, as intended)
  - top-level window navigation to an unregistered origin is still denied (main-window protection unregressed)
  - invalid (non-http/https) origins are rejected by the command

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a blank preview iframe in the native app by introducing a dynamic origin allowlist and a new `register_preview_origin` Tauri command. The web app now registers the external preview origin and waits before navigating so legitimate previews load while main-window protections stay intact.

- **Bug Fixes**
  - Added `register_preview_origin` command and permissions; wired in `build.rs` and `capabilities/default.json`.
  - Introduced session-scoped `PreviewOriginState`; `on_navigation` now allows registered origins alongside control and sandbox origins.
  - Web app awaits `registerPreviewOrigin(origin)` before setting production preview iframe `src` (desktop only).
  - Normalizes and validates origins (http/https; origin-only, no path/query).
  - Unregistered external origins and top-level navigations remain blocked; tests cover policy and normalization.

<sup>Written for commit a30a4d132fce5bdbe254424829063194ec37aa5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

