### PR TITLE
perf(task-board): raise task PR poll interval from 10s to 60s

### DIFF
--- a/apps/web/src/hooks/use-task-board-item-prs.ts
+++ b/apps/web/src/hooks/use-task-board-item-prs.ts
@@ -5,9 +5,11 @@ import { useStudioTools } from "@/lib/studio-tools";
 
 /** Poll interval for a task's PRs while the dialog is open. The tool fetches
  *  live GitHub state — PR/checks status and the checks→QA hand-off it drives —
- *  so a short interval keeps the review lane moving without a webhook. The query
- *  is only active while the dialog (and thus this hook) is mounted. */
-const PRS_POLL_INTERVAL_MS = 10_000;
+ *  so a periodic refresh keeps the review lane moving without a webhook. Kept at
+ *  one minute to stay well within GitHub's rate limits, since every poll fans
+ *  out to live GitHub PR + checks calls. The query is only active while the
+ *  dialog (and thus this hook) is mounted. */
+const PRS_POLL_INTERVAL_MS = 60_000;
 
 /**
  * A task's linked PRs, each with live state fetched from GitHub via the


### PR DESCRIPTION
## Summary

Raises the task dialog's PR poll interval from **10s → 60s** (`apps/web/src/hooks/use-task-board-item-prs.ts`).

`useTaskBoardItemPrs` polls `TASK_BOARD_ITEM_PRS_GET`, which fans out to **live GitHub PR + checks calls** on every poll. At 10s this was the most aggressive GitHub-backed poll in the app and a top contributor to the GitHub rate-limit errors we've been seeing:

- `failed to list pull requests: GitHub API rate limit exceeded` (tool-level, "Enviar para revisão")
- `Streamable HTTP error: Error POSTing to endpoint: too many requests` (transport-level 429, "Publicar em produção")

60s aligns this poll with the other PR-panel polls in `use-pr-data.ts` (which already use `POLL = 60_000`).

## Notes / affected areas

- The query is only active while the task dialog is mounted, so this only affects users with a task dialog open.
- Trade-off: PR/checks status in the task dialog now refreshes at most once per minute instead of every 10s. The checks→QA hand-off the tool drives is slightly less snappy but still webhook-free.

## Testing

- `bun run fmt` ✅ (no changes)
- Comment-only + constant change; no test coverage for the interval value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increased the task dialog PR poll interval from 10s to 60s to cut GitHub API calls and reduce rate‑limit errors. Aligns with other PR-panel polls; PR/checks status now refreshes at most once per minute while the dialog is open.

<sup>Written for commit 3ed544faf4540ee2b382b4b2a78d5e4a1aac8e1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

