### PR TITLE
feat(commerce-onboarding): make GA4 optional in the sources dialog

### DIFF
--- a/apps/web/src/routes/commerce-onboarding/companions-core.test.ts
+++ b/apps/web/src/routes/commerce-onboarding/companions-core.test.ts
@@ -275,9 +275,9 @@ describe("isCompanionConfigured", () => {
 });
 
 describe("REQUIRED_BINDING_TYPES", () => {
-  it("marks analytics as the required source and others as optional", () => {
-    expect(REQUIRED_BINDING_TYPES.has("google-analytics")).toBe(true);
-    expect(REQUIRED_BINDING_TYPES.has("vtex")).toBe(false);
+  it("requires no source — analytics is optional like the rest", () => {
+    expect(REQUIRED_BINDING_TYPES.has("google-analytics")).toBe(false);
+    expect(REQUIRED_BINDING_TYPES.size).toBe(0);
   });
 });
 

--- a/apps/web/src/routes/commerce-onboarding/companions-core.ts
+++ b/apps/web/src/routes/commerce-onboarding/companions-core.ts
@@ -78,12 +78,11 @@ export interface CompanionCardModel {
  *  (e.g. "google-analytics"), from the commerce-discovery status endpoint. */
 export type SaBindings = Record<string, { resource: string | null }>;
 
-/** Binding types a merchant MUST connect for the report to be worth anything —
- *  analytics is the baseline data source, everything else only enriches it.
- *  Cards for these render under "Required" and gate the continue button. */
-export const REQUIRED_BINDING_TYPES: ReadonlySet<string> = new Set([
-  "google-analytics",
-]);
+/** Binding types a merchant MUST connect before continuing. Currently empty —
+ *  no source is mandatory; the continue gate falls back to "any source ready"
+ *  (see companion-mcps-section). Add a binding type here to make it required
+ *  again. */
+export const REQUIRED_BINDING_TYPES: ReadonlySet<string> = new Set([]);
 
 /**
  * Whether a linked binding actually has what it needs to produce data. A


### PR DESCRIPTION
## Summary
- GA4 (google-analytics) is no longer a required connection in the commerce onboarding sources dialog: `REQUIRED_BINDING_TYPES` is now empty.
- With no required source, the continue gate falls back to the pre-existing "any source ready" path in `companion-mcps-section.tsx`, and the "Required" pill no longer renders on any card.
- The set stays in place as the extension point — adding a binding type back makes it required again.

## Testing
- Inverted the unit test that asserted `google-analytics` was required; it now asserts the set is empty.
- `bun test src/routes/commerce-onboarding/` — 80 pass.
- `bun run fmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make GA4 (`google-analytics`) optional in the commerce onboarding sources dialog by emptying `REQUIRED_BINDING_TYPES`. The continue button now uses the “any source ready” path, and the “Required” pill no longer shows; tests updated to reflect no required sources.

<sup>Written for commit 0882cdadecd5b8a2d53e3e675b70e9390bee59ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

