### PR TITLE
fix(task-board): stop the review gate failing closed when GitHub is unreadable

### DIFF
--- a/apps/api/src/tools/task-board/merge-pr.ts
+++ b/apps/api/src/tools/task-board/merge-pr.ts
@@ -19,7 +19,17 @@ export async function mergeLinkedPr(
 ): Promise<boolean> {
   const prs = await ctx.storage.taskBoard.listPrs(taskBoardItemId, orgId);
   const pr = prs[0];
-  if (!pr) return false;
+  // Every `return false` below is logged. They used to be silent, and that
+  // silence cost hours: a task with a verified approval and a green, mergeable
+  // PR simply stayed In Review, and the only way to tell WHICH guard rejected it
+  // was to reason backwards from an unchanged row. A refused merge is not a
+  // routine outcome — it strands the card — so say why.
+  if (!pr) {
+    console.warn(
+      `[task-board] merge skipped — no linked PR on ${taskBoardItemId}`,
+    );
+    return false;
+  }
   // Never ship on red or in-flight CI — the ship button hides in this case, but
   // guard the server path too (auto-merge, a stale client). Only a definite
   // failing/pending blocks; an unknown (null) does not.
@@ -34,7 +44,13 @@ export async function mergeLinkedPr(
     owner: pr.repoOwner,
     name: pr.repoName,
   });
