### PR TITLE
fix(sandbox): use decobot identity for unattributable git commits

### DIFF
--- a/apps/api/src/shared/github-clone-info.ts
+++ b/apps/api/src/shared/github-clone-info.ts
@@ -34,6 +34,20 @@ export interface GitHubCloneInfo {
 }
 
 /**
+ * decobot (github.com/decobot, id 114028756) — deco's shared GitHub identity
+ * for automated commits when the real author can't be resolved. Its noreply
+ * commit-email format is deterministic from its public id+login (no private
+ * email lookup or verification needed) and always resolves to a real,
+ * verified GitHub account, which is required by GitHub App installation
+ * tokens (see below) and by private-repo CI/CD collaboration checks (e.g.
+ * Vercel) that reject commits whose author can't be matched to an account.
+ */
+const DECOBOT_GIT_IDENTITY = {
+  name: "Deco Bot",
+  email: "114028756+decobot@users.noreply.github.com",
+} as const;
+
+/**
  * Public-repo clone (no token, no /user lookup). Anonymous HTTPS clone works
  * for any public GitHub repo; push back will fail (no creds) but that's the
  * documented constraint of public-clone mode.
@@ -44,8 +58,8 @@ export function buildAnonymousCloneInfo(
 ): GitHubCloneInfo {
   return {
     cloneUrl: `https://github.com/${owner}/${name}.git`,
-    gitUserName: "Deco Studio",
-    gitUserEmail: "studio@deco.cx",
+    gitUserName: DECOBOT_GIT_IDENTITY.name,
+    gitUserEmail: DECOBOT_GIT_IDENTITY.email,
   };
 }
 
@@ -110,26 +124,32 @@ export async function buildCloneInfo(
 
   const cloneUrl = `https://x-access-token:${accessToken}@github.com/${owner}/${name}.git`;
 
-  let gitUserName = "Deco Studio";
-  let gitUserEmail = "studio@deco.cx";
-  try {
-    const res = await fetch("https://api.github.com/user", {
-      headers: {
-        Authorization: `token ${accessToken}`,
-        Accept: "application/vnd.github+json",
-      },
-    });
-    if (res.ok) {
-      const user = (await res.json()) as {
-        name?: string | null;
-        login: string;
-        email?: string | null;
-      };
-      gitUserName = user.name || user.login;
-      gitUserEmail = user.email || `${user.login}@users.noreply.github.com`;
+  let gitUserName: string = DECOBOT_GIT_IDENTITY.name;
+  let gitUserEmail: string = DECOBOT_GIT_IDENTITY.email;
+  // GitHub App installation tokens (ghs_...) can never resolve via GET /user —
+  // that endpoint only accepts user-to-server OAuth tokens/PATs and always
+  // 401s for them. Skip the guaranteed-to-fail call and keep the decobot
+  // fallback; only broad user OAuth tokens can look up a real identity here.
+  if (!accessToken.startsWith("ghs_")) {
+    try {
+      const res = await fetch("https://api.github.com/user", {
+        headers: {
+          Authorization: `token ${accessToken}`,
+          Accept: "application/vnd.github+json",
+        },
+      });
+      if (res.ok) {
+        const user = (await res.json()) as {
+          name?: string | null;
+          login: string;
+          email?: string | null;
+        };
+        gitUserName = user.name || user.login;
+        gitUserEmail = user.email || `${user.login}@users.noreply.github.com`;
+      }
+    } catch {
+      // Fallback to decobot identity — don't block the caller.
     }
-  } catch {
-    // Fallback to defaults — don't block the caller.
   }
 
   return { cloneUrl, gitUserName, gitUserEmail };


### PR DESCRIPTION
## Summary
- `GET /user` always 401s for GitHub App installation tokens (`ghs_...`), so repo-scoped connections silently fell through to the hardcoded `"Deco Studio" <studio@deco.cx>` identity on **every** commit — not a rare fallback, guaranteed every time.
- GitHub can't match `studio@deco.cx` to any account (confirmed via `gh api repos/.../commits/<sha>` returning `author: null`), so downstream collaboration checks that gate on commit-author verification (e.g. Vercel's private-repo Pro-team protection) block the deployment outright.
- Swapped the fallback to `decobot`'s GitHub noreply commit email (`114028756+decobot@users.noreply.github.com`) — deterministic from its public id+login, needs no email verification, and always resolves to a real, already-collaborator account on affected repos.
- Also skip the `/user` call entirely when the token is `ghs_...`, since it's guaranteed to fail rather than a flaky upstream — matches the existing comment's intent ("don't block the caller") without wasting a request every clone.

## Test plan
- [x] `bun run fmt` — no changes
- [x] `tsc --noEmit` on `apps/api` — clean
- [ ] Verify a fresh sandbox commit on a repo-scoped connection now shows `decobot` as author on GitHub
- [ ] Confirm a previously-blocked Vercel preview deployment (private repo, Pro team) now passes the collaboration check

cc @pedrofrxncx for review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use decobot for unattributable git commits and skip `/user` for `ghs_` tokens, so commits resolve to a real account and private repo deployments (e.g. Vercel) no longer fail collaboration checks.

- **Bug Fixes**
  - Set default git identity to decobot: name "Deco Bot", email "114028756+decobot@users.noreply.github.com".
  - Skip `GET /user` when the token is `ghs_...` (GitHub App installation tokens always 401).
  - Keep user lookup for other tokens; fall back to decobot if lookup fails.

<sup>Written for commit 125c475c46f7c56f414459b52e365adcf4ffb0f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

