### PR TITLE
feat(github): add opt-in Sync button for the CMS preview header

### DIFF
--- a/apps/web/src/components/thread/github/header-actions.tsx
+++ b/apps/web/src/components/thread/github/header-actions.tsx
@@ -503,6 +503,9 @@ function HeaderButtonRenderer(props: {
   ) {
     return (
       <div className="flex items-center gap-2">
+        {props.showSync ? (
+          <SyncButton t={t} busy={actionBusy} onClick={props.onSync} />
+        ) : null}
         <WithTooltip label={tooltipLabel}>
           <MergeSplitButton
             baseBranch={props.prBase}
@@ -512,9 +515,6 @@ function HeaderButtonRenderer(props: {
             onReview={props.onReview}
           />
         </WithTooltip>
-        {props.showSync ? (
-          <SyncButton t={t} busy={actionBusy} onClick={props.onSync} />
-        ) : null}
       </div>
     );
   }
@@ -527,6 +527,9 @@ function HeaderButtonRenderer(props: {
 
   return (
     <div className="flex items-center gap-2">
+      {props.showSync ? (
+        <SyncButton t={t} busy={actionBusy} onClick={props.onSync} />
+      ) : null}
       <WithTooltip label={tooltipLabel}>
         <Button
           size="sm"
@@ -581,9 +584,6 @@ function HeaderButtonRenderer(props: {
             </span>
           </Button>
         </WithTooltip>
-      ) : null}
-      {props.showSync ? (
-        <SyncButton t={t} busy={actionBusy} onClick={props.onSync} />
       ) : null}
     </div>
   );

--- a/apps/web/src/components/thread/github/header-actions.tsx
+++ b/apps/web/src/components/thread/github/header-actions.tsx
@@ -299,6 +299,20 @@ export function HeaderActions({ virtualMcpId }: Props) {
   const baseBranch =
     effectiveBranchMeta.kind === "ready" ? effectiveBranchMeta.base : "main";
 
+  // Org-level opt-in (metadata.syncButtonEnabled) so a business user doesn't
+  // have to know they need to commit before they can rebase. One
+  // deterministic chat prompt: commit local changes, pull --rebase (picks up
+  // anything a teammate pushed straight to this branch), rebase onto the
+  // latest base, push.
+  const showSync =
+    vm?.metadata?.syncButtonEnabled === true &&
+    Boolean(githubRepo) &&
+    Boolean(githubHeadBranch);
+  const handleSync = () => {
+    if (isStreaming || !githubHeadBranch) return;
+    void send(tpl.syncBranch({ branch: githubHeadBranch, base: baseBranch }));
+  };
+
   const refreshPrState = async () => {
     await Promise.all([
       prQuery.refetch(),
@@ -400,6 +414,8 @@ export function HeaderActions({ virtualMcpId }: Props) {
         onActivate={onActivate}
         showPublishSide={showPublishSide}
         onPublishSide={onPublishSide}
+        showSync={showSync}
+        onSync={handleSync}
         publishGate={publishGate}
         prNumber={pr?.number}
         prBase={pr?.base}
@@ -456,6 +472,8 @@ function HeaderButtonRenderer(props: {
   onActivate: (action: HeaderButton["action"]) => void;
   showPublishSide: boolean;
   onPublishSide: () => void;
+  showSync: boolean;
+  onSync: () => void;
   publishGate: PublishGate;
   prNumber?: number;
   prBase?: string;
@@ -484,15 +502,20 @@ function HeaderButtonRenderer(props: {
     props.prBase != null
   ) {
     return (
-      <WithTooltip label={tooltipLabel}>
-        <MergeSplitButton
-          baseBranch={props.prBase}
-          disabled={disabled}
-          loading={loading}
-          onPublish={() => props.onSquashMerge(props.prNumber!)}
-          onReview={props.onReview}
-        />
-      </WithTooltip>
+      <div className="flex items-center gap-2">
+        <WithTooltip label={tooltipLabel}>
+          <MergeSplitButton
+            baseBranch={props.prBase}
+            disabled={disabled}
+            loading={loading}
+            onPublish={() => props.onSquashMerge(props.prNumber!)}
+            onReview={props.onReview}
+          />
+        </WithTooltip>
+        {props.showSync ? (
+          <SyncButton t={t} busy={actionBusy} onClick={props.onSync} />
+        ) : null}
+      </div>
     );
   }
 
@@ -559,7 +582,36 @@ function HeaderButtonRenderer(props: {
           </Button>
         </WithTooltip>
       ) : null}
+      {props.showSync ? (
+        <SyncButton t={t} busy={actionBusy} onClick={props.onSync} />
+      ) : null}
     </div>
+  );
+}
+
+/**
+ * Same visual weight as the primary "Submit for review" button (variant
+ * "default") — this is a peer action, not a secondary one, so a business
+ * user reads it as equally first-class.
+ */
+function SyncButton({
+  t,
+  busy,
+  onClick,
+}: {
+  t: TFunction;
+  busy: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <WithTooltip label={t("thread.headerActions.syncTooltip")}>
+      <Button size="sm" variant="default" disabled={busy} onClick={onClick}>
+        <RefreshCw01 className="size-4 shrink-0 @3xl/panel-header:hidden" />
+        <span className="@max-3xl/panel-header:hidden">
+          {t("thread.headerActions.sync")}
+        </span>
+      </Button>
+    </WithTooltip>
   );
 }
 

--- a/apps/web/src/components/thread/github/message-templates.test.ts
+++ b/apps/web/src/components/thread/github/message-templates.test.ts
@@ -73,6 +73,15 @@ describe("message-templates", () => {
     expect(out.toLowerCase()).toContain("re-run");
   });
 
+  test("syncBranch references the branch + base and covers commit, pull --rebase, and rebase onto base", () => {
+    const out = tpl.syncBranch({ branch: "feat/x", base: "main" });
+    expect(out).toContain("feat/x");
+    expect(out).toContain("origin/main");
+    expect(out.toLowerCase()).toContain("commit");
+    expect(out).toContain("git pull --rebase");
+    expect(out).toContain("git rebase origin/main");
+  });
+
   test("all templates include the button-confirmed reinforcement", () => {
     const outputs = [
       tpl.commitAndPush({ branch: "x" }),
@@ -85,6 +94,7 @@ describe("message-templates", () => {
       tpl.reviewPr({ prNumber: 1 }),
       tpl.mergeSquash({ prNumber: 1 }),
       tpl.rerunCheck({ prNumber: 1, checkName: "a" }),
+      tpl.syncBranch({ branch: "x", base: "main" }),
     ];
     for (const out of outputs) {
       expect(out.toLowerCase()).toContain("user clicked this action");

--- a/apps/web/src/components/thread/github/message-templates.ts
+++ b/apps/web/src/components/thread/github/message-templates.ts
@@ -13,6 +13,7 @@
 
 export interface TemplateContext {
   branch?: string;
+  base?: string;
   prNumber?: number;
   failingChecks?: string[];
   checkName?: string;
@@ -40,6 +41,18 @@ export function reopenPr(ctx: Pick<TemplateContext, "prNumber">): string {
 
 export function rebaseOnBase(ctx: Pick<TemplateContext, "branch">): string {
   return `Rebase \`${ctx.branch}\` on the latest base and force-push with --force-with-lease. ${BUTTON_CONFIRMED}`;
+}
+
+/**
+ * Full sync: catches up with work from both directions — a teammate who
+ * pushed straight to this branch, and the base branch moving on. Kept as one
+ * explicit command sequence (not "sync appropriately") so a business user
+ * clicking this gets the same deterministic outcome every time.
+ */
+export function syncBranch(
+  ctx: Pick<TemplateContext, "branch" | "base">,
+): string {
+  return `Sync \`${ctx.branch}\` with everyone else's work: \`git add -A\`, commit any pending local changes with a concise conventional-commit message (skip if the working tree is clean), \`git pull --rebase\` to bring in anything pushed directly to \`origin/${ctx.branch}\`, then \`git rebase origin/${ctx.base}\` to catch up with the base branch. Resolve any conflicts that come up, then push the result (force-with-lease only if the rebase rewrote commits already on the remote). ${BUTTON_CONFIRMED}`;
 }
 
 export function rerunCheck(

--- a/apps/web/src/i18n/en/thread.ts
+++ b/apps/web/src/i18n/en/thread.ts
@@ -92,6 +92,9 @@ export const thread = {
   "thread.headerActions.publishDirectlySkipReview":
     "Publish directly, skipping review",
   "thread.headerActions.publishedPr": "Published PR #{prNumber}",
+  "thread.headerActions.sync": "Sync",
+  "thread.headerActions.syncTooltip":
+    "Save your changes and catch up with everyone else's work",
   "thread.headerActions.published": "Published",
   "thread.headerActions.publishNeedsReview":
     "This change needs review before publishing.",

--- a/apps/web/src/i18n/en/virtual-mcp.ts
+++ b/apps/web/src/i18n/en/virtual-mcp.ts
@@ -213,9 +213,9 @@ Define step-by-step how the agent should handle requests.
   "virtualMcp.virtualMcp.publishPolicyOpen": "Publish freely",
   "virtualMcp.virtualMcp.publishPolicyOpenDescription":
     "Publish any change directly, without review.",
-  "virtualMcp.virtualMcp.syncButton": "Sync button",
-  "virtualMcp.virtualMcp.syncButtonDescription":
-    "Show a \"Sync\" action in the preview's ⋯ menu that asks the agent to save your changes and catch up with everyone else's work.",
+  "virtualMcp.virtualMcp.teamSync": "Team sync",
+  "virtualMcp.virtualMcp.teamSyncDescription":
+    "Add a Sync button that saves your changes and catches up with your team's latest work.",
   "virtualMcp.virtualMcp.sandbox": "Sandbox",
   "virtualMcp.virtualMcp.settings": "Settings",
   "virtualMcp.virtualMcp.spaceNotFound": "Space not found",

--- a/apps/web/src/i18n/en/virtual-mcp.ts
+++ b/apps/web/src/i18n/en/virtual-mcp.ts
@@ -213,6 +213,9 @@ Define step-by-step how the agent should handle requests.
   "virtualMcp.virtualMcp.publishPolicyOpen": "Publish freely",
   "virtualMcp.virtualMcp.publishPolicyOpenDescription":
     "Publish any change directly, without review.",
+  "virtualMcp.virtualMcp.syncButton": "Sync button",
+  "virtualMcp.virtualMcp.syncButtonDescription":
+    "Show a \"Sync\" action in the preview's ⋯ menu that asks the agent to save your changes and catch up with everyone else's work.",
   "virtualMcp.virtualMcp.sandbox": "Sandbox",
   "virtualMcp.virtualMcp.settings": "Settings",
   "virtualMcp.virtualMcp.spaceNotFound": "Space not found",

--- a/apps/web/src/i18n/pt-br/thread.ts
+++ b/apps/web/src/i18n/pt-br/thread.ts
@@ -96,6 +96,9 @@ export const thread = {
   "thread.headerActions.publishDirectlySkipReview":
     "Publicar diretamente, pulando a revisão",
   "thread.headerActions.publishedPr": "PR #{prNumber} publicado",
+  "thread.headerActions.sync": "Sincronizar",
+  "thread.headerActions.syncTooltip":
+    "Salva suas alterações e atualiza com o trabalho de todos",
   "thread.headerActions.published": "Publicado",
   "thread.headerActions.publishNeedsReview":
     "Esta alteração precisa de revisão antes de publicar.",

--- a/apps/web/src/i18n/pt-br/virtual-mcp.ts
+++ b/apps/web/src/i18n/pt-br/virtual-mcp.ts
@@ -216,9 +216,9 @@ Defina passo a passo como o agente deve tratar as solicitações.
   "virtualMcp.virtualMcp.publishPolicyOpen": "Publicar sem revisão",
   "virtualMcp.virtualMcp.publishPolicyOpenDescription":
     "Publica qualquer alteração diretamente, sem revisão.",
-  "virtualMcp.virtualMcp.syncButton": "Botão de sincronização",
-  "virtualMcp.virtualMcp.syncButtonDescription":
-    'Mostra uma ação "Sincronizar" no menu ⋯ do preview que pede ao agente para salvar suas alterações e se atualizar com o trabalho de todos.',
+  "virtualMcp.virtualMcp.teamSync": "Sincronização com o time",
+  "virtualMcp.virtualMcp.teamSyncDescription":
+    "Adiciona um botão Sincronizar que salva suas alterações e atualiza com o trabalho mais recente do time.",
   "virtualMcp.virtualMcp.sandbox": "Sandbox",
   "virtualMcp.virtualMcp.settings": "Configurações",
   "virtualMcp.virtualMcp.spaceNotFound": "Espaço não encontrado",

--- a/apps/web/src/i18n/pt-br/virtual-mcp.ts
+++ b/apps/web/src/i18n/pt-br/virtual-mcp.ts
@@ -216,6 +216,9 @@ Defina passo a passo como o agente deve tratar as solicitações.
   "virtualMcp.virtualMcp.publishPolicyOpen": "Publicar sem revisão",
   "virtualMcp.virtualMcp.publishPolicyOpenDescription":
     "Publica qualquer alteração diretamente, sem revisão.",
+  "virtualMcp.virtualMcp.syncButton": "Botão de sincronização",
+  "virtualMcp.virtualMcp.syncButtonDescription":
+    'Mostra uma ação "Sincronizar" no menu ⋯ do preview que pede ao agente para salvar suas alterações e se atualizar com o trabalho de todos.',
   "virtualMcp.virtualMcp.sandbox": "Sandbox",
   "virtualMcp.virtualMcp.settings": "Configurações",
   "virtualMcp.virtualMcp.spaceNotFound": "Espaço não encontrado",

--- a/apps/web/src/views/virtual-mcp/index.tsx
+++ b/apps/web/src/views/virtual-mcp/index.tsx
@@ -1108,38 +1108,12 @@ function VirtualMcpDetailViewWithData({
                         control={form.control}
                         onCommit={flushAndSave}
                       />
-                      <div className="flex items-center justify-between gap-4">
-                        <div className="space-y-0.5 min-w-0">
-                          <Label className="font-normal text-foreground">
-                            {t("virtualMcp.virtualMcp.syncButton")}
-                          </Label>
-                          <p className="text-xs text-muted-foreground">
-                            {t("virtualMcp.virtualMcp.syncButtonDescription")}
-                          </p>
-                        </div>
-                        <Switch
-                          className="shrink-0"
-                          checked={
-                            form.watch("metadata.syncButtonEnabled") ?? false
-                          }
-                          onCheckedChange={(checked) => {
-                            form.setValue(
-                              "metadata.syncButtonEnabled",
-                              checked,
-                              {
-                                shouldDirty: true,
-                              },
-                            );
-                            flushAndSave();
-                          }}
-                        />
-                      </div>
                     </CardContent>
                   </>
                 )}
 
                 {/* Editing — content-editing preferences (auto-open the CMS,
-                    compact field descriptions). */}
+                    team sync, compact field descriptions). */}
                 <div className="border-t border-border -mx-6" />
                 <CardContent className="p-0 space-y-5">
                   <div className="flex flex-col gap-1">
@@ -1169,6 +1143,30 @@ function VirtualMcpDetailViewWithData({
                             { ...layoutMeta, cmsDefaultOpen: checked },
                             { shouldDirty: true },
                           );
+                          flushAndSave();
+                        }}
+                      />
+                    </div>
+                  )}
+                  {hasGithubRepo && (
+                    <div className="flex items-center justify-between gap-4">
+                      <div className="space-y-0.5 min-w-0">
+                        <Label className="font-normal text-foreground">
+                          {t("virtualMcp.virtualMcp.teamSync")}
+                        </Label>
+                        <p className="text-xs text-muted-foreground">
+                          {t("virtualMcp.virtualMcp.teamSyncDescription")}
+                        </p>
+                      </div>
+                      <Switch
+                        className="shrink-0"
+                        checked={
+                          form.watch("metadata.syncButtonEnabled") ?? false
+                        }
+                        onCheckedChange={(checked) => {
+                          form.setValue("metadata.syncButtonEnabled", checked, {
+                            shouldDirty: true,
+                          });
                           flushAndSave();
                         }}
                       />

--- a/apps/web/src/views/virtual-mcp/index.tsx
+++ b/apps/web/src/views/virtual-mcp/index.tsx
@@ -1108,6 +1108,32 @@ function VirtualMcpDetailViewWithData({
                         control={form.control}
                         onCommit={flushAndSave}
                       />
+                      <div className="flex items-center justify-between gap-4">
+                        <div className="space-y-0.5 min-w-0">
+                          <Label className="font-normal text-foreground">
+                            {t("virtualMcp.virtualMcp.syncButton")}
+                          </Label>
+                          <p className="text-xs text-muted-foreground">
+                            {t("virtualMcp.virtualMcp.syncButtonDescription")}
+                          </p>
+                        </div>
+                        <Switch
+                          className="shrink-0"
+                          checked={
+                            form.watch("metadata.syncButtonEnabled") ?? false
+                          }
+                          onCheckedChange={(checked) => {
+                            form.setValue(
+                              "metadata.syncButtonEnabled",
+                              checked,
+                              {
+                                shouldDirty: true,
+                              },
+                            );
+                            flushAndSave();
+                          }}
+                        />
+                      </div>
                     </CardContent>
                   </>
                 )}

--- a/packages/shared/src/sdk/types/virtual-mcp.ts
+++ b/packages/shared/src/sdk/types/virtual-mcp.ts
@@ -631,6 +631,22 @@ const fastPreviewMetadataField = z
   );
 
 /**
+ * Reusable `metadata.syncButtonEnabled` field. When true, the CMS preview's
+ * overflow (⋯) menu shows a "Sync" action. Clicking it sends a chat prompt
+ * telling the agent to commit any pending local changes, `git pull --rebase`
+ * this branch (picks up commits a teammate pushed directly to the same
+ * branch), rebase onto the latest base branch, and push — so a business user
+ * never has to know the git steps themselves. Off by default.
+ */
+const syncButtonEnabledMetadataField = z
+  .boolean()
+  .nullable()
+  .optional()
+  .describe(
+    "Show a 'Sync' action in the CMS preview's overflow menu that tells the agent to commit pending changes, pull --rebase this branch, and rebase onto the latest base branch. Off by default.",
+  );
+
+/**
  * Virtual MCP entity schema - single source of truth
  * Compliant with collections binding pattern
  */
@@ -715,6 +731,7 @@ export const VirtualMCPEntitySchema = z.object({
           "Blocks form: opt in to showing a field's schema description as a hover tooltip on its title, instead of the default inline text below the title.",
         ),
       fastPreview: fastPreviewMetadataField,
+      syncButtonEnabled: syncButtonEnabledMetadataField,
     })
     .loose()
     .describe("Metadata"),
@@ -829,6 +846,7 @@ export const VirtualMCPCreateDataSchema = z.object({
           "Blocks form: opt in to showing a field's schema description as a hover tooltip on its title, instead of the default inline text below the title.",
         ),
       fastPreview: fastPreviewMetadataField,
+      syncButtonEnabled: syncButtonEnabledMetadataField,
     })
     .loose()
     .nullable()
@@ -924,6 +942,7 @@ export const VirtualMCPUpdateDataSchema = z.object({
           "Blocks form: opt in to showing a field's schema description as a hover tooltip on its title, instead of the default inline text below the title.",
         ),
       fastPreview: fastPreviewMetadataField,
+      syncButtonEnabled: syncButtonEnabledMetadataField,
     })
     .loose()
     .nullable()


### PR DESCRIPTION
## Summary
- Adds an opt-in "Team sync" toggle (Virtual MCP settings > CMS > Editing) that shows a **Sync** button in the GitHub header actions, first in the row (Sync, Submit for review, Publish).
- Clicking Sync sends one deterministic chat prompt: commit pending changes, `git pull --rebase` (picks up commits a teammate pushed directly to the branch), rebase onto the latest base, and push — so a business user never has to know they need to commit before they can rebase.
- Off by default; gated on a linked GitHub repo and a resolved branch.

## Testing notes
- `bun run fmt`, `bun run lint`, `bun run --cwd=apps/web check` all pass.
- Added/updated unit tests in `message-templates.test.ts` for the new `syncBranch` prompt template.
- i18n keys added/renamed in both `en` and `pt-br`, verified via the `satisfies` compile-time check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in Sync button to the CMS GitHub header to help users save changes and catch up with the base and teammate commits in one click. Off by default; when enabled, it appears first in the header (Sync, Submit, Publish) for repos with a resolved branch.

- **New Features**
  - `Team sync` toggle in Virtual MCP → CMS → Editing shows a primary “Sync” button before Submit/Publish.
  - “Sync” sends a deterministic `syncBranch` prompt: commit pending changes, `git pull --rebase`, `git rebase origin/<base>`, then push.
  - Added i18n (en, pt-br), unit tests for `syncBranch`, and `metadata.syncButtonEnabled` in the Virtual MCP schemas.

- **Migration**
  - Off by default. Enable via Settings → CMS → Editing → `Team sync`.
  - Requires a linked GitHub repo and a resolved head branch.

<sup>Written for commit f71ee83c4e9f611be3563adf4b36305a82995478. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

