### PR TITLE
fix(thread): friendlier sandbox setup copy in header

### DIFF
--- a/apps/web/src/components/thread/github/panel-state.test.ts
+++ b/apps/web/src/components/thread/github/panel-state.test.ts
@@ -113,7 +113,7 @@ describe("selectHeaderButton", () => {
     expect(r.variant).toBe("outline");
   });
 
-  test("lifecycle.idle → 'Starting sandbox…' (disabled, spinner)", () => {
+  test("lifecycle.idle → 'Preparing environment…' (disabled, spinner)", () => {
     const r = selectHeaderButton(
       happyInput({
         lifecycle: { phase: "idle" },
@@ -121,7 +121,7 @@ describe("selectHeaderButton", () => {
         claimPhase: null,
       }),
     );
-    expect(r.label).toBe("Starting sandbox…");
+    expect(r.label).toBe("Preparing environment…");
     expect(r.disabled).toBe(true);
     expect(r.loading).toBe(true);
     expect(r.variant).toBe("outline");
@@ -171,7 +171,7 @@ describe("selectHeaderButton", () => {
     expect(r.label).toBe("Connecting to sandbox");
   });
 
-  test("idle + claimPhase = ready → 'Starting sandbox…' (generic)", () => {
+  test("idle + claimPhase = ready → 'Preparing environment…' (generic)", () => {
     // ready means the daemon claim handle is up but lifecycle hasn't yet
     // emitted its first event. Generic copy is correct here.
     const r = selectHeaderButton(
@@ -181,10 +181,10 @@ describe("selectHeaderButton", () => {
         claimPhase: { kind: "ready" },
       }),
     );
-    expect(r.label).toBe("Starting sandbox…");
+    expect(r.label).toBe("Preparing environment…");
   });
 
-  test("idle + claimPhase = claiming → 'Starting sandbox…' (generic)", () => {
+  test("idle + claimPhase = claiming → 'Preparing environment…' (generic)", () => {
     // `claiming` is intentionally absent from `idleClaimCopy` — falls through
     // to the generic label.
     const r = selectHeaderButton(
@@ -194,7 +194,7 @@ describe("selectHeaderButton", () => {
         claimPhase: { kind: "claiming", since: 0 },
       }),
     );
-    expect(r.label).toBe("Starting sandbox…");
+    expect(r.label).toBe("Preparing environment…");
   });
 
   test("lifecycle.cloning → 'Cloning repo…' (disabled, spinner)", () => {

--- a/apps/web/src/i18n/en/thread.ts
+++ b/apps/web/src/i18n/en/thread.ts
@@ -113,7 +113,7 @@ export const thread = {
   "thread.headerActions.runningTests": "Running tests…",
   "thread.headerActions.squashMergeTooltip":
     "Squash-merge PR #{prNumber} into {base}",
-  "thread.headerActions.startingSandbox": "Starting sandbox…",
+  "thread.headerActions.startingSandbox": "Preparing environment…",
   "thread.headerActions.submitForReview": "Submit for review",
   "thread.headerActions.switchingTo": "Switching to {branch}…",
   "thread.headerActions.syncWith": "Sync with {base}",
@@ -123,11 +123,11 @@ export const thread = {
   "thread.headerActions.waitingForApprovalsTooltip":
     "Waiting for required approvals",
   "thread.headerActions.waitingForBranchTooltip":
-    "Waiting for branch metadata from the sandbox daemon",
+    "Almost ready — finishing setting up your environment",
   "thread.headerActions.waitingForDaemonTooltip":
-    "Waiting for the sandbox daemon to come online",
+    "Getting your environment ready — this only takes a moment",
   "thread.headerActions.waitingForSandboxBranchTooltip":
-    "Waiting for sandbox branch",
+    "Getting your environment ready — this only takes a moment",
   "thread.headerActions.waitingOnChecksTooltip":
     "Waiting on {count} check(s) to finish",
   "thread.mergeSplitButton.moreActionsAriaLabel": "More actions",

--- a/apps/web/src/i18n/pt-br/thread.ts
+++ b/apps/web/src/i18n/pt-br/thread.ts
@@ -117,7 +117,7 @@ export const thread = {
   "thread.headerActions.runningTests": "Executando testes…",
   "thread.headerActions.squashMergeTooltip":
     "Squash-merge do PR #{prNumber} em {base}",
-  "thread.headerActions.startingSandbox": "Iniciando sandbox…",
+  "thread.headerActions.startingSandbox": "Preparando ambiente…",
   "thread.headerActions.submitForReview": "Enviar para revisão",
   "thread.headerActions.switchingTo": "Mudando para {branch}…",
   "thread.headerActions.syncWith": "Sincronizar com {base}",
@@ -127,11 +127,11 @@ export const thread = {
   "thread.headerActions.waitingForApprovalsTooltip":
     "Aguardando aprovações obrigatórias",
   "thread.headerActions.waitingForBranchTooltip":
-    "Aguardando metadados da branch do daemon da sandbox",
+    "Quase lá — terminando de preparar seu ambiente",
   "thread.headerActions.waitingForDaemonTooltip":
-    "Aguardando o daemon da sandbox ficar online",
+    "Preparando seu ambiente — leva só um instante",
   "thread.headerActions.waitingForSandboxBranchTooltip":
-    "Aguardando branch da sandbox",
+    "Preparando seu ambiente — leva só um instante",
   "thread.headerActions.waitingOnChecksTooltip":
     "Aguardando {count} verificação(ões) terminar",
   "thread.mergeSplitButton.moreActionsAriaLabel": "Mais ações",


### PR DESCRIPTION
## Summary
The header button (shown while the environment is starting) exposed internal jargon that meant nothing to users. Reported: the tooltip **"Aguardando o daemon da sandbox ficar online"**.

Replaced the label + related tooltips with plain-language copy in both `en` and `pt-br`.

| key | before (en) | after (en) |
|---|---|---|
| `startingSandbox` | Starting sandbox… | Preparing environment… |
| `waitingForDaemonTooltip` | Waiting for the sandbox daemon to come online | Getting your environment ready — this only takes a moment |
| `waitingForBranchTooltip` | Waiting for branch metadata from the sandbox daemon | Almost ready — finishing setting up your environment |
| `waitingForSandboxBranchTooltip` | Waiting for sandbox branch | Getting your environment ready — this only takes a moment |

pt-br mirrors these.

## Testing
- Copy-only change (i18n dictionaries). `bun run fmt` applied.

## Affected areas
Thread header action button during sandbox/environment startup (`apps/web/src/components/thread/github/panel-state.ts`, `header-actions.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made the thread header copy friendlier during environment startup, replacing “sandbox daemon” jargon with clear messages in `en` and `pt-br`. Updated tests to assert the new “Preparing environment…” label.

- **Bug Fixes**
  - Replaced `thread.headerActions.startingSandbox` and waiting tooltips with simple messages (e.g., “Preparing environment…”).
  - Updated panel-state tests to expect the new label.

<sup>Written for commit c7cee18939be88df3b19a961d87124e82cca8615. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

