### PR TITLE
fix(sandbox): continue a run whose dispatch stream socket drops

### DIFF
--- a/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
@@ -96,6 +96,44 @@ describe("ndjsonLines", () => {
     expect(thrown).toBeInstanceOf(Error);
     expect((thrown as Error).message).toMatch(/non-JSON line/);
   });
+
+  test("a socket closed mid-stream is unreachable, so the run continues", async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('{"chunks":[]}\n'));
+      },
+      pull(controller) {
+        controller.error(
+          new Error("The socket connection was closed unexpectedly."),
+        );
+      },
+    });
+    const seen: unknown[] = [];
+    let thrown: unknown;
+    try {
+      for await (const line of ndjsonLines(body)) seen.push(line);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(seen).toEqual([{ chunks: [] }]);
+    expect(thrown).toBeInstanceOf(SandboxUnreachableError);
+  });
+
+  test("a non-transport read failure stays terminal", async () => {
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.error(new Error("unauthorized"));
+      },
+    });
+    let thrown: unknown;
+    try {
+      for await (const _ of ndjsonLines(body)) void _;
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    expect(thrown).not.toBeInstanceOf(SandboxUnreachableError);
+  });
 });
 
 describe("isUnreachableStatus", () => {

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -34,6 +34,7 @@ import { sleep } from "@decocms/shared/std";
 import type { SandboxClient } from "@decocms/sandbox/dispatch/sandbox-client";
 import { harnessRunResultSchema } from "@decocms/sandbox/dispatch/schemas";
 import type { SandboxProvider } from "@decocms/sandbox/provider";
+import { isTransientStreamError } from "@/harnesses/decopilot/built-in-tools/subtask";
 import type { HarnessId, HarnessStreamInput } from "@/harnesses/lib/types";
 import {
   claudeCodeEnvFromCredential,
@@ -574,7 +575,22 @@ export async function* ndjsonLines(
       const timeout = sleep(DAEMON_SILENCE_TIMEOUT_MS, { signal: idle.signal })
         .then(() => "silent" as const)
         .catch(() => "read-won" as const);
-      const step = await Promise.race([next, timeout]);
+      const step = await Promise.race([next, timeout]).catch((err: unknown) => {
+        // The body's socket broke mid-run. This is the port-forward
+        // WebSocket to the pod (`AgentSandboxRunner.openForwarder`), and the
+        // API server hanging it up is not the harness failing — the checkout
+        // is intact and the turn is continuable, exactly like the silence
+        // timeout below. Without this the read rejection travels as a plain
+        // Error, `dispatchWithContinuation` refuses to retry it, and a
+        // transient socket close permanently fails the run (and burns the
+        // org's task quota).
+        if (signal?.aborted) throw err;
+        const message = err instanceof Error ? err.message : String(err);
+        if (!isTransientStreamError(message)) throw err;
+        throw new SandboxUnreachableError(
+          `the sandbox stream broke mid-run: ${message}`,
+        );
+      });
       if (step === "silent") {
         if (signal?.aborted) return;
         throw new SandboxUnreachableError(


### PR DESCRIPTION
## Summary

A sandbox-hosted run streams its frames to Studio over a **port-forward WebSocket through the EKS API server** (`AgentSandboxRunner.openForwarder` → `daemonUrl = http://127.0.0.1:<port>`). When the API server hangs that stream up mid-run, the read rejects with Bun's `The socket connection was closed unexpectedly`, and `ndjsonLines` let it travel as a plain `Error` — which `dispatchWithContinuation` deliberately refuses to retry ("a harness that crashed reported a terminal").

The result is that the **hard** case was handled and the **easy** one was not:

- lost node, socket never closes → 90s silence timeout → `SandboxUnreachableError` → re-provision and continue ✅
- socket simply closes → plain `Error` → run terminally failed ❌ — with the work intact in the checkout, and one of the org's task-quota executions burned.

This classifies a transient read rejection as `SandboxUnreachableError` so the existing continuation path (re-provision, `resume`, don't re-open the message) handles it. The predicate already existed for exactly this — `isTransientStreamError` in `subtask.ts`, which literally lists this error text — and was only wired into decopilot subagents.

## Evidence (prod, 2026-08-05)

Nine runs died this way, four in one 24-minute window; **zero on Aug 4**.

| | |
|---|---|
| Where | `[Decopilot] stream pump error for thread thrd_…` on `deco-studio-worker-*`. No matching line in any sandbox pod — the *reader* threw, not the harness. |
| Not the model / gateway | `daemonUrl` is a local port-forward listener. Nothing leaves the VPC, so no NAT or gateway idle timeout is involved. |
| Not one node or pod | The three deaths at 21:15:59 / 21:16:05 / 21:16:36 sat on `l8hpm`, `xrl2r`, `kg6ww` — three different nodes. The only shared component was worker pod `wfxzw`. |
| Not a fixed timeout | Durations 5m32s, 5m33s, 6m28s, 12m44s. |
| Clean close, not an error | `ws.on("error")` logs a `port-forward … failed` warn; none at any death timestamp. |

DBOS is not the lever here: `dbos.workflow_status` showed 156 SUCCESS / 0 ERROR because the projector records "the run failed" as a *successful* projection (`projector-workflow.ts:265`). Durability covers the projection, not the agent's outcome, so the retry decision lives entirely in this transport classification.

## Testing

`bun test apps/api/src/harnesses/sandbox-dispatch-client.test.ts` — 19 pass. Two added:

- a socket closed mid-stream yields the frames already read, then throws `SandboxUnreachableError` (so the run continues)
- a non-transport read failure (`unauthorized`) stays terminal

`bun run fmt` and `bun run --cwd=apps/api check` clean.

## Follow-ups (not in this PR)

1. **Why the API server closes the WS** is unproven — leading candidate is apiserver-side stream termination (instance rotation / GOAWAY), consistent with clean closes clustered on one worker. This PR makes it survivable either way.
2. `MAX_DISPATCH_ATTEMPTS = 2` allows one continuation; a 3-in-37s cluster could exhaust it.
3. **Sandbox pod logs are heavily sampled** — 6 lines per pod across the whole death window, for a daemon that logs every frame. That's why the original investigation couldn't answer "what did the daemon see".
4. **Architecture-level**: `runner.ts:602` already knows the in-cluster Service URL (`<pod>.<ns>.svc.cluster.local:9000`) and uses it only as a fallback. Making that the primary dispatch path would take the API server out of a run's critical path entirely.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classify dropped sandbox dispatch WebSocket reads as `SandboxUnreachableError` so runs re-provision and resume instead of failing. Prevents terminal failures on clean socket closes and avoids burning task quota.

- **Bug Fixes**
  - In `ndjsonLines`, catch read errors, use `isTransientStreamError` to detect transport drops, and rethrow `SandboxUnreachableError`; non-transport read errors remain terminal.
  - Added tests: mid-stream close yields prior frames then throws `SandboxUnreachableError`; `unauthorized` stays terminal.

<sup>Written for commit 80b66a5bb4d6010aae1ada301e6d8c23a7cfb7c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5780?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

