### PR TITLE
fix(web): honor typed branch name in branch picker's New button

### DIFF
--- a/apps/web/src/components/thread/github/branch-picker.tsx
+++ b/apps/web/src/components/thread/github/branch-picker.tsx
@@ -256,9 +256,15 @@ export function BranchPicker({
                 variant="outline"
                 size="sm"
                 className="h-7 shrink-0"
-                onClick={() => pick(generateBranchName(userLabel))}
+                onClick={() =>
+                  pick(search.trim() || generateBranchName(userLabel))
+                }
               >
-                {t("thread.branchPicker.new")}
+                {search.trim()
+                  ? t("thread.branchPicker.createBranch", {
+                      name: search.trim(),
+                    })
+                  : t("thread.branchPicker.new")}
               </Button>
             )}
           </div>

--- a/apps/web/src/i18n/en/thread.ts
+++ b/apps/web/src/i18n/en/thread.ts
@@ -5,6 +5,7 @@ export const thread = {
     "Couldn't load branches from GitHub. You can still pick from your branches.",
   "thread.branchPicker.couldntLoadPullRequests":
     "Couldn't load pull requests from GitHub.",
+  "thread.branchPicker.createBranch": 'Create "{name}"',
   "thread.branchPicker.hiddenForkPrs":
     "{count} PR(s) from forks hidden — open on a branch in this repo",
   "thread.branchPicker.last7Days": "Last 7 days",

--- a/apps/web/src/i18n/pt-br/thread.ts
+++ b/apps/web/src/i18n/pt-br/thread.ts
@@ -7,6 +7,7 @@ export const thread = {
     "Não foi possível carregar branches do GitHub. Você ainda pode escolher entre suas branches.",
   "thread.branchPicker.couldntLoadPullRequests":
     "Não foi possível carregar pull requests do GitHub.",
+  "thread.branchPicker.createBranch": 'Criar "{name}"',
   "thread.branchPicker.hiddenForkPrs":
     "{count} PR(s) de forks ocultado(s) — abra em uma branch deste repositório",
   "thread.branchPicker.last7Days": "Últimos 7 dias",


### PR DESCRIPTION
## Summary
- The branch picker's "New" button always minted a random branch name via `generateBranchName`, completely ignoring whatever text was typed into the search box.
- The button now uses the typed search text (trimmed) as the branch name when present, and only falls back to a generated random name when the search box is empty.
- Button label switches to `Create "<name>"` when there's typed text, so the action being taken is clear.

## Test plan
- [x] `bun run --cwd=apps/web check` passes
- [x] `bun run fmt:check` passes
- [x] `bun run lint` — no new errors introduced
- [ ] Manual verification in a GitHub-connected org: type a nonexistent branch name in the branch picker and confirm clicking the button sets the thread's branch to that exact name; confirm leaving the search empty still generates a random branch as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the branch picker "New" button to use the typed search text as the branch name, falling back to a generated name only when the field is empty. Update the button label to Create "<name>" and add `thread.branchPicker.createBranch` i18n strings in `en` and `pt-br`.

<sup>Written for commit d035fa592d67c2609d0debc6d2ba09e018bc87c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

