### PR TITLE
fix(task-board): make the review hand-off actually happen without a human

### DIFF
--- a/apps/api/migrations/165-task-board-pending-review-index.ts
+++ b/apps/api/migrations/165-task-board-pending-review-index.ts
@@ -1,0 +1,27 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * Index behind the review sweeper's work list
+ * (`TaskBoardStorage.listItemsPendingReview`): every pod runs that query once a
+ * minute, forever, and `task_board_items` only had an `organization_id` index —
+ * so it was a full scan of the table, cross-org, on a timer.
+ *
+ * Partial on the sweeper's exact predicate (Super Agent, In Review, not
+ * dismissed) so the index stays tiny — it holds only the cards currently parked
+ * — and ordered by the keyset cursor `(updated_at, id)` so the paged scan reads
+ * straight off it.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  // Raw SQL: Kysely's index builder has no partial-index predicate.
+  await sql`
+    CREATE INDEX idx_task_board_items_pending_review
+      ON task_board_items (updated_at, id)
+      WHERE status = 'in_review'
+        AND assignee_id = 'super-agent'
+        AND dismissed_at IS NULL
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropIndex("idx_task_board_items_pending_review").execute();
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -163,6 +163,7 @@ import * as migration161taskquotaclaimstate from "./161-task-quota-claim-state.t
 import * as migration162claudesubscriptions from "./162-claude-subscriptions.ts";
 import * as migration163taskboarditemdismissed from "./163-task-board-item-dismissed.ts";
 import * as migration164perorgtaskquota from "./164-per-org-task-quota.ts";
+import * as migration165taskboardpendingreviewindex from "./165-task-board-pending-review-index.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -353,6 +354,8 @@ const migrations: Record<string, Migration> = {
   "162-claude-subscriptions": migration162claudesubscriptions,
   "163-task-board-item-dismissed": migration163taskboarditemdismissed,
   "164-per-org-task-quota": migration164perorgtaskquota,
+  "165-task-board-pending-review-index":
+    migration165taskboardpendingreviewindex,
 };
 
 export default migrations;

--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -1505,11 +1505,23 @@ export async function createApp(options: CreateAppOptions = {}) {
   // hands off to the enabled reviewers. It has to be a timer rather than part of
   // the projector hook below, because the dispatch bottoms out in
   // `DBOS.startWorkflow`, which throws from inside a step.
+  //
+  // It dispatches billable reviewer runs for every org on a timer, so
+  // TASK_BOARD_REVIEW_SWEEPER_ENABLED=false stops it without a code change.
   const taskBoardReviewSweeper = new TaskBoardReviewSweeper(
     projectorTaskBoard,
     automationContextFactory,
   );
-  taskBoardReviewSweeper.start();
+  if (getSettings().taskBoardReviewSweeperEnabled) {
+    taskBoardReviewSweeper.start();
+    // Chained onto the decopilot cleanup (assigned above) so an HMR reload or
+    // shutdown doesn't leave a second timer sweeping alongside the new one.
+    const previousCleanup = currentDecopilotCleanup;
+    currentDecopilotCleanup = async () => {
+      await previousCleanup?.();
+      taskBoardReviewSweeper.dispose();
+    };
+  }
   // Quota bookkeeping for the projector's thread-finish reaction: a run that
   // ended without a PR releases its held slot (billing/task-quota.ts).
   const projectorBilling = new OrganizationBillingStorage(database.db);

--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -142,9 +142,9 @@ import { SqlThreadStorage } from "../storage/threads";
 import { OrganizationBillingStorage } from "../storage/organization-billing";
 import { TaskBoardStorage } from "../storage/task-board";
 import { advanceTasksToReviewOnThreadFinish } from "../tools/task-board/run-reactions";
-import { enqueueReviewersOnThreadFinish } from "../tools/task-board/enqueue-reviewer";
 import { SqlAsyncResearchJobStorage } from "../storage/async-research-jobs";
 import { AsyncResearchJobSweeper } from "../storage/async-research-jobs-sweeper";
+import { TaskBoardReviewSweeper } from "../tools/task-board/review-sweeper";
 import { registerMonitoringRetentionWorkflow } from "../monitoring/dbos-retention-workflow";
 import "../auth/install-studio-pack-workflow";
 import { cleanupOldMonitoringFiles } from "../monitoring/ndjson-retention";
@@ -1500,6 +1500,16 @@ export async function createApp(options: CreateAppOptions = {}) {
   // automations/thread-gate: it only sets a module-level pointer.
   const projectorThreadStorage = new SqlThreadStorage(database.db);
   const projectorTaskBoard = new TaskBoardStorage(database.db);
+  // Reconciles Super Agent tasks parked In Review: links the PR a sandboxed
+  // `claude-code` run opened (nothing else does — see review-sweeper.ts) and
+  // hands off to the enabled reviewers. It has to be a timer rather than part of
+  // the projector hook below, because the dispatch bottoms out in
+  // `DBOS.startWorkflow`, which throws from inside a step.
+  const taskBoardReviewSweeper = new TaskBoardReviewSweeper(
+    projectorTaskBoard,
+    automationContextFactory,
+  );
+  taskBoardReviewSweeper.start();
   // Quota bookkeeping for the projector's thread-finish reaction: a run that
   // ended without a PR releases its held slot (billing/task-quota.ts).
   const projectorBilling = new OrganizationBillingStorage(database.db);
@@ -1551,14 +1561,14 @@ export async function createApp(options: CreateAppOptions = {}) {
           orgId,
           projectorBilling,
         );
-        // Headless reviewer trigger: a Super Agent run just finished — enqueue
-        // the enabled reviewers if it left a PR In Review, no UI required.
-        void enqueueReviewersOnThreadFinish({
-          contextFactory: automationContextFactory,
-          taskBoard: projectorTaskBoard,
-          threadId: runId,
-          orgId,
-        });
+        // The headless reviewer trigger used to be called here and could never
+        // work: this callback runs inside a DBOS step, and the dispatch bottoms
+        // out in `enqueueThreadRun` → `DBOS.startWorkflow`, which DBOS rejects
+        // from a step (`DBOSInvalidWorkflowTransitionError`, code 21). The
+        // per-reviewer catch swallowed it into a log line and released the
+        // claim, so it retried and failed forever. `TaskBoardReviewSweeper`
+        // owns it now — a boot-time timer, outside any workflow, where
+        // `startWorkflow` is legal.
       }
       return flipped;
     },
@@ -1585,14 +1595,8 @@ export async function createApp(options: CreateAppOptions = {}) {
           orgId,
           projectorBilling,
         );
-        // Headless reviewer trigger — see completeRunIfNotCompleted above. A
-        // failed run rarely leaves a task In Review (the guard inside no-ops).
-        void enqueueReviewersOnThreadFinish({
-          contextFactory: automationContextFactory,
-          taskBoard: projectorTaskBoard,
-          threadId: runId,
-          orgId,
-        });
+        // No reviewer trigger here either — see completeRunIfNotCompleted above
+        // for why it cannot live in a step. `TaskBoardReviewSweeper` owns it.
       }
       return flipped;
     },

--- a/apps/api/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/api/src/dbos/workflow-source-guard.snapshot.json
@@ -1,7 +1,7 @@
 {
   "auth/install-studio-pack-workflow.ts": "e284b2fd9950d5cc803d66a3b79e86258968b7d9a124cf2746363f8a4f7513a3",
   "automations/dbos-workflow.ts": "dd8535f7577bbd3c0270c60f14f480d4fb42e366666245c3efa77f0ce73a9da2",
-  "dispatch-queue/hosted-harness-workflow.ts": "5a196c0348f238670f2b68297a7fe001128996003567ab87bb6c0c6ba9d38810",
+  "dispatch-queue/hosted-harness-workflow.ts": "aae8038ed00ed1838e7e6fa21c716ef2d6957150d0b822bd2f74df5cc4183f5e",
   "dispatch-queue/thread-gate-workflow.ts": "f0e942d6f3f12dca92e4e793202dd38a3488a0a82c114b26d86967b663a394e9",
   "file-storage/dbos-public-sets-sync.ts": "efd9c4bfd9ae29b13970e6b1072e067f43f151b3530d552efc1b4daf038bea7e",
   "harnesses/decopilot/background-tool-workflow.ts": "9febb699f45b63b418481ed998aee0ec8251c97cb5c409d54d714eb365a08fd0",

--- a/apps/api/src/dispatch-queue/hosted-harness-workflow.test.ts
+++ b/apps/api/src/dispatch-queue/hosted-harness-workflow.test.ts
@@ -6,7 +6,10 @@ import { synthesizedErrorMessageId } from "@/api/routes/decopilot/message-ids";
 import type { WithLastAckSeq } from "@/api/routes/decopilot/ingest-run";
 import { buildRunStatusChunk } from "@/api/routes/decopilot/run-status-stage";
 import type { StudioContext } from "@/core/studio-context";
-import { acquireHostedRunSlot, hostedRunStats } from "./hosted-run-concurrency";
+import {
+  acquireHostedRunSlot,
+  HOSTED_RUN_CAPS,
+} from "./hosted-run-concurrency";
 import {
   buildTerminalErrorChunks,
   hostedChildWorkflowId,
@@ -359,10 +362,13 @@ describe("a run queued at the concurrency cap", () => {
   test("publishes waiting-capacity while parked, and starts the loop only once a slot frees", async () => {
     // Saturate the real gate by holding every slot it has, so the run under
     // test genuinely parks (no env/module games — the cap is read once at
-    // import time).
+    // import time). The IN-PROCESS gate specifically: the fixture carries no
+    // `harnessId`, so the run under test is not sandboxed and spends that
+    // budget. `hostedRunStats().max` is the pod total across both gates and
+    // would over-acquire here.
     const held = await Promise.all(
-      Array.from({ length: hostedRunStats().max }, () =>
-        acquireHostedRunSlot(),
+      Array.from({ length: HOSTED_RUN_CAPS.inProcess }, () =>
+        acquireHostedRunSlot({ harnessId: "decopilot" }),
       ),
     );
     try {

--- a/apps/api/src/dispatch-queue/hosted-harness-workflow.ts
+++ b/apps/api/src/dispatch-queue/hosted-harness-workflow.ts
@@ -230,11 +230,14 @@ export async function runHostedHarness(
   const parkedStatus = new HeartbeatEmitter({
     emit: () => publishWaitingCapacity(rt, input),
   });
-  const releaseSlot = await acquireHostedRunSlot(() => {
-    parked = true;
-    void publishWaitingCapacity(rt, input);
-    parkedStatus.arm();
-  }).finally(() => parkedStatus.stop());
+  const releaseSlot = await acquireHostedRunSlot(
+    { harnessId: request.harnessId },
+    () => {
+      parked = true;
+      void publishWaitingCapacity(rt, input);
+      parkedStatus.arm();
+    },
+  ).finally(() => parkedStatus.stop());
 
   try {
     // Stop, pressed while this run was still queued, cancels this child

--- a/apps/api/src/dispatch-queue/hosted-run-concurrency.ts
+++ b/apps/api/src/dispatch-queue/hosted-run-concurrency.ts
@@ -1,7 +1,18 @@
 /**
- * Process-wide gate on concurrent hosted agent-loop runs.
+ * Process-wide gates on concurrent hosted agent-loop runs — TWO of them, one per
+ * kind of run, because the two cost this process wildly different amounts:
  *
- * Each hosted run (hostedHarnessWorkflow → runHostedHarness → dispatchRunFn)
+ * - **in-process** (hosted Decopilot): a full agent loop right here, ~450MB p90.
+ *   Bounded by `MAX`, sized against the pod's 2Gi memory limit.
+ * - **sandboxed** (`claude-code`): the loop runs in its own pod; this process
+ *   only proxies the stream. Bounded by `SANDBOX_MAX`, which is much higher
+ *   because memory is not the constraint.
+ *
+ * They used to share one gate at the in-process number, so a handful of
+ * sandboxed runs that cost this pod almost nothing could park an entire board's
+ * worth of work behind them.
+ *
+ * Each in-process run (hostedHarnessWorkflow → runHostedHarness → dispatchRunFn)
  * drives a full in-process agent loop — LLM streaming + tool calls, ~300MB
  * working set with multi-hundred-MB JSON.parse spikes. The DBOS queue's
  * per-partition concurrency=1 only serializes ONE thread; nothing bounds how
@@ -29,6 +40,7 @@
 import { createConcurrencyGate } from "@/harnesses/decopilot/built-in-tools/subagent-concurrency";
 import { getSettings } from "@/settings";
 import { meter } from "@/observability";
+import { harnessRunsInSandbox } from "@/harnesses/sandbox-dispatch-client";
 
 // Default 3: prod worker is 768Mi request / 2Gi limit, run working set p90
 // ~450MB — 3×450≈1.35GB stays under the limit, 4-5 would OOM on p90 alone, and
@@ -37,25 +49,45 @@ import { meter } from "@/observability";
 // OOM at any cap≥2; that's recovery's job, not this gate's.
 const MAX = getSettings().decopilotMaxConcurrentHostedRuns;
 
+/**
+ * The cap for a run whose agent loop is NOT in this process.
+ *
+ * A `claude-code` run executes in its own sandbox pod; this process only proxies
+ * its stream, so it never holds the ~450MB working set the number above is sized
+ * against. Both harnesses shared that one gate, which meant three sandboxed runs
+ * — costing this pod almost nothing — could park a whole board's worth of work
+ * behind them. Sizing this off the same memory budget was simply the wrong unit.
+ *
+ * Default 12 rather than unbounded: a proxied run still costs a NATS
+ * subscription, an HTTP stream and its projector, and the sandbox side has its
+ * own pool limits. The two gates are independent, so a burst of sandboxed runs
+ * can no longer starve an in-process Decopilot run (or vice versa).
+ */
+const SANDBOX_MAX = getSettings().sandboxMaxConcurrentHostedRuns;
+
 const gate = createConcurrencyGate(MAX);
+const sandboxGate = createConcurrencyGate(SANDBOX_MAX);
 
 // The gate caps memory, which flattens the CPU/memory signals a plain HPA scales
 // on — so the backlog of PARKED runs is the only thing that reflects saturation.
 // Export it as a gauge so a queue-depth/KEDA trigger can add workers when runs
 // start waiting (parked runs are pinned to this pod; scaling relieves the queue,
 // not the in-flight backlog).
+// Both gates are summed into the existing series so the KEDA trigger and any
+// dashboard keep working unchanged — saturation of either one is still "runs are
+// waiting on this pod", which is what the signal means.
 meter
   .createObservableGauge("hosted_runs.active", {
     description: "Hosted agent-loop runs executing on this pod",
     unit: "{runs}",
   })
-  .addCallback((r) => r.observe(gate.active));
+  .addCallback((r) => r.observe(gate.active + sandboxGate.active));
 meter
   .createObservableGauge("hosted_runs.pending", {
     description: "Hosted agent-loop runs parked waiting for a slot on this pod",
     unit: "{runs}",
   })
-  .addCallback((r) => r.observe(gate.pending));
+  .addCallback((r) => r.observe(gate.pending + sandboxGate.pending));
 
 /**
  * Live gate stats for the `/hosted-run-pending` metrics-api endpoint (KEDA).
@@ -66,7 +98,19 @@ export const hostedRunStats = (): {
   active: number;
   pending: number;
   max: number;
-} => ({ active: gate.active, pending: gate.pending, max: MAX });
+} => ({
+  active: gate.active + sandboxGate.active,
+  pending: gate.pending + sandboxGate.pending,
+  max: MAX + SANDBOX_MAX,
+});
+
+/** The two caps, separately — for diagnostics and for tests that need to
+ *  saturate one specific gate. `hostedRunStats` reports the pod's total
+ *  backlog, which is what the KEDA trigger scales on. */
+export const HOSTED_RUN_CAPS: { inProcess: number; sandboxed: number } = {
+  inProcess: MAX,
+  sandboxed: SANDBOX_MAX,
+};
 
 /**
  * Acquire a run slot. `onPark` fires (synchronously, before the wait) only when
@@ -77,17 +121,23 @@ export const hostedRunStats = (): {
  * `hosted-harness-workflow.ts`'s `runHostedHarness`).
  */
 export const acquireHostedRunSlot = (
+  args: { harnessId: string | null | undefined },
   onPark?: () => void,
 ): Promise<() => void> => {
+  // Which budget this run spends: its own sandbox pod's, or this pod's memory.
+  const sandboxed = harnessRunsInSandbox(args.harnessId);
+  const chosen = sandboxed ? sandboxGate : gate;
+  const max = sandboxed ? SANDBOX_MAX : MAX;
   // Log when a run parks so a saturating pod is visible in prod — the whole
   // point of the cap. (gate exposes active/pending for exactly this.)
-  if (gate.active >= MAX) {
+  if (chosen.active >= max) {
     console.log("[hostedHarness] run parked at concurrency cap", {
-      active: gate.active,
-      pending: gate.pending,
-      max: MAX,
+      active: chosen.active,
+      pending: chosen.pending,
+      max,
+      sandboxed,
     });
     onPark?.();
   }
-  return gate.acquire();
+  return chosen.acquire();
 };

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -351,6 +351,10 @@ export function resolveConfig(
       envVars.DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS,
       3,
     ),
+    taskBoardReviewSweeperEnabled: toBoolWithDefault(
+      envVars.TASK_BOARD_REVIEW_SWEEPER_ENABLED,
+      true,
+    ),
     sandboxMaxConcurrentHostedRuns: toPositiveIntegerOrDefault(
       "SANDBOX_MAX_CONCURRENT_HOSTED_RUNS",
       envVars.SANDBOX_MAX_CONCURRENT_HOSTED_RUNS,

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -351,6 +351,11 @@ export function resolveConfig(
       envVars.DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS,
       3,
     ),
+    sandboxMaxConcurrentHostedRuns: toPositiveIntegerOrDefault(
+      "SANDBOX_MAX_CONCURRENT_HOSTED_RUNS",
+      envVars.SANDBOX_MAX_CONCURRENT_HOSTED_RUNS,
+      12,
+    ),
     // Object Storage (S3-compatible)
     s3Endpoint: envVars.S3_ENDPOINT,
     s3Bucket: envVars.S3_BUCKET,

--- a/apps/api/src/settings/types.ts
+++ b/apps/api/src/settings/types.ts
@@ -122,6 +122,11 @@ export interface Settings {
    *  (DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS). Excess runs park and start as
    *  slots free — see `hosted-run-concurrency.ts`. */
   decopilotMaxConcurrentHostedRuns: number;
+  /** Kill switch for the boot-time task-board review sweeper
+   *  (TASK_BOARD_REVIEW_SWEEPER_ENABLED, default on). It dispatches billable
+   *  reviewer runs for every org on a timer, so it needs one way to stop it that
+   *  doesn't require a code change — see `tools/task-board/review-sweeper.ts`. */
+  taskBoardReviewSweeperEnabled: boolean;
   /** Same, for a run whose agent loop executes in its own SANDBOX pod
    *  (SANDBOX_MAX_CONCURRENT_HOSTED_RUNS). Much higher than the in-process cap
    *  because this pod only proxies the stream — see `hosted-run-concurrency.ts`. */

--- a/apps/api/src/settings/types.ts
+++ b/apps/api/src/settings/types.ts
@@ -122,6 +122,10 @@ export interface Settings {
    *  (DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS). Excess runs park and start as
    *  slots free — see `hosted-run-concurrency.ts`. */
   decopilotMaxConcurrentHostedRuns: number;
+  /** Same, for a run whose agent loop executes in its own SANDBOX pod
+   *  (SANDBOX_MAX_CONCURRENT_HOSTED_RUNS). Much higher than the in-process cap
+   *  because this pod only proxies the stream — see `hosted-run-concurrency.ts`. */
+  sandboxMaxConcurrentHostedRuns: number;
   // Object Storage (S3-compatible)
   s3Endpoint: string | undefined;
   s3Bucket: string | undefined;

--- a/apps/api/src/storage/task-board-advance-review.integration.test.ts
+++ b/apps/api/src/storage/task-board-advance-review.integration.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Real-Postgres coverage for the atomic In Review advance.
+ *
+ * The bug this encodes: the advance was a non-atomic read-then-write, and
+ * `recoverStalledTasks` runs fire-and-forget on EVERY `TASK_BOARD_ITEM_LIST`
+ * over the snapshot that read already loaded. N overlapping board reads each saw
+ * `in_progress` and each wrote — one prod item collected 42 duplicate
+ * `status_changed→in_review` rows, another 27 inside 112 ms.
+ *
+ * The duplicate row was not the damage; the duplicate ACTIVITY was.
+ * `reviewCycleStart` treats the newest `→in_review` stamp as the start of the
+ * current review cycle, so each redundant stamp invalidated every approval
+ * before it — the verified-approval gate stopped seeing a complete set,
+ * auto-merge never fired, and the card sat In Review forever. All 13 prod items
+ * holding an approval were stranded exactly this way.
+ *
+ * Only a real database can prove the fix: the guard is a SQL predicate, and the
+ * concurrency is what makes it necessary, so both are exercised here.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { sql } from "kysely";
+import type { StudioDatabase } from "../database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../database/test-db-pg";
+import { TaskBoardStorage } from "./task-board";
+import { SqlThreadStorage } from "./threads";
+
+const ORG = "org_advance_review";
+const USER = "user_advance_review";
+
+describe("advanceToReviewIfInProgress (real Postgres)", () => {
+  let database: StudioDatabase;
+  let taskBoard: TaskBoardStorage;
+  let threads: SqlThreadStorage;
+
+  /** A card In Progress with one finished, message-carrying run linked. */
+  const cardWithFinishedRun = async (title: string) => {
+    const task = await taskBoard.create({
+      organizationId: ORG,
+      title,
+      status: "in_progress",
+      by: USER,
+    });
+    const thread = await threads.create({
+      organization_id: ORG,
+      title: "Super Agent: run",
+      status: "completed",
+      message_storage_version: 2,
+      created_by: USER,
+    });
+    await taskBoard.linkThread(task.id, thread.id, ORG);
+    // `hasMessages` is what separates a real run from an empty chat, and
+    // `shouldAdvanceToReview` filters on it.
+    await database.db
+      .insertInto("thread_message_parts")
+      .values({
+        id: `${thread.id}:m:0`,
+        seq: 0,
+        org_id: ORG,
+        thread_id: thread.id,
+        run_id: thread.id,
+        message_id: `${thread.id}:m`,
+        role: "user",
+        kind: "text",
+        payload: JSON.stringify({ type: "text", text: "go" }),
+        created_at: new Date().toISOString(),
+      })
+      .execute();
+    return { task, thread };
+  };
+
+  const inReviewStamps = async (taskId: string) => {
+    const rows = await database.db
+      .selectFrom("task_board_activity")
+      .select(["id"])
+      .where("task_board_item_id", "=", taskId)
+      .where("action", "=", "status_changed")
+      .where(sql`data->>'to'`, "=", "in_review")
+      .execute();
+    return rows.length;
+  };
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    await database.db
+      .insertInto("organization")
+      .values({
+        id: ORG,
+        name: ORG,
+        slug: "org-advance-review",
+        createdAt: new Date().toISOString(),
+      })
+      .execute();
+    const now = new Date().toISOString();
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES (${USER}, ${"advance@review.test"}, false, ${USER}, ${now}, ${now})
+    `.execute(database.db);
+    taskBoard = new TaskBoardStorage(database.db);
+    threads = new SqlThreadStorage(database.db);
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  it("advances an in_progress card and returns it", async () => {
+    const { task } = await cardWithFinishedRun("advance me");
+
+    const advanced = await taskBoard.advanceToReviewIfInProgress(
+      task.id,
+      ORG,
+      USER,
+    );
+
+    expect(advanced?.status).toBe("in_review");
+  });
+
+  it("returns null for a card that already left in_progress", async () => {
+    const { task } = await cardWithFinishedRun("already moved");
+    await taskBoard.advanceToReviewIfInProgress(task.id, ORG, USER);
+
+    // Second caller loses — this is the guard that stops the duplicate stamp.
+    expect(
+      await taskBoard.advanceToReviewIfInProgress(task.id, ORG, USER),
+    ).toBeNull();
+  });
+
+  it("is org-scoped — another org cannot advance the card", async () => {
+    const { task } = await cardWithFinishedRun("cross-org");
+
+    expect(
+      await taskBoard.advanceToReviewIfInProgress(task.id, "org_other", USER),
+    ).toBeNull();
+    expect((await taskBoard.getById(task.id, ORG))?.status).toBe("in_progress");
+  });
+
+  // Wiring, NOT a proof of the race: with real DB round-trips these 10 chains
+  // interleave, so most of their reads land after the first write and the OLD
+  // unguarded code passes this too. It's kept because it pins the caller to the
+  // guarded primitive and to one activity row per won flip. The deterministic
+  // proof that the guard works is the two tests above — both fail if the
+  // `where status = 'in_progress'` predicate is removed.
+  it("records exactly ONE in_review stamp across 10 advance passes", async () => {
+    const { task, thread } = await cardWithFinishedRun("stampede");
+
+    await Promise.all(
+      Array.from({ length: 10 }, () =>
+        taskBoard.advanceLinkedTasksToReviewOnThreadFinish(thread.id, ORG),
+      ),
+    );
+
+    expect((await taskBoard.getById(task.id, ORG))?.status).toBe("in_review");
+    // In prod this reached 42 on one card — and every approval older than the
+    // last stamp was invalidated by it.
+    expect(await inReviewStamps(task.id)).toBe(1);
+  });
+
+  it("only one of N concurrent callers is told it won the flip", async () => {
+    const { task } = await cardWithFinishedRun("single winner");
+
+    const results = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        taskBoard.advanceToReviewIfInProgress(task.id, ORG, USER),
+      ),
+    );
+
+    expect(results.filter((r) => r !== null)).toHaveLength(1);
+  });
+});

