### PR TITLE
fix(decopilot): stop priming the model to cd out of the project root

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/vm-tools/schemas.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/vm-tools/schemas.ts
@@ -9,9 +9,10 @@ export const ReadInputSchema = z.object({
   path: z
     .string()
     .describe(
-      "File path. Relative paths resolve against the project root (e.g. " +
-        "'src/index.ts'); absolute paths are accepted for files outside the " +
-        "project (e.g. '/home/sandbox/deck.thumbnail.jpg').",
+      "File path. Prefer relative paths — they resolve against the project " +
+        "root (e.g. 'src/index.ts'). Absolute paths are accepted but only " +
+        "for files you already know exist outside the project; do not guess " +
+        "one.",
     ),
   offset: z
     .number()
@@ -140,7 +141,10 @@ export const GLOB_DESCRIPTION =
 
 export const BASH_DESCRIPTION =
   "Execute a shell command in the VM's project directory. " +
-  "Working directory is the project root. Timeout default 30s, max 2min.\n\n" +
+  "Working directory is already the project root — the git checkout, when " +
+  "the agent has a repo. Never `cd` to an absolute path you guessed " +
+  "(there is no `/home/sandbox` project dir); run git and build commands " +
+  "as-is from the default cwd. Timeout default 30s, max 2min.\n\n" +
   "The organization filesystem is mounted at `org/`:\n" +
   "- `org/home/` — the org's shared home folder (editable, " +
   "shared across runs). Organize it " +


### PR DESCRIPTION
## Summary

A prod thread running the canned GitHub "Sync \`staging\`" action failed with:

```
fatal: not a git repository (or any parent up to mount point /home)
```

The model had run `cd /home/sandbox && git status`. It didn't need to `cd` at all — the `bash` tool already runs with cwd = project root (`/app`, the git checkout). `/home/sandbox` is the sandbox user's *home*, never a checkout.

The sandbox was healthy: its `sandbox_runner_state` row had `workdir=/app`, `repo=deco-sites/faststore-fila`, `branch=staging`. No clone race, no reprovision, nothing in VictoriaLogs for that window beyond nginx access logs.

Where the prompt helped it go wrong: the only absolute path anywhere in the tool descriptions was `/home/sandbox/deck.thumbnail.jpg` in the `read` tool's `path` describe. That's the string the model reached for.

## Changes

Two description edits in `vm-tools/schemas.ts`:
- `read`'s `path`: dropped the `/home/sandbox/...` example, tell it to prefer relative paths and not to guess an absolute one.
- `BASH_DESCRIPTION`: say explicitly that cwd is already the git checkout, and not to `cd` to a guessed absolute path.

## Testing

Prompt-text only — no logic touched. `bun run fmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified `bash` and `read` tool prompts to stop the model from leaving the project root, preventing "not a git repository" errors. Commands now clearly run from the git checkout, and paths default to relative.

- **Bug Fixes**
  - Updated `BASH_DESCRIPTION` to state cwd is the project root and to not `cd` to guessed absolute paths.
  - Updated `read`’s `path` description to prefer relative paths and removed the `/home/sandbox/...` example.

<sup>Written for commit acad83b80603f539bb969b4a01a7f3164f38b8be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

