### PR TITLE
feat(task-board): kanban card agent thread as a real footer

### DIFF
--- a/apps/web/src/components/qa-agent-icon.tsx
+++ b/apps/web/src/components/qa-agent-icon.tsx
@@ -2,8 +2,8 @@ import { cn } from "@deco/ui/lib/utils.ts";
 import { QA_AGENT_ICON_URL } from "@/sdk";
 import { useT } from "@/i18n/use-t.ts";
 
-/** The QA Agent shield-check glyph, rendered as a round avatar so it sits
- *  alongside the Super Agent and member avatars in the assignee picker. */
+/** The QA Agent glyph, rendered as a round avatar so it sits alongside the
+ *  Super Agent and member avatars in the assignee picker. */
 export function QaAgentIcon({
   size = 16,
   className,

--- a/apps/web/src/layouts/task-board/config.tsx
+++ b/apps/web/src/layouts/task-board/config.tsx
@@ -6,9 +6,17 @@ import {
   Loading02,
 } from "@untitledui/icons";
 import type { StudioToolOutput as ToolOutput } from "@decocms/shared/tools/tool-io";
+import {
+  isReviewerThreadTitle,
+  REVIEWER_KINDS,
+  type ReviewerKind,
+} from "@decocms/shared/task-board";
 import type { TranslationKey } from "@/i18n/use-t.ts";
 
-export { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
+export {
+  SUPER_AGENT_ASSIGNEE_ID,
+  isReviewerThreadTitle,
+} from "@decocms/shared/task-board";
 
 export type TaskBoardItem = ToolOutput<"TASK_BOARD_ITEM_LIST">["items"][number];
 export type TaskBoardItemStatus = TaskBoardItem["status"];
@@ -46,6 +54,19 @@ export function primaryThread(
   item: TaskBoardItem,
 ): TaskBoardItemThread | undefined {
   return item.threads[0];
+}
+
+/** The QA/code-review threads linked to this task, in `REVIEWER_KINDS` order —
+ *  present only once that reviewer has actually run. */
+export function reviewerThreads(
+  item: TaskBoardItem,
+): { kind: ReviewerKind; thread: TaskBoardItemThread }[] {
+  return REVIEWER_KINDS.flatMap((kind) => {
+    const thread = item.threads.find((t) =>
+      isReviewerThreadTitle(t.title, kind),
+    );
+    return thread ? [{ kind, thread }] : [];
+  });
 }
 
 /**

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -1821,7 +1821,7 @@ function TaskCard({
       )}
 
       {mainThread && (
-        <div className="-mx-3 flex flex-col gap-1.5 border-t border-border px-3 pt-2">
+        <div className="-mx-3 flex flex-col gap-1.5 border-t border-border px-3 pt-3">
           <AgentThreadFooterRow
             icon={<SuperAgentIcon size={14} />}
             name={t("taskBoard.taskDialog.superAgentDefaultName")}

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -1751,7 +1751,7 @@ function TaskCard({
         else onOpen();
       }}
       className={cn(
-        "group flex shrink-0 cursor-grab flex-col gap-2 rounded-xl bg-card px-3 py-2.5 text-left card-shadow hover:bg-accent/60 active:cursor-grabbing",
+        "group relative flex shrink-0 cursor-grab flex-col gap-2 rounded-xl bg-card px-3 py-2.5 text-left card-shadow hover:bg-accent/60 active:cursor-grabbing",
         selected && "bg-accent",
         className,
       )}
@@ -1811,9 +1811,11 @@ function TaskCard({
             e.stopPropagation();
             onRerun();
           }}
-          // Hover-revealed: every Super-Agent card qualifies, so showing it
-          // always would put a button on nearly the whole board.
-          className="flex items-center gap-1.5 self-end rounded-md border border-border bg-background px-2 py-1 text-xs font-medium text-foreground opacity-0 transition-opacity hover:bg-accent focus-visible:opacity-100 group-hover:opacity-100"
+          // Absolutely positioned so it never reserves layout space: every
+          // Super-Agent card qualifies, so a flow-positioned hover button
+          // left a permanent empty gap on every card, and showing it
+          // unconditionally would put a button on nearly the whole board.
+          className="pointer-events-none absolute bottom-2 right-2 z-10 flex items-center gap-1.5 rounded-md border border-border bg-background px-2 py-1 text-xs font-medium text-foreground opacity-0 shadow-sm transition-opacity hover:bg-accent focus-visible:pointer-events-auto focus-visible:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100"
         >
           <RefreshCw01 size={12} />
           {t("taskBoard.taskBoard.rerun")}

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useRef, useState } from "react";
-import type { CSSProperties } from "react";
+import type { CSSProperties, ReactNode } from "react";
 import { createPortal } from "react-dom";
 import {
   DndContext,
@@ -62,6 +62,8 @@ import {
   DropdownMenuTrigger,
 } from "@deco/ui/components/dropdown-menu.tsx";
 import { SuperAgentIcon } from "@/components/super-agent-icon";
+import { QaAgentIcon } from "@/components/qa-agent-icon";
+import { CodeReviewerIcon } from "@/components/code-reviewer-icon";
 import { GitHubIcon } from "@/components/icons/github-icon";
 import {
   Dialog,
@@ -87,8 +89,10 @@ import {
 import { formatTimeAgo } from "@/lib/format-time";
 import {
   insertSortOrder,
+  isReviewerThreadTitle,
   isTaskBlocked,
   primaryThread,
+  reviewerThreads,
   PRIORITIES,
   PRIORITY_CONFIG,
   runSortOrders,
@@ -101,10 +105,15 @@ import {
   type TaskBoardItemPriority,
   type TaskBoardItemStatus,
   type TaskBoardItemTag,
+  type TaskBoardItemThread,
   type Member,
 } from "./config";
 import { useTags } from "@/hooks/use-tags";
-import { TaskBoardItemDialog, toEndOfDayIso } from "./task-dialog";
+import {
+  TaskBoardItemDialog,
+  threadStatusStyle,
+  toEndOfDayIso,
+} from "./task-dialog";
 import { AssigneePickerContent } from "./assignee-picker";
 import { SubscriptionPaywallDialog } from "./subscription-paywall-dialog";
 import { RerunDialog } from "./rerun-dialog";
@@ -1699,7 +1708,16 @@ function TaskCard({
 }) {
   const t = useT();
   const StatusIcon = STATUS_CONFIG[item.status].icon;
-  const lastMessage = primaryThread(item)?.lastMessage;
+  // The Super Agent's own thread, not one of its reviewers' — falls back to
+  // the most recent thread overall so a card still shows something before the
+  // reviewer/main distinction exists (e.g. mid-migration data).
+  const mainThread =
+    item.threads.find(
+      (thr) =>
+        !isReviewerThreadTitle(thr.title, "qa") &&
+        !isReviewerThreadTitle(thr.title, "code_review"),
+    ) ?? primaryThread(item);
+  const reviewThreads = reviewerThreads(item);
 
   const showAutoFix =
     onAutoFix &&
@@ -1756,12 +1774,6 @@ function TaskCard({
         />
       </div>
 
-      {lastMessage && (
-        <p className="line-clamp-2 pl-6 text-xs leading-snug text-muted-foreground">
-          {lastMessage}
-        </p>
-      )}
-
       {(isTaskBlocked(item) ||
         item.priority !== "none" ||
         Boolean(item.dueDate) ||
@@ -1807,7 +1819,76 @@ function TaskCard({
           {t("taskBoard.taskBoard.rerun")}
         </button>
       )}
+
+      {mainThread && (
+        <div className="-mx-3 flex flex-col gap-1.5 border-t border-border px-3 pt-2">
+          <AgentThreadFooterRow
+            icon={<SuperAgentIcon size={14} />}
+            name={t("taskBoard.taskDialog.superAgentDefaultName")}
+            thread={mainThread}
+          />
+          {reviewThreads.map(({ kind, thread }) => (
+            <AgentThreadFooterRow
+              key={thread.threadId}
+              icon={
+                kind === "qa" ? (
+                  <QaAgentIcon size={14} />
+                ) : (
+                  <CodeReviewerIcon size={14} />
+                )
+              }
+              name={t(
+                kind === "qa"
+                  ? "taskBoard.taskDialog.qaAgentLabel"
+                  : "taskBoard.taskDialog.codeReviewerLabel",
+              )}
+              thread={thread}
+            />
+          ))}
+        </div>
+      )}
     </button>
+  );
+}
+
+/**
+ * One agent's row in the card footer, all on a single truncated line: glyph,
+ * name, its live status — e.g. the red "Error" state — then a preview of the
+ * thread's last message. A condensed version of `ThreadActivityItem`'s status
+ * row in the task dialog.
+ */
+function AgentThreadFooterRow({
+  icon,
+  name,
+  thread,
+}: {
+  icon: ReactNode;
+  name: string;
+  thread: TaskBoardItemThread;
+}) {
+  const t = useT();
+  const state = thread.status ? threadStatusStyle(thread.status, t) : null;
+
+  return (
+    <div className="flex items-center gap-1.5">
+      {icon}
+      <span className="shrink-0 text-xs font-medium text-foreground">
+        {name}
+      </span>
+      {state && (
+        <span
+          className={cn("flex shrink-0 items-center gap-1", state.className)}
+        >
+          <state.icon size={12} className={cn(state.spin && "animate-spin")} />
+          <span className="text-xs">{state.label}</span>
+        </span>
+      )}
+      {thread.lastMessage && (
+        <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+          {thread.lastMessage}
+        </span>
+      )}
+    </div>
   );
 }
 

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -793,7 +793,7 @@ export function TaskBoardItemDialog({
 }
 
 /** Live-status style for a linked thread (agent session). */
-function threadStatusStyle(
+export function threadStatusStyle(
   status: NonNullable<TaskBoardItemThread["status"]>,
   t: ReturnType<typeof useT>,
 ): {

--- a/packages/shared/src/sdk/lib/constants.ts
+++ b/packages/shared/src/sdk/lib/constants.ts
@@ -271,10 +271,12 @@ export const parseDevConnectionId = devConnectionPrefix.is;
 export const SUPER_AGENT_ICON_URL =
   "https://assets.decocache.com/decocms/fd07a578-6b1c-40f1-bc05-88a3b981695d/f7fc4ffa81aec04e37ae670c3cd4936643a7b269.png";
 
-/** The QA Agent glyph — a shield-check, distinguishing its review thread from
- *  the Super Agent capybara on the task card. */
+/** The QA Agent glyph — a bug/testing magnifier, distinguishing its review
+ *  thread from the Super Agent capybara on the task card. Deliberately NOT a
+ *  checkmark/shield-check: that glyph read as "already verified" even while
+ *  the QA run was still in progress or had failed. */
 export const QA_AGENT_ICON_URL =
-  "https://api.iconify.design/lucide:shield-check.svg?color=%2316a34a";
+  "https://api.iconify.design/lucide:bug.svg?color=%23f59e0b";
 
 /** The Code Reviewer glyph — a code-inspection magnifier. */
 export const CODE_REVIEWER_ICON_URL =

--- a/plugins/ban-cross-tree-imports.test.ts
+++ b/plugins/ban-cross-tree-imports.test.ts
@@ -1,5 +1,20 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+
+// Each test here spawns a real `oxlint` subprocess. Under CI's parallel test
+// load (this file, ban-e2e-app-imports, and ban-web-server-imports all spawn
+// oxlint concurrently), process-spawn scheduling can occasionally exceed
+// bun's 5000ms default test timeout even though the fixture itself lints in
+// well under a second locally — see the timed-out "bans @/ import" /
+// "bans relative apps/api reach-in" failures in CI run 92623000778.
+setDefaultTimeout(20_000);
 
 const ROOT = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
 const TMP = `${ROOT}/.ban-cross-tree.tmp`;

--- a/plugins/ban-e2e-app-imports.test.ts
+++ b/plugins/ban-e2e-app-imports.test.ts
@@ -1,5 +1,19 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+
+// Each test here spawns a real `oxlint` subprocess. Under CI's parallel test
+// load (this file, ban-cross-tree-imports, and ban-web-server-imports all
+// spawn oxlint concurrently), process-spawn scheduling can occasionally
+// exceed bun's 5000ms default test timeout even though the fixture itself
+// lints in well under a second locally.
+setDefaultTimeout(20_000);
 
 const ROOT = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
 const TMP = `${ROOT}/.ban-e2e-app-imports.tmp`;

--- a/plugins/ban-web-server-imports.test.ts
+++ b/plugins/ban-web-server-imports.test.ts
@@ -1,5 +1,19 @@
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  setDefaultTimeout,
+  test,
+} from "bun:test";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+
+// Each test here spawns a real `oxlint` subprocess. Under CI's parallel test
+// load (this file, ban-cross-tree-imports, and ban-e2e-app-imports all spawn
+// oxlint concurrently), process-spawn scheduling can occasionally exceed
+// bun's 5000ms default test timeout even though the fixture itself lints in
+// well under a second locally.
+setDefaultTimeout(20_000);
 
 const ROOT = new URL("..", import.meta.url).pathname.replace(/\/$/, "");
 const TMP = `${ROOT}/.ban-web-server.tmp`;


### PR DESCRIPTION
## What is this contribution about?
Task board cards showed the linked agent thread's last message as a description-like paragraph directly under the title, which read as if the card had a second description rather than a live agent status. This replaces it with an actual footer: an edge-to-edge divider (spans the full card width, not inset by the card's padding) followed by one row per linked agent thread — Super Agent always, then QA Agent / Code Reviewer once each has actually run — each showing its icon, name, live status (e.g. red "Error"), and a truncated preview of its last message. Also swapped the QA Agent's green shield-check glyph for a neutral bug icon, since the checkmark read as "already verified" even while a QA run was still in progress or had failed.

## How did you verify your code works?
Ran `bun run fmt`, `bun run --cwd=apps/web check` (tsc), and `bunx oxlint` on the touched files — all clean. Ran the existing task-board unit tests (`bun test apps/web/src/layouts/task-board`) — 37 pass, 0 fail. Manually verified the rendered footer by seeding a local Postgres task-board item with three linked threads (Super Agent `failed`, QA Agent `completed`, Code Reviewer `in_progress`, each with a distinct last message) and confirming the card renders the icon/name/status/preview row for each, with the divider spanning the card's full width.

## Screenshots/Demonstration
Iterated on the layout directly with the user via screenshots in-session (single-line row with icon, name, colored status, and truncated message preview; divider flush with both card edges).

## How to Test
1. Assign a task to the Super Agent (or seed a task with linked threads directly in Postgres for a quick check).
2. Open the board and observe the card's footer: a full-width divider, then the Super Agent row, followed by QA Agent / Code Reviewer rows once those reviewers have run.
3. Expected outcome: each row is a single truncated line (icon + name + status + message preview), and the divider touches both the left and right edges of the card like a real footer.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turned the agent thread preview on task cards into a real footer with a full-width divider and clearer spacing. Also floated the card re-run button so it doesn’t reserve layout space, and switched the QA Agent icon to a neutral bug.

- **New Features**
  - Added an edge-to-edge footer listing the Super Agent, then QA/Code Reviewer rows once they’ve run; each row shows icon, name, live status, and a truncated last message.
  - Updated `QA_AGENT_ICON_URL` to a bug icon for clearer in-progress/failed states.

- **Bug Fixes**
  - Re-run button is now absolutely positioned and only interactive on hover/focus, removing it from flow so the hidden state doesn’t leave a gap.
  - Raised `bun:test` timeout to 20s in plugin tests that spawn `oxlint` to prevent CI flakes.

<sup>Written for commit e601e91e6b5d43bcc5483c4b8d246c6200f85a5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