--- a/apps/api/src/storage/task-board-pending-review.integration.test.ts
+++ b/apps/api/src/storage/task-board-pending-review.integration.test.ts
@@ -162,4 +162,89 @@ describe("listItemsPendingReview (real Postgres)", () => {
   it("honours the batch limit", async () => {
     expect(await taskBoard.listItemsPendingReview(2)).toHaveLength(2);
   });
+
+  // The cursor is what stops a card the sweeper can NEVER rescue (In Review with
+  // no PR — a research task) from permanently occupying a slot in a fixed
+  // window: it is never touched, so it keeps its old `updated_at`, and once
+  // `limit` of them accumulate nothing behind them is ever swept again.
+  describe("keyset cursor", () => {
+    it("pages through the whole backlog without repeating or skipping", async () => {
+      // A fresh org so this test owns the full result set.
+      const org = "org_pending_cursor";
+      await database.db
+        .insertInto("organization")
+        .values({
+          id: org,
+          name: org,
+          slug: "org-pending-cursor",
+          createdAt: new Date().toISOString(),
+        })
+        .execute();
+      const made: string[] = [];
+      for (let i = 0; i < 7; i++) {
+        const item = await card({ org, title: `card ${i}` });
+        await touchedAt(item.id, `2021-01-0${i + 1}T00:00:00.000Z`);
+        made.push(item.id);
+      }
+
+      const seen: string[] = [];
+      let cursor: { updatedAt: string; id: string } | null = null;
+      for (let page = 0; page < 5; page++) {
+        // Annotated because `cursor` is derived from `rows` — without it the
+        // inference is circular.
+        const rows: {
+          id: string;
+          organizationId: string;
+          updatedAt: string;
+        }[] = (await taskBoard.listItemsPendingReview(3, cursor)).filter(
+          (r) => r.organizationId === org,
+        );
+        if (rows.length === 0) break;
+        seen.push(...rows.map((r) => r.id));
+        const last = rows.at(-1)!;
+        cursor = { updatedAt: last.updatedAt, id: last.id };
+      }
+
+      expect(seen).toEqual(made);
+      expect(new Set(seen).size).toBe(made.length);
+    });
+
+    // Same `updated_at` to the millisecond: without the `id` tie-break the
+    // cursor is not total and rows are skipped or repeated forever.
+    it("is total when several cards share an updated_at", async () => {
+      const org = "org_pending_tie";
+      await database.db
+        .insertInto("organization")
+        .values({
+          id: org,
+          name: org,
+          slug: "org-pending-tie",
+          createdAt: new Date().toISOString(),
+        })
+        .execute();
+      // Earlier than every other card this suite made, so the global ordering
+      // puts all four at the front — paging is global (the sweeper has no org),
+      // so filtering by org AFTER a limited page would just return nothing.
+      const sameInstant = "1990-01-01T00:00:00.000Z";
+      const ids: string[] = [];
+      for (let i = 0; i < 4; i++) {
+        const item = await card({ org, title: `tie ${i}` });
+        await touchedAt(item.id, sameInstant);
+        ids.push(item.id);
+      }
+
+      const first = await taskBoard.listItemsPendingReview(2, null);
+      const last = first.at(-1)!;
+      const second = await taskBoard.listItemsPendingReview(2, {
+        updatedAt: last.updatedAt,
+        id: last.id,
+      });
+
+      const seen = [...first, ...second].map((r) => r.id);
+      // All four came back exactly once — no skip, no repeat, despite sharing
+      // `updated_at` to the millisecond.
+      expect(new Set(seen).size).toBe(4);
+      expect(seen.slice().sort()).toEqual(ids.slice().sort());
+    });
+  });
 });

