### PR TITLE
fix(sections-editor): fade array-item action buttons in/out via CSS

### DIFF
--- a/apps/web/ct/harness/ct-utils.ts
+++ b/apps/web/ct/harness/ct-utils.ts
@@ -16,6 +16,21 @@ export async function hoverFieldDescription(
   return page.getByText(description);
 }
 
+/**
+ * Open a row's "…" actions menu by its visible label. The trigger collapses
+ * to zero width until the row is hovered, so hover first to give Playwright
+ * a real click target.
+ */
+export async function openRowActionsMenu(
+  component: Locator,
+  label: string,
+): Promise<void> {
+  await component.getByText(label, { exact: true }).hover();
+  await component
+    .getByRole("button", { name: `Open actions for ${label}`, exact: true })
+    .click();
+}
+
 /** Parse the harness's `form-value` <pre> back into a JS value. */
 export async function readFormValue(component: Locator): Promise<unknown> {
   const txt = await component.getByTestId("form-value").textContent();

--- a/apps/web/ct/tests/array-field.ct.tsx
+++ b/apps/web/ct/tests/array-field.ct.tsx
@@ -120,9 +120,11 @@ test("delete removes the targeted item from the list", async ({
     .poll(() => readFormValue(component))
     .toEqual({ tags: ["a", "b"] });
 
-  // The per-row actions trigger is in the DOM (opacity-0 until hover) and clickable.
-  // `exact` disambiguates the button from the sortable row (whose accessible
-  // name embeds the button label).
+  // The per-row actions trigger collapses to zero width until the row is
+  // hovered, so hover the row first to reveal it before clicking. `exact`
+  // disambiguates the button from the sortable row (whose accessible name
+  // embeds the button label).
+  await component.getByText("a", { exact: true }).hover();
   await component
     .getByRole("button", { name: "Open actions for a", exact: true })
     .click();
@@ -151,6 +153,9 @@ test("duplicate inserts a copy right after the targeted item", async ({
     .poll(() => readFormValue(component))
     .toEqual({ tags: ["a", "b"] });
 
+  // The per-row actions trigger collapses to zero width until the row is
+  // hovered, so hover the row first to reveal it before clicking.
+  await component.getByText("a", { exact: true }).hover();
   await component
     .getByRole("button", { name: "Open actions for a", exact: true })
     .click();

--- a/apps/web/ct/tests/array-field.ct.tsx
+++ b/apps/web/ct/tests/array-field.ct.tsx
@@ -1,7 +1,11 @@
 import { expect, test } from "@playwright/experimental-ct-react";
 import { SchemaFormHarness } from "../harness/schema-form-harness";
 import { sectionWithProps, TEST_RESOLVE_TYPE } from "../harness/fixtures";
-import { readBreadcrumb, readFormValue } from "../harness/ct-utils";
+import {
+  openRowActionsMenu,
+  readBreadcrumb,
+  readFormValue,
+} from "../harness/ct-utils";
 
 test("empty array shows an Add item button and no count badge", async ({
   mount,
@@ -120,14 +124,7 @@ test("delete removes the targeted item from the list", async ({
     .poll(() => readFormValue(component))
     .toEqual({ tags: ["a", "b"] });
 
-  // The per-row actions trigger collapses to zero width until the row is
-  // hovered, so hover the row first to reveal it before clicking. `exact`
-  // disambiguates the button from the sortable row (whose accessible name
-  // embeds the button label).
-  await component.getByText("a", { exact: true }).hover();
-  await component
-    .getByRole("button", { name: "Open actions for a", exact: true })
-    .click();
+  await openRowActionsMenu(component, "a");
   // The DropdownMenu content is portaled onto document.body — query via page.
   await page.getByRole("menuitem", { name: "Delete" }).click();
 
@@ -153,12 +150,7 @@ test("duplicate inserts a copy right after the targeted item", async ({
     .poll(() => readFormValue(component))
     .toEqual({ tags: ["a", "b"] });
 
-  // The per-row actions trigger collapses to zero width until the row is
-  // hovered, so hover the row first to reveal it before clicking.
-  await component.getByText("a", { exact: true }).hover();
-  await component
-    .getByRole("button", { name: "Open actions for a", exact: true })
-    .click();
+  await openRowActionsMenu(component, "a");
   // The DropdownMenu content is portaled onto document.body — query via page.
   await page.getByRole("menuitem", { name: "Duplicate" }).click();
 

--- a/apps/web/ct/tests/array-object-drilldown.ct.tsx
+++ b/apps/web/ct/tests/array-object-drilldown.ct.tsx
@@ -261,9 +261,11 @@ test("deleting a row removes the right item from the array", async ({
     />,
   );
 
-  // Open the actions menu for the Alpha row (button is in the DOM though
-  // hidden). exact: true — the row wrapper is also a role=button whose
-  // accessible name CONTAINS "Open actions for Alpha".
+  // The per-row actions trigger collapses to zero width until the row is
+  // hovered, so hover the row first to reveal it before clicking. exact:
+  // true — the row wrapper is also a role=button whose accessible name
+  // CONTAINS "Open actions for Alpha".
+  await itemRow(component, "Alpha").hover();
   await component
     .getByRole("button", { name: "Open actions for Alpha", exact: true })
     .click();

--- a/apps/web/ct/tests/array-object-drilldown.ct.tsx
+++ b/apps/web/ct/tests/array-object-drilldown.ct.tsx
@@ -2,7 +2,11 @@ import { expect, test } from "@playwright/experimental-ct-react";
 import type { Locator } from "@playwright/test";
 import { SchemaFormHarness } from "../harness/schema-form-harness";
 import { sectionWithProps, TEST_RESOLVE_TYPE } from "../harness/fixtures";
-import { readBreadcrumb, readFormValue } from "../harness/ct-utils";
+import {
+  openRowActionsMenu,
+  readBreadcrumb,
+  readFormValue,
+} from "../harness/ct-utils";
 
 /**
  * The sortable row wrapper is a role=button whose accessible NAME concatenates
@@ -261,14 +265,7 @@ test("deleting a row removes the right item from the array", async ({
     />,
   );
 
-  // The per-row actions trigger collapses to zero width until the row is
-  // hovered, so hover the row first to reveal it before clicking. exact:
-  // true — the row wrapper is also a role=button whose accessible name
-  // CONTAINS "Open actions for Alpha".
-  await itemRow(component, "Alpha").hover();
-  await component
-    .getByRole("button", { name: "Open actions for Alpha", exact: true })
-    .click();
+  await openRowActionsMenu(component, "Alpha");
   // DropdownMenu content is portaled onto document.body -> query via page.
   await page.getByRole("menuitem", { name: "Delete" }).click();
 

--- a/apps/web/src/components/sections-editor/fields/array-row.tsx
+++ b/apps/web/src/components/sections-editor/fields/array-row.tsx
@@ -22,6 +22,45 @@ import { cn } from "@deco/ui/lib/utils.ts";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 
+// Width/margin snap instantly (no visible slide) while opacity does the
+// actual animating. On reveal the snap has no delay, so the button is
+// already full-size before opacity starts rising. On hide the snap is
+// delayed until the fade-out finishes, so it's invisible when it happens.
+//
+// This button is toggled on (hidden) — always shown, no hover dependency.
+const ACTION_BUTTON_SHOWN =
+  "w-6 ml-0 opacity-100 [transition:opacity_150ms_ease-out,width_0ms,margin-left_0ms]";
+// No button on this row is toggled on — everyone starts fully collapsed
+// (zero width) so the label gets the space, and hover reveals the whole
+// group. group-has-[:focus-visible] (not group-focus-within) so keyboard
+// Tab reveals it too, without a mouse click sticking it open (clicking a
+// <button> focuses it, but doesn't count as :focus-visible).
+const ACTION_BUTTON_HIDDEN =
+  "w-0 -ml-2 opacity-0 [transition:opacity_150ms_ease-out,width_0ms_150ms,margin-left_0ms_150ms] " +
+  "group-hover:ml-0 group-hover:w-6 group-hover:opacity-100 group-hover:[transition:opacity_150ms_ease-out,width_0ms,margin-left_0ms] " +
+  "group-has-[:focus-visible]:ml-0 group-has-[:focus-visible]:w-6 group-has-[:focus-visible]:opacity-100 group-has-[:focus-visible]:[transition:opacity_150ms_ease-out,width_0ms,margin-left_0ms]";
+// A sibling button on this row IS toggled on, so the whole action-button
+// group already reserves its width — this button just isn't the active
+// one. Stay at full width and only fade opacity, so a sibling toggling on
+// or off never shifts this button (or the label) horizontally.
+const ACTION_BUTTON_RESERVED_HIDDEN =
+  "w-6 ml-0 opacity-0 [transition:opacity_150ms_ease-out,width_0ms_150ms,margin-left_0ms_150ms] " +
+  "group-hover:opacity-100 group-has-[:focus-visible]:opacity-100";
+
+// `reserved`: true when ANY button on this row is toggled on, so the whole
+// group keeps its reserved width even for the buttons that aren't
+// themselves active. `active`: this specific button is toggled on.
+function actionButtonVisibilityClass(reserved: boolean, active: boolean) {
+  return cn(
+    "h-6 shrink-0 overflow-hidden",
+    active
+      ? ACTION_BUTTON_SHOWN
+      : reserved
+        ? ACTION_BUTTON_RESERVED_HIDDEN
+        : ACTION_BUTTON_HIDDEN,
+  );
+}
+
 export function ArrayRowContent({
   labelText,
   imageSrc,
@@ -126,10 +165,7 @@ export function SortableArrayRow({
               size="icon"
               aria-label={hidden ? "Show item" : "Hide item"}
               className={cn(
-                "size-6 shrink-0",
-                hidden
-                  ? "opacity-100"
-                  : "opacity-0 transition-opacity group-hover:opacity-100",
+                actionButtonVisibilityClass(hidden === true, hidden === true),
               )}
               onClick={(e) => {
                 e.stopPropagation();
@@ -152,7 +188,10 @@ export function SortableArrayRow({
             variant="ghost"
             size="icon"
             aria-label={`Open actions for ${labelText}`}
-            className="size-6 shrink-0 opacity-0 transition-opacity group-hover:opacity-100"
+            className={cn(
+              actionButtonVisibilityClass(hidden === true, false),
+              "data-[state=open]:ml-0 data-[state=open]:w-6 data-[state=open]:opacity-100 data-[state=open]:[transition:opacity_150ms_ease-out,width_0ms,margin-left_0ms]",
+            )}
             onClick={(e) => e.stopPropagation()}
             onPointerDown={(e) => e.stopPropagation()}
           >

--- a/apps/web/src/components/sections-editor/fields/field-label.tsx
+++ b/apps/web/src/components/sections-editor/fields/field-label.tsx
@@ -44,7 +44,7 @@ export function FieldDescriptionTooltip({
   const tooltipsEnabled = useFieldDescriptionTooltips(virtualMcpId);
   if (!description || !tooltipsEnabled) return children;
   return (
-    <Tooltip>
+    <Tooltip delayDuration={300}>
       <TooltipTrigger asChild>
         {cloneElement(children, {
           className: cn(children.props.className, DESCRIPTION_AFFORDANCE_CLASS),


### PR DESCRIPTION
## Summary
- Port the zero-width-collapse + opacity-fade action-button treatment from the blocks root list (`section-list.tsx`, branch `claude/hazy-mapping-kettle`) to array item rows (`array-row.tsx`), which every array field in the form renders via `SortableArrayRow`.
- Hide/show and actions-menu buttons now collapse to zero width when idle so the label gets full space, and only reserve width once a button is actually toggled on — hover/keyboard-focus reveals them as a pure opacity fade with no layout shift.

## Test plan
- [ ] `bun run fmt` and `bunx oxlint apps/web/src/components/sections-editor/fields/array-row.tsx` pass
- [ ] Manually verify in the sections editor: open a form with an array field (e.g. links/banners), hover a row and confirm the hide/menu buttons fade in without shifting the label; toggle "hide" on an item and confirm the row no longer shifts when hovering siblings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ported zero-width collapse with opacity fade for array-item action buttons to prevent label shifts on hover and keyboard focus. Centralized the CT hover-then-click flow in `openRowActionsMenu` and updated tests.

- **Bug Fixes**
  - Idle buttons collapse to w-0; reveal via opacity on hover or focus (no layout shift).
  - Reserve group width when any button is toggled so siblings and labels don't move.
  - Added a 300ms hover delay for compact-description tooltips to reduce accidental popups.

- **Refactors**
  - Added `actionButtonVisibilityClass` to centralize button visibility and transitions.
  - Extracted `openRowActionsMenu` CT helper and used it across tests to remove duplication.

<sup>Written for commit bd0d8f31704f354eaa52b8e29d72914c7b808804. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

