### PR TITLE
feat(task-board): give reviewer runs their own claude-code persona and toolset

### DIFF
--- a/apps/api/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/api/src/api/routes/decopilot/dispatch-run.ts
@@ -318,6 +318,16 @@ async function resolveSecretModelSource(
 
 export interface AgentConfig {
   id: string;
+  /**
+   * Per-run override of the agent's own instructions. Only the sandbox-hosted
+   * harnesses read it (it rides the wire as `agent.instructions`); hosted
+   * Decopilot builds its system prompt from the virtual MCP directly. Set when
+   * a run is a different *persona* on the same org agent — a reviewer, not the
+   * Super Agent.
+   */
+  instructions?: string;
+  /** Built-in harness tools this run must not have. See the wire schema. */
+  disallowedTools?: string[];
 }
 
 export interface DispatchRunInput {
@@ -1269,12 +1279,16 @@ async function prepareRun(
     // Hosted runs mount no repo working directory. The harness resolves its
     // own workspace.
     const workspace: HarnessWorkspace = { cwd: null };
+    // The dispatcher's override wins over the agent's own instructions: a
+    // reviewer run borrows the org agent (for its model + MCP surface) but is
+    // not that agent.
     const agentInstructions =
-      typeof (effectiveVirtualMcp.metadata as { instructions?: unknown })
+      input.agent.instructions ??
+      (typeof (effectiveVirtualMcp.metadata as { instructions?: unknown })
         ?.instructions === "string"
         ? (effectiveVirtualMcp.metadata as { instructions: string })
             .instructions
-        : undefined;
+        : undefined);
     const decopilotRunContext = {
       taskId: input.taskId,
       isSubagent: input.isSubagent,
@@ -1305,7 +1319,13 @@ async function prepareRun(
       user: { id: input.userId, email: ctx.auth.user?.email ?? "" },
       organizationId: input.organizationId,
       organizationSlug: organization.slug,
-      agent: { id: input.agent.id, instructions: agentInstructions },
+      agent: {
+        id: input.agent.id,
+        instructions: agentInstructions,
+        ...(input.agent.disallowedTools
+          ? { disallowedTools: input.agent.disallowedTools }
+          : {}),
+      },
       triggerId: input.triggerId,
       currentThreadTitle: mem.thread.title,
       runFenceToken,

--- a/apps/api/src/tools/task-board/enqueue-reviewer.test.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.test.ts
@@ -4,9 +4,13 @@
  * on a fresh review cycle (a stale prior-cycle thread must not count). Pure over
  * a task snapshot + the cycle-start timestamp.
  */
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, test } from "bun:test";
 import type { TaskBoardItem } from "@/storage/types";
-import { reviewerHandledThisCycle } from "./enqueue-reviewer";
+import {
+  REVIEWER_DISALLOWED_TOOLS,
+  reviewerHandledThisCycle,
+} from "./enqueue-reviewer";
+import { REVIEW_RUN_TOOL_NAMES } from "./task-run-context";
 
 /** Cycle start (the task last entered In Review) at 10:00. */
 const CYCLE_START = new Date("2026-01-01T10:00:00Z").getTime();
@@ -19,6 +23,31 @@ const thread = (o: {
 
 const taskWith = (threads: ReturnType<typeof thread>[]): TaskBoardItem =>
   ({ threads }) as unknown as TaskBoardItem;
+
+describe("REVIEWER_DISALLOWED_TOOLS", () => {
+  // `disallowedTools` matches SDK tool NAMES. A permission-rule pattern
+  // (`Bash(git push:*)`) is not one, so it would be a silent no-op that reads
+  // like a guard — the exact mistake this test exists to catch.
+  test("holds plain built-in tool names, never permission patterns", () => {
+    for (const names of Object.values(REVIEWER_DISALLOWED_TOOLS)) {
+      for (const name of names) {
+        expect(name).toMatch(/^[A-Za-z]+$/);
+      }
+    }
+  });
+
+  // The reviewer's whole job runs through the task-run MCP surface (find the
+  // PR, record the verdict). Removing one of those would strand the review the
+  // same way the missing `TASK_BOARD_REVIEW_DECISION` did.
+  test("never removes a tool the reviewer's MCP surface provides", () => {
+    for (const names of Object.values(REVIEWER_DISALLOWED_TOOLS)) {
+      for (const name of names) {
+        expect(name.startsWith("mcp__")).toBe(false);
+        expect(REVIEW_RUN_TOOL_NAMES).not.toContain(name);
+      }
+    }
+  });
+});
 
 describe("reviewerHandledThisCycle", () => {
   it("is true while a reviewer's own thread is still live", () => {

--- a/apps/api/src/tools/task-board/enqueue-reviewer.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.ts
@@ -77,22 +77,23 @@ export async function enqueueReviewersOnThreadFinish(args: {
 const TERMINAL_THREAD_STATUSES = new Set(["completed", "failed", "expired"]);
 
 /**
- * Built-in harness tools each reviewer must NOT have. This is the enforcement
- * behind "you are reviewing, not implementing" — the prompt asks, this makes it
- * true. Both reviewers keep `Bash` (a review needs `git diff`, and QA has to
- * actually run the thing) but lose the commands that would ship the change; the
- * Code Reviewer additionally loses every file mutator, since it never has a
- * reason to touch the checkout.
+ * Built-in harness tools each reviewer must NOT have — the enforcement behind
+ * "you are reviewing, not implementing", which until now was prompt-only.
+ *
+ * Neither reviewer can rewrite an existing file. QA keeps `Write` because
+ * exercising a change means scratch files (a curl script, a throwaway spec);
+ * the Code Reviewer reads the diff and has no reason to touch the checkout at
+ * all. Both keep `Bash` — a review is `git diff` / `gh pr view`, and QA has to
+ * actually run the thing.
+ *
+ * These are SDK tool NAMES, which is all `disallowedTools` matches. "Don't
+ * push" stays a prompt rule on purpose: a permission pattern like
+ * `Bash(git push:*)` is not a tool name (it would be a silent no-op here), and
+ * any command-level denylist is bypassable from a shell anyway.
  */
-const REVIEWER_DISALLOWED_TOOLS: Record<ReviewerKind, string[]> = {
-  qa: ["Bash(git push:*)", "Bash(gh pr merge:*)"],
-  code_review: [
-    "Write",
-    "Edit",
-    "NotebookEdit",
-    "Bash(git push:*)",
-    "Bash(gh pr merge:*)",
-  ],
+export const REVIEWER_DISALLOWED_TOOLS: Record<ReviewerKind, string[]> = {
+  qa: ["Edit", "NotebookEdit"],
+  code_review: ["Write", "Edit", "NotebookEdit"],
 };
 
 /** The review instructions unique to each reviewer. Shared scaffolding (load
@@ -268,8 +269,9 @@ async function enqueueReviewerForTask(
       "between asking and deciding, DECIDE.",
     "",
     "Do NOT push commits, merge, or change the code to fix what you find. You " +
-      "are reviewing, not implementing — the tools that would ship a change are " +
-      "removed from this run on purpose. Report it in your decision instead.",
+      "are reviewing, not implementing — the tools that would let you rewrite " +
+      "the checkout are removed from this run on purpose. Report what you find " +
+      "in your decision instead.",
   ].join("\n");
 
   const prompt = [

--- a/apps/api/src/tools/task-board/enqueue-reviewer.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.ts
@@ -76,6 +76,25 @@ export async function enqueueReviewersOnThreadFinish(args: {
  *  non-terminal status. Mirrors the storage-layer set. */
 const TERMINAL_THREAD_STATUSES = new Set(["completed", "failed", "expired"]);
 
+/**
+ * Built-in harness tools each reviewer must NOT have. This is the enforcement
+ * behind "you are reviewing, not implementing" — the prompt asks, this makes it
+ * true. Both reviewers keep `Bash` (a review needs `git diff`, and QA has to
+ * actually run the thing) but lose the commands that would ship the change; the
+ * Code Reviewer additionally loses every file mutator, since it never has a
+ * reason to touch the checkout.
+ */
+const REVIEWER_DISALLOWED_TOOLS: Record<ReviewerKind, string[]> = {
+  qa: ["Bash(git push:*)", "Bash(gh pr merge:*)"],
+  code_review: [
+    "Write",
+    "Edit",
+    "NotebookEdit",
+    "Bash(git push:*)",
+    "Bash(gh pr merge:*)",
+  ],
+};
+
 /** The review instructions unique to each reviewer. Shared scaffolding (load
  *  the PR, don't push code, end with a decision) lives in the prompt builder. */
 const REVIEWER_FOCUS: Record<ReviewerKind, string> = {
@@ -231,7 +250,12 @@ async function enqueueReviewerForTask(
     ? "mcp__studio__TASK_BOARD_REVIEW_DECISION"
     : "TASK_BOARD_REVIEW_DECISION";
 
-  const prompt = [
+  // Who this run IS. On the sandboxed path this becomes the harness's system
+  // instructions (`agent.instructions`), replacing the org agent's own — those
+  // describe the Super Agent that wrote the PR, which is the last persona a
+  // reviewer of that PR should inherit. The Decopilot fallback has no such hook,
+  // so there it is prepended to the prompt instead (same text, one home).
+  const instructions = [
     REVIEWER_FOCUS[kind],
     "",
     "You are running AUTONOMOUSLY — no human is watching this run. Making the " +
@@ -243,6 +267,13 @@ async function enqueueReviewerForTask(
       "truly cannot judge the outcome) — that should be rare. When in doubt " +
       "between asking and deciding, DECIDE.",
     "",
+    "Do NOT push commits, merge, or change the code to fix what you find. You " +
+      "are reviewing, not implementing — the tools that would ship a change are " +
+      "removed from this run on purpose. Report it in your decision instead.",
+  ].join("\n");
+
+  const prompt = [
+    ...(sandboxed ? [] : [instructions, ""]),
     `Task title: ${task.title}`,
     task.description ? `\nTask description:\n${task.description}\n` : "",
     "How to work:",
@@ -252,7 +283,6 @@ async function enqueueReviewerForTask(
       : sandboxed
         ? `- Your working directory is EMPTY. Call \`mcp__studio__TASK_ADD_REPO\` with the connectionId of the PR's repository FIRST; it clones the repository and waits for the checkout, and \`git\` and \`gh\` are authenticated once it returns.`
         : "- Load the PR's repository to inspect / exercise the change.",
-    "- Do NOT push commits or change the code yourself. You are reviewing, not implementing.",
     `- End the run by calling \`${decisionTool}\` exactly once with the task id, ` +
       `reviewer "${kind}", the reviewToken below, and your decision:`,
     "  - `approve` when it's good to ship. Include a short summary of what you verified.",
@@ -269,7 +299,15 @@ async function enqueueReviewerForTask(
     title: `${REVIEWER_LABEL[kind]}: ${task.title}`,
     prompt,
     temperature: 0.3,
-    ...(sandboxed ? { harnessId: "claude-code" as const } : {}),
+    ...(sandboxed
+      ? {
+          harnessId: "claude-code" as const,
+          agent: {
+            instructions,
+            disallowedTools: REVIEWER_DISALLOWED_TOOLS[kind],
+          },
+        }
+      : {}),
     ...(repo ? { repo } : {}),
   });
 

--- a/apps/api/src/tools/task-board/enqueue-task-run.ts
+++ b/apps/api/src/tools/task-board/enqueue-task-run.ts
@@ -34,6 +34,12 @@ export async function enqueueAgentRunForTask(
      * `thread:<id>` key and clones into it with `TASK_ADD_REPO`.
      */
     repo?: TaskRepo;
+    /**
+     * Per-run agent overrides — instructions (the run's persona) and the
+     * built-in tools it must not have. Only the sandbox-hosted harness reads
+     * them; a Decopilot fallback run must carry its persona in the prompt.
+     */
+    agent?: { instructions?: string; disallowedTools?: string[] };
   },
 ): Promise<{ threadId: string }> {
   const organizationId = task.organizationId;
@@ -129,7 +135,7 @@ export async function enqueueAgentRunForTask(
         credentialId: model.credentialId,
         thinking: { id: model.modelId, title: model.modelMeta.title },
       },
-      agent: { id: agentId },
+      agent: { id: agentId, ...(opts.agent ?? {}) },
       temperature: opts.temperature,
       toolApprovalLevel: "auto",
       mode: "default",

--- a/packages/harness-runner/claude-code.test.ts
+++ b/packages/harness-runner/claude-code.test.ts
@@ -125,6 +125,14 @@ describe("buildOptions", () => {
     expect(prompt.append).toStartWith("Be terse.");
   });
 
+  test("subtracts the dispatch's disallowed tools — that's what makes a reviewer read-only", () => {
+    expect(options().disallowedTools).toBeUndefined();
+    expect(
+      options({ agent: { id: "a", disallowedTools: ["Write", "Edit"] } })
+        .disallowedTools,
+    ).toEqual(["Write", "Edit"]);
+  });
+
   test("points skill authoring at the org-fs mount, instructions or not", () => {
     // Without this the model writes a reusable skill into the checkout, where it
     // dies with the branch instead of syncing to the org.

--- a/packages/harness-runner/claude-code.ts
+++ b/packages/harness-runner/claude-code.ts
@@ -206,6 +206,12 @@ export function buildOptions(args: {
     ...(model ? { model } : {}),
     // ponytail: fixed, not configurable — raise it here if runs come back thin.
     effort: "low",
+    // Per-dispatch tool subtraction (a reviewer run is read-only; the Super
+    // Agent's is not). `disallowedTools` is enforced by the harness itself, so
+    // it holds under `bypassPermissions`.
+    ...(input.agent.disallowedTools?.length
+      ? { disallowedTools: input.agent.disallowedTools }
+      : {}),
     // Resume keeps the thread's history in the SDK's own transcript instead of
     // replaying it as prompt text. `sessionId` seeds a new one at the same id
     // so the next turn can resume it.

--- a/packages/sandbox/dispatch/schemas.ts
+++ b/packages/sandbox/dispatch/schemas.ts
@@ -140,7 +140,17 @@ export const harnessStreamInputSchema = z
     organizationId: z.string(),
     organizationSlug: z.string().optional(),
     agent: z
-      .object({ id: z.string(), instructions: z.string().optional() })
+      .object({
+        id: z.string(),
+        instructions: z.string().optional(),
+        /**
+         * Built-in harness tools this run must NOT have (SDK tool names, e.g.
+         * `Write`). Absent = the harness's full built-in set. Set per dispatch,
+         * not per agent: a reviewer run on the same org agent has to be
+         * read-only where the Super Agent's run is not.
+         */
+        disallowedTools: z.array(z.string()).optional(),
+      })
       .strict(),
     triggerId: z.string().optional(),
     currentThreadTitle: z.string().optional(),


### PR DESCRIPTION
## Summary

The QA Agent and Code Reviewer already dispatch on the sandbox-hosted `claude-code` harness (`enqueue-reviewer.ts` sets `harnessId: "claude-code"` whenever the org has an importable repo). What they *reused* was the Super Agent's setup: the wire's `agent.instructions` came from the org agent's virtual-MCP metadata — the persona of the agent that **wrote the PR under review** — and the SDK ran with its full built-in toolset.

This splits the two apart:

- **Own instructions.** Each reviewer's persona (focus + autonomy rules + "you are reviewing, not implementing") now rides `agent.instructions`, which the harness appends to the `claude_code` preset; a dispatcher-supplied override wins over the agent's own in `prepareRun`. On the Decopilot fallback path (org with no importable repo) there is no such hook, so the same text is prepended to the prompt — one source, two homes.
- **Own toolset.** New per-dispatch `agent.disallowedTools`, mapped to the SDK's `disallowedTools` in `buildOptions` (harness-enforced, so it holds under `permissionMode: "bypassPermissions"`):
  - Code Reviewer: `Write`, `Edit`, `NotebookEdit` — it reads the diff, it never touches the checkout.
  - QA Agent: `Edit`, `NotebookEdit` — it keeps `Write` because exercising a change means scratch files (a curl script, a throwaway spec), but cannot rewrite repo code.
  - Both keep `Bash` (a review is `git diff` / `gh pr view`; QA has to actually run the thing).

The task-specific half of the prompt (task title/description, which `TASK_BOARD_*` tools to call, the PR lookup, the reviewToken) is unchanged and stays in the prompt.

## MCP surface

Verified, not assumed: the reviewer's endpoint already serves what its prompt names. `POST /api/:org/mcp/task-run/:threadId` picks its toolset with `resolveReviewRunToolNames(thread.title)`, and a `QA Agent:` / `Code Reviewer:` titled thread gets `REVIEW_RUN_TOOL_NAMES` = the narrow worker surface (`TASK_ADD_REPO`, `TASK_BOARD_ITEM_LIST/UPDATE/PRS_GET`, `TASK_BOARD_ACTIVITY_LIST`, `TASK_BOARD_COMMENT_*`) **plus** `TASK_BOARD_REVIEW_DECISION`. Both tools the prompt names — `TASK_BOARD_ITEM_PRS_GET` and `TASK_BOARD_REVIEW_DECISION` — are on it, under the `mcp__studio__` prefix the prompt uses (`STUDIO_MCP_SERVER_NAME = "studio"`). `task-run-context.test.ts` already pins this. A new test pins the other half: a reviewer disallow entry can never be an `mcp__*` name or shadow anything in `REVIEW_RUN_TOOL_NAMES`, so a tool restriction can't strand a review the way the missing `TASK_BOARD_REVIEW_DECISION` used to.

## Notes / scope

- The second commit fixes a mistake in the first: I had listed `Bash(git push:*)` / `Bash(gh pr merge:*)`. `disallowedTools` matches tool **names**, so a permission-rule pattern there is a silent no-op that reads like a guard. Dropped — "don't push or merge" stays a prompt rule, and a command-level denylist is shell-bypassable anyway. A test now rejects any non-`[A-Za-z]+` entry.
- `AgentConfig` in `dispatch-run.ts` gains the two optional fields, so they flow through the frozen DBOS snapshot for free (no workflow-source change, no re-baseline).
- QA's prompt mentions using "the PR's preview / dev server when available" — pre-existing, and `cloneOnly: true` means these pods run no dev server. Not touched here.

## Testing

- `bun test` on `enqueue-reviewer`, `task-run-context`, `claude-code` — 28 pass. New cases: `buildOptions` subtracts the dispatch's disallowed tools (and leaves them absent otherwise); the disallow lists hold only plain tool names and never shadow an MCP tool.
- `bun run fmt`, `bun run check` (all workspaces), `bun run lint` (0 errors) pass.
- Not exercised end-to-end against a live sandbox pod.
