### PR TITLE
feat(task-board): re-run a whole selection, not one card at a time

### DIFF
--- a/apps/web/src/i18n/en/task-board.ts
+++ b/apps/web/src/i18n/en/task-board.ts
@@ -183,6 +183,9 @@ export const taskBoard = {
     "The Super Agent will start a fresh run on this task.",
   "taskBoard.rerun.descriptionTakeover":
     "The Super Agent will start a fresh run on this task. A run is still open on it — that one will be stopped.",
+  "taskBoard.rerun.titleMany": "Re-run {count} tasks?",
+  "taskBoard.rerun.descriptionMany":
+    "The Super Agent will start a fresh run on each of the {count} selected tasks. Any run still open on them will be stopped.",
   "taskBoard.rerun.cancel": "Cancel",
   "taskBoard.rerun.confirm": "Re-run",
   "taskBoard.subscriptionPaywall.trialTitle": "Subscribe to keep auto-fixing",

--- a/apps/web/src/i18n/pt-br/task-board.ts
+++ b/apps/web/src/i18n/pt-br/task-board.ts
@@ -190,6 +190,9 @@ export const taskBoard = {
     "O Super Agent vai iniciar uma nova execução nesta tarefa.",
   "taskBoard.rerun.descriptionTakeover":
     "O Super Agent vai iniciar uma nova execução nesta tarefa. Ainda há uma execução aberta nela — essa será interrompida.",
+  "taskBoard.rerun.titleMany": "Executar {count} tarefas de novo?",
+  "taskBoard.rerun.descriptionMany":
+    "O Super Agent vai iniciar uma nova execução em cada uma das {count} tarefas selecionadas. Qualquer execução ainda aberta nelas será interrompida.",
   "taskBoard.rerun.cancel": "Cancelar",
   "taskBoard.rerun.confirm": "Executar de novo",
   "taskBoard.subscriptionPaywall.trialTitle":

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -351,24 +351,24 @@ export function TaskBoardPage() {
   };
   // The task awaiting a re-run confirmation, or null. A re-run supersedes the
   // task's live run, so it is confirmed rather than fired on click.
-  const [rerunTarget, setRerunTarget] = useState<TaskBoardItem | null>(null);
+  // One entry for a card's own Re-run, many for a selection.
+  const [rerunTargets, setRerunTargets] = useState<TaskBoardItem[]>([]);
   const confirmRerun = () => {
-    if (!rerunTarget) return;
+    if (rerunTargets.length === 0) return;
     // Same GitHub precondition as delegating: the run is expected to open a PR.
     if (blockSuperAgentWithoutGithub(SUPER_AGENT_ASSIGNEE_ID)) {
-      setRerunTarget(null);
+      setRerunTargets([]);
       return;
     }
-    actions.rerun.mutate(
-      { id: rerunTarget.id },
-      {
-        onError: (err) => {
-          onDelegateError(err as Error);
-          setRerunTarget(null);
-        },
-        onSuccess: () => setRerunTarget(null),
-      },
-    );
+    // ponytail: fire-and-forget per task, like every other bulk action here —
+    // the board reconciles from the invalidation each one triggers.
+    for (const target of rerunTargets)
+      actions.rerun.mutate(
+        { id: target.id },
+        { onError: (err) => onDelegateError(err as Error) },
+      );
+    setRerunTargets([]);
+    clearSelection();
   };
   const { data: membersData } = useMembers();
   const members = (membersData?.data?.members ?? []) as Member[];
@@ -659,7 +659,7 @@ export function TaskBoardPage() {
               { onError: onDelegateError },
             );
           }}
-          onRerun={setRerunTarget}
+          onRerun={(item) => setRerunTargets([item])}
         />
       ) : (
         <div className="min-h-0 flex-1 overflow-y-auto px-4 pt-6 pb-16 sm:px-8">
@@ -755,7 +755,7 @@ export function TaskBoardPage() {
                 // the card path does the same, so the takeover warning has one
                 // home. Closing the task dialog first keeps them unstacked.
                 closeDialog();
-                setRerunTarget(activeItem);
+                setRerunTargets([activeItem]);
               }
             : undefined
         }
