### PR TITLE
fix(billing): refund the quota when the run reactor is the terminal writer

### DIFF
--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -1052,6 +1052,17 @@ export async function createApp(options: CreateAppOptions = {}) {
   const cancelReactorDeps: RunReactorDeps = {
     storage: threadStorage,
     sseHub,
+    // A force-failed run (reaped / cancelled / ghost / in-band error) never
+    // reaches the projector, so this reactor is its only terminal writer — and
+    // owes the board the pass the projector's own terminals already run. Same
+    // storages, built here because this wiring precedes theirs.
+    onThreadFinished: (threadId, orgId) =>
+      advanceTasksToReviewOnThreadFinish(
+        new TaskBoardStorage(database.db),
+        threadId,
+        orgId,
+        new OrganizationBillingStorage(database.db),
+      ),
   };
 
   const runRegistry = new RunRegistry(cancelReactorDeps);

--- a/apps/api/src/api/routes/decopilot/run-reactor.test.ts
+++ b/apps/api/src/api/routes/decopilot/run-reactor.test.ts
@@ -430,4 +430,69 @@ describe("run reactor", () => {
     expect(statusEvent).toBeDefined();
     expect(statusEvent!.data.message_id).toBe("m1");
   });
+
+  // A force-failed run never reaches the projector, so this reactor is its
+  // only terminal writer. Without the hook the task card stays parked In
+  // Progress and its quota charge is never released — the customer pays for a
+  // run that produced nothing.
+  describe("thread-finish hook on a force-fail", () => {
+    const depsWith = (
+      transitions: boolean,
+      finished: Array<[string, string]>,
+      hook?: () => Promise<void>,
+    ): RunReactorDeps => ({
+      storage: {
+        update: async () => null,
+        get: async () => ({
+          id: "run_1",
+          organization_id: "org_1",
+          created_by: "user_1",
+          status: "failed",
+        }),
+        forceFailIfInProgress: async () => transitions,
+      } as unknown as ThreadStoragePort,
+      sseHub: { emit: () => {} },
+      onThreadFinished: async (threadId, orgId) => {
+        finished.push([threadId, orgId]);
+        if (hook) await hook();
+      },
+    });
+
+    const runFailed = (reason: "error" | "cancelled" | "reaped") => [
+      {
+        event: {
+          type: "RUN_FAILED" as const,
+          taskId: "run_1",
+          orgId: "org_1",
+          reason,
+        },
+        state: undefined,
+      },
+    ];
+
+    for (const reason of ["error", "cancelled", "reaped"] as const) {
+      test(`fires for reason '${reason}'`, async () => {
+        const finished: Array<[string, string]> = [];
+        await reactAll(runFailed(reason), depsWith(true, finished));
+        expect(finished).toEqual([["run_1", "org_1"]]);
+      });
+    }
+
+    test("does NOT fire when the force-fail was a no-op", async () => {
+      // Another writer already settled this run — it owns the board pass, and
+      // firing here could refund a claim its terminal deliberately kept.
+      const finished: Array<[string, string]> = [];
+      await reactAll(runFailed("error"), depsWith(false, finished));
+      expect(finished).toEqual([]);
+    });
+
+    test("a throwing hook never breaks the reactor", async () => {
+      const finished: Array<[string, string]> = [];
+      const deps = depsWith(true, finished, () => {
+        throw new Error("board unavailable");
+      });
+      await expect(reactAll(runFailed("error"), deps)).resolves.toBeUndefined();
+      expect(finished).toEqual([["run_1", "org_1"]]);
+    });
+  });
 });

--- a/apps/api/src/api/routes/decopilot/run-reactor.ts
+++ b/apps/api/src/api/routes/decopilot/run-reactor.ts
@@ -60,6 +60,19 @@ const RUN_FAILURE_RECORD: Record<
 export interface RunReactorDeps {
   storage: ThreadStoragePort;
   sseHub: { emit(orgId: string, event: SSEEvent): void };
+  /**
+   * The thread just reached a terminal status *because this reactor wrote it*.
+   *
+   * Every other terminal writer runs the task-board thread-finish pass
+   * (advance to In Review + release an unproductive task-quota charge) from
+   * its projector wrapper. RUN_FAILED is the one terminal this reactor owns
+   * outright — reaped / cancelled / ghost / error force-fails never reach the
+   * projector — so without this hook those runs leave the card parked In
+   * Progress and the quota charged for a run that produced nothing.
+   *
+   * Optional so a caller with no board (tests, the desktop path) can omit it.
+   */
+  onThreadFinished?: (threadId: string, orgId: string) => Promise<void>;
 }
 
 // ============================================================================
