### PR TITLE
fix(commerce-onboarding): make the GA4/GSC connect dialog explain itself

### DIFF
--- a/apps/web/src/i18n/en/commerce-onboarding.ts
+++ b/apps/web/src/i18n/en/commerce-onboarding.ts
@@ -15,8 +15,6 @@ export const commerceOnboarding = {
   "commerceOnboarding.companionCard.editConfiguration": "Edit configuration",
   "commerceOnboarding.companionCard.finishSetup": "Finish setup",
   "commerceOnboarding.companionCard.required": "Required",
-  "commerceOnboarding.companionCard.grantAccessDescription":
-    "Grant our reader access and provide the identifier",
   "commerceOnboarding.githubConfigForm.cancel": "Cancel",
   "commerceOnboarding.githubConfigForm.failedToSave":
     "Couldn't save the configuration",
@@ -41,20 +39,91 @@ export const commerceOnboarding = {
   "commerceOnboarding.githubConfigForm.searchRepositoryPlaceholder":
     "Search repository",
   "commerceOnboarding.githubConfigForm.selectRepository": "Select a repository",
-  "commerceOnboarding.saBindingForm.bind": "Bind",
-  "commerceOnboarding.saBindingForm.bindError": "Couldn't bind.",
+  "commerceOnboarding.saBindingForm.bind": "Connect",
+  "commerceOnboarding.saBindingForm.bindError": "Couldn't connect.",
   "commerceOnboarding.saBindingForm.cancel": "Cancel",
   "commerceOnboarding.saBindingForm.connectedSuccess": "{label} connected",
   "commerceOnboarding.saBindingForm.copyEmailLabel":
-    "Copy the service account e-mail",
+    "Copy the reader account e-mail",
   "commerceOnboarding.saBindingForm.emailCopied": "E-mail copied",
   "commerceOnboarding.saBindingForm.googleLoginAlternative":
-    "authorize via Google login",
+    "Sign in with Google instead",
   "commerceOnboarding.saBindingForm.resourceIdRequired":
     "Provide the {resourceLabel}",
   "commerceOnboarding.saBindingForm.storeUrlUnavailable":
-    "Store URL unavailable — reload the page.",
+    "Store URL unavailable. Reload the page.",
   "commerceOnboarding.saBindingForm.verifying": "Verifying...",
+  "commerceOnboarding.saBinding.sampleDomain": "yourstore.com",
+  "commerceOnboarding.saBinding.oauthNote":
+    "Google is still reviewing our app, so its login screen warns that the app isn't verified.",
+  "commerceOnboarding.saBinding.ga4.openConsole": "Open Google Analytics",
+  "commerceOnboarding.saBinding.ga4.step1":
+    "In Google Analytics, open Admin › Property access management.",
+  "commerceOnboarding.saBinding.ga4.step2":
+    "Click +, choose Add users, paste this e-mail and pick the Viewer role.",
+  "commerceOnboarding.saBinding.ga4.step3":
+    "Copy the property ID from Admin › Property details and paste it here.",
+  "commerceOnboarding.saBinding.ga4.resourceLabel": "Property ID",
+  "commerceOnboarding.saBinding.ga4.resourcePlaceholder": "123456789",
+  "commerceOnboarding.saBinding.ga4.resourceHint":
+    "Digits only, without the 'properties/' prefix.",
+  "commerceOnboarding.saBinding.gsc.openConsole": "Open Search Console",
+  "commerceOnboarding.saBinding.gsc.step1":
+    "In Search Console, open Settings › Users and permissions.",
+  "commerceOnboarding.saBinding.gsc.step2":
+    "Click Add user, paste this e-mail and choose the Full permission.",
+  "commerceOnboarding.saBinding.gsc.step3":
+    "Copy the property address exactly as the picker shows it and paste it here.",
+  "commerceOnboarding.saBinding.gsc.resourceLabel": "Site or property",
+  "commerceOnboarding.saBinding.gsc.resourcePlaceholder": "sc-domain:{host}",
+  "commerceOnboarding.saBinding.gsc.resourceHint":
+    "Domain property, or the full URL prefix (https://www.{host}/).",
+  "commerceOnboarding.saBinding.remediation.noAccess.title":
+    "We still can't reach this resource in {label}.",
+  "commerceOnboarding.saBinding.remediation.noAccess.ga4.1":
+    "Check that {email} is listed under Admin › Property access management with the Viewer role.",
+  "commerceOnboarding.saBinding.remediation.noAccess.ga4.2":
+    "Check the property ID: digits only, without the 'properties/' prefix.",
+  "commerceOnboarding.saBinding.remediation.noAccess.ga4.3":
+    "Google can take a few seconds to apply the access. Try again.",
+  "commerceOnboarding.saBinding.remediation.noAccess.gsc.1":
+    "Check that {email} is listed under Settings › Users and permissions.",
+  "commerceOnboarding.saBinding.remediation.noAccess.gsc.2":
+    "The permission has to be Full or Restricted. 'Unverified' doesn't work.",
+  "commerceOnboarding.saBinding.remediation.noAccess.gsc.3":
+    "Check that the address matches exactly what Search Console shows.",
+  "commerceOnboarding.saBinding.remediation.noWebStream.title":
+    "This GA4 property has no web data stream (site) configured.",
+  "commerceOnboarding.saBinding.remediation.noWebStream.1":
+    "In GA4, go to Admin › Data streams.",
+  "commerceOnboarding.saBinding.remediation.noWebStream.2":
+    "Click Add stream › Web.",
+  "commerceOnboarding.saBinding.remediation.noWebStream.3":
+    "Enter your store's site URL and save the stream.",
+  "commerceOnboarding.saBinding.remediation.noWebStream.4":
+    "Come back and try again. App-only properties need a manual link, so talk to support.",
+  "commerceOnboarding.saBinding.remediation.noMatch.title":
+    "That resource doesn't match this store's domain.",
+  "commerceOnboarding.saBinding.remediation.noMatch.ga4.1":
+    "Check the property ID. It probably belongs to another site.",
+  "commerceOnboarding.saBinding.remediation.noMatch.ga4.2":
+    "In GA4 the measured site shows under Admin › Data streams › your web stream › stream URL.",
+  "commerceOnboarding.saBinding.remediation.noMatch.gsc.1":
+    "Check that you picked the Search Console property for this store.",
+  "commerceOnboarding.saBinding.remediation.noMatch.gsc.2":
+    "The address has to cover the same domain as the diagnostic.",
+  "commerceOnboarding.saBinding.remediation.alreadyBound.title":
+    "This resource is already linked to another store.",
+  "commerceOnboarding.saBinding.remediation.alreadyBound.1":
+    "If it really belongs to this store, talk to support for a manual review.",
+  "commerceOnboarding.saBinding.remediation.alreadyBound.2":
+    "If you typed the wrong id, check it and try again.",
+  "commerceOnboarding.saBinding.remediation.unknown.title":
+    "We couldn't verify access to this resource.",
+  "commerceOnboarding.saBinding.remediation.unknown.1":
+    "Go back over the steps above and try again.",
+  "commerceOnboarding.saBinding.remediation.unknown.2":
+    "If it keeps failing, talk to support.",
   "commerceOnboarding.vtexConfigForm.accountNameLabel": "Account name",
   "commerceOnboarding.vtexConfigForm.accountNamePlaceholder":
     "Your VTEX account name",

--- a/apps/web/src/i18n/pt-br/commerce-onboarding.ts
+++ b/apps/web/src/i18n/pt-br/commerce-onboarding.ts
@@ -17,8 +17,6 @@ export const commerceOnboarding = {
   "commerceOnboarding.companionCard.editConfiguration": "Editar configuração",
   "commerceOnboarding.companionCard.finishSetup": "Concluir configuração",
   "commerceOnboarding.companionCard.required": "Obrigatório",
-  "commerceOnboarding.companionCard.grantAccessDescription":
-    "Conceda acesso ao nosso leitor e informe o identificador",
   "commerceOnboarding.githubConfigForm.cancel": "Cancelar",
   "commerceOnboarding.githubConfigForm.failedToSave":
     "Não foi possível salvar a configuração",
@@ -44,20 +42,91 @@ export const commerceOnboarding = {
     "Buscar repositório",
   "commerceOnboarding.githubConfigForm.selectRepository":
     "Selecione um repositório",
-  "commerceOnboarding.saBindingForm.bind": "Vincular",
-  "commerceOnboarding.saBindingForm.bindError": "Não foi possível vincular.",
+  "commerceOnboarding.saBindingForm.bind": "Conectar",
+  "commerceOnboarding.saBindingForm.bindError": "Não foi possível conectar.",
   "commerceOnboarding.saBindingForm.cancel": "Cancelar",
   "commerceOnboarding.saBindingForm.connectedSuccess": "{label} conectado",
   "commerceOnboarding.saBindingForm.copyEmailLabel":
-    "Copiar e-mail do service account",
+    "Copiar e-mail da nossa conta leitora",
   "commerceOnboarding.saBindingForm.emailCopied": "E-mail copiado",
   "commerceOnboarding.saBindingForm.googleLoginAlternative":
-    "autorizar via login do Google",
+    "Entrar com o Google mesmo assim",
   "commerceOnboarding.saBindingForm.resourceIdRequired":
     "Informe o {resourceLabel}",
   "commerceOnboarding.saBindingForm.storeUrlUnavailable":
-    "URL da loja indisponível — recarregue a página.",
+    "URL da loja indisponível. Recarregue a página.",
   "commerceOnboarding.saBindingForm.verifying": "Verificando...",
+  "commerceOnboarding.saBinding.sampleDomain": "sualoja.com.br",
+  "commerceOnboarding.saBinding.oauthNote":
+    "O nosso app ainda está em revisão pelo Google, então a tela de login avisa que ele não é verificado.",
+  "commerceOnboarding.saBinding.ga4.openConsole": "Abrir o Google Analytics",
+  "commerceOnboarding.saBinding.ga4.step1":
+    "No Google Analytics, abra Admin › Acesso à propriedade.",
+  "commerceOnboarding.saBinding.ga4.step2":
+    "Clique em +, escolha Adicionar usuários, cole este e-mail e marque a função Leitor.",
+  "commerceOnboarding.saBinding.ga4.step3":
+    "Copie o ID da propriedade em Admin › Detalhes da propriedade e cole aqui.",
+  "commerceOnboarding.saBinding.ga4.resourceLabel": "ID da propriedade",
+  "commerceOnboarding.saBinding.ga4.resourcePlaceholder": "123456789",
+  "commerceOnboarding.saBinding.ga4.resourceHint":
+    "Só dígitos, sem o prefixo 'properties/'.",
+  "commerceOnboarding.saBinding.gsc.openConsole": "Abrir o Search Console",
+  "commerceOnboarding.saBinding.gsc.step1":
+    "No Search Console, abra Configurações › Usuários e permissões.",
+  "commerceOnboarding.saBinding.gsc.step2":
+    "Clique em Adicionar usuário, cole este e-mail e escolha a permissão Total.",
+  "commerceOnboarding.saBinding.gsc.step3":
+    "Copie o endereço da propriedade exatamente como aparece no seletor e cole aqui.",
+  "commerceOnboarding.saBinding.gsc.resourceLabel": "Site ou propriedade",
+  "commerceOnboarding.saBinding.gsc.resourcePlaceholder": "sc-domain:{host}",
+  "commerceOnboarding.saBinding.gsc.resourceHint":
+    "Propriedade de domínio, ou o prefixo de URL completo (https://www.{host}/).",
+  "commerceOnboarding.saBinding.remediation.noAccess.title":
+    "Ainda não conseguimos acessar este recurso no {label}.",
+  "commerceOnboarding.saBinding.remediation.noAccess.ga4.1":
+    "Confira se {email} aparece em Admin › Acesso à propriedade com a função Leitor.",
+  "commerceOnboarding.saBinding.remediation.noAccess.ga4.2":
+    "Confira o ID da propriedade: só dígitos, sem o prefixo 'properties/'.",
+  "commerceOnboarding.saBinding.remediation.noAccess.ga4.3":
+    "O Google pode levar alguns segundos para aplicar o acesso. Tente de novo.",
+  "commerceOnboarding.saBinding.remediation.noAccess.gsc.1":
+    "Confira se {email} aparece em Configurações › Usuários e permissões.",
+  "commerceOnboarding.saBinding.remediation.noAccess.gsc.2":
+    "A permissão precisa ser Total ou Restrita. 'Não verificado' não funciona.",
+  "commerceOnboarding.saBinding.remediation.noAccess.gsc.3":
+    "Confira se o endereço está exatamente como aparece no Search Console.",
+  "commerceOnboarding.saBinding.remediation.noWebStream.title":
+    "Esta propriedade do GA4 não tem um fluxo de dados da Web (site) configurado.",
+  "commerceOnboarding.saBinding.remediation.noWebStream.1":
+    "No GA4, vá em Admin › Fluxos de dados.",
+  "commerceOnboarding.saBinding.remediation.noWebStream.2":
+    "Clique em Adicionar fluxo › Web.",
+  "commerceOnboarding.saBinding.remediation.noWebStream.3":
+    "Informe a URL do site da sua loja e salve o fluxo.",
+  "commerceOnboarding.saBinding.remediation.noWebStream.4":
+    "Volte aqui e tente de novo. Propriedades só de app precisam de vínculo manual, fale com o suporte.",
+  "commerceOnboarding.saBinding.remediation.noMatch.title":
+    "O recurso informado não corresponde ao domínio desta loja.",
+  "commerceOnboarding.saBinding.remediation.noMatch.ga4.1":
+    "Confira o ID da propriedade. Provavelmente é de outro site.",
+  "commerceOnboarding.saBinding.remediation.noMatch.ga4.2":
+    "No GA4, o site medido aparece em Admin › Fluxos de dados › seu fluxo Web › URL do stream.",
+  "commerceOnboarding.saBinding.remediation.noMatch.gsc.1":
+    "Confira se você escolheu a propriedade do Search Console desta loja.",
+  "commerceOnboarding.saBinding.remediation.noMatch.gsc.2":
+    "O endereço precisa cobrir o mesmo domínio do diagnóstico.",
+  "commerceOnboarding.saBinding.remediation.alreadyBound.title":
+    "Este recurso já está vinculado a outra loja.",
+  "commerceOnboarding.saBinding.remediation.alreadyBound.1":
+    "Se ele é mesmo desta loja, fale com o suporte para uma revisão manual.",
+  "commerceOnboarding.saBinding.remediation.alreadyBound.2":
+    "Se digitou o id errado, confira e tente novamente.",
+  "commerceOnboarding.saBinding.remediation.unknown.title":
+    "Não foi possível verificar o acesso a este recurso.",
+  "commerceOnboarding.saBinding.remediation.unknown.1":
+    "Revise os passos acima e tente novamente.",
+  "commerceOnboarding.saBinding.remediation.unknown.2":
+    "Se continuar falhando, fale com o suporte.",
   "commerceOnboarding.vtexConfigForm.accountNameLabel": "Nome da conta",
   "commerceOnboarding.vtexConfigForm.accountNamePlaceholder":
     "Nome da sua conta VTEX",

--- a/apps/web/src/routes/commerce-onboarding/companion-card-view.tsx
+++ b/apps/web/src/routes/commerce-onboarding/companion-card-view.tsx
@@ -45,12 +45,15 @@ export function CompanionCardView({
         </span>
       )}
       <div className="flex min-w-0 flex-1 items-center gap-3 sm:items-start">
+        {/* Size comes from the `size` prop alone: IntegrationIcon also emits a
+            min-w-* for its size, which a `size-[…]` override doesn't beat, so
+            overriding the box here would render it wider than it is tall. */}
         <IntegrationIcon
           icon={icon}
           name={title}
           size="sm"
           fit="contain"
-          className="size-[30px] shrink-0 p-1"
+          className="shrink-0 p-1"
         />
         {/* Title + description stacked so the benefit line sits under the title. */}
         <div className="flex min-w-0 flex-col gap-1">

--- a/apps/web/src/routes/commerce-onboarding/companion-card.tsx
+++ b/apps/web/src/routes/commerce-onboarding/companion-card.tsx
@@ -1,3 +1,4 @@
+import { siteUrlToHost } from "@decocms/shared/reports/site-url";
 import { IntegrationIcon } from "@/components/integration-icon";
 import { KEYS } from "@/lib/query-keys";
 import { useT } from "@/i18n/use-t.ts";
@@ -349,25 +350,27 @@ function SaConnectAction({
       )}
 
       <Dialog open={open} onOpenChange={handleOpenChange}>
-        <DialogContent className="sm:max-w-lg">
+        {/* No DialogDescription: the numbered steps immediately below the title
+            are the description, so `aria-describedby` is opted out explicitly
+            rather than left dangling. */}
+        <DialogContent
+          aria-describedby={undefined}
+          className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-lg"
+        >
           <DialogHeader className="flex-row items-center gap-3 space-y-0 text-left">
             <IntegrationIcon
               icon={card.icon}
               name={card.title}
-              size="md"
+              size="sm"
               fit="contain"
-              className="p-1.5"
+              className="p-1"
             />
-            <div className="flex min-w-0 flex-1 flex-col gap-1">
-              <DialogTitle>{card.title}</DialogTitle>
-              <DialogDescription>
-                {t("commerceOnboarding.companionCard.grantAccessDescription")}
-              </DialogDescription>
-            </div>
+            <DialogTitle className="min-w-0 flex-1">{card.title}</DialogTitle>
           </DialogHeader>
           <SaBindingForm
             provider={provider}
             siteUrl={siteUrl}
+            siteHost={siteUrlToHost(siteUrl)}
             selfClient={selfClient}
             org={org}
             initialResourceId={card.boundResource ?? undefined}
@@ -520,9 +523,9 @@ function CompanionConfiguration({
             <IntegrationIcon
               icon={card.icon}
               name={card.title}
-              size="md"
+              size="sm"
               fit="contain"
-              className="p-1.5"
+              className="p-1"
             />
             <div className="flex min-w-0 flex-1 flex-col gap-1">
               <DialogTitle>{card.title}</DialogTitle>

--- a/apps/web/src/routes/commerce-onboarding/companion-forms/sa-binding-copy.test.ts
+++ b/apps/web/src/routes/commerce-onboarding/companion-forms/sa-binding-copy.test.ts
@@ -1,10 +1,23 @@
 import { describe, expect, test } from "bun:test";
+import { en } from "@/i18n/en/index.ts";
+import { ptBR } from "@/i18n/pt-br/index.ts";
 import {
   BIND_PROVIDER_COPY,
   PROVIDER_BY_BINDING_TYPE,
   remediationFor,
-  SA_EMAIL,
 } from "./sa-binding-copy.ts";
+
+const PROVIDERS = ["ga4", "gsc"] as const;
+
+/** Every reason the commerce-discovery bind endpoint can return, plus an
+ *  unknown one to prove the fallback. */
+const REASONS = [
+  "no-access",
+  "no-web-stream",
+  "no-match",
+  "resource_already_bound",
+  "something-new",
+];
 
 describe("PROVIDER_BY_BINDING_TYPE", () => {
   test("maps only the two Google companions to provider codes", () => {
@@ -14,40 +27,76 @@ describe("PROVIDER_BY_BINDING_TYPE", () => {
   });
 });
 
-describe("connect steps always name the shared SA", () => {
-  test("both providers instruct adding the SA email", () => {
-    for (const provider of ["ga4", "gsc"] as const) {
-      const joined = BIND_PROVIDER_COPY[provider].connectSteps.join(" ");
-      expect(joined).toContain(SA_EMAIL);
+describe("BIND_PROVIDER_COPY", () => {
+  test("console deep links point at the product the steps describe", () => {
+    expect(BIND_PROVIDER_COPY.ga4.consoleUrl).toContain("analytics.google.com");
+    expect(BIND_PROVIDER_COPY.gsc.consoleUrl).toContain("search-console");
+  });
+
+  test("the steps tell the user to paste the SA e-mail", () => {
+    for (const provider of PROVIDERS) {
+      const steps = BIND_PROVIDER_COPY[provider].steps;
+      expect(steps).toHaveLength(3);
+      expect(steps.map((k) => en[k]).join(" ")).toContain("paste this e-mail");
+    }
+  });
+
+  test("every key resolves in both dictionaries", () => {
+    for (const provider of PROVIDERS) {
+      const copy = BIND_PROVIDER_COPY[provider];
+      const keys = [
+        copy.consoleLinkKey,
+        copy.resourceLabelKey,
+        copy.resourcePlaceholderKey,
+        copy.resourceHintKey,
+        ...copy.steps,
+      ];
+      for (const key of keys) {
+        expect(en[key]?.length ?? 0).toBeGreaterThan(0);
+        expect(ptBR[key]?.length ?? 0).toBeGreaterThan(0);
+      }
     }
   });
 });
 
 describe("remediationFor", () => {
+  test("every reason resolves to a title plus at least one step, in both dictionaries", () => {
+    for (const provider of PROVIDERS) {
+      for (const reason of REASONS) {
+        const r = remediationFor(provider, reason);
+        expect(r.stepKeys.length).toBeGreaterThan(0);
+        for (const key of [r.titleKey, ...r.stepKeys]) {
+          expect(en[key]?.length ?? 0).toBeGreaterThan(0);
+          expect(ptBR[key]?.length ?? 0).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+
   test("no-web-stream (site URL missing on GA) walks through adding a web stream", () => {
     const r = remediationFor("ga4", "no-web-stream");
-    expect(r.title).toContain("fluxo de dados da Web");
-    expect(r.steps.join(" ")).toContain("Adicionar fluxo");
+    expect(en[r.titleKey]).toContain("web data stream");
+    expect(r.stepKeys.map((k) => en[k]).join(" ")).toContain("Add stream");
   });
 
   test("no-access is provider-specific (GSC calls out the unusable permission)", () => {
-    expect(remediationFor("ga4", "no-access").steps.join(" ")).toContain(
-      SA_EMAIL,
-    );
-    expect(remediationFor("gsc", "no-access").steps.join(" ")).toContain(
-      "Não verificado",
-    );
+    const ga4 = remediationFor("ga4", "no-access");
+    const gsc = remediationFor("gsc", "no-access");
+    expect(ga4.stepKeys).not.toEqual(gsc.stepKeys);
+    // {email} is interpolated by the form, so the SA address has to be asked for
+    // by the string rather than baked into it.
+    expect(ga4.stepKeys.map((k) => en[k]).join(" ")).toContain("{email}");
+    expect(gsc.stepKeys.map((k) => en[k]).join(" ")).toContain("Unverified");
   });
 
   test("resource_already_bound points to manual review", () => {
-    expect(
-      remediationFor("ga4", "resource_already_bound").steps.join(" "),
-    ).toContain("suporte");
+    const r = remediationFor("ga4", "resource_already_bound");
+    expect(r.stepKeys.map((k) => en[k]).join(" ")).toContain("support");
   });
 
-  test("unknown reason falls back to a safe generic remediation", () => {
-    const r = remediationFor("gsc", "something-new");
-    expect(r.title.length).toBeGreaterThan(0);
-    expect(r.steps.length).toBeGreaterThan(0);
+  test("unknown reason falls back to the generic remediation", () => {
+    expect(remediationFor("gsc", "something-new").titleKey).toBe(
+      "commerceOnboarding.saBinding.remediation.unknown.title",
+    );
   });
 });

--- a/apps/web/src/routes/commerce-onboarding/companion-forms/sa-binding-copy.ts
+++ b/apps/web/src/routes/commerce-onboarding/companion-forms/sa-binding-copy.ts
@@ -1,12 +1,17 @@
-// Copy + step-by-step guidance for the shared-SA binding flow (the consent-free
-// lane). Pure data/functions so the instructions are unit-testable and the form
-// stays presentational. The whole point: tell the user EXACTLY what to do —
-// both to grant access up front and to fix a specific failure (e.g. a GA4
-// property with no web data stream ⇒ no site URL to verify against).
+// Structure + translation keys for the shared-SA binding flow (the consent-free
+// lane). Pure data/functions so the guidance is unit-testable and the form stays
+// presentational. The whole point: tell the user EXACTLY what to do, both to
+// grant access up front and to fix a specific failure (e.g. a GA4 property with
+// no web data stream ⇒ no site URL to verify against).
+//
+// Every user-facing string lives in the i18n dictionaries; this module only
+// names the keys (typed, so a missing translation is a compile error).
+
+import type { TranslationKey } from "@/i18n/use-t.ts";
 
 export type BindProvider = "ga4" | "gsc";
 
-/** The shared service account the client grants access to — never a human
+/** The shared service account the client grants access to, never a human
  *  account (no consent screen, no god-login to protect). */
 export const SA_EMAIL = "deco-reader@decocms.iam.gserviceaccount.com";
 
@@ -18,121 +23,123 @@ export const PROVIDER_BY_BINDING_TYPE: Record<string, BindProvider> = {
 };
 
 export interface BindProviderCopy {
-  /** Human label, e.g. "Google Analytics". */
+  /** Human label, e.g. "Google Analytics". Product name, not translated. */
   label: string;
-  /** Field label for the id the user pastes. */
-  resourceLabel: string;
-  resourcePlaceholder: string;
-  /** Where to find that id. */
-  resourceHint: string;
-  /** Ordered steps to grant the SA access + locate the id. */
-  connectSteps: string[];
+  /** Deep link to the console the steps describe. */
+  consoleUrl: string;
+  consoleLinkKey: TranslationKey;
+  /** The three things to do, one short line each. */
+  steps: readonly [TranslationKey, TranslationKey, TranslationKey];
+  /** Field label / placeholder / hint for the id the user pastes. */
+  resourceLabelKey: TranslationKey;
+  resourcePlaceholderKey: TranslationKey;
+  resourceHintKey: TranslationKey;
 }
 
 export const BIND_PROVIDER_COPY: Record<BindProvider, BindProviderCopy> = {
   ga4: {
     label: "Google Analytics",
-    resourceLabel: "ID da propriedade",
-    resourcePlaceholder: "ex: 123456789",
-    resourceHint:
-      "No GA4: Admin → Detalhes da propriedade → ID da propriedade (só números).",
-    connectSteps: [
-      "Abra o Google Analytics (GA4) da sua loja.",
-      "Vá em Admin → Acesso à propriedade (Gerenciamento de acesso).",
-      `Clique em + → Adicionar usuários, cole ${SA_EMAIL} e conceda o papel Leitor.`,
-      "Copie o ID da propriedade (Admin → Detalhes da propriedade) e cole abaixo.",
+    consoleUrl: "https://analytics.google.com/analytics/web/#/admin",
+    consoleLinkKey: "commerceOnboarding.saBinding.ga4.openConsole",
+    steps: [
+      "commerceOnboarding.saBinding.ga4.step1",
+      "commerceOnboarding.saBinding.ga4.step2",
+      "commerceOnboarding.saBinding.ga4.step3",
     ],
+    resourceLabelKey: "commerceOnboarding.saBinding.ga4.resourceLabel",
+    resourcePlaceholderKey:
+      "commerceOnboarding.saBinding.ga4.resourcePlaceholder",
+    resourceHintKey: "commerceOnboarding.saBinding.ga4.resourceHint",
   },
   gsc: {
     label: "Google Search Console",
-    resourceLabel: "Site / propriedade",
-    resourcePlaceholder: "ex: sc-domain:sualoja.com.br",
-    resourceHint:
-      "Use o mesmo formato que aparece no Search Console: sc-domain:sualoja.com.br ou https://www.sualoja.com.br/.",
-    connectSteps: [
-      "Abra o Google Search Console da sua loja.",
-      "Vá em Configurações → Usuários e permissões.",
-      `Clique em Adicionar usuário, cole ${SA_EMAIL} e escolha permissão Completa.`,
-      "Copie o endereço do site como aparece no seletor de propriedades e cole abaixo.",
+    consoleUrl: "https://search.google.com/search-console",
+    consoleLinkKey: "commerceOnboarding.saBinding.gsc.openConsole",
+    steps: [
+      "commerceOnboarding.saBinding.gsc.step1",
+      "commerceOnboarding.saBinding.gsc.step2",
+      "commerceOnboarding.saBinding.gsc.step3",
     ],
+    resourceLabelKey: "commerceOnboarding.saBinding.gsc.resourceLabel",
+    resourcePlaceholderKey:
+      "commerceOnboarding.saBinding.gsc.resourcePlaceholder",
+    resourceHintKey: "commerceOnboarding.saBinding.gsc.resourceHint",
   },
 };
 
 export interface RemediationCopy {
-  title: string;
-  steps: string[];
+  titleKey: TranslationKey;
+  stepKeys: readonly TranslationKey[];
 }
 
 /**
  * Map a bind failure `reason` to concrete, provider-specific next steps. The
  * backend already returns a one-line pt-BR `detail`; this turns each failure
  * into an actionable checklist the form renders inline. `no-web-stream` is the
- * "site URL missing on GA" case — the property has no web data stream to verify
+ * "site URL missing on GA" case: the property has no web data stream to verify
  * the domain against, so we walk the user through creating one.
  */
 export function remediationFor(
   provider: BindProvider,
   reason: string,
 ): RemediationCopy {
-  const label = BIND_PROVIDER_COPY[provider].label;
   switch (reason) {
     case "no-access":
       return {
-        title: `Ainda não conseguimos acessar este recurso no ${label}.`,
-        steps:
+        titleKey: "commerceOnboarding.saBinding.remediation.noAccess.title",
+        stepKeys:
           provider === "ga4"
             ? [
-                `Confirme que ${SA_EMAIL} foi adicionado em Admin → Acesso à propriedade com o papel Leitor.`,
-                "Confira se o ID da propriedade está correto (só números, sem o prefixo 'properties/').",
-                "A concessão de acesso pode levar alguns segundos — tente novamente.",
+                "commerceOnboarding.saBinding.remediation.noAccess.ga4.1",
+                "commerceOnboarding.saBinding.remediation.noAccess.ga4.2",
+                "commerceOnboarding.saBinding.remediation.noAccess.ga4.3",
               ]
             : [
-                `Confirme que ${SA_EMAIL} foi adicionado em Configurações → Usuários e permissões.`,
-                "A permissão precisa ser Completa ou Restrita — 'Não verificado' não funciona.",
-                "Confira se o endereço do site está exatamente como aparece no Search Console.",
+                "commerceOnboarding.saBinding.remediation.noAccess.gsc.1",
+                "commerceOnboarding.saBinding.remediation.noAccess.gsc.2",
+                "commerceOnboarding.saBinding.remediation.noAccess.gsc.3",
               ],
       };
     case "no-web-stream":
       // GA4-specific: the property measures no website, so there's no defaultUri
       // (site URL) to check ownership against.
       return {
-        title:
-          "Esta propriedade do GA4 não tem um fluxo de dados da Web (site) configurado.",
-        steps: [
-          "No GA4, vá em Admin → Fluxos de dados.",
-          "Clique em Adicionar fluxo → Web.",
-          "Informe a URL do site da sua loja e salve o fluxo.",
-          "Volte aqui e tente vincular de novo. (Propriedades só de app precisam de vínculo manual — fale com o suporte.)",
+        titleKey: "commerceOnboarding.saBinding.remediation.noWebStream.title",
+        stepKeys: [
+          "commerceOnboarding.saBinding.remediation.noWebStream.1",
+          "commerceOnboarding.saBinding.remediation.noWebStream.2",
+          "commerceOnboarding.saBinding.remediation.noWebStream.3",
+          "commerceOnboarding.saBinding.remediation.noWebStream.4",
         ],
       };
     case "no-match":
       return {
-        title: `O recurso informado não corresponde ao domínio desta loja.`,
-        steps:
+        titleKey: "commerceOnboarding.saBinding.remediation.noMatch.title",
+        stepKeys:
           provider === "ga4"
             ? [
-                "Verifique se digitou o ID da propriedade certa — provavelmente é de outro site.",
-                "No GA4, o site medido aparece em Admin → Fluxos de dados → (seu fluxo Web) → URL do stream.",
+                "commerceOnboarding.saBinding.remediation.noMatch.ga4.1",
+                "commerceOnboarding.saBinding.remediation.noMatch.ga4.2",
               ]
             : [
-                "Verifique se selecionou a propriedade do Search Console referente a esta loja.",
-                "O endereço precisa cobrir o mesmo domínio do diagnóstico.",
+                "commerceOnboarding.saBinding.remediation.noMatch.gsc.1",
+                "commerceOnboarding.saBinding.remediation.noMatch.gsc.2",
               ],
       };
     case "resource_already_bound":
       return {
-        title: "Este recurso já está vinculado a outra loja.",
-        steps: [
-          "Se este recurso é realmente desta loja, fale com o suporte para uma revisão manual.",
-          "Caso tenha digitado o id errado, confira e tente novamente.",
+        titleKey: "commerceOnboarding.saBinding.remediation.alreadyBound.title",
+        stepKeys: [
+          "commerceOnboarding.saBinding.remediation.alreadyBound.1",
+          "commerceOnboarding.saBinding.remediation.alreadyBound.2",
         ],
       };
     default:
       return {
-        title: "Não foi possível verificar o acesso a este recurso.",
-        steps: [
-          "Revise os passos de acesso acima e tente novamente.",
-          "Se persistir, fale com o suporte.",
+        titleKey: "commerceOnboarding.saBinding.remediation.unknown.title",
+        stepKeys: [
+          "commerceOnboarding.saBinding.remediation.unknown.1",
+          "commerceOnboarding.saBinding.remediation.unknown.2",
         ],
       };
   }

--- a/apps/web/src/routes/commerce-onboarding/companion-forms/sa-binding-form.tsx
+++ b/apps/web/src/routes/commerce-onboarding/companion-forms/sa-binding-form.tsx
@@ -7,14 +7,13 @@ import {
   FormDescription,
   FormField,
   FormItem,
-  FormLabel,
   FormMessage,
 } from "@deco/ui/components/form.tsx";
 import { Input } from "@deco/ui/components/input.tsx";
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Copy01 } from "@untitledui/icons";
+import { Copy01, LinkExternal01 } from "@untitledui/icons";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
@@ -41,16 +40,19 @@ interface SaBindResult {
 }
 
 /**
- * The consent-free "connect a Google source" form: it tells the user exactly
- * what to do (grant the shared SA access + where to find the id), sends the id
- * to COMMERCE_DISCOVERY_BIND (which verifies ownership server-side), and on
- * failure renders a reason-specific checklist — e.g. a GA4 property with no web
- * data stream gets the steps to add one. Optionally offers the old OAuth flow
- * behind a low-key link.
+ * The consent-free "connect a Google source" form. Google OAuth is still in
+ * review (its login screen warns the app is unverified), so the default lane is
+ * a shared service account: the user grants deco-reader@… read access in their
+ * own console and pastes the resource id back. Three short steps, the e-mail to
+ * copy, the id to paste. The id goes to COMMERCE_DISCOVERY_BIND, which verifies
+ * ownership server-side; on failure this renders a reason-specific checklist
+ * (e.g. a GA4 property with no web data stream gets the steps to add one). The
+ * OAuth route stays available at the bottom, with the reason it is second.
  */
 export function SaBindingForm({
   provider,
   siteUrl,
+  siteHost,
   selfClient,
   org,
   initialResourceId,
@@ -60,6 +62,8 @@ export function SaBindingForm({
 }: {
   provider: BindProvider;
   siteUrl?: string;
+  /** The merchant's domain, woven into the example so it reads as their store. */
+  siteHost?: string | null;
   selfClient: Client;
   org: { id: string };
   initialResourceId?: string;
@@ -73,6 +77,7 @@ export function SaBindingForm({
   const [remediation, setRemediation] = useState<
     (RemediationCopy & { detail?: string }) | null
   >(null);
+  const host = siteHost || t("commerceOnboarding.saBinding.sampleDomain");
 
   const schema = z.object({
     resourceId: z
@@ -81,7 +86,7 @@ export function SaBindingForm({
       .min(
         1,
         t("commerceOnboarding.saBindingForm.resourceIdRequired", {
-          resourceLabel: copy.resourceLabel.toLowerCase(),
+          resourceLabel: t(copy.resourceLabelKey).toLowerCase(),
         }),
       ),
   });
@@ -138,55 +143,90 @@ export function SaBindingForm({
     toast.success(t("commerceOnboarding.saBindingForm.emailCopied"));
   };
 
-  return (
-    <form onSubmit={handleSubmit} className="space-y-4">
-      <ol className="space-y-2 text-sm text-muted-foreground">
-        {copy.connectSteps.map((step, i) => (
-          <li key={step} className="flex gap-2">
-            <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-muted text-xs font-medium text-foreground">
-              {i + 1}
-            </span>
-            <span>{step}</span>
-          </li>
-        ))}
-      </ol>
-
-      <div className="flex items-center gap-2 rounded-lg border border-border bg-muted/40 p-2">
-        <code className="min-w-0 flex-1 truncate text-xs text-foreground">
-          {SA_EMAIL}
-        </code>
-        <Button
-          type="button"
-          variant="ghost"
-          size="icon-sm"
-          onClick={copyEmail}
-          aria-label={t("commerceOnboarding.saBindingForm.copyEmailLabel")}
+  // Each step owns the control it talks about: step 1 the link out to the
+  // console, step 2 the e-mail to paste there, step 3 the id to bring back. The
+  // instruction and the thing it refers to never end up in different blocks.
+  const controlFor = (index: number) => {
+    if (index === 0) {
+      return (
+        <a
+          href={copy.consoleUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground underline underline-offset-2 hover:text-foreground"
         >
-          <Copy01 size={16} />
-        </Button>
-      </div>
-
+          <LinkExternal01 size={14} />
+          {t(copy.consoleLinkKey)}
+        </a>
+      );
+    }
+    if (index === 1) {
+      return (
+        <div className="flex w-full items-center gap-2 rounded-lg border border-input bg-muted/40 p-2">
+          <code className="min-w-0 flex-1 truncate text-sm text-foreground">
+            {SA_EMAIL}
+          </code>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-sm"
+            onClick={copyEmail}
+            aria-label={t("commerceOnboarding.saBindingForm.copyEmailLabel")}
+          >
+            <Copy01 size={16} />
+          </Button>
+        </div>
+      );
+    }
+    return (
       <Form {...form}>
         <FormField
           control={form.control}
           name="resourceId"
           render={({ field }) => (
-            <FormItem>
-              <FormLabel>{copy.resourceLabel}</FormLabel>
+            <FormItem className="w-full">
               <FormControl>
                 <Input
                   {...field}
-                  placeholder={copy.resourcePlaceholder}
+                  placeholder={t(copy.resourcePlaceholderKey, { host })}
                   disabled={isPending}
                   autoComplete="off"
+                  aria-label={t(copy.resourceLabelKey)}
                 />
               </FormControl>
-              <FormDescription>{copy.resourceHint}</FormDescription>
+              <FormDescription>
+                {t(copy.resourceHintKey, { host })}
+              </FormDescription>
               <FormMessage />
             </FormItem>
           )}
         />
       </Form>
+    );
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+      {/* One card per step: the three actions happen in someone else's product,
+          so each gets its own bounded block instead of blurring into a list. */}
+      <ol className="space-y-2">
+        {copy.steps.map((step, i) => (
+          <li
+            key={step}
+            className="flex gap-3 rounded-lg border border-border p-4"
+          >
+            <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-muted text-sm font-medium text-foreground">
+              {i + 1}
+            </span>
+            <div className="flex min-w-0 flex-1 flex-col items-start gap-2">
+              <p className="text-sm leading-5 text-foreground">
+                {t(step, { host })}
+              </p>
+              {controlFor(i)}
+            </div>
+          </li>
+        ))}
+      </ol>
 
       {remediation && (
         <div
@@ -194,13 +234,13 @@ export function SaBindingForm({
           className="space-y-2 rounded-lg border border-destructive/40 bg-destructive/5 p-3"
         >
           <p className="text-sm font-medium text-foreground">
-            {remediation.title}
+            {t(remediation.titleKey, { label: copy.label })}
           </p>
           <ol className="space-y-1 text-sm text-muted-foreground">
-            {remediation.steps.map((step) => (
-              <li key={step} className="flex gap-2">
+            {remediation.stepKeys.map((key) => (
+              <li key={key} className="flex gap-2">
                 <span aria-hidden>•</span>
-                <span>{step}</span>
+                <span>{t(key, { email: SA_EMAIL })}</span>
               </li>
             ))}
           </ol>
@@ -215,34 +255,34 @@ export function SaBindingForm({
         </p>
       )}
 
-      <DialogFooter className="flex-col gap-2 pt-2 sm:flex-row sm:items-center sm:justify-between">
-        {onOAuthInstead ? (
+      {onOAuthInstead && (
+        <p className="text-sm leading-5 text-muted-foreground">
+          {t("commerceOnboarding.saBinding.oauthNote")}{" "}
           <button
             type="button"
             onClick={onOAuthInstead}
             disabled={isPending}
-            className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground disabled:opacity-50"
+            className="underline underline-offset-2 hover:text-foreground disabled:opacity-50"
           >
             {t("commerceOnboarding.saBindingForm.googleLoginAlternative")}
           </button>
-        ) : (
-          <span />
-        )}
-        <div className="flex gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={onDone}
-            disabled={isPending}
-          >
-            {t("commerceOnboarding.saBindingForm.cancel")}
-          </Button>
-          <Button type="submit" disabled={isPending}>
-            {isPending
-              ? t("commerceOnboarding.saBindingForm.verifying")
-              : t("commerceOnboarding.saBindingForm.bind")}
-          </Button>
-        </div>
+        </p>
+      )}
+
+      <DialogFooter className="gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onDone}
+          disabled={isPending}
+        >
+          {t("commerceOnboarding.saBindingForm.cancel")}
+        </Button>
+        <Button type="submit" disabled={isPending}>
+          {isPending
+            ? t("commerceOnboarding.saBindingForm.verifying")
+            : t("commerceOnboarding.saBindingForm.bind")}
+        </Button>
       </DialogFooter>
     </form>
   );


### PR DESCRIPTION
## Summary

Connecting Google Analytics or Search Console runs through the **shared service-account lane** — Google OAuth is still in review, so its login screen warns the app is unverified, and the consent-free route is the default.

The dialog didn't explain any of that. It showed four dense sentences, a bare service-account e-mail with no label, an input, and a micro-link reading "autorizar via login do Google". Nothing told the user what the e-mail was or why Google login wasn't the obvious path, so the whole flow read as a workaround.

## What changed

**Three step cards, each owning the control it talks about**
- Step 1: the deep link into the right Google console
- Step 2: the e-mail to paste there (copy button)
- Step 3: the id to bring back (input + format hint)

The instruction and the thing it refers to no longer sit in separate blocks.

**Copy**
- One tight line per step instead of four dense sentences.
- The GSC placeholder and hint use the merchant's own domain (`sc-domain:theirstore.com`) rather than a generic sample.
- The OAuth route is now one explained line — "Google is still reviewing our app, so its login screen warns that the app isn't verified" — plus the link, instead of an unexplained micro-link.
- "Vincular"/"Bind" → "Conectar"/"Connect".
- Dropped the redundant dialog description and the standalone field labels that the step sentences already introduce; the input keeps an `aria-label`, and `aria-describedby` is opted out explicitly rather than left dangling.
- Header logo 48px → 36px.

**i18n**
All of this copy was hardcoded pt-BR in `sa-binding-copy.ts`, against the repo's i18n rule. It now lives in the en + pt-BR dictionaries; the module holds keys and structure only.

**Drive-by bug fix**
The source-card icons on the connect step rendered **36×30**, not square: `IntegrationIcon` emits a `min-w-*` alongside its size, and Tailwind-merge treats `min-w` as a separate group from `size-*`, so a `size-[30px]` override left min-width holding the box wider than it was tall. The call site now lets the `size` prop own the box.

Note this is a footgun in `IntegrationIcon` itself — any consumer overriding the box via className gets a rectangle. The only other overriding call site (`chat/context-panel.tsx`) is square by luck (`size-6` with `size="xs"`, whose min-width is also 24px). Left alone as out of scope; worth a follow-up.

## Testing

- `bun run check`, `bun run lint` (0 errors), `bunx knip` — all clean
- `bun test apps/web/src/routes/commerce-onboarding` — 83 pass
- `sa-binding-copy.test.ts` now asserts every key resolves in **both** dictionaries, so a missing translation fails the suite. Tests that encoded the old hardcoded pt-BR strings were inverted, not appended to.
- Verified interactively in both languages, both themes, and across every `COMMERCE_DISCOVERY_BIND` failure remediation (no-access, no-web-stream, no-match, already-bound, unknown) via a throwaway backend-free harness, which is **not** part of this PR.

## Screenshots

Dropping the before/after in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the GA4/GSC connect dialog into three clear steps with inline controls, explained why OAuth isn’t the default, and moved all copy to i18n. Also fixed the non-square source-card icon.

- **New Features**
  - Three step cards: open console (deep link), copy reader e-mail, paste resource id.
  - Provider-specific copy in `en` and `pt-BR`, with dynamic domain examples (e.g. `sc-domain:yourstore.com`).
  - Inline remediation guidance based on server reasons (no-access, no-web-stream, no-match, already-bound, unknown).
  - “Bind” → “Connect”; smaller header icon; input keeps an accessible label; `aria-describedby` opted out.
  - OAuth alternative kept with a one-line note about the unverified app state.

- **Bug Fixes**
  - Source-card icons render square by letting the `size` prop own the box (removed conflicting min-width override).

<sup>Written for commit 42c8f6a80a610771094742144f19a093e4d68972. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