@@ -785,9 +785,9 @@ export function TaskBoardPage() {
       />
 
       <RerunDialog
-        item={rerunTarget}
+        items={rerunTargets}
         pending={actions.rerun.isPending}
-        onOpenChange={(open) => !open && setRerunTarget(null)}
+        onOpenChange={(open) => !open && setRerunTargets([])}
         onConfirm={confirmRerun}
       />
 
@@ -850,6 +850,25 @@ export function TaskBoardPage() {
                   clearSelection();
                 }
               : undefined
+          }
+          onRerun={
+            // Same eligibility as a card's own Re-run button: delegated to the
+            // Super Agent and not Done. Offered only when every selected card
+            // qualifies, so the action never silently skips part of a selection.
+            (() => {
+              const targets = Array.from(selectedIds).flatMap((id) => {
+                const item = items.find((i) => i.id === id);
+                return item ? [item] : [];
+              });
+              return targets.length === selectedIds.size &&
+                targets.every(
+                  (item) =>
+                    item.assigneeId === SUPER_AGENT_ASSIGNEE_ID &&
+                    item.status !== "done",
+                )
+                ? () => setRerunTargets(targets)
+                : undefined;
+            })()
           }
           onDelete={() => {
             actions.removeMany.mutate(Array.from(selectedIds));
@@ -935,6 +954,7 @@ function SelectionBar({
   onAssign,
   onSetDueDate,
   onAutoFix,
+  onRerun,
   onDelete,
   onClear,
 }: {
@@ -948,6 +968,9 @@ function SelectionBar({
   /** Bulk-assign to the Super Agent — only offered when every selected card
    *  is still in Backlog/To Do (see `TaskBoardPage`). */
   onAutoFix?: () => void;
+  /** Bulk re-run — only offered when every selected card is a Super Agent card
+   *  that isn't Done (see `TaskBoardPage`). */
+  onRerun?: () => void;
   onDelete: () => void;
   onClear: () => void;
 }) {
@@ -1062,6 +1085,17 @@ function SelectionBar({
           >
             <Lightning01 size={14} />
             {t("taskBoard.taskBoard.autoFix")}
+          </button>
+        )}
+
+        {onRerun && (
+          <button
+            type="button"
+            onClick={onRerun}
+            className="flex items-center gap-1.5 rounded-full border border-border px-3 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-accent"
+          >
+            <RefreshCw01 size={14} />
+            {t("taskBoard.taskBoard.rerun")}
           </button>
         )}
 

--- a/apps/web/src/layouts/task-board/rerun-dialog.tsx
+++ b/apps/web/src/layouts/task-board/rerun-dialog.tsx
@@ -38,28 +38,37 @@ export function hasUnfinishedRun(item: TaskBoardItem): boolean {
 }
 
 export function RerunDialog({
-  item,
+  items,
   pending,
   onOpenChange,
   onConfirm,
 }: {
-  /** The task to re-run, or null when the dialog is closed. */
-  item: TaskBoardItem | null;
+  /** The tasks to re-run; empty when the dialog is closed. One card or a whole
+   *  selection — the only difference is the copy. */
+  items: TaskBoardItem[];
   pending?: boolean;
   onOpenChange: (open: boolean) => void;
   onConfirm: () => void;
 }) {
   const t = useT();
+  const count = items.length;
+  const takeover = items.some(hasUnfinishedRun);
 
   return (
-    <Dialog open={item !== null} onOpenChange={onOpenChange}>
+    <Dialog open={count > 0} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-md">
         <DialogHeader>
-          <DialogTitle>{t("taskBoard.rerun.title")}</DialogTitle>
+          <DialogTitle>
+            {count > 1
+              ? t("taskBoard.rerun.titleMany", { count })
+              : t("taskBoard.rerun.title")}
+          </DialogTitle>
           <DialogDescription>
-            {item && hasUnfinishedRun(item)
-              ? t("taskBoard.rerun.descriptionTakeover")
-              : t("taskBoard.rerun.description")}
+            {count > 1
+              ? t("taskBoard.rerun.descriptionMany", { count })
+              : takeover
+                ? t("taskBoard.rerun.descriptionTakeover")
+                : t("taskBoard.rerun.description")}
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>


### PR DESCRIPTION
#5768 gave every Super-Agent card a Re-run, but only one at a time. The board
that needs it (demo-storefront: 63 items, all delegated, 46 parked) is exactly
the one where clicking 46 cards is not a recovery path.

Re-run now sits in the selection bar next to Auto-fix, gated on the same
predicate as the card button — delegated to the Super Agent and not Done —
required of *every* selected card, so the action never silently skips part of a
selection. `RerunDialog` takes a list instead of one item (one card passes a
single-element array), with plural copy and the takeover warning stated
unconditionally for a selection, since the board cannot tell a streaming run
from a wedged one for any of them.

Confirm fires TASK_BOARD_ITEM_RERUN per id, the same fire-and-forget shape as
the bar's other bulk actions, and clears the selection. No bulk tool variant:
one error surfaces (paywall/quota) rather than one per item — worth revisiting
if N grows.

## Testing
- `bun run --cwd=apps/web check` clean
- `bun test apps/web/src/layouts/task-board/` — 48 pass (the 4 failures are an untracked local `ci-fix/` copy dir, unrelated)
- `bun run fmt`, `bun run lint` — 0 errors

Existing `hasUnfinishedRun` unit test still covers the takeover predicate; the bulk gate is the same expression as the card's `showRerun`.

## Follow-ups
- A bulk `TASK_BOARD_ITEM_RERUN` variant + per-item error surfacing, if N gets large enough that N round-trips or a swallowed mid-batch quota error bites.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add bulk Re-run to the task board so you can re-run a whole selection of Super Agent tasks at once. This speeds up recovery on large boards and avoids clicking each card.

- New Features
  - Added Re-run to the selection bar next to Auto-fix. Shown only when all selected cards are delegated to the Super Agent and not Done, so nothing is skipped.
  - Updated `RerunDialog` to accept multiple items with plural copy; for multi-select, it warns that any open runs will be stopped.
  - Confirm triggers `TASK_BOARD_ITEM_RERUN` for each selected id and then clears the selection; errors surface once, consistent with other bulk actions.

<sup>Written for commit 4294a76a40802f62aef3393b8c52b9f6725d7868. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