@@ -252,6 +265,15 @@ async function react(event: RunEvent, deps: RunReactorDeps): Promise<void> {
         event.orgId,
         createDecopilotFinishEvent(event.taskId, "failed"),
       );
+      // This reactor just became the terminal writer for the run, so it owes
+      // the board the same thread-finish pass every other terminal writer does
+      // — see `onThreadFinished`. Best-effort: a board/quota failure must not
+      // sink the SSE the UI is waiting on, and the hook logs its own errors.
+      await deps
+        .onThreadFinished?.(event.taskId, event.orgId)
+        .catch((err) =>
+          console.error("[run-reactor] thread-finish hook failed", err),
+        );
       return;
     }
 


### PR DESCRIPTION
## The bug, from production

One org's auto-task quota: **5 executions charged, 1 delivered.** Four runs
died, and every one left its card parked In Progress with the charge standing.

The thread-finish pass — advance to In Review, release an unproductive
task-quota charge — hangs off the projector's terminal writers
(`markRunFailed`, `completeRunIfNotCompleted`). But `RUN_FAILED` is a terminal
the **run reactor** owns outright: `forceFailIfInProgress` plus a direct column
write, for reaped / cancelled / ghost / in-band-error runs that never reach the
projector. That path had no hook, so a run that failed there:

- kept its charge `held` forever — the refund keys off a *finished thread*, and
  the only finish signal never fired;
- left the card In Progress with a dead thread behind it, which is also why the
  board looked like more was running than was.

The production rows identify the path exactly: `failure_kind = 'error'` with
`failure_reason = "Run ended with an error — see the run's messages"` is
`RUN_FAILURE_RECORD.error`, written only here.

## The fix

An optional `onThreadFinished` on `RunReactorDeps`, wired in `app.ts` to
`advanceTasksToReviewOnThreadFinish` — the identical call the projector's own
terminal wrappers make. Three properties are load-bearing:

- **Fires only when this reactor actually transitioned the row.** A no-op
  force-fail means another writer settled the run and owns the pass; firing
  anyway could release a charge that writer's terminal deliberately kept.
- **Runs after the SSE emits, and swallows its own errors.** A board or quota
  failure must not sink the terminal event the UI is waiting on.
- **Same function, not a copy.** The refund keeps ONE decision site over
  durable facts (no PR, card below In Review, no live sibling run).

## Not in this diff

*Why* those runs died. Four ended with `The socket connection was closed
unexpectedly` from the harness's own upstream fetch — a separate investigation.
This change only stops a failed run from being billed as a delivered one.

Also ruled out along the way, with evidence rather than assumption: KEDA
scale-down was **not** the cause. The worker scale-down landed at `21:17:10`,
while the two runs died at `21:15:59` and `21:16:05` — 71 and 65 seconds
*before* it. Causality runs the other way: the runs died, the queue metric
dropped, KEDA scaled in. And `dbos.workflow_status` shows no failed workflow in
the window (156 SUCCESS, 2 CANCELLED) — the durable projection worked; it
faithfully recorded a run that had failed.

## Testing

`run-reactor.test.ts`, following the file's existing fake-deps convention:
the hook fires for `error` / `cancelled` / `reaped`, does **not** fire when the
force-fail no-ops, and a throwing hook can't break the reactor.

`bun test apps/api/src/api/routes/decopilot apps/api/src/billing apps/api/src/tools/task-board`
→ 759 pass. `bun run check`, `fmt`, `lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect billing when a run fails via the reactor path by advancing the task to In Review and refunding the held quota. Prevents cards from staying In Progress and charges from remaining held for runs that produced nothing.

- **Bug Fixes**
  - Added optional `onThreadFinished` to `RunReactorDeps`, wired to `advanceTasksToReviewOnThreadFinish` in `app.ts`.
  - Fires only when `forceFailIfInProgress` transitions the row; runs after SSE emit; errors are swallowed.
  - Covers `RUN_FAILED` for reaped/cancelled/ghost/in-band error paths that never hit the projector.
  - Tests added to confirm hook firing, no-op behavior when already terminal, and resilience to hook errors.

<sup>Written for commit f2679ffac1cd44041103cb5fb77f1b18674fdd7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

