### PR TITLE
feat(commerce-onboarding): rename connect CTA to "View diagnostic" and add skip button

### DIFF
--- a/apps/web/src/i18n/en/routes.ts
+++ b/apps/web/src/i18n/en/routes.ts
@@ -138,9 +138,8 @@ export const routes = {
   "routes.commerceOnboarding.connectModal.somethingWentWrong":
     "Something went wrong generating your report. Try again in a moment.",
   "routes.commerceOnboarding.connectModal.openingReport": "Opening report...",
-  "routes.commerceOnboarding.connectModal.connectToolToContinue":
-    "Connect your analytics to continue",
-  "routes.commerceOnboarding.connectModal.viewFullReport": "View full report",
+  "routes.commerceOnboarding.connectModal.viewDiagnostic": "View diagnostic",
+  "routes.commerceOnboarding.connectModal.skip": "Skip",
   "routes.commerceOnboarding.connectModal.close": "Close",
   "routes.commerceOnboarding.connectModal.quote":
     "I was grinning ear to ear, because we had already spotted all of it, we just didn't know what to do next... you brought a really meaningful perspective on the next steps.",

--- a/apps/web/src/i18n/pt-br/routes.ts
+++ b/apps/web/src/i18n/pt-br/routes.ts
@@ -142,10 +142,8 @@ export const routes = {
     "Algo deu errado ao gerar seu relatório. Tente novamente em instantes.",
   "routes.commerceOnboarding.connectModal.openingReport":
     "Abrindo relatório...",
-  "routes.commerceOnboarding.connectModal.connectToolToContinue":
-    "Conecte sua analytics para continuar",
-  "routes.commerceOnboarding.connectModal.viewFullReport":
-    "Ver relatório completo",
+  "routes.commerceOnboarding.connectModal.viewDiagnostic": "Ver diagnóstico",
+  "routes.commerceOnboarding.connectModal.skip": "Pular",
   "routes.commerceOnboarding.connectModal.close": "Fechar",
   "routes.commerceOnboarding.connectModal.quote":
     "Eu tava sorrindo de orelha a orelha, porque tudo aquilo a gente já tinha identificado, mas a gente não sabia o que fazer... vocês trouxeram uma visão bem significativa para os próximos passos.",

--- a/apps/web/src/routes/commerce-onboarding/commerce-connect-modal.tsx
+++ b/apps/web/src/routes/commerce-onboarding/commerce-connect-modal.tsx
@@ -40,10 +40,11 @@ import { parseSelfToolResult } from "./self-tool-result.ts";
  * Blocking commerce-onboarding connections step, rendered as a modal OVER the
  * org (the report page behind it stays mounted and blurred) instead of as a
  * standalone `/commerce-onboarding` screen. Non-dismissable: no close button, no
- * escape/overlay close — the only way forward is connecting at least one data
- * source, which enables the "Ver relatório completo" CTA. `onComplete` is called
- * once the run is triggered so the caller can drop the `connect` search param and
- * reveal the report.
+ * escape/overlay close — the way forward is connecting at least one data source
+ * (enabling the "Ver diagnóstico" CTA) or skipping via the secondary "Pular"
+ * button shown while nothing is connected. `onComplete` is called once the run
+ * is triggered so the caller can drop the `connect` search param and reveal the
+ * report.
  */
 export function CommerceConnectModal({ siteUrl }: { siteUrl?: string }) {
   const navigate = useNavigate();
@@ -255,22 +256,36 @@ function CommerceConnectModalContent({
               {runError}
             </p>
           ) : null}
-          <ConnectFooterButton
-            ready={ready}
-            pending={runMutation.isPending}
-            label={
-              runMutation.isPending
-                ? t("routes.commerceOnboarding.connectModal.openingReport")
-                : !ready
-                  ? t(
-                      "routes.commerceOnboarding.connectModal.connectToolToContinue",
-                    )
-                  : t("routes.commerceOnboarding.connectModal.viewFullReport")
-            }
-            onClick={() => void openReport()}
-          >
-            <ArrowRight size={18} />
-          </ConnectFooterButton>
+          <div className="flex gap-3">
+            <div className="min-w-0 flex-1">
+              <ConnectFooterButton
+                ready={ready}
+                pending={runMutation.isPending}
+                label={
+                  runMutation.isPending
+                    ? t("routes.commerceOnboarding.connectModal.openingReport")
+                    : t("routes.commerceOnboarding.connectModal.viewDiagnostic")
+                }
+                onClick={() => void openReport()}
+              >
+                <ArrowRight size={18} />
+              </ConnectFooterButton>
+            </div>
+            {!ready ? (
+              // Escape hatch while nothing is connected: same run-then-reveal
+              // flow as the primary CTA, just without any source connected.
+              <Button
+                type="button"
+                variant="secondary"
+                size="lg"
+                className="h-auto min-h-12 shrink-0 rounded-lg py-3 text-base font-medium leading-tight"
+                disabled={runMutation.isPending}
+                onClick={() => void openReport()}
+              >
+                {t("routes.commerceOnboarding.connectModal.skip")}
+              </Button>
+            ) : null}
+          </div>
         </>
       }
     >

--- a/packages/e2e/tests/commerce-onboarding.spec.ts
+++ b/packages/e2e/tests/commerce-onboarding.spec.ts
@@ -255,12 +255,12 @@ test.describe("Commerce onboarding route isolation", () => {
 
     // After site setup the flow hands off to the org: it redirects off
     // /commerce-onboarding to the report route, where the blocking connections
-    // modal (with the "View full report" CTA) opens over the report.
+    // modal (with the "View diagnostic" CTA) opens over the report.
     await page.waitForURL((url) => url.pathname !== "/commerce-onboarding", {
       timeout: 20_000,
     });
     await expect(
-      page.getByRole("button", { name: "View full report" }),
+      page.getByRole("button", { name: "View diagnostic" }),
     ).toBeVisible({
       timeout: 20_000,
     });
@@ -283,7 +283,7 @@ test.describe("Commerce onboarding route isolation", () => {
     await page.goto("/commerce-onboarding?siteUrl=https://example.com/path");
 
     await expect(
-      page.getByRole("button", { name: "View full report" }),
+      page.getByRole("button", { name: "View diagnostic" }),
     ).toBeVisible({
       timeout: 20_000,
     });
@@ -344,7 +344,7 @@ test.describe("Commerce onboarding route isolation", () => {
 
     await page.goto("/commerce-onboarding?siteUrl=example.com");
     await expect(
-      page.getByRole("button", { name: "View full report" }),
+      page.getByRole("button", { name: "View diagnostic" }),
     ).toBeVisible({
       timeout: 20_000,
     });
@@ -353,14 +353,14 @@ test.describe("Commerce onboarding route isolation", () => {
 
     await expect(page.getByLabel("Site URL")).toHaveCount(0);
     await expect(
-      page.getByRole("button", { name: "View full report" }),
+      page.getByRole("button", { name: "View diagnostic" }),
     ).toBeVisible({
       timeout: 20_000,
     });
     // The old "Companion MCPs" placeholder was replaced by the companion
     // section, whose header is hidden when no companion requirements resolve
     // (the case in this e2e env). The ready view is already asserted via the
-    // "Ver relatório completo" CTA above; here we only guard against leaking raw
+    // "View diagnostic" CTA above; here we only guard against leaking raw
     // connection titles into the onboarding view.
     await expect(page.getByText("Commerce Discovery MCP")).toHaveCount(0);
     await expect(page.getByText("Commerce Discovery agent")).toHaveCount(0);
@@ -400,7 +400,7 @@ test.describe("Commerce onboarding route isolation", () => {
       timeout: 1_000,
     });
     await expect(
-      page.getByRole("button", { name: "View full report" }),
+      page.getByRole("button", { name: "View diagnostic" }),
     ).toBeVisible({ timeout: 20_000 });
   });
 
@@ -425,7 +425,7 @@ test.describe("Commerce onboarding route isolation", () => {
     await page.getByLabel("Site URL").fill("example.com");
     await page.getByRole("button", { name: "Continue" }).click();
     await expect(
-      page.getByRole("button", { name: "View full report" }),
+      page.getByRole("button", { name: "View diagnostic" }),
     ).toBeVisible({
       timeout: 20_000,
     });
@@ -446,9 +446,9 @@ test.describe("Commerce onboarding route isolation", () => {
 
     // The connect step is a blocking modal over the org: it must NOT be
     // dismissable. Pressing Escape leaves it open; the only way forward is the
-    // "View full report" CTA.
+    // "View diagnostic" CTA.
     const reportCta = page.getByRole("button", {
-      name: "View full report",
+      name: "View diagnostic",
     });
     await expect(reportCta).toBeVisible({ timeout: 20_000 });
     await page.keyboard.press("Escape");


### PR DESCRIPTION
## Summary

The connections step no longer requires GA4, so the blocking connect modal needed a way forward with zero sources connected:

- The footer CTA now reads **"Ver diagnóstico" / "View diagnostic"** in both states (previously "Conecte sua analytics para continuar" while disabled and "Ver relatório completo" when enabled). The trailing arrow still renders only while the button is enabled.
- When **zero sources are connected**, a secondary **"Pular" / "Skip"** button appears next to the primary CTA. It runs the same `openReport()` flow (still triggers `COMMERCE_DISCOVERY_RUN` so the report isn't revealed empty, with the same error handling), just without any source connected. It disables while the run is pending.
- Replaced the `connectToolToContinue` / `viewFullReport` i18n keys with `viewDiagnostic`, and added `skip` (en + pt-BR).

## Testing

- `bun run --cwd=apps/web check` and `bun run --cwd=packages/e2e check` pass; `bun run fmt` clean.
- Updated `packages/e2e/tests/commerce-onboarding.spec.ts`: all "View full report" CTA assertions now assert "View diagnostic" (in the e2e env the CTA renders enabled).

Affected area: commerce onboarding connect modal (`apps/web/src/routes/commerce-onboarding/`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the commerce onboarding connect CTA to "View diagnostic" and added a "Skip" button when no sources are connected, so users can run the diagnostic without GA4. The modal stays blocking but now allows progress without a connected source.

- **New Features**
  - Primary CTA always reads "View diagnostic"; arrow appears only when enabled.
  - New secondary "Skip" button shows when zero sources are connected; runs the same openReport flow and disables while pending.
  - Modal remains non-dismissable.

- **Migration**
  - Replaced i18n keys: removed `connectToolToContinue` and `viewFullReport`; added `viewDiagnostic` and `skip` (en, pt-BR).
  - Updated e2e tests to assert "View diagnostic".

<sup>Written for commit def0b9fea24955373b841e734afad1e87ed7e6f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