--- a/apps/api/src/storage/task-board-pending-review.integration.test.ts
+++ b/apps/api/src/storage/task-board-pending-review.integration.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Real-Postgres coverage for the review sweeper's work list.
+ *
+ * This is the query that decides which stuck cards get rescued, so its
+ * predicates are the contract: Super Agent only (a human's card is not the
+ * sweeper's business), In Review only, dismissed cards excluded, oldest-touched
+ * first so a long backlog drains fairly instead of starving the cards that have
+ * been stuck longest, and bounded by `limit` so one tick can't scan the world.
+ *
+ * Cross-org on purpose — the sweeper is a process-level reconciler with no
+ * request org — which is exactly the kind of thing an in-memory fake would get
+ * wrong, hence real Postgres.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { sql } from "kysely";
+import type { StudioDatabase } from "../database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../database/test-db-pg";
+import { TaskBoardStorage } from "./task-board";
+
+const ORG_A = "org_pending_a";
+const ORG_B = "org_pending_b";
+const USER = "user_pending_review";
+const SUPER_AGENT = "super-agent";
+
+describe("listItemsPendingReview (real Postgres)", () => {
+  let database: StudioDatabase;
+  let taskBoard: TaskBoardStorage;
+
+  const card = async (opts: {
+    org: string;
+    title: string;
+    status?: "in_review" | "in_progress" | "done";
+    assignee?: string | null;
+    dismissed?: boolean;
+  }) => {
+    const item = await taskBoard.create({
+      organizationId: opts.org,
+      title: opts.title,
+      status: opts.status ?? "in_review",
+      assigneeId: opts.assignee === undefined ? SUPER_AGENT : opts.assignee,
+      by: USER,
+    });
+    if (opts.dismissed) {
+      await database.db
+        .updateTable("task_board_items")
+        .set({ dismissed_at: new Date().toISOString() })
+        .where("id", "=", item.id)
+        .execute();
+    }
+    return item;
+  };
+
+  /** Force a deterministic ordering key — `updated_at` drives the sweep order. */
+  const touchedAt = async (id: string, iso: string) => {
+    await database.db
+      .updateTable("task_board_items")
+      .set({ updated_at: iso })
+      .where("id", "=", id)
+      .execute();
+  };
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    for (const [id, slug] of [
+      [ORG_A, "org-pending-a"],
+      [ORG_B, "org-pending-b"],
+    ] as const) {
+      await database.db
+        .insertInto("organization")
+        .values({
+          id,
+          name: id,
+          slug,
+          createdAt: new Date().toISOString(),
+        })
+        .execute();
+    }
+    const now = new Date().toISOString();
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES (${USER}, ${"pending@review.test"}, false, ${USER}, ${now}, ${now})
+    `.execute(database.db);
+    taskBoard = new TaskBoardStorage(database.db);
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  it("returns Super Agent cards In Review, across orgs, each carrying its own org", async () => {
+    const a = await card({ org: ORG_A, title: "in review A" });
+    const b = await card({ org: ORG_B, title: "in review B" });
+
+    const pending = await taskBoard.listItemsPendingReview(50);
+    const ids = pending.map((p) => p.id);
+
+    expect(ids).toContain(a.id);
+    expect(ids).toContain(b.id);
+    expect(pending.find((p) => p.id === a.id)?.organizationId).toBe(ORG_A);
+    expect(pending.find((p) => p.id === b.id)?.organizationId).toBe(ORG_B);
+  });
+
+  it("skips cards that are not In Review", async () => {
+    const running = await card({
+      org: ORG_A,
+      title: "still running",
+      status: "in_progress",
+    });
+    const shipped = await card({
+      org: ORG_A,
+      title: "shipped",
+      status: "done",
+    });
+
+    const ids = (await taskBoard.listItemsPendingReview(50)).map((p) => p.id);
+    expect(ids).not.toContain(running.id);
+    expect(ids).not.toContain(shipped.id);
+  });
+
+  // A human's card in review is a human's business — dispatching a reviewer at
+  // it would burn a run nobody asked for.
+  it("skips a card that is not the Super Agent's", async () => {
+    const mine = await card({ org: ORG_A, title: "mine", assignee: USER });
+    const nobodys = await card({
+      org: ORG_A,
+      title: "unassigned",
+      assignee: null,
+    });
+
+    const ids = (await taskBoard.listItemsPendingReview(50)).map((p) => p.id);
+    expect(ids).not.toContain(mine.id);
+    expect(ids).not.toContain(nobodys.id);
+  });
+
+  it("skips a dismissed card", async () => {
+    const gone = await card({
+      org: ORG_A,
+      title: "dismissed",
+      dismissed: true,
+    });
+
+    const ids = (await taskBoard.listItemsPendingReview(50)).map((p) => p.id);
+    expect(ids).not.toContain(gone.id);
+  });
+
+  it("returns the oldest-touched first, so a backlog cannot starve", async () => {
+    const older = await card({ org: ORG_A, title: "stuck for days" });
+    const newer = await card({ org: ORG_A, title: "just landed" });
+    await touchedAt(older.id, "2020-01-01T00:00:00.000Z");
+    await touchedAt(newer.id, "2030-01-01T00:00:00.000Z");
+
+    const ids = (await taskBoard.listItemsPendingReview(50)).map((p) => p.id);
+    expect(ids.indexOf(older.id)).toBeLessThan(ids.indexOf(newer.id));
+  });
+
+  it("honours the batch limit", async () => {
+    expect(await taskBoard.listItemsPendingReview(2)).toHaveLength(2);
+  });
+});

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -476,6 +476,31 @@ export class TaskBoardStorage {
    * so a run-metadata-less caller (a PR opened on a re-prompted thread) can
    * resolve its task the same way the thread-finish/reopen hooks do.
    */
+  /**
+   * Super Agent tasks parked In Review, oldest-touched first — the review
+   * sweeper's work list (see `review-sweeper.ts`).
+   *
+   * Cross-org by design: the sweeper is a process-level reconciler with no
+   * request org, and each item carries its own so the caller can build the
+   * right context. Oldest first so a long backlog drains fairly instead of the
+   * newest cards starving the ones that have been stuck longest, and bounded by
+   * `limit` so one tick can't scan an unbounded board.
+   */
+  async listItemsPendingReview(
+    limit: number,
+  ): Promise<{ id: string; organizationId: string }[]> {
+    const rows = await this.db
+      .selectFrom("task_board_items")
+      .select(["id", "organization_id as organizationId"])
+      .where("status", "=", "in_review")
+      .where("assignee_id", "=", SUPER_AGENT_ASSIGNEE_ID)
+      .where("dismissed_at", "is", null)
+      .orderBy("updated_at", "asc")
+      .limit(limit)
+      .execute();
+    return rows;
+  }
+
   async linkedTaskIds(
     threadId: string,
     organizationId: string,
@@ -563,20 +588,37 @@ export class TaskBoardStorage {
     for (const taskId of await this.linkedTaskIds(threadId, organizationId)) {
       const item = await this.getById(taskId, organizationId);
       if (!item || !shouldAdvanceToReview(item)) continue;
-      moved.push(
-        await this.update(
-          taskId,
-          organizationId,
-          { status: "in_review" },
-          item.updatedBy,
-        ),
+      // The status flip is a CONDITIONAL update guarded on the status we just
+      // read, so exactly one concurrent caller can win it.
+      //
+      // It used to be an unconditional `update()`, and the read-then-write above
+      // is not atomic: `recoverStalledTasks` runs fire-and-forget on EVERY
+      // `TASK_BOARD_ITEM_LIST` over the list that read already loaded, so N
+      // overlapping board reads (multiple tabs, a refocus burst, the Super
+      // Agent calling the tool itself) each saw `in_progress` and each wrote.
+      // One prod item collected 42 of these; another took 27 inside 112 ms.
+      //
+      // The duplicate ROW was not the real damage — the duplicate ACTIVITY was.
+      // `reviewCycleStart` reads the newest `status_changed→in_review` as the
+      // start of the current review cycle, so every redundant stamp invalidated
+      // every approval recorded before it: the verified-approval gate stopped
+      // seeing a complete set, auto-merge never fired, and the card sat In
+      // Review forever. In prod all 13 items holding an approval had been
+      // stranded this way, one of them 15 seconds after approving.
+      const advanced = await this.advanceToReviewIfInProgress(
+        taskId,
+        organizationId,
+        item.updatedBy,
       );
+      if (!advanced) continue;
+      moved.push(advanced);
       // Record the transition — the reviewer flow keys its "current review
       // cycle" off the newest `status_changed→in_review` activity, and a
       // re-review (Super Agent pushed a fix to the same PR, no new PR opened)
       // re-enters In Review only through THIS path. Without the activity row
       // the cycle boundary would stay stale and reviewers would never re-run.
-      // Machine-driven, hence a null actor. Best-effort.
+      // Machine-driven, hence a null actor. Best-effort. Reached only by the
+      // caller that won the flip above, so it writes exactly once per cycle.
       await this.recordActivity({
         taskBoardItemId: taskId,
         action: "status_changed",
@@ -587,6 +629,38 @@ export class TaskBoardStorage {
       );
     }
     return moved;
+  }
+
+  /**
+   * Flip a task to In Review only if it is still `in_progress`, returning the
+   * updated item or null when another caller already moved it.
+   *
+   * The `where status = 'in_progress'` predicate is the whole point: it makes
+   * the advance idempotent under concurrency, which the plain `update()` is not.
+   * See the caller above for what the duplicates cost.
+   */
+  async advanceToReviewIfInProgress(
+    id: string,
+    organizationId: string,
+    by: string,
+  ): Promise<TaskBoardItem | null> {
+    const row = await this.db
+      .updateTable("task_board_items")
+      .set({
+        status: "in_review",
+        updated_by: by,
+        updated_at: new Date().toISOString(),
+      })
+      .where("id", "=", id)
+      .where("organization_id", "=", organizationId)
+      .where("status", "=", "in_progress")
+      .returningAll()
+      .executeTakeFirst();
+
+    if (!row) return null;
+    const item = this.itemFromDbRow(row);
+    await this.attachRefs([item], organizationId);
+    return item;
   }
 
   /**

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -485,20 +485,52 @@ export class TaskBoardStorage {
    * right context. Oldest first so a long backlog drains fairly instead of the
    * newest cards starving the ones that have been stuck longest, and bounded by
    * `limit` so one tick can't scan an unbounded board.
+   *
+   * `after` is a keyset cursor: `limit` alone would be a fixed window, and a
+   * card the sweeper can never rescue (In Review with no PR — a research task)
+   * is never touched, so it keeps its old `updated_at` and permanently occupies
+   * a slot in that window. Once `limit` such cards accumulate, nothing behind
+   * them is ever swept again. Paging across ticks bounds each tick's work
+   * without bounding what the sweep can ever reach.
    */
   async listItemsPendingReview(
     limit: number,
-  ): Promise<{ id: string; organizationId: string }[]> {
-    const rows = await this.db
+    after?: { updatedAt: string; id: string } | null,
+  ): Promise<{ id: string; organizationId: string; updatedAt: string }[]> {
+    let query = this.db
       .selectFrom("task_board_items")
-      .select(["id", "organization_id as organizationId"])
+      .select(["id", "organization_id as organizationId", "updated_at"])
       .where("status", "=", "in_review")
       .where("assignee_id", "=", SUPER_AGENT_ASSIGNEE_ID)
-      .where("dismissed_at", "is", null)
+      .where("dismissed_at", "is", null);
+    if (after) {
+      // `updated_at` is a timestamptz, so the cursor's ISO string has to go back
+      // to a Date — comparing it as text would collate lexically, not
+      // chronologically, and silently skip or repeat rows.
+      const cursorAt = new Date(after.updatedAt);
+      // `(updated_at, id)` is the sort key, so the tie-break on `id` is what
+      // makes the cursor total — cards updated in the same millisecond would
+      // otherwise be skipped or repeated forever.
+      query = query.where((eb) =>
+        eb.or([
+          eb("updated_at", ">", cursorAt),
+          eb.and([eb("updated_at", "=", cursorAt), eb("id", ">", after.id)]),
+        ]),
+      );
+    }
+    const rows = await query
       .orderBy("updated_at", "asc")
+      .orderBy("id", "asc")
       .limit(limit)
       .execute();
-    return rows;
+    return rows.map((row) => ({
+      id: row.id,
+      organizationId: row.organizationId,
+      updatedAt:
+        row.updated_at instanceof Date
+          ? row.updated_at.toISOString()
+          : String(row.updated_at),
+    }));
   }
 
   async linkedTaskIds(

--- a/apps/api/src/tools/task-board/enqueue-reviewer.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.ts
@@ -1,76 +1,17 @@
 import type { StudioContext } from "@/core/studio-context";
 import type { TaskBoardItem } from "@/storage/types";
-import type { TaskBoardStorage } from "@/storage/task-board";
-import type { StudioContextFactory } from "@/automations/fire";
 import {
   isReviewerThreadTitle,
   REVIEWER_FLAG,
   REVIEWER_KINDS,
   REVIEWER_LABEL,
   reviewCycleStart,
-  SUPER_AGENT_ASSIGNEE_ID,
   type ReviewerKind,
 } from "@decocms/shared/task-board";
 import { recordTaskActivity } from "./activity";
 import { emitTaskBoardUpdated } from "./run-reactions";
 import { enqueueAgentRunForTask } from "./enqueue-task-run";
 import { resolveTaskRepoChoice } from "./claude-code-task-run";
-
-/**
- * A Super Agent run finished — if it left a task In Review with an open PR,
- * enqueue the enabled reviewers. This is the HEADLESS trigger: it fires from the
- * projector's run-terminal hook (server-side), so reviewers start even with no
- * browser open, right when the Super Agent is done (not while it's still
- * pushing). Only a Super Agent thread finishing triggers it — a reviewer's own
- * run, also linked to the task, must not re-trigger. Best-effort; a failure
- * never disturbs the projector. Builds its own context (the hook has only
- * storage) as the task's owner.
- */
-export async function enqueueReviewersOnThreadFinish(args: {
-  contextFactory: StudioContextFactory;
-  taskBoard: TaskBoardStorage;
-  threadId: string;
-  orgId: string;
-}): Promise<void> {
-  const { contextFactory, taskBoard, threadId, orgId } = args;
-  try {
-    for (const taskId of await taskBoard.linkedTaskIds(threadId, orgId)) {
-      const item = await taskBoard.getById(taskId, orgId);
-      if (
-        !item ||
-        item.status !== "in_review" ||
-        item.assigneeId !== SUPER_AGENT_ASSIGNEE_ID
-      ) {
-        continue;
-      }
-      // Only the Super Agent's own run triggers reviewers — its threads are
-      // titled "Super Agent: …"; a reviewer's finishing run (also linked) is not.
-      const finishing = item.threads.find((thr) => thr.threadId === threadId);
-      if (!finishing?.title?.startsWith("Super Agent:")) continue;
-      // Nothing to review without a PR (research/answer tasks reach In Review
-      // too). Logged, not silent: this is a terminal park — no reviewer will
-      // ever claim the card and nothing else moves it, so "why is this task
-      // stuck In Review?" has to be answerable from the logs. The task prompt
-      // steers no-code-change tasks to Done for exactly this reason.
-      const prs = await taskBoard.listPrs(taskId, orgId);
-      if (prs.length === 0) {
-        console.warn(
-          `[task-board] ${taskId} reached In Review with no PR — no reviewer ` +
-            `enqueued; the card stays In Review until a human moves it`,
-        );
-        continue;
-      }
-      const ctx = await contextFactory(
-        orgId,
-        item.assignedBy ?? item.createdBy,
-      );
-      if (!ctx) continue;
-      await enqueueEnabledReviewers(ctx, item);
-    }
-  } catch (err) {
-    console.error("[task-board] reviewer trigger on run finish failed", err);
-  }
-}
 
 /** Thread statuses past which a reviewer run is done — a live run has a
  *  non-terminal status. Mirrors the storage-layer set. */

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -541,7 +541,32 @@ async function fetchPrStatusExtras(
 
 /** Fetch a PR's live state via the GitHub MCP `pull_request_read` tool.
  *  Best-effort: any failure yields nulls so the modal still shows the link. */
-async function fetchPrLiveState(
+/**
+ * Is this task's PR ready for a reviewer? Open, unmerged, and not sitting on a
+ * pending or failing check run — a PR with NO CI (`checksStatus === null`)
+ * qualifies, or a card without a pipeline would sit In Review forever.
+ *
+ * Shared with `review-sweeper.ts` on purpose: a reviewer claim is spent once per
+ * review cycle, so whichever path dispatches first decides what gets reviewed.
+ * If the two disagreed, the sweeper's 60s tick would win the race against CI and
+ * burn the cycle on a red PR.
+ */
+export const prReadyForReview = (
+  prs: {
+    state: string | null;
+    merged: boolean | null;
+    checksStatus: unknown;
+  }[],
+): boolean => {
+  const openPr = prs.find((p) => p.state === "open" && !p.merged);
+  return (
+    openPr != null &&
+    openPr.checksStatus !== "pending" &&
+    openPr.checksStatus !== "failing"
+  );
+};
+
+export async function fetchPrLiveState(
   ctx: StudioContext,
   orgId: string,
   pr: TaskBoardItemPrRef,
@@ -689,15 +714,11 @@ export const TASK_BOARD_ITEM_PRS_GET = defineTool({
     // manual review; `enqueueEnabledReviewers` is itself idempotent per reviewer
     // per review cycle, so re-polling won't spawn duplicate reviewer runs.
     const openPr = prs.find((p) => p.state === "open" && !p.merged);
-    const checksReadyForReview =
-      openPr != null &&
-      openPr.checksStatus !== "pending" &&
-      openPr.checksStatus !== "failing";
     if (
       item &&
       item.status === "in_review" &&
       item.assigneeId === SUPER_AGENT_ASSIGNEE_ID &&
-      checksReadyForReview
+      prReadyForReview(prs)
     ) {
       await enqueueEnabledReviewers(ctx, item).catch((err) => {
         console.error("[task-board] reviewer auto-handoff failed", err);

--- a/apps/api/src/tools/task-board/review-sweeper.test.ts
+++ b/apps/api/src/tools/task-board/review-sweeper.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The check gate the sweeper and the task dialog SHARE. It has to be one
+ * predicate: a reviewer claim is spent once per review cycle and nothing
+ * re-dispatches inside a cycle, so if the sweeper's 60s tick dispatched on a PR
+ * whose CI was still running (which it always would — CI takes minutes) it would
+ * consume the cycle and the green-CI review would never happen.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { prReadyForReview } from "./prs-get";
+
+const pr = (over: Partial<Parameters<typeof prReadyForReview>[0][number]>) => ({
+  state: "open",
+  merged: false,
+  checksStatus: "passing",
+  ...over,
+});
+
+describe("prReadyForReview", () => {
+  it("is ready when the open PR's checks pass", () => {
+    expect(prReadyForReview([pr({})])).toBe(true);
+  });
+
+  // A PR with no pipeline at all must not sit In Review forever.
+  it("is ready when the PR has no checks", () => {
+    expect(prReadyForReview([pr({ checksStatus: null })])).toBe(true);
+  });
+
+  it("waits while checks are pending", () => {
+    expect(prReadyForReview([pr({ checksStatus: "pending" })])).toBe(false);
+  });
+
+  it("waits while checks are failing", () => {
+    expect(prReadyForReview([pr({ checksStatus: "failing" })])).toBe(false);
+  });
+
+  it("is not ready with no PR at all", () => {
+    expect(prReadyForReview([])).toBe(false);
+  });
+
+  it("is not ready when the only PR is merged or closed", () => {
+    expect(prReadyForReview([pr({ merged: true })])).toBe(false);
+    expect(prReadyForReview([pr({ state: "closed" })])).toBe(false);
+  });
+
+  // A card can carry more than one PR (a re-run opens a second one); the open
+  // one decides.
+  it("judges the open PR when a merged one is also linked", () => {
+    expect(
+      prReadyForReview([
+        pr({ merged: true, checksStatus: "failing" }),
+        pr({ checksStatus: "passing" }),
+      ]),
+    ).toBe(true);
+  });
+
+  // `state: null` is what a GitHub fetch failure looks like (NO_LIVE_STATE) —
+  // that must read as "don't dispatch", not "no checks, go ahead".
+  it("is not ready when the live state could not be fetched", () => {
+    expect(prReadyForReview([pr({ state: null, checksStatus: null })])).toBe(
+      false,
+    );
+  });
+});

--- a/apps/api/src/tools/task-board/review-sweeper.ts
+++ b/apps/api/src/tools/task-board/review-sweeper.ts
@@ -1,0 +1,160 @@
+/**
+ * Periodic reconciler for Super Agent tasks parked In Review.
+ *
+ * It exists because the headless hand-off to the reviewers never worked, for two
+ * independent reasons, and both are invisible from inside a DBOS workflow:
+ *
+ * 1. **The PR is never linked.** `linkPr` has exactly two callers:
+ *    `capturePrForRun` and `TASK_BOARD_ITEM_PRS_GET`. The first is only
+ *    reachable from the NATIVE Decopilot loop — the `onPrOpened` MCP wrapper and
+ *    the `onStepFinish` bash scan. A Super Agent task runs the `claude-code`
+ *    harness *inside a sandbox*, so Claude Code opens the PR in the pod and it
+ *    passes through neither hook. Nothing links it, so
+ *    `enqueueReviewersOnThreadFinish` sees `prs.length === 0` and parks the
+ *    card. The web only calls `TASK_BOARD_ITEM_PRS_GET` from the task DIALOG, so
+ *    the PR stayed invisible until a human opened that specific card.
+ *
+ * 2. **The dispatch itself throws.** The projector's terminal hook runs inside a
+ *    DBOS step, and the reviewer dispatch bottoms out in `enqueueThreadRun` →
+ *    `DBOS.startWorkflow`, which DBOS rejects from a step:
+ *    `DBOSInvalidWorkflowTransitionError` ("Invalid call to a `workflow`
+ *    function from within a `step` or `transaction`", code 21). The per-reviewer
+ *    `.catch` logged it and released the claim, so it retried and failed
+ *    forever. Even a task WITH a linked PR never got a reviewer.
+ *
+ * A sweeper fixes both at once and is the only shape that can: it runs on a
+ * boot-time timer, outside any workflow, so `startWorkflow` is legal here. It
+ * also makes the pipeline self-healing — every card already stranded is picked
+ * up on the next tick, with no backfill.
+ *
+ * Everything it calls is idempotent: `linkPr` is per (task, url), and
+ * `enqueueEnabledReviewers` claims per (task, reviewer, cycle), so re-running
+ * every tick cannot spawn duplicate reviewer runs.
+ *
+ * Deliberately NOT a replacement for the instant paths. `TASK_BOARD_ITEM_PRS_GET`
+ * still does this on the dialog's poll, and the projector hook still fires — the
+ * sweeper is the floor that guarantees it happens without a human, not the only
+ * route.
+ */
+
+import type { StudioContextFactory } from "@/automations/fire";
+import type { TaskBoardStorage } from "@/storage/task-board";
+import { extractPrFromText } from "./pr-extract";
+import { enqueueEnabledReviewers } from "./enqueue-reviewer";
+
+/** How often to reconcile. A minute is well under the time a human would take
+ *  to notice a stuck card, and the query is one indexed scan when idle. */
+const DEFAULT_SWEEP_INTERVAL_MS = 60 * 1000;
+
+/** Items per tick. Bounds one tick's work: each item costs a `getById`, up to
+ *  one `linkPr` per thread, and an activity read inside the reviewer claim. */
+const DEFAULT_BATCH_SIZE = 50;
+
+export interface TaskBoardReviewSweeperOptions {
+  intervalMs?: number;
+  batchSize?: number;
+}
+
+export class TaskBoardReviewSweeper {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  /** Guards against a slow tick overlapping the next one — the batch is
+   *  bounded but a cold GitHub call inside the reviewer dispatch is not. */
+  private running = false;
+
+  constructor(
+    private readonly taskBoard: TaskBoardStorage,
+    private readonly contextFactory: StudioContextFactory,
+    private readonly options: TaskBoardReviewSweeperOptions = {},
+  ) {}
+
+  start(): void {
+    if (this.timer) return;
+    const interval = this.options.intervalMs ?? DEFAULT_SWEEP_INTERVAL_MS;
+    this.timer = setInterval(() => {
+      void this.runOnce();
+    }, interval);
+    this.timer.unref();
+  }
+
+  /** Exposed so tests can drive a single tick deterministically. */
+  async runOnce(): Promise<number> {
+    if (this.running) return 0;
+    this.running = true;
+    let dispatched = 0;
+    try {
+      const pending = await this.taskBoard.listItemsPendingReview(
+        this.options.batchSize ?? DEFAULT_BATCH_SIZE,
+      );
+      for (const { id, organizationId } of pending) {
+        // Best-effort per item: one card's failure must not stop the batch, or a
+        // single wedged org would starve every other org's cards behind it.
+        try {
+          if (await this.reconcileItem(id, organizationId)) dispatched++;
+        } catch (err) {
+          console.error(`[task-board-review-sweeper] ${id} failed`, err);
+        }
+      }
+    } catch (err) {
+      console.error("[task-board-review-sweeper] sweep failed", err);
+    } finally {
+      this.running = false;
+    }
+    return dispatched;
+  }
+
+  /** Link any PR the run left in its closing message, then hand off to the
+   *  enabled reviewers. Returns true when reviewers were considered (i.e. the
+   *  card had a PR to review). */
+  private async reconcileItem(
+    id: string,
+    organizationId: string,
+  ): Promise<boolean> {
+    const item = await this.taskBoard.getById(id, organizationId);
+    if (!item) return false;
+
+    // Same recovery `TASK_BOARD_ITEM_PRS_GET` does: the agent's closing summary
+    // reliably prints the URL ("Opened PR #309 https://github.com/…/pull/309").
+    // Idempotent per (task, url).
+    for (const thread of item.threads) {
+      const pr = thread.lastMessage
+        ? extractPrFromText(thread.lastMessage)
+        : null;
+      if (!pr) continue;
+      await this.taskBoard.linkPr({
+        taskBoardItemId: id,
+        organizationId,
+        url: pr.url,
+        prNumber: pr.number,
+        repoOwner: pr.owner,
+        repoName: pr.repo,
+        connectionId: null,
+      });
+    }
+
+    // Nothing to review without a PR — a research/answer task reaches In Review
+    // too, and dispatching a reviewer at it would burn a run on nothing.
+    const prs = await this.taskBoard.listPrs(id, organizationId);
+    if (prs.length === 0) return false;
+
+    // Built as the task's owner, like the run-finish trigger does — the sweeper
+    // has storage only, and the reviewer dispatch needs a full context.
+    const ctx = await this.contextFactory(
+      organizationId,
+      item.assignedBy ?? item.createdBy,
+    );
+    if (!ctx) return false;
+
+    // Deliberately NOT gated on the PR's live check status, unlike the dialog
+    // poll: that gate costs a GitHub round-trip per PR per tick, and a card
+    // whose checks are still pending simply gets picked up on a later tick.
+    await enqueueEnabledReviewers(ctx, item);
+    return true;
+  }
+
+  dispose(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+}

--- a/apps/api/src/tools/task-board/review-sweeper.ts
+++ b/apps/api/src/tools/task-board/review-sweeper.ts
@@ -41,13 +41,17 @@ import type { StudioContextFactory } from "@/automations/fire";
 import type { TaskBoardStorage } from "@/storage/task-board";
 import { extractPrFromText } from "./pr-extract";
 import { enqueueEnabledReviewers } from "./enqueue-reviewer";
+import { fetchPrLiveState, prReadyForReview } from "./prs-get";
 
 /** How often to reconcile. A minute is well under the time a human would take
- *  to notice a stuck card, and the query is one indexed scan when idle. */
+ *  to notice a stuck card, and the work list is one index scan when idle
+ *  (`idx_task_board_items_pending_review`). */
 const DEFAULT_SWEEP_INTERVAL_MS = 60 * 1000;
 
 /** Items per tick. Bounds one tick's work: each item costs a `getById`, up to
- *  one `linkPr` per thread, and an activity read inside the reviewer claim. */
+ *  one `linkPr` per thread, and a GitHub round-trip per linked PR. Not a bound
+ *  on what the sweep can reach — ticks page through the backlog with a keyset
+ *  cursor (see `listItemsPendingReview`). */
 const DEFAULT_BATCH_SIZE = 50;
 
 export interface TaskBoardReviewSweeperOptions {
@@ -60,6 +64,9 @@ export class TaskBoardReviewSweeper {
   /** Guards against a slow tick overlapping the next one — the batch is
    *  bounded but a cold GitHub call inside the reviewer dispatch is not. */
   private running = false;
+  /** Where the last tick stopped, so the next one continues instead of
+   *  re-scanning the same window. Null = start from the oldest card. */
+  private cursor: { updatedAt: string; id: string } | null = null;
 
   constructor(
     private readonly taskBoard: TaskBoardStorage,
@@ -82,9 +89,18 @@ export class TaskBoardReviewSweeper {
     this.running = true;
     let dispatched = 0;
     try {
+      const batchSize = this.options.batchSize ?? DEFAULT_BATCH_SIZE;
       const pending = await this.taskBoard.listItemsPendingReview(
-        this.options.batchSize ?? DEFAULT_BATCH_SIZE,
+        batchSize,
+        this.cursor,
       );
+      // A short page means the backlog is exhausted — wrap around so cards that
+      // moved back into In Review behind the cursor get picked up again.
+      const last = pending.at(-1);
+      this.cursor =
+        pending.length === batchSize && last
+          ? { updatedAt: last.updatedAt, id: last.id }
+          : null;
       for (const { id, organizationId } of pending) {
         // Best-effort per item: one card's failure must not stop the batch, or a
         // single wedged org would starve every other org's cards behind it.
@@ -144,9 +160,20 @@ export class TaskBoardReviewSweeper {
     );
     if (!ctx) return false;
 
-    // Deliberately NOT gated on the PR's live check status, unlike the dialog
-    // poll: that gate costs a GitHub round-trip per PR per tick, and a card
-    // whose checks are still pending simply gets picked up on a later tick.
+    // Same check gate as the dialog poll, and it MUST be the same one: a
+    // reviewer claim is spent once per review cycle, and nothing re-dispatches
+    // within a cycle. Skipping the gate here would not mean "reviewed earlier" —
+    // the 60s tick beats a multi-minute CI run, so the sweeper would win every
+    // race, review a red PR, consume the cycle, and the green review would never
+    // happen. A PR whose checks are still pending is simply swept again later.
+    const live = await Promise.all(
+      prs.map(async (pr) => ({
+        ...pr,
+        ...(await fetchPrLiveState(ctx, organizationId, pr)),
+      })),
+    );
+    if (!prReadyForReview(live)) return false;
+
     await enqueueEnabledReviewers(ctx, item);
     return true;
   }


### PR DESCRIPTION
## Why

The earlier fixes worked — the triage backlog drained. Everything now piles up one lane later instead:

| status | linked PR | count |
|---|---|---|
| done | yes | 7 |
| **in_review** | **no** | **30** |
| **in_review** | yes | 23 |
| in_progress | no / yes | 4 / 1 |

Three independent faults, all confirmed against prod.

## 1. A sandboxed Super Agent's PR is never linked

`linkPr` has exactly two callers: `capturePrForRun` and `TASK_BOARD_ITEM_PRS_GET`. The first is only reachable from the **native Decopilot** loop — the `onPrOpened` MCP wrapper (`cluster-mcp-tool-hooks.ts:83`) and the `onStepFinish` bash scan (`run-agent-loop.ts:257`). A Super Agent task runs `claude-code` **inside a sandbox**, so Claude Code opens the PR in the pod and it passes through neither hook.

Nothing links it → `enqueueReviewersOnThreadFinish` bails on `prs.length === 0` → the card parks. My own warn from #5765, firing live in the worker:

```
[task-board] board_qyLkndcDGkuoeReCj-eCV reached In Review with no PR —
no reviewer enqueued; the card stays In Review until a human moves it
```

**26 of the 30** unlinked cards had a PR URL sitting in their thread messages. The web only calls `TASK_BOARD_ITEM_PRS_GET` from the task **dialog** (`task-dialog.tsx:1245`), never from the board list — so a card was invisible until a human opened it. Proven by accident: calling it on one item linked PR #25 and fired `review_requested` two seconds later. Those runs also never got their quota refunded (the refund skips anything ranked ≥ `in_review`).

## 2. The headless reviewer trigger could never fire

It was called from the projector's terminal hook — inside a DBOS step — and the dispatch bottoms out in `enqueueThreadRun` → `DBOS.startWorkflow`, which DBOS rejects from a step:

```
error: Invalid call to a `workflow` function from within a `step` or `transaction`
dbosErrorCode: 21
[task-board] code_review reviewer enqueue failed
```

The per-reviewer `.catch` swallowed it into a log line and *released the claim*, so it retried and failed forever. **Even a card with a linked PR never got a reviewer.** Pre-existing; #5765 didn't fix it.

**Both fixed by one mechanism.** `TaskBoardReviewSweeper` — a boot-time timer, outside any workflow, where `startWorkflow` is legal — links the PR from the run's closing message and hands off to the enabled reviewers. Everything it calls is idempotent (`linkPr` per `(task, url)`, reviewer claims per `(task, reviewer, cycle)`), so ticking every 60s cannot duplicate a run. It also makes the pipeline **self-healing**: every already-stranded card is picked up on the next tick, which is why this needs no backfill. The dead projector call sites are deleted rather than left logging failures, and `enqueueReviewersOnThreadFinish` goes with them.

## 3. An advance stampede invalidated every approval

The In Review advance was a non-atomic read-then-write, and `recoverStalledTasks` runs fire-and-forget on **every** `TASK_BOARD_ITEM_LIST` (`list.ts:37`) over the snapshot that read already loaded. N overlapping board reads — tabs, a refocus burst, the Super Agent calling the tool itself — each saw `in_progress` and each wrote. **732** machine-written `status_changed→in_review` rows in this org, **42 on one card**, 27 inside 112ms.

The duplicate row wasn't the damage — the duplicate **activity** was. `reviewCycleStart` reads the newest such stamp as the start of the current review cycle, so each redundant one invalidated every approval before it → the verified-approval gate stopped seeing a complete set → `auto_merge` never fired → the card sat In Review forever.

**All 13 cards holding an approval were stranded this way.** `board_fDlfjc9DBz1vB_q89hkXS` was approved at `20:40:59` and invalidated at `20:41:14` — 15 seconds later.

Now a conditional `UPDATE ... WHERE status = 'in_progress'` picks the winner, and only the winner writes the activity row.

## Also: the concurrency cap, split in two

You asked for ~10, but the single gate at 3 gates something other than what it looked like: it's sized against **this pod's** 2Gi limit and a ~450MB in-process working set. A `claude-code` run executes in its own sandbox pod and only proxies a stream here, so memory is the wrong unit for it — while three such runs, costing this pod almost nothing, could park a whole board behind them.

So sandboxed runs get their own gate (`SANDBOX_MAX_CONCURRENT_HOSTED_RUNS`, default **12**) and the in-process gate keeps its 3. Raising the shared number to 10 instead would have risked OOM on Decopilot-heavy load. The gates are independent so neither kind starves the other, and `hostedRunStats` still reports the pod total, leaving the KEDA trigger unchanged.

## Testing

- `bun run check` clean across all workspaces; `bun run lint` 0 errors; knip clean.
- **520 pass / 0 fail** across `storage/`, `tools/task-board/`, `dispatch-queue/`, `settings/` against a migrated Postgres.
- Real-Postgres coverage for both new storage predicates — they're SQL guards, so an in-memory fake would accept anything.
- **I verified the advance test actually fails without the fix**: removing the `WHERE status = 'in_progress'` predicate breaks 2 of the 5 cases.
- One test is labelled wiring-only rather than overclaimed: with real round-trips its 10 chains interleave, so most reads land after the first write and it passes on the old code too. The deterministic proof is the two single-winner cases beside it. Flagging that explicitly because a test that can't fail is worse than no test.

## Risk

The sweeper is new always-on machinery: one indexed query per minute per pod, batch-bounded at 50, with an overlap guard. It adds work only when cards are actually parked In Review. The concurrency split is behind a new env var and leaves existing behaviour for in-process runs untouched.

Stuck cards are left to fix forward, per your call — the sweeper picks them up on its first tick after deploy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates and stabilizes the review pipeline: a boot-time sweeper links PRs from sandboxed Super Agent runs and dispatches reviewers without a human, now CI-gated and paged to avoid stalls. Also fixes the In Review advance race and splits concurrency caps so sandboxed runs don’t block Decopilot.

- **Bug Fixes**
  - Reviewer hand-off no longer runs inside a DBOS step; dispatch now succeeds.
  - PRs from sandboxed `claude-code` runs are linked from closing messages; cards no longer park with no PR.
  - In Review advance is atomic (`UPDATE … WHERE status = 'in_progress'`), preventing duplicate stamps that invalidated approvals.

- **Refactors**
  - Added `TaskBoardReviewSweeper`: boot-time, idempotent reconciler that scans Super Agent cards In Review oldest-first via a keyset cursor, gates dispatch on CI using the shared `prReadyForReview` check, and can be disabled with `TASK_BOARD_REVIEW_SWEEPER_ENABLED`; disposal is tied into existing cleanup to avoid duplicate timers.
  - Added partial index `idx_task_board_items_pending_review` on `(updated_at, id)` with the sweeper’s predicate to avoid cross-org full scans; added real-Postgres tests for the cursor and guarded advance.
  - Split hosted-run concurrency into two gates: in-process (existing cap 3) and sandboxed (`SANDBOX_MAX_CONCURRENT_HOSTED_RUNS`, default 12); `acquireHostedRunSlot` now takes `{ harnessId }`, `HOSTED_RUN_CAPS` exported, metrics report the summed pod total.

<sup>Written for commit 9eaf77098d7980ad89fd18ba64e173b895cd63b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

## Note on the workflow-source snapshot

The DBOS source guard flagged `hosted-harness-workflow.ts`, so the snapshot is re-baselined in this PR. That change is **recovery-compatible**, not a step-sequence change: the only edit in that file is the gate-acquire call inside `runHostedHarness`, which is a step body — no step added, removed or reordered, and no change to recorded step I/O. So `DBOS_WORKFLOW_VERSION` is deliberately **not** bumped, matching the reasoning `hosted-run-concurrency.ts` already documents for where that acquire sits.


