### PR TITLE
feat(cms): use production for add-section gallery previews under fast preview

### DIFF
--- a/apps/web/src/components/sandbox/content/app-editor.tsx
+++ b/apps/web/src/components/sandbox/content/app-editor.tsx
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 import { cn } from "@deco/ui/lib/utils.js";
 import { ScrollArea } from "@deco/ui/components/scroll-area.tsx";
 import { AddSectionModal } from "@/components/sections-editor/add-section-modal";
+import { useSectionPreviewBase } from "@/components/sections-editor/use-section-preview-base";
 import { appLabel } from "@/components/sections-editor/page-list";
 import type { LiveMeta } from "@/components/sections-editor/resolve-schema";
 import type { SectionCatalogEntry } from "@/components/sections-editor/section-catalog";
@@ -46,6 +47,12 @@ export function AppEditor({
   previewBaseUrl?: string | null;
 }) {
   const t = useT();
+  // Section-gallery previews render against the sandbox dev server, falling
+  // back to the Fast Preview production deployment while the sandbox boots.
+  const sectionPreviewBase = useSectionPreviewBase({
+    virtualMcpId,
+    sandboxUrl: previewBaseUrl,
+  });
   const resolveType =
     typeof block?.__resolveType === "string" ? block.__resolveType : "";
   const schema = resolveAppEditorSchema(resolveType, meta, excludeFields);
@@ -209,7 +216,7 @@ export function AppEditor({
                 decofile={decofile}
                 meta={meta}
                 onSaveReferencedBlock={saveReferencedBlock}
-                previewBaseUrl={previewBaseUrl}
+                previewBaseUrl={sectionPreviewBase}
                 onAddSectionItem={handleAddSectionItem}
                 onRequestAddSection={handleRequestAddSection}
                 sandbox={{ orgSlug, virtualMcpId, branch }}
@@ -228,7 +235,7 @@ export function AppEditor({
         </div>
       </ScrollArea>
 
-      {previewBaseUrl && (
+      {sectionPreviewBase && (
         <AddSectionModal
           open={addSectionOpen}
           onOpenChange={(open) => {
@@ -237,7 +244,7 @@ export function AppEditor({
           }}
           meta={meta}
           decofile={decofile}
-          previewBaseUrl={previewBaseUrl}
+          previewBaseUrl={sectionPreviewBase}
           onSelect={(entry) => {
             void handleSelectSection(entry);
           }}

--- a/apps/web/src/components/sandbox/hooks/sandbox-events-context.tsx
+++ b/apps/web/src/components/sandbox/hooks/sandbox-events-context.tsx
@@ -31,7 +31,7 @@ import {
 } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useProjectContext, useVirtualMCP } from "@/sdk";
-import { sanitizeProductionUrl } from "@decocms/shared/deco-site-production-url";
+import { resolveFastPreview } from "@/sdk/fast-preview";
 import { KEYS, invalidateVirtualMcpQueries } from "@/lib/query-keys";
 import { exponentialBackoffWithJitter } from "@decocms/shared/std";
 
@@ -229,9 +229,7 @@ export function SandboxEventsProvider({
   // from disk, and a refetch could revert an optimistic edit against a committed
   // `blocks.gen.json`.
   const vmcp = useVirtualMCP(virtualMcpId ?? undefined);
-  const fastPreviewActive =
-    !!sanitizeProductionUrl(vmcp?.metadata?.productionUrl) &&
-    vmcp?.metadata?.fastPreview === true;
+  const fastPreviewActive = resolveFastPreview(vmcp?.metadata).active;
   const fastPreviewActiveRef = useRef(fastPreviewActive);
   // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- keep the SSE closure reading the latest value without reconnecting
   fastPreviewActiveRef.current = fastPreviewActive;

--- a/apps/web/src/components/sections-editor/section-preview-url.test.ts
+++ b/apps/web/src/components/sections-editor/section-preview-url.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { buildDraftPreviewUrl } from "./section-preview-url";
+import {
+  buildDraftPreviewUrl,
+  resolveSectionPreviewBase,
+} from "./section-preview-url";
 
 const PROD = "https://www.acme.com";
+const SANDBOX = "https://h.preview-studio.decocms.com";
 
 describe("buildDraftPreviewUrl", () => {
   it("targets the real page on the production origin", () => {
@@ -84,5 +88,83 @@ describe("buildDraftPreviewUrl", () => {
       }),
     );
     expect(url.pathname).toBe("/produto/tenis-123/p");
+  });
+});
+
+describe("resolveSectionPreviewBase", () => {
+  it("prefers the sandbox dev server when Fast Preview is off", () => {
+    expect(
+      resolveSectionPreviewBase({
+        sandboxUrl: SANDBOX,
+        productionUrl: PROD,
+        fastPreviewActive: false,
+      }),
+    ).toBe(SANDBOX);
+  });
+
+  it("uses production when Fast Preview is active, even if the sandbox is up", () => {
+    // Mirrors the main canvas, which paints production for the whole Fast
+    // Preview session rather than swapping to the sandbox once it boots.
+    expect(
+      resolveSectionPreviewBase({
+        sandboxUrl: SANDBOX,
+        productionUrl: PROD,
+        fastPreviewActive: true,
+      }),
+    ).toBe(PROD);
+  });
+
+  it("uses production while the sandbox is still booting (no sandbox URL yet)", () => {
+    expect(
+      resolveSectionPreviewBase({
+        sandboxUrl: null,
+        productionUrl: PROD,
+        fastPreviewActive: true,
+      }),
+    ).toBe(PROD);
+  });
+
+  it("falls back to the sandbox when Fast Preview is active but has no production URL", () => {
+    // The `fastPreviewActive` gate already requires a production URL, so this
+    // is defensive: a truthy flag with no URL must not blank the gallery.
+    expect(
+      resolveSectionPreviewBase({
+        sandboxUrl: SANDBOX,
+        productionUrl: null,
+        fastPreviewActive: true,
+      }),
+    ).toBe(SANDBOX);
+  });
+
+  it("returns null when neither base is available", () => {
+    expect(
+      resolveSectionPreviewBase({
+        sandboxUrl: null,
+        productionUrl: null,
+        fastPreviewActive: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("never leaks production into the gallery when Fast Preview is off", () => {
+    // The negative gate: a set productionUrl must be ignored unless the flag
+    // is on, so the gallery is withheld rather than pointing at production.
+    expect(
+      resolveSectionPreviewBase({
+        sandboxUrl: null,
+        productionUrl: PROD,
+        fastPreviewActive: false,
+      }),
+    ).toBeNull();
+  });
+
+  it("treats an undefined sandbox URL as absent", () => {
+    expect(
+      resolveSectionPreviewBase({
+        sandboxUrl: undefined,
+        productionUrl: undefined,
+        fastPreviewActive: false,
+      }),
+    ).toBeNull();
   });
 });

--- a/apps/web/src/components/sections-editor/section-preview-url.ts
+++ b/apps/web/src/components/sections-editor/section-preview-url.ts
@@ -86,3 +86,35 @@ export function buildSectionPreviewUrl(
   );
   return url.toString();
 }
+
+/**
+ * Base origin for the section-gallery previews (`/live/previews`).
+ *
+ * Section thumbnails render a single ISOLATED component via deco's runtime
+ * `/live/previews` route, so the base must be a deco-runtime origin. This is a
+ * mode switch, not a boot fallback:
+ *   - Fast Preview ON  → ALWAYS the production deployment, for the whole
+ *     session. It does not depend on the sandbox being up and never swaps back
+ *     to it — like the main canvas, which also paints production whenever Fast
+ *     Preview is on. Renders against DEPLOYED code, which is representative for
+ *     a "pick a section" gallery.
+ *   - Fast Preview OFF → the sandbox dev server (the previous behaviour).
+ *
+ * Unlike `buildDraftPreviewUrl` (framework-agnostic, GET on the site's real
+ * routes), there is no framework-agnostic way to render one isolated component,
+ * so the production path only works when production is itself a deco-runtime
+ * site — the same assumption the sandbox dev server already satisfies.
+ *
+ * Returns `null` when neither base is available (no sandbox URL and Fast
+ * Preview off), so the caller can withhold the gallery entirely.
+ */
+export function resolveSectionPreviewBase(input: {
+  sandboxUrl: string | null | undefined;
+  productionUrl: string | null | undefined;
+  fastPreviewActive: boolean;
+}): string | null {
+  if (input.fastPreviewActive && input.productionUrl) {
+    return input.productionUrl;
+  }
+  return input.sandboxUrl ?? null;
+}

--- a/apps/web/src/components/sections-editor/sections-editor.tsx
+++ b/apps/web/src/components/sections-editor/sections-editor.tsx
@@ -47,6 +47,7 @@ import { extractMatcherGlobals, extractMatchers } from "./matcher-picker";
 import { PageVariantTabs, VariantTabIcon } from "./page-variant-tabs";
 import { MakeReusableModal } from "./make-reusable-modal";
 import { AddSectionModal } from "./add-section-modal";
+import { useSectionPreviewBase } from "./use-section-preview-base";
 import type { SectionCatalogEntry } from "./section-catalog";
 import { SectionVariantList } from "./section-variant-list";
 import { headerBackTargetIndex } from "./schema-form-breadcrumb";
@@ -182,6 +183,12 @@ export function SectionsEditor({
     inset?.entity?.id === virtualMcpId
       ? (inset.entity.metadata?.siteSlug ?? null)
       : null;
+  // Section-gallery previews render against the sandbox dev server, falling
+  // back to the Fast Preview production deployment while the sandbox boots.
+  const sectionPreviewBase = useSectionPreviewBase({
+    virtualMcpId,
+    sandboxUrl: previewUrl,
+  });
 
   const [selectedSectionIndex, setSelectedSectionIndex] = useState<
     number | null
@@ -1397,7 +1404,7 @@ export function SectionsEditor({
   const availableMatcherGlobals =
     meta && decofile ? extractMatcherGlobals(meta, decofile) : [];
   const canAddSection =
-    !isGlobalBlockMode && !!(previewUrl && meta && decofile);
+    !isGlobalBlockMode && !!(sectionPreviewBase && meta && decofile);
 
   const ruleSchema =
     ruleResolveType && meta ? resolveSchema(ruleResolveType, meta) : null;
@@ -2760,7 +2767,7 @@ export function SectionsEditor({
             decofile={decofile}
             onSaveReferencedBlock={saveReferencedBlock}
             sandbox={sandbox}
-            previewBaseUrl={previewUrl}
+            previewBaseUrl={sectionPreviewBase}
             onRequestAddSection={handleRequestAddSection}
           />
         </ScrollArea>
@@ -2783,7 +2790,7 @@ export function SectionsEditor({
             decofile={decofile}
             onSaveReferencedBlock={saveReferencedBlock}
             sandbox={sandbox}
-            previewBaseUrl={previewUrl}
+            previewBaseUrl={sectionPreviewBase}
             onRequestAddSection={handleRequestAddSection}
           />
         </ScrollArea>
@@ -2906,7 +2913,7 @@ export function SectionsEditor({
         onSubmit={handleMakeReusableSubmit}
       />
 
-      {previewUrl && (
+      {sectionPreviewBase && (
         <AddSectionModal
           open={addSectionOpen}
           onOpenChange={(open) => {
@@ -2915,7 +2922,7 @@ export function SectionsEditor({
           }}
           meta={meta}
           decofile={decofile}
-          previewBaseUrl={previewUrl}
+          previewBaseUrl={sectionPreviewBase}
           onSelect={handleSelectSectionFromModal}
         />
       )}

--- a/apps/web/src/components/sections-editor/use-section-preview-base.ts
+++ b/apps/web/src/components/sections-editor/use-section-preview-base.ts
@@ -1,0 +1,27 @@
+import { useVirtualMCP } from "@/sdk";
+import { resolveFastPreview } from "@/sdk/fast-preview";
+import { resolveSectionPreviewBase } from "./section-preview-url";
+
+/**
+ * Effective base origin for the Add Section gallery previews.
+ *
+ * Fast Preview ON → always the production deployment; OFF → the sandbox dev
+ * server (see `resolveSectionPreviewBase`). Fast Preview is gated the same way
+ * everywhere (`resolveFastPreview`): the switch is on AND a production URL is
+ * set.
+ *
+ * Returns `null` when neither base is available, so callers withhold the
+ * gallery instead of rendering broken thumbnails.
+ */
+export function useSectionPreviewBase(input: {
+  virtualMcpId: string;
+  sandboxUrl: string | null | undefined;
+}): string | null {
+  const vmcp = useVirtualMCP(input.virtualMcpId);
+  const { productionUrl, active } = resolveFastPreview(vmcp?.metadata);
+  return resolveSectionPreviewBase({
+    sandboxUrl: input.sandboxUrl,
+    productionUrl,
+    fastPreviewActive: active,
+  });
+}

--- a/apps/web/src/sdk/fast-preview.ts
+++ b/apps/web/src/sdk/fast-preview.ts
@@ -1,0 +1,23 @@
+import { sanitizeProductionUrl } from "@decocms/shared/deco-site-production-url";
+
+/**
+ * The Fast Preview gate, in ONE place.
+ *
+ * Fast Preview is on when the CMS switch (`metadata.fastPreview`) is set AND a
+ * valid production URL is persisted — a bare flag with no URL is inert (there
+ * is nothing to render against). Pure so it serves every source of the vmcp
+ * metadata (the `useVirtualMCP` query, the ambient inset entity) without a
+ * hook, and so the gate can't drift across the surfaces that read it.
+ */
+export function resolveFastPreview(
+  metadata:
+    | { productionUrl?: string | null; fastPreview?: boolean | null }
+    | null
+    | undefined,
+): { productionUrl: string | null; active: boolean } {
+  const productionUrl = sanitizeProductionUrl(metadata?.productionUrl);
+  return {
+    productionUrl,
+    active: !!productionUrl && metadata?.fastPreview === true,
+  };
+}


### PR DESCRIPTION
## Summary

The **Add Section** gallery renders section thumbnails via the deco-runtime `/live/previews` route. Its base was hardcoded to the **sandbox dev server**, so the gallery was broken — or entirely unreachable — while the sandbox booted, even when the main canvas was already showing the production **Fast Preview**.

This is a **mode switch, not a boot fallback**:
- **Fast Preview ON** → **always** the production deployment, for the whole session. It does not depend on the sandbox being up and never swaps back to it, mirroring the main canvas. Renders against *deployed* code, which is representative for a "pick a section" gallery.
- **Fast Preview OFF** → the sandbox dev server (previous behaviour).

## Changes

- Add `resolveSectionPreviewBase` (pure) + `useSectionPreviewBase` hook to pick the base by mode.
- Thread the resolved base through **both** the modal render guard **and** the gates that *open* the modal (`canAddSection` and SchemaForm's inline section picker), so the gallery is reachable during boot / when the sandbox never comes up.
- Extract the Fast Preview gate into a shared `resolveFastPreview(metadata)` helper, consumed by the new hook and `sandbox-events-context` (the predicate was duplicated).
- Unit tests for the pure resolver.

## Testing

- `bun test` on `section-preview-url.test.ts` — 13 pass
- `bun run check` (web) — exit 0
- `bun run lint` — 0 errors · `bun run fmt` clean · `knip` no orphan exports

## Constraints / caveats

- **Only valid when production is a deco-runtime site.** Isolated single-component previews (`/live/previews`) have no framework-agnostic equivalent, unlike the canvas's `?__draft=` draft render. The production path is gated behind Fast Preview, whose semantics already assume a linked deco deployment for this surface.
- Renders **deployed** code, not the working-tree (a section added locally but not yet deployed will list in the gallery but preview blank). Documented in the helper comment.

## Review

Reviewed via `/review-pr` (7 parallel critics). Fixed one blocker (open-gates still bound to the sandbox URL, making production unreachable during boot), one important duplication finding (triplicated Fast Preview gate → shared helper), and minor comment/test gaps.

## Follow-ups (out of scope)

- Convert the third copy of the gate in `preview.tsx` to `resolveFastPreview` (deferred — reordering churn in a complex core file).
- E2E asserting the gallery opens with Fast Preview on + sandbox down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)