### PR TITLE
fix(decopilot): bound and catch the inspect_page Browserless call

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.ts
@@ -20,6 +20,11 @@ import { createOutputPreview, estimateJsonTokens } from "./read-tool-output";
 import { toStudioStorageUri } from "../studio-storage-uri";
 import { LARGE_RESULT_TOKEN_THRESHOLD } from "./constants";
 
+// Browserless call itself has no bound beyond the inner page.goto timeout (30s) —
+// if Browserless is unresponsive the outer fetch can hang the harness run forever.
+// Give it headroom over the inner timeout instead of leaving it unbounded.
+const BROWSERLESS_FETCH_TIMEOUT_MS = 45_000;
+
 const InspectPageInputSchema = z.object({
   url: z.string().url().describe("The URL of the web page to inspect."),
   evaluate: z
@@ -116,16 +121,29 @@ export function createInspectPageTool(
           waitUntil: input.waitUntil,
         });
 
-        const response = await fetch(
-          `${browserless.baseUrl}/function?token=${encodeURIComponent(
-            browserless.token,
-          )}`,
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/javascript" },
-            body: code,
-          },
-        );
+        let response: Response;
+        try {
+          response = await fetch(
+            `${browserless.baseUrl}/function?token=${encodeURIComponent(
+              browserless.token,
+            )}`,
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/javascript" },
+              body: code,
+              signal: AbortSignal.timeout(BROWSERLESS_FETCH_TIMEOUT_MS),
+            },
+          );
+        } catch (err) {
+          const isTimeout = err instanceof Error && err.name === "TimeoutError";
+          return {
+            success: false,
+            error: isTimeout
+              ? `Browserless function call timed out after ${BROWSERLESS_FETCH_TIMEOUT_MS}ms`
+              : `Browserless function call failed: ${err instanceof Error ? err.message : String(err)}`,
+            url: input.url,
+          };
+        }
 
         if (!response.ok) {
           const errorText = await response.text().catch(() => "Unknown error");


### PR DESCRIPTION
Addresses finding #2 from issue #5789 (agent runtime reliability scan): the `inspect_page` built-in tool's outer `fetch()` to Browserless had no timeout/signal — only the inner `page.goto()` call inside the Browserless function body had a 30s bound. If Browserless itself is unresponsive (not just slow page navigation), the fetch call — and the harness run awaiting the tool result — would hang indefinitely with no way out. A thrown fetch/network error also propagated out of `execute()` uncaught, instead of returning a clean `{success: false, error}` result the way every other failure path in this file already does.

Fix: wrap the fetch in `AbortSignal.timeout(45_000)` (comfortably above the inner 30s page timeout) and a try/catch that returns a `success: false` tool result on timeout or network failure, consistent with the file's existing error-handling shape.

Failure scenario without the fix: Browserless is slow/unresponsive → the tool call never resolves → the decopilot run stalls indefinitely waiting on this one tool. With the fix, it fails cleanly after 45s with a readable error the model can react to.

Reviewer check: `cd apps/api && bunx tsc --noEmit` (clean) and `bunx oxlint src/harnesses/lib/decopilot/built-in-tools/inspect-page.ts` (0 warnings/errors) — no existing test file for this tool, so no test was invented per the coverage-test rule; the fix is a small, behavior-additive error-handling change verified by typecheck + lint. Full CI validates the rest.

Local checks run: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bunx oxlint` on the touched file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the `inspect_page` tool’s Browserless call with a 45s timeout and clean error handling to prevent harness runs from hanging when Browserless is unresponsive. Errors now return `{ success: false, error }` instead of throwing.

- **Bug Fixes**
  - Added `AbortSignal.timeout(45_000)` to the outer `fetch` for the Browserless function.
  - Wrapped the call in try/catch and return a `success: false` result on timeout or network failure.

<sup>Written for commit c7dbbc3ebfb943af891110179526a5af22900a13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

