### PR TITLE
refactor(web): drop the standalone /$org/board route

### DIFF
--- a/apps/web/src/components/thread/open-in-board-button.tsx
+++ b/apps/web/src/components/thread/open-in-board-button.tsx
@@ -1,4 +1,3 @@
-import { useProjectContext } from "@/sdk";
 import { useNavigate } from "@tanstack/react-router";
 import { LayoutAlt01 } from "@untitledui/icons";
 import {
@@ -13,13 +12,13 @@ import { useT } from "@/i18n/use-t.ts";
 import { ToolbarIconButton } from "@/components/toolbar-icon-button";
 
 /**
- * Header action: when the current thread is linked to a task board item, jump
- * to the board with that task's modal open. Renders nothing when the thread has
- * no linked task (or the board is disabled — the lookup returns null then).
+ * Header action: when the current thread is linked to a task board item, open
+ * the Tasks overlay in the main panel with that task's modal open (same
+ * `?main=board` surface as the Tasks toggle). Renders nothing when the thread
+ * has no linked task (or the board is disabled — the lookup returns null then).
  */
 export function OpenInBoardButton() {
   const t = useT();
-  const { org } = useProjectContext();
   const { taskId } = useChatTask();
   const navigate = useNavigate();
   const boardTaskId = useTaskForThread(taskId);
@@ -34,9 +33,12 @@ export function OpenInBoardButton() {
             aria-label={t("thread.openInBoardButton.openTaskAriaLabel")}
             onClick={() =>
               navigate({
-                to: "/$org/board",
-                params: { org: org.slug },
-                search: { task: boardTaskId },
+                to: ".",
+                search: (prev: Record<string, unknown>) => ({
+                  ...prev,
+                  main: "board",
+                  task: boardTaskId,
+                }),
               })
             }
           >

--- a/apps/web/src/layouts/main-panel-tabs/index.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/index.tsx
@@ -77,8 +77,8 @@ function TabBody({
   }
   if (activeTab === "board") {
     // Task board opened next to chat via the Tasks toggle (`?main=board`).
-    // The main panel already supplies the card chrome, so render the inner
-    // page inside a full-height flex column (mirrors the standalone route).
+    // The main panel already supplies the card chrome, so the page only needs
+    // a full-height flex column around it.
     return (
       <div className="flex h-full min-h-0 flex-col overflow-hidden">
         <TaskBoardPage />

--- a/apps/web/src/layouts/org-home/index.tsx
+++ b/apps/web/src/layouts/org-home/index.tsx
@@ -33,9 +33,12 @@ export default function OrgHome() {
   // Suspense read (cache-warm from the shell); used to validate the main agent
   // still exists so a deleted one falls back to the Super Agent.
   const agents = useVirtualMCPs();
-  const { connect, siteUrl } = useSearch({ strict: false }) as {
+  // `main` carries a deep link into a main-panel overlay (e.g. `board` =
+  // Tasks, `files` = Library) through the redirect to the landing thread.
+  const { connect, siteUrl, main } = useSearch({ strict: false }) as {
     connect?: string;
     siteUrl?: string;
+    main?: string;
   };
   // Stable id for this mount, used only when there's no reusable "New chat".
   const [freshId] = useState(() => crypto.randomUUID());
@@ -66,7 +69,7 @@ export default function OrgHome() {
     <Navigate
       to="/$org/$taskId"
       params={{ org: org.slug, taskId }}
-      search={{ virtualmcpid: landingAgentId, connect, siteUrl }}
+      search={{ virtualmcpid: landingAgentId, connect, siteUrl, main }}
       replace
     />
   );

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -135,18 +135,6 @@ void import("../agent-shell-layout/index.tsx").catch(() => {});
 
 type Layout = "board" | "list";
 
-export default function TaskBoard() {
-  return (
-    <div className="min-h-0 flex-1 pt-0 pr-1 pb-1 pl-0">
-      <div className="h-full p-0.5 pt-0.25">
-        <div className="card-shadow flex h-full flex-col overflow-hidden rounded-[0.75rem] bg-background">
-          <TaskBoardPage />
-        </div>
-      </div>
-    </div>
-  );
-}
-
 const DATE_FMT = new Intl.DateTimeFormat(undefined, {
   month: "short",
   day: "numeric",

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -1,6 +1,7 @@
 /**
- * Task board (/$org/board) — the org's own board of tasks (title,
+ * Task board (`?main=board`) — the org's own board of tasks (title,
  * description, status, priority, assignee), independent of chat threads.
+ * Rendered as a main-panel overlay tab; there is no standalone route.
  */
 
 import { useRef, useState } from "react";
@@ -404,7 +405,7 @@ export function TaskBoardPage() {
   const studio = useStudioTools();
   const { org, locator } = useProjectContext();
   const navigate = useNavigate();
-  // Deep link: `/$org/board?task=<id>` opens that task's modal (from a linked
+  // Deep link: `?main=board&task=<id>` opens that task's modal (from a linked
   // chat's "open in board" button). Derived, so it opens as soon as the item
   // loads without an effect.
   const { task: deepLinkTaskId } = useSearch({ strict: false }) as {
@@ -417,9 +418,8 @@ export function TaskBoardPage() {
   const clearDeepLink = () => {
     if (deepLinkTaskId)
       navigate({
-        to: "/$org/board",
-        params: { org: org.slug },
-        search: {},
+        to: ".",
+        search: ({ task: _task, ...rest }: Record<string, unknown>) => rest,
         replace: true,
       });
   };

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -302,6 +302,9 @@ const unifiedChatSearchSchema = z.object({
   preview: z.string().optional(),
   id: z.string().optional(),
   toolName: z.string().optional(),
+  /** Deep-links a task board card's modal open inside the `main=board`
+   *  overlay (set by a linked chat's "open in board" button). */
+  task: z.string().optional(),
   tasks: z.number().optional(),
   mainOpen: z.number().optional(),
   autosend: z.string().optional(),
@@ -351,20 +354,6 @@ const orgIndexRoute = createRoute({
   validateSearch: orgIndexSearchSchema,
   pendingComponent: ShellRouteLoading,
   component: lazyRouteComponent(() => import("./layouts/org-home/index.tsx")),
-});
-
-// Task board (/$org/board) — org-owned task board. `task` deep-links a
-// specific card's modal open (used by the "open in board" button from a
-// linked chat).
-const boardSearchSchema = z.object({
-  task: z.string().optional(),
-});
-
-const boardRoute = createRoute({
-  getParentRoute: () => orgShellLayout,
-  path: "/board",
-  validateSearch: boardSearchSchema,
-  component: lazyRouteComponent(() => import("./layouts/task-board/index.tsx")),
 });
 
 // ============================================
@@ -619,7 +608,6 @@ const agentShellWithChildren = agentShellLayout.addChildren([unifiedChatRoute]);
 
 const orgShellWithChildren = orgShellLayout.addChildren([
   orgIndexRoute,
-  boardRoute,
   agentShellWithChildren,
 ]);
 

--- a/packages/e2e/tests/task-board-drag.spec.ts
+++ b/packages/e2e/tests/task-board-drag.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Kanban drag-and-drop on /$org/board.
+ * Kanban drag-and-drop on the Tasks overlay (`/$org?main=board`).
  *
  * These guard two regressions that the pre-dnd-kit implementation shipped:
  * a card dropped into another lane stayed permanently faded (its `dragend`
@@ -57,7 +57,7 @@ async function statusByTitle(request: APIRequestContext, orgSlug: string) {
 
 async function openBoard(page: Page, orgSlug: string) {
   await page.setViewportSize({ width: 1280, height: 800 });
-  await page.goto(`/${orgSlug}/board`);
+  await page.goto(`/${orgSlug}?main=board`);
   await expect(page.locator('button:has-text("Card 0")')).toBeVisible();
 }
 

--- a/packages/e2e/tests/task-description-markdown.spec.ts
+++ b/packages/e2e/tests/task-description-markdown.spec.ts
@@ -44,7 +44,7 @@ interface TaskBoardItem {
 }
 
 async function openTask(page: Page, orgSlug: string, title: string) {
-  await page.goto(`/${orgSlug}/board`);
+  await page.goto(`/${orgSlug}?main=board`);
   const card = page.getByText(title, { exact: true });
   await card.waitFor({ state: "visible", timeout: FIRST_PAINT_MS });
   await card.click();


### PR DESCRIPTION
## Summary

The task board already renders as a main-panel overlay tab (`?main=board`, opened by the Tasks toggle in the panel tab bar), so the standalone `/$org/board` route was a second door to the same `TaskBoardPage` component. This deletes the route and sends its two entry points through the overlay.

- **`router.tsx`** — `boardRoute` + `boardSearchSchema` removed. `task` (the card deep-link) moves onto `unifiedChatSearchSchema`, so it now lives on the thread route's URL.
- **`open-in-board-button.tsx`** — navigates `to: "."` with `{ main: "board", task }` instead of `/$org/board?task=<id>`, matching how the Tasks toggle and `home-tasks`' "open board" already work.
- **`task-board/index.tsx`** — `clearDeepLink` drops `task` from the current search instead of navigating to the (now deleted) route.
- **`org-home/index.tsx`** — `/$org` now forwards `main` through its redirect to the landing thread. It was silently dropping the param despite the `orgIndexRoute` comment claiming it was kept, so `/$org?main=board` opened nothing.

No behavior removed: the board, its deep link, and the "open in board" button all still work — just on one surface instead of two.

## Testing

- `bun run fmt`, `bun run --cwd=apps/web check`, `bun run --cwd=packages/e2e check`, `bun run lint` — clean (the 14 lint warnings are pre-existing on `main`).
- The two board e2e specs (`task-board-drag`, `task-description-markdown`) were updated to enter via `/$org?main=board` — they're the coverage for the new `main`-forwarding redirect. Not run locally (needs Postgres + NATS up); relying on CI.

## Affected areas

Web routing only — no API, storage, or wire-contract changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dropped the standalone `/$org/board` route and unified the Task Board under the main-panel overlay (`?main=board`). Deep links and the “Open in board” action now go through the thread route for one consistent surface.

- **Refactors**
  - Removed `/$org/board` and `boardSearchSchema`; moved `task` into `unifiedChatSearchSchema` and deleted the now-orphaned default export wrapper (overlay uses `TaskBoardPage`).
  - “Open in board” now navigates to `.?main=board&task=<id>`; clearing removes `task` from the current search.
  - `/$org` redirect now forwards `main`, so `/$org?main=board` correctly opens Tasks.
  - Updated e2e specs to enter via `/$org?main=board`.

- **Migration**
  - Replace any `/$org/board` links with `/$org?main=board`.
  - For card deep links, pass `task=<id>` on the thread route query alongside `main=board`.

<sup>Written for commit 013ab10bfa7095cb666c3b48f08f4ed7bff7eefe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