-  if (!conn) return false;
+  if (!conn) {
+    console.warn(
+      `[task-board] merge blocked — no active GitHub connection for ` +
+        `${pr.repoOwner}/${pr.repoName} (PR #${pr.number})`,
+    );
+    return false;
+  }
   const client = await clientFromConnection(conn, ctx, true);
   try {
     const result = await client.callTool(
@@ -49,7 +65,18 @@ export async function mergeLinkedPr(
       undefined,
       { timeout: MERGE_TIMEOUT_MS },
     );
-    return !(result as { isError?: boolean })?.isError;
+    // GitHub refusing the merge (branch protection, a required review, a lost
+    // race) comes back as `isError` on an otherwise successful tool call — NOT
+    // as a throw, so the catch below never saw it. Surface the payload: this is
+    // the case that looks identical to "nothing happened" from the outside.
+    if ((result as { isError?: boolean })?.isError) {
+      console.error(
+        `[task-board] merge refused by GitHub on PR #${pr.number}:`,
+        JSON.stringify((result as { content?: unknown })?.content),
+      );
+      return false;
+    }
+    return true;
   } catch (err) {
     console.error("[task-board] merge PR failed", err);
     return false;

--- a/apps/api/src/tools/task-board/pr-ready-for-review.test.ts
+++ b/apps/api/src/tools/task-board/pr-ready-for-review.test.ts
@@ -1,0 +1,84 @@
+/**
+ * The reviewer hand-off gate, and specifically what it does when it does NOT
+ * know the PR's state.
+ *
+ * This froze the review pipeline in prod. `fetchPrLiveState` is best-effort and
+ * returns EVERY field as `null` when the GitHub call fails, so the previous
+ * `state === "open"` form answered "not ready" for every card the moment GitHub
+ * went quiet — and the sweeper rejected its whole batch through a plain `return
+ * false` that logged nothing. 45 cards sat In Review with dispatching stopped
+ * dead and no error anywhere.
+ *
+ * So the rule under test is: only a DEFINITE reason blocks. Unknown means "we
+ * could not ask", not "no".
+ */
+import { describe, expect, test } from "bun:test";
+import { prReadyForReview } from "./prs-get";
+
+type Pr = Parameters<typeof prReadyForReview>[0][number];
+
+const pr = (o: Partial<Pr> = {}): Pr => ({
+  state: "open",
+  merged: false,
+  checksStatus: null,
+  ...o,
+});
+
+describe("prReadyForReview", () => {
+  test("an open PR with no CI is ready — a card without a pipeline must not sit forever", () => {
+    expect(prReadyForReview([pr({ checksStatus: null })])).toBe(true);
+  });
+
+  test("an open PR with passing checks is ready", () => {
+    expect(prReadyForReview([pr({ checksStatus: "passing" })])).toBe(true);
+  });
+
+  // The regression. All-null is what a failed GitHub read looks like.
+  test("unknown state does NOT block — this is the prod freeze", () => {
+    expect(
+      prReadyForReview([{ state: null, merged: null, checksStatus: null }]),
+    ).toBe(true);
+  });
+
+  test("unknown state with a known-pending check still blocks", () => {
+    expect(
+      prReadyForReview([
+        { state: null, merged: null, checksStatus: "pending" },
+      ]),
+    ).toBe(false);
+  });
+
+  test("a definitely closed PR blocks", () => {
+    expect(prReadyForReview([pr({ state: "closed" })])).toBe(false);
+  });
+
+  test("a definitely merged PR blocks", () => {
+    expect(prReadyForReview([pr({ merged: true })])).toBe(false);
+  });
+
+  test("pending checks block — the sweeper's 60s tick must not beat CI", () => {
+    expect(prReadyForReview([pr({ checksStatus: "pending" })])).toBe(false);
+  });
+
+  test("failing checks block", () => {
+    expect(prReadyForReview([pr({ checksStatus: "failing" })])).toBe(false);
+  });
+
+  test("no PRs at all is not ready", () => {
+    expect(prReadyForReview([])).toBe(false);
+  });
+
+  // A task can accumulate several PRs across re-runs; one live candidate is
+  // enough, and a closed earlier attempt must not veto it.
+  test("a closed old PR alongside an open one is ready", () => {
+    expect(
+      prReadyForReview([pr({ state: "closed" }), pr({ state: "open" })]),
+    ).toBe(true);
+  });
+
+  test("every PR merged or closed is not ready", () => {
+    expect(
+      prReadyForReview([pr({ merged: true }), pr({ state: "closed" })]),
+    ).toBe(false);
+  });
+});

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -542,9 +542,20 @@ async function fetchPrStatusExtras(
 /** Fetch a PR's live state via the GitHub MCP `pull_request_read` tool.
  *  Best-effort: any failure yields nulls so the modal still shows the link. */
 /**
- * Is this task's PR ready for a reviewer? Open, unmerged, and not sitting on a
- * pending or failing check run — a PR with NO CI (`checksStatus === null`)
- * qualifies, or a card without a pipeline would sit In Review forever.
+ * Is this task's PR ready for a reviewer? Only a DEFINITE reason blocks —
+ * a PR we know is closed or merged, or one sitting on a pending/failing check.
+ * Anything unknown does not block.
+ *
+ * That distinction is the whole point, and getting it backwards froze the review
+ * pipeline in prod. `fetchPrLiveState` is best-effort: every field comes back
+ * `null` when the GitHub call fails, so a version of this that asked for
+ * `state === "open"` answered "not ready" for EVERY card the moment GitHub went
+ * quiet. The sweeper then rejected its whole batch through a plain `return
+ * false` that logs nothing, and dispatching stopped dead with no error anywhere.
+ * Unknown means "we could not ask", not "no".
+ *
+ * `mergeLinkedPr` already had this right for checks ("Only a definite
+ * failing/pending blocks; an unknown (null) does not") — this now matches it.
  *
  * Shared with `review-sweeper.ts` on purpose: a reviewer claim is spent once per
  * review cycle, so whichever path dispatches first decides what gets reviewed.
@@ -558,11 +569,12 @@ export const prReadyForReview = (
     checksStatus: unknown;
   }[],
 ): boolean => {
-  const openPr = prs.find((p) => p.state === "open" && !p.merged);
+  // A PR is a candidate unless we positively know it's finished with.
+  const candidate = prs.find((p) => p.state !== "closed" && p.merged !== true);
   return (
-    openPr != null &&
-    openPr.checksStatus !== "pending" &&
-    openPr.checksStatus !== "failing"
+    candidate != null &&
+    candidate.checksStatus !== "pending" &&
+    candidate.checksStatus !== "failing"
   );
 };
 

--- a/apps/api/src/tools/task-board/review-sweeper.test.ts
+++ b/apps/api/src/tools/task-board/review-sweeper.test.ts
@@ -54,11 +54,17 @@ describe("prReadyForReview", () => {
     ).toBe(true);
   });
 
-  // `state: null` is what a GitHub fetch failure looks like (NO_LIVE_STATE) —
-  // that must read as "don't dispatch", not "no checks, go ahead".
-  it("is not ready when the live state could not be fetched", () => {
+  // INVERTED. This used to assert that an unfetchable live state reads as
+  // "don't dispatch". It shipped, and it froze the review pipeline: every field
+  // of `NO_LIVE_STATE` is null, so the moment GitHub stopped answering, this
+  // returned false for EVERY card and the sweeper rejected its whole batch
+  // through a `return false` that logs nothing — 45 cards parked In Review with
+  // no error anywhere. Unknown means "we could not ask", not "no"; only a
+  // definite closed/merged/pending/failing blocks. See
+  // `pr-ready-for-review.test.ts` for the full truth table.
+  it("is ready when the live state could not be fetched — unknown must not block", () => {
     expect(prReadyForReview([pr({ state: null, checksStatus: null })])).toBe(
-      false,
+      true,
     );
   });
 });

--- a/apps/api/src/tools/task-board/review-sweeper.ts
+++ b/apps/api/src/tools/task-board/review-sweeper.ts
@@ -172,6 +172,18 @@ export class TaskBoardReviewSweeper {
         ...(await fetchPrLiveState(ctx, organizationId, pr)),
       })),
     );
+    // `fetchPrLiveState` is best-effort and yields ALL-NULL fields when the
+    // GitHub call fails, which is indistinguishable from a PR whose state we
+    // simply haven't got. `prReadyForReview` no longer treats that as "not
+    // ready" (it used to, and a quiet GitHub then froze every card), but a whole
+    // batch of unreadable PRs is still worth one line — otherwise a broken
+    // GitHub connection is invisible from this side.
+    if (live.every((pr) => pr.state === null)) {
+      console.warn(
+        `[task-board-review-sweeper] ${id}: no live PR state from GitHub ` +
+          `(${live.length} PR(s)) — proceeding on unknown`,
+      );
+    }
     if (!prReadyForReview(live)) return false;
 
     await enqueueEnabledReviewers(ctx, item);


### PR DESCRIPTION
## The freeze

45 cards parked In Review, reviewer dispatch stopped dead at `22:01:39`, nothing merged — and **no error anywhere**.

`fetchPrLiveState` is best-effort: it returns `NO_LIVE_STATE` (every field `null`) whenever the GitHub call fails. `prReadyForReview` asked for `state === "open"`, so the moment GitHub stopped answering it returned false for **every** card. The sweeper then rejected its whole batch through a plain `return false` that logs nothing — so there was no error, no dispatch, and no way to distinguish "swept and rejected everything" from "not running at all".

Live state for an approved, mergeable PR, straight from prod:

```json
{"number":46,"state":null,"draft":null,"merged":null,
 "mergeable":null,"checksStatus":null,"checks":[],"title":null}
```

## The fix

Unknown means "we could not ask", not "no". Only a **definite** reason blocks now: a PR we positively know is closed or merged, or one sitting on a pending/failing check.

```diff
-  const openPr = prs.find((p) => p.state === "open" && !p.merged);
+  const candidate = prs.find((p) => p.state !== "closed" && p.merged !== true);
```

`mergeLinkedPr` already had this right for checks — *"Only a definite failing/pending blocks; an unknown (null) does not"* — so the gate now matches its sibling instead of contradicting it.

**On the gate itself:** I added it one PR ago to stop the sweeper's 60s tick beating CI and burning a review cycle on a red PR. Sharing the gate with the dialog poll was right; fail-closed-on-unknown was not, and it turned a GitHub blip into a dead pipeline. Pending/failing checks still block, so the original race stays closed.

## Every silent failure now speaks

`mergeLinkedPr` had **three** `return false` paths that logged nothing, and the worst one is subtle: GitHub refusing a merge (branch protection, a required review, a lost race) arrives as `isError` on an otherwise *successful* tool call — not as a throw — so the `catch` never saw it. A task with a verified approval and a green, mergeable PR simply stayed In Review and emitted nothing; working out which guard rejected it meant reasoning backwards from an unchanged DB row. That cost hours of this investigation.

All three now log, and the sweeper logs once when a card's PRs all come back with null state — so a broken GitHub connection is visible from this side instead of silently nulling every field.

## Testing

- **400 pass / 0 fail** across `tools/task-board/` and `storage/` (migrated Postgres); typecheck and lint clean.
- Full truth table for the gate, including the all-null case. **Verified it fails against the old predicate** — I reverted the one-line change and watched the test go red, so it's genuinely load-bearing.
- **Inverted** the existing `is not ready when the live state could not be fetched` test rather than adding mine beside it. It explicitly encoded the bug ("that must read as *don't dispatch*"), so leaving it would have meant two tests asserting opposite things.

## Not fixed here — this is configuration, not code

`resolveGithubConnection` prefers a repo-scoped connection over the org-level one:

```ts
if (repo) { const matching = active.find(c => scope?.owner === repo.owner && scope?.repo === repo.name);
            if (matching) return matching; }   // ← always wins
return active.find(c => getRepoScope(c) === null) ?? active[0] ?? null;  // never reached
```

In the affected org, **both** repo-scoped connections for the repo return empty live state, while the org-level connection is verifiably healthy (`GITHUB_LIST_USER_ORGS` through it returns installation `112016830` for `deco-sites`). So every read and merge goes through a broken connection while a working one sits unused. Those connections need repairing or removing — this PR only stops that outage from silently freezing the whole board.

One correction for the record: `CONNECTION_TEST` is not a usable health signal for these. It POSTs a bare `ping` with only `connection_token` as Bearer, and OAuth-backed connections have `connection_token: null`, so it reports `healthy: false` for all of them regardless of whether they work.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the task-board review gate from failing closed when GitHub live state is unreadable, avoiding pipeline freezes. Only definite closed/merged or pending/failing checks block; unknown now allows dispatch.

- **Bug Fixes**
  - Gate: treat unknown as allowed; block only if PR is definitively closed/merged or checks are pending/failing (uses `state !== "closed" && merged !== true`).
  - Aligns gate with `mergeLinkedPr` policy where unknown check status does not block.
  - Logging: log all skipped/blocked merge paths, surface GitHub “merge refused” `isError` payloads, and warn when a sweep sees all-null live state.
  - Tests: add full truth-table for the gate and invert the prior “unfetchable means not ready” test.

<sup>Written for commit 659556ba01da138b5cb2f95fd6b2d7ef40950b1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

