### PR TITLE
fix(task-board): re-check status/assignee before the sweeper dispatches reviewers

### DIFF
--- a/apps/api/src/tools/task-board/review-sweeper.ts
+++ b/apps/api/src/tools/task-board/review-sweeper.ts
@@ -39,6 +39,7 @@
 
 import type { StudioContextFactory } from "@/automations/fire";
 import type { TaskBoardStorage } from "@/storage/task-board";
+import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
 import { extractPrFromText } from "./pr-extract";
 import { enqueueEnabledReviewers } from "./enqueue-reviewer";
 import { fetchPrLiveState, prReadyForReview } from "./prs-get";
@@ -127,6 +128,18 @@ export class TaskBoardReviewSweeper {
   ): Promise<boolean> {
     const item = await this.taskBoard.getById(id, organizationId);
     if (!item) return false;
+    // Re-check against the fresh row: `listItemsPendingReview` scanned a
+    // possibly-stale snapshot, and a human can bounce/reassign the card between
+    // that scan and this reconcile. Without this the sweeper would still
+    // dispatch reviewers at a task that's no longer awaiting the Super Agent's
+    // review — the same gate `TASK_BOARD_ITEM_PRS_GET` applies before its own
+    // `enqueueEnabledReviewers` call.
+    if (
+      item.status !== "in_review" ||
+      item.assigneeId !== SUPER_AGENT_ASSIGNEE_ID
+    ) {
+      return false;
+    }
 
     // Same recovery `TASK_BOARD_ITEM_PRS_GET` does: the agent's closing summary
     // reliably prints the URL ("Opened PR #309 https://github.com/…/pull/309").


### PR DESCRIPTION
Bug found while auditing `review-sweeper.ts` for concurrency issues (task-board backend hardening focus area).

`TaskBoardReviewSweeper.reconcileItem` re-fetches the item via `getById` but never re-checks its status/assignee before calling `enqueueEnabledReviewers` — unlike `TASK_BOARD_ITEM_PRS_GET` in `prs-get.ts`, which explicitly gates the same call on `item.status === "in_review" && item.assigneeId === SUPER_AGENT_ASSIGNEE_ID`.

Failure scenario: `listItemsPendingReview` scans a batch of in-review Super-Agent cards; the sweeper's 60s tick then works through them one at a time. If a human reassigns a card away from the Super Agent, or bounces it back to In Progress, in the window between that scan and the item's own reconcile, the sweeper still dispatches reviewer agent runs at it — spending the reviewer's once-per-cycle claim on a task nobody asked to have reviewed anymore.

Fix: re-check `item.status`/`item.assigneeId` against the freshly-fetched row before proceeding, mirroring the existing gate in `prs-get.ts` exactly.

How to verify: `cd apps/api && bunx tsc --noEmit` and `bun test src/tools/task-board/review-sweeper.test.ts` (both green). No new test added — exercising `reconcileItem` itself needs a stubbed `StudioContextFactory`/storage, which per this repo's testing tiers belongs in e2e, not unit; the existing `prReadyForReview` unit tests already cover the shared readiness gate this change composes with.

Locally ran: `bun run fmt`, `bunx oxlint src/tools/task-board/review-sweeper.ts` (clean), `bunx tsc --noEmit` in apps/api (clean), the targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-check `status` and `assigneeId` in `TaskBoardReviewSweeper.reconcileItem` before enqueuing reviewers. Prevents dispatching reviewer runs for cards reassigned or moved out of review after the pending-review scan.

<sup>Written for commit e806fa70ca3c7ca215a84338ddb5c942706f926f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

