### PR TITLE
i18n(sections-editor): translate array-row's hardcoded labels

### DIFF
--- a/apps/web/src/components/sections-editor/fields/array-row.tsx
+++ b/apps/web/src/components/sections-editor/fields/array-row.tsx
@@ -21,6 +21,7 @@ import {
 import { cn } from "@deco/ui/lib/utils.ts";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { useT } from "@/i18n/use-t.ts";
 
 // Width/margin snap instantly (no visible slide) while opacity does the
 // actual animating. On reveal the snap has no delay, so the button is
@@ -105,6 +106,7 @@ export function SortableArrayRow({
   onDuplicate: () => void;
   onRemove: () => void;
 }) {
+  const t = useT();
   const { attributes, listeners, setNodeRef, transform, isDragging } =
     useSortable({
       id: sortableId,
@@ -163,7 +165,11 @@ export function SortableArrayRow({
               type="button"
               variant="ghost"
               size="icon"
-              aria-label={hidden ? "Show item" : "Hide item"}
+              aria-label={
+                hidden
+                  ? t("sectionsEditor.arrayField.showItem")
+                  : t("sectionsEditor.arrayField.hideItem")
+              }
               className={cn(
                 actionButtonVisibilityClass(hidden === true, hidden === true),
               )}
@@ -177,7 +183,9 @@ export function SortableArrayRow({
             </Button>
           </TooltipTrigger>
           <TooltipContent side="bottom">
-            {hidden ? "Show item" : "Hide item"}
+            {hidden
+              ? t("sectionsEditor.arrayField.showItem")
+              : t("sectionsEditor.arrayField.hideItem")}
           </TooltipContent>
         </Tooltip>
       )}
@@ -187,7 +195,9 @@ export function SortableArrayRow({
             type="button"
             variant="ghost"
             size="icon"
-            aria-label={`Open actions for ${labelText}`}
+            aria-label={t("sectionsEditor.arrayField.openActionsFor", {
+              label: labelText,
+            })}
             className={cn(
               actionButtonVisibilityClass(hidden === true, false),
               "data-[state=open]:ml-0 data-[state=open]:w-6 data-[state=open]:opacity-100 data-[state=open]:[transition:opacity_150ms_ease-out,width_0ms,margin-left_0ms]",
@@ -201,14 +211,14 @@ export function SortableArrayRow({
         <DropdownMenuContent align="end">
           <DropdownMenuItem onClick={onDuplicate}>
             <Copy01 size={14} />
-            Duplicate
+            {t("sectionsEditor.arrayField.duplicate")}
           </DropdownMenuItem>
           <DropdownMenuItem
             className="text-destructive focus:text-destructive"
             onClick={onRemove}
           >
             <Trash01 size={14} />
-            Delete
+            {t("sectionsEditor.arrayField.delete")}
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/apps/web/src/i18n/en/sections-editor.ts
+++ b/apps/web/src/i18n/en/sections-editor.ts
@@ -17,6 +17,7 @@ export const sectionsEditor = {
   "sectionsEditor.arrayField.delete": "Delete",
   "sectionsEditor.arrayField.duplicate": "Duplicate",
   "sectionsEditor.arrayField.hideItem": "Hide item",
+  "sectionsEditor.arrayField.openActionsFor": "Open actions for {label}",
   "sectionsEditor.arrayField.sectionPickerNotAvailable":
     "Section picker is not available in this editor.",
   "sectionsEditor.arrayField.showItem": "Show item",

--- a/apps/web/src/i18n/pt-br/sections-editor.ts
+++ b/apps/web/src/i18n/pt-br/sections-editor.ts
@@ -19,6 +19,7 @@ export const sectionsEditor = {
   "sectionsEditor.arrayField.delete": "Excluir",
   "sectionsEditor.arrayField.duplicate": "Duplicar",
   "sectionsEditor.arrayField.hideItem": "Ocultar item",
+  "sectionsEditor.arrayField.openActionsFor": "Abrir ações para {label}",
   "sectionsEditor.arrayField.sectionPickerNotAvailable":
     "O seletor de seção não está disponível neste editor.",
   "sectionsEditor.arrayField.showItem": "Mostrar item",


### PR DESCRIPTION
Follows the ongoing i18n hardening pass on `apps/web/src` (repo rule: user-facing copy must go through `t()`).

`array-row.tsx` (the drag-list row rendered by `array-field.tsx` in the sections editor) hardcoded five English strings — the show/hide toggle's `aria-label` and tooltip, the actions-menu `aria-label`, and the Duplicate/Delete menu items. `apps/web/src/i18n/{en,pt-br}/sections-editor.ts` already carried translated `arrayField.showItem/hideItem/duplicate/delete` keys (used by a sibling component) that this row simply never adopted, so pt-br users saw English here. Added the one missing key, `arrayField.openActionsFor`, mirroring the existing `sectionVariantList.openActionsFor` pattern.

A reviewer can confirm with `cd apps/web && bunx tsc --noEmit` and `bunx oxlint apps/web/src/components/sections-editor/fields/array-row.tsx apps/web/src/i18n/en/sections-editor.ts apps/web/src/i18n/pt-br/sections-editor.ts` (both ran clean locally). No behavior change beyond string source — same DOM/labels for English users, translated ones now render in pt-br. Full CI (`bun run check`) validates the rest.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translated user-facing labels in the sections editor’s array row. Wired the component to `t()` and added the missing i18n key for the actions button aria-label so pt-br users see localized text.

- **Bug Fixes**
  - Replaced hardcoded labels (show/hide, actions aria-label, duplicate/delete) with `t("sectionsEditor.arrayField.*")`.
  - Added `sectionsEditor.arrayField.openActionsFor` in `en` and `pt-br`.
  - No UI or behavior changes for English; pt-br now shows translations.

<sup>Written for commit e0c4dbc0c5ff506b0301ad08af6df6f1ebf76785. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

