### PR TITLE
fix(commerce-onboarding): warn when SA connection status is unreadable instead of rendering sources as disconnected

### DIFF
--- a/apps/api/src/tools/reports/auth-client.test.ts
+++ b/apps/api/src/tools/reports/auth-client.test.ts
@@ -492,12 +492,13 @@ describe("fetchCommerceDiscoveryConnectionStatus", () => {
       },
     );
 
-    expect(out.ga4).toEqual({
+    expect(out.claimed).toBe(true);
+    expect(out.providers.ga4).toEqual({
       connected: true,
       via: "sa",
       resource: "123456789",
     });
-    expect(out.gsc?.connected).toBe(false);
+    expect(out.providers.gsc?.connected).toBe(false);
     expect(captured).toEqual([
       {
         method: "GET",
@@ -506,7 +507,7 @@ describe("fetchCommerceDiscoveryConnectionStatus", () => {
     ]);
   });
 
-  test("treats a 409 (never upgraded) as everything disconnected, not a throw", async () => {
+  test("flags a 409 (not claimed for this org) as claimed:false, not a throw", async () => {
     const out = await fetchCommerceDiscoveryConnectionStatus(
       { siteUrl: "https://example.com", orgId: "org_123" },
       {
@@ -516,6 +517,6 @@ describe("fetchCommerceDiscoveryConnectionStatus", () => {
           Response.json({ error: "not_upgraded" }, { status: 409 }),
       },
     );
-    expect(out).toEqual({});
+    expect(out).toEqual({ providers: {}, claimed: false });
   });
 });

--- a/apps/api/src/tools/reports/auth-client.ts
+++ b/apps/api/src/tools/reports/auth-client.ts
@@ -388,13 +388,18 @@ export type CommerceDiscoveryConnectionStatus = z.infer<
  * Read per-provider connection status for a store — the single source of truth
  * the studio card renders as "Conectado", unifying both lanes (Studio-vault
  * OAuth and shared-SA binding). Read-only; soft-tolerant: a report that was
- * never upgraded (404/409) reports everything disconnected rather than throwing,
- * so the onboarding UI degrades cleanly before the first upgrade.
+ * never upgraded, or claimed by a different org (404/409), returns
+ * `claimed: false` with empty providers rather than throwing. `claimed` lets
+ * the UI tell "site not readable for this org" apart from "nothing connected"
+ * — without it, an existing SA binding silently renders as disconnected.
  */
 export async function fetchCommerceDiscoveryConnectionStatus(
   input: { siteUrl: string; orgId: string },
   options: CommerceDiscoveryAuthOptions = {},
-): Promise<CommerceDiscoveryConnectionStatus> {
+): Promise<{
+  providers: CommerceDiscoveryConnectionStatus;
+  claimed: boolean;
+}> {
   const baseUrl = resolveBaseUrl(options);
   const apiKey = resolveApiKey(options);
   const fetchImpl = options.fetchImpl ?? fetch;
@@ -409,11 +414,14 @@ export async function fetchCommerceDiscoveryConnectionStatus(
   });
 
   if (response.status === 404 || response.status === 409) {
-    return {};
+    return { providers: {}, claimed: false };
   }
   if (!response.ok) {
     throw new Error(await responseErrorMessage(response));
   }
   const parsed = ConnectionStatusSchema.safeParse(await response.json());
-  return parsed.success ? parsed.data.providers : {};
+  return {
+    providers: parsed.success ? parsed.data.providers : {},
+    claimed: true,
+  };
 }

--- a/apps/api/src/tools/reports/status.ts
+++ b/apps/api/src/tools/reports/status.ts
@@ -17,6 +17,11 @@ const CommerceDiscoveryStatusOutputSchema = z.object({
       resource: z.string().nullable(),
     }),
   ),
+  claimed: z
+    .boolean()
+    .describe(
+      "False when the site isn't claimed/upgraded for this org — providers is then empty because the status is unreadable, NOT because nothing is connected. The UI must warn instead of rendering existing bindings as disconnected.",
+    ),
 });
 
 export const COMMERCE_DISCOVERY_CONNECTION_STATUS = defineTool({
@@ -43,10 +48,9 @@ export const COMMERCE_DISCOVERY_CONNECTION_STATUS = defineTool({
       throw new Error(normalized.error);
     }
 
-    const providers = await fetchCommerceDiscoveryConnectionStatus({
+    return fetchCommerceDiscoveryConnectionStatus({
       siteUrl: normalized.value,
       orgId: organization.id,
     });
-    return { providers };
   },
 });

--- a/apps/web/src/i18n/en/routes.ts
+++ b/apps/web/src/i18n/en/routes.ts
@@ -159,6 +159,8 @@ export const routes = {
   "routes.commerceOnboarding.companionSection.loadErrorDescription":
     "Something went wrong loading your integrations.",
   "routes.commerceOnboarding.companionSection.retry": "Try again",
+  "routes.commerceOnboarding.companionSection.statusUnavailable":
+    "We couldn't verify your Google connections right now — sources you already connected may show as disconnected. You can still continue.",
   "routes.oauthCallback.authenticationComplete": "Authentication complete.",
   "routes.oauthCallback.authenticationFailed": "MCP authentication failed",
   "routes.oauthCallback.authenticationFailedTitle": "Authentication Failed",

--- a/apps/web/src/i18n/pt-br/routes.ts
+++ b/apps/web/src/i18n/pt-br/routes.ts
@@ -165,6 +165,8 @@ export const routes = {
   "routes.commerceOnboarding.companionSection.loadErrorDescription":
     "Algo deu errado ao carregar suas integrações.",
   "routes.commerceOnboarding.companionSection.retry": "Tentar novamente",
+  "routes.commerceOnboarding.companionSection.statusUnavailable":
+    "Não conseguimos verificar suas conexões do Google agora — fontes que você já conectou podem aparecer como desconectadas. Você ainda pode continuar.",
   "routes.oauthCallback.authenticationComplete": "Autenticação concluída.",
   "routes.oauthCallback.authenticationFailed": "Falha na autenticação do MCP",
   "routes.oauthCallback.authenticationFailedTitle": "Autenticação Falhou",

--- a/apps/web/src/routes/commerce-onboarding/companion-mcps-section.tsx
+++ b/apps/web/src/routes/commerce-onboarding/companion-mcps-section.tsx
@@ -132,6 +132,7 @@ function CompanionMcpsSectionContent({
   onReadinessChange?: (hasConnectedSource: boolean) => void;
   focusFieldKey?: string;
 }) {
+  const t = useT();
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id ?? "";
   const normalizedSite = siteUrl ? normalizeReportsSiteUrl(siteUrl) : null;
@@ -149,7 +150,7 @@ function CompanionMcpsSectionContent({
     orgSlug: org.slug,
   });
 
-  const { cards } = useCommerceCompanions({
+  const { cards, saStatusUnavailable } = useCommerceCompanions({
     selfClient,
     org,
     cdConnectionId,
@@ -184,10 +185,14 @@ function CompanionMcpsSectionContent({
   // so a config that never offers Analytics can't trap the user. Derived during
   // render (not an effect) so the parent's button re-enables the same pass a
   // source becomes ready.
+  // When the SA connection status couldn't be read, an existing GA4/GSC binding
+  // renders as disconnected — fail open (with the warning below) instead of
+  // trapping a user who already connected behind a gate they can't satisfy.
   const ready =
-    requiredCards.length > 0
+    saStatusUnavailable ||
+    (requiredCards.length > 0
       ? requiredCards.every(isReady)
-      : cards.length === 0 || cards.some(isReady);
+      : cards.length === 0 || cards.some(isReady));
   onReadinessChange?.(ready);
 
   // Empty: nothing to connect → render nothing (the parent footer still shows
@@ -249,6 +254,14 @@ function CompanionMcpsSectionContent({
         {connectError && (
           <p role="alert" className="mb-3 text-sm text-destructive">
             {connectError}
+          </p>
+        )}
+        {saStatusUnavailable && (
+          <p
+            role="status"
+            className="mb-3 rounded-lg border border-warning/40 bg-warning/10 p-3 text-sm text-foreground"
+          >
+            {t("routes.commerceOnboarding.companionSection.statusUnavailable")}
           </p>
         )}
         {/* Single list, required source(s) first — the "Obrigatório" pill on the

--- a/apps/web/src/routes/commerce-onboarding/use-commerce-companions.ts
+++ b/apps/web/src/routes/commerce-onboarding/use-commerce-companions.ts
@@ -42,6 +42,9 @@ interface ConnectionStatusResult {
       resource?: string | null;
     }
   >;
+  /** False ⇒ the site isn't claimed for this org, so providers is empty
+   *  because the status is unreadable — NOT because nothing is connected. */
+  claimed?: boolean;
 }
 
 export function useCommerceCompanions({
@@ -54,7 +57,7 @@ export function useCommerceCompanions({
   org: CompanionOrg;
   cdConnectionId: string;
   siteUrl?: string;
-}): { cards: CompanionCardModel[] } {
+}): { cards: CompanionCardModel[]; saStatusUnavailable: boolean } {
   // 1) CD's live config schema (on the CD connection's OWN client).
   const cdClient = useMCPClient({
     connectionId: cdConnectionId,
@@ -275,6 +278,11 @@ export function useCommerceCompanions({
       saBindings[bindingType] = { resource: p.resource ?? null };
     }
   }
+  // The status couldn't actually be read (query failed, or the site isn't
+  // claimed for this org): an existing SA binding would render as disconnected.
+  // Callers must surface a warning and not hard-gate on SA cards.
+  const saStatusUnavailable =
+    !!siteUrl && (statusQuery.isError || statusQuery.data?.claimed === false);
 
   const cards = buildCompanionCards({
     requirements,
@@ -287,5 +295,5 @@ export function useCommerceCompanions({
     saBindings,
   });
 
-  return { cards };
+  return { cards, saStatusUnavailable };
 }

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -1983,6 +1983,7 @@ export interface StudioToolIO {
           resource: string | null;
         }
       >;
+      claimed: boolean;
     };
   };
   COLLECTION_VIRTUAL_MCP_CREATE: {


### PR DESCRIPTION
## Summary

A user who had already bound GA4 via the shared service-account lane (typed the property id, bind verified and persisted) came back to the onboarding connections dialog and was stuck: the GA4 card read as disconnected, asked for the property again, and the continue gate stayed blocked — with no error anywhere.

Root cause: the SA lane's source of truth is `COMMERCE_DISCOVERY_CONNECTION_STATUS`, and `fetchCommerceDiscoveryConnectionStatus` coerced a 404/409 from Commerce Discovery (site not claimed/upgraded for this org — e.g. the domain was re-claimed by another org) into a silent `{}`. The frontend cannot tell "status unreadable" apart from "nothing connected", so an existing binding rendered as disconnected and hard-gated the user. Re-binding then fails with `resource_already_bound`, leaving no way out.

## Changes

- **api**: `COMMERCE_DISCOVERY_CONNECTION_STATUS` now returns `claimed: boolean` — 404/409 becomes `{ providers: {}, claimed: false }` instead of a bare `{}`. Tool contracts regenerated.
- **web**: `useCommerceCompanions` exposes `saStatusUnavailable` (status query errored, or `claimed: false`). The companions section then:
  - shows an amber notice ("we couldn't verify your Google connections — already-connected sources may show as disconnected; you can still continue"), i18n'd in en + pt-BR;
  - fails open on the continue gate, matching the modal's existing philosophy that a status failure must not permanently trap the user behind a disabled button.

Genuinely-empty status (site claimed, nothing bound) behaves exactly as before: cards show connect, gate blocks.

## Testing

- Inverted the unit test that encoded the old behavior (409 → `{}`) to assert `{ providers: {}, claimed: false }`; happy path now asserts `claimed: true`.
- `bun test`, `bun run check`, `bun run lint`, `bun run fmt` all pass.

## Follow-up

`normalizeReportsSiteUrl` does not canonicalize `www.`, so binding under one host variant and returning under the other queries a different diagnostic and hits this same trap (plus a 409 on re-bind). Left out of this PR since it changes the identity of existing claims.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where GA4/GSC connected via the shared service account appeared disconnected when the site status couldn’t be read, blocking Continue. We now show a warning and allow continuing; the API distinguishes unreadable status with `claimed: false`.

- **Bug Fixes**
  - API: `COMMERCE_DISCOVERY_CONNECTION_STATUS` now returns `{ providers, claimed }`; 404/409 → `{ providers: {}, claimed: false }`. `fetchCommerceDiscoveryConnectionStatus` updated to match.
  - Web: `useCommerceCompanions` exposes `saStatusUnavailable`; the companions section shows a warning and fails open the Continue gate when status is unavailable.
  - i18n: Added notice copy in `en` and `pt-BR`.
  - Types/tests: Updated tool IO and unit tests to expect `claimed` and the new fallback shape.

<sup>Written for commit 4e6cbef989255ea3ed24ce91a6dcc05f17c361c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

