### PR TITLE
fix(task-board): re-run a task on its PR's branch instead of opening another PR

### DIFF
--- a/apps/api/src/harnesses/decopilot/tools.ts
+++ b/apps/api/src/harnesses/decopilot/tools.ts
@@ -24,6 +24,7 @@ import type { GithubRepo } from "@decocms/shared/sdk";
 import type { StudioContext } from "@/core/studio-context";
 import {
   getThreadGithubRepo,
+  getThreadPinnedRef,
   resolveSandboxBranch,
 } from "@/tools/sandbox/thread-repo";
 import type { PassthroughClient } from "@/mcp-clients/virtual-mcp/passthrough-client";
@@ -300,6 +301,10 @@ export async function assembleDecopilotTools(
     // real repo-agents never carry one. When present it pins the thread to a
     // dedicated `thread:<id>` sandbox branch (not the shared "ephemeral" one).
     const threadRepo = await getThreadGithubRepo(ctx, extras.threadId);
+    // Must be read here too, not just in `resolveSandboxBranchForThread`: this
+    // derivation and the dispatch path's have to agree exactly, and a pin seen
+    // by only one of them would provision a second pod for the same thread.
+    const pinnedRef = await getThreadPinnedRef(ctx, extras.threadId);
     const vmContext: VmContext | null = input.user.id
       ? {
           virtualMcpId: input.agent.id,
@@ -311,6 +316,7 @@ export async function assembleDecopilotTools(
             threadRepo,
             agentRepo: vmMetadata.githubRepo,
             runBranch: runContext.branch,
+            pinnedRef,
           }),
           userId: input.user.id,
           // Used by share_with_user to scope artifacts under

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -402,6 +402,9 @@ export function resolveConfig(
       envVars.STUDIO_SANDBOX_PROVIDER,
     ),
     sandboxStickyHeadRefEnabled: toBool(envVars.SANDBOX_STICKY_HEAD_REF),
+    taskBoardRerunReusesPrBranch: toBool(
+      envVars.TASK_BOARD_RERUN_REUSES_PR_BRANCH,
+    ),
     sandboxReleaseOnRunEndEnabled: toBool(envVars.SANDBOX_RELEASE_ON_RUN_END),
     sandboxReleaseGraceMs: toPositiveIntegerOrDefault(
       "SANDBOX_RELEASE_GRACE_MS",

--- a/apps/api/src/settings/types.ts
+++ b/apps/api/src/settings/types.ts
@@ -170,6 +170,11 @@ export interface Settings {
    *  Off by default — see `sandbox/head-ref.ts` for the boot-path change this
    *  gates and why it ships behind its own flag. */
   sandboxStickyHeadRefEnabled: boolean;
+  /** A task re-run pushes to the existing pull request's branch instead of
+   *  forking a new one (TASK_BOARD_RERUN_REUSES_PR_BRANCH). Own flag because it
+   *  changes which sandbox a dispatch resolves to; off by default. See
+   *  `enqueue-super-agent.ts`. */
+  taskBoardRerunReusesPrBranch: boolean;
   /** Bring a `cloneOnly` sandbox's shutdown forward when its harness run
    *  finishes, instead of leaving it idle to the 15-min claim TTL
    *  (SANDBOX_RELEASE_ON_RUN_END). Own flag because it changes the dispatch hot

--- a/apps/api/src/tools/sandbox/thread-repo.test.ts
+++ b/apps/api/src/tools/sandbox/thread-repo.test.ts
@@ -155,3 +155,50 @@ test("a repo-less run pinned to its own bare key does not join the ephemeral poo
     }),
   ).toBe("thread:t1");
 });
+
+// `pinnedRef` is what stops a task re-run from opening a second pull request:
+// it must beat every derivation below it, or the run forks a fresh
+// `sandbox/thread-<new-id>` branch and the daemon's shutdown push publishes a
+// duplicate PR.
+
+test("a pinned ref wins over a thread-bound repo's derived branch", () => {
+  expect(
+    resolveSandboxBranch({
+      threadId: "t1",
+      threadRepo: { connectionId: "conn_a" } as GithubRepo,
+      agentRepo: { connectionId: "conn_b" } as GithubRepo,
+      runBranch: "main",
+      pinnedRef: "sandbox/thread-older-conn_a",
+    }),
+  ).toBe("sandbox/thread-older-conn_a");
+});
+
+test("a pinned ref wins over the bare thread key and the ephemeral fallback", () => {
+  expect(
+    resolveSandboxBranch({
+      threadId: "t1",
+      threadRepo: null,
+      runBranch: threadBranch("t1"),
+      pinnedRef: "fix/some-pr-branch",
+    }),
+  ).toBe("fix/some-pr-branch");
+  expect(
+    resolveSandboxBranch({
+      threadId: "t1",
+      threadRepo: null,
+      pinnedRef: "fix/some-pr-branch",
+    }),
+  ).toBe("fix/some-pr-branch");
+});
+
+test("an absent pinned ref changes nothing", () => {
+  for (const pinnedRef of [null, undefined, ""]) {
+    expect(
+      resolveSandboxBranch({
+        threadId: "t1",
+        threadRepo: { connectionId: "conn_a" } as GithubRepo,
+        pinnedRef,
+      }),
+    ).toBe("thread:t1/conn_a");
+  }
+});

--- a/apps/api/src/tools/sandbox/thread-repo.ts
+++ b/apps/api/src/tools/sandbox/thread-repo.ts
@@ -193,7 +193,21 @@ export function resolveSandboxBranch(args: {
   agentRepo?: GithubRepo | null;
   /** Explicit branch for this run, when the caller has one. */
   runBranch?: string | null;
+  /**
+   * A REAL git ref this run must land on, pinned on the thread at dispatch
+   * (`metadata.pinnedRef`). Set when a task re-run has to update an existing
+   * pull request instead of opening another one: the derived `thread:<id>` key
+   * is per-thread, and every re-run is a new thread, so deriving would fork a
+   * new branch and therefore a new PR — which is exactly how one task ended up
+   * with four open PRs for the same change.
+   *
+   * Wins over every derivation below, deliberately. Two re-runs of the same
+   * task then share one sandbox, which is correct: they share a branch, and
+   * sharing beats two pods force-pushing over each other.
+   */
+  pinnedRef?: string | null;
 }): string {
+  if (args.pinnedRef) return args.pinnedRef;
   // A run dispatched on the BARE `thread:<id>` key keeps it, repo or not: that
   // is a sandbox-hosted task run that started with no repo and had one bound
   // mid-run by `TASK_ADD_REPO`. Deriving from the repo instead would move the
@@ -211,7 +225,21 @@ export function resolveSandboxBranch(args: {
   return args.runBranch ?? `thread:${args.threadId}`;
 }
 
-/** `resolveSandboxBranch` with the thread's bound repo read for you. */
+/**
+ * Read the real git ref pinned on the thread (`metadata.pinnedRef`), or null.
+ * See {@link resolveSandboxBranch}'s `pinnedRef`. Never throws.
+ */
+export async function getThreadPinnedRef(
+  ctx: StudioContext,
+  threadId: string | undefined | null,
+): Promise<string | null> {
+  const meta = await getThreadMeta(ctx, threadId);
+  const ref = (meta as { pinnedRef?: unknown } | null)?.pinnedRef;
+  return typeof ref === "string" && ref.length > 0 ? ref : null;
+}
+
+/** `resolveSandboxBranch` with the thread's bound repo and pinned ref read for
+ *  you. */
 export async function resolveSandboxBranchForThread(
   ctx: StudioContext,
   args: {
@@ -220,10 +248,11 @@ export async function resolveSandboxBranchForThread(
     runBranch?: string | null;
   },
 ): Promise<string> {
-  return resolveSandboxBranch({
-    ...args,
-    threadRepo: await getThreadGithubRepo(ctx, args.threadId),
-  });
+  const [threadRepo, pinnedRef] = await Promise.all([
+    getThreadGithubRepo(ctx, args.threadId),
+    getThreadPinnedRef(ctx, args.threadId),
+  ]);
+  return resolveSandboxBranch({ ...args, threadRepo, pinnedRef });
 }
 
 /**

--- a/apps/api/src/tools/task-board/enqueue-super-agent.ts
+++ b/apps/api/src/tools/task-board/enqueue-super-agent.ts
@@ -6,7 +6,9 @@ import {
   rollbackTaskExecution,
   TaskQuotaError,
 } from "../../billing/task-quota";
+import { getSettings } from "@/settings";
 import { enqueueAgentRunForTask } from "./enqueue-task-run";
+import { fetchPrHeadRef } from "./prs-get";
 import {
   buildClaudeCodeTaskPrompt,
   resolveTaskRepoChoice,
@@ -125,6 +127,26 @@ export function buildSuperAgentTaskPrompt(
   ].join("\n");
 }
 
+/**
+ * The head branch of the task's linked PR `prNumber`, or null when we can't
+ * confirm one. Null is the safe answer everywhere it appears: the caller then
+ * dispatches exactly as it does today (a fresh derived branch), which is the
+ * behavior this whole path is trying to improve on but is never WRONG — it just
+ * costs another PR.
+ */
+async function resolveRerunBranch(
+  ctx: StudioContext,
+  task: TaskBoardItem,
+  prNumber: number,
+): Promise<string | null> {
+  const prs = await ctx.storage.taskBoard
+    .listPrs(task.id, task.organizationId)
+    .catch(() => []);
+  const pr = prs.find((p) => p.number === prNumber);
+  if (!pr) return null;
+  return fetchPrHeadRef(ctx, task.organizationId, pr).catch(() => null);
+}
+
 export async function enqueueSuperAgentForTask(
   ctx: StudioContext,
   task: TaskBoardItem,
@@ -143,6 +165,23 @@ export async function enqueueSuperAgentForTask(
   const claim = await claimTaskExecution(ctx, task);
 
   try {
+    // A re-run told to update an existing PR must land on that PR's BRANCH.
+    // Asking the model to `gh pr checkout` (which the prompt does, and has
+    // done all along) cannot work on its own: the sandbox key is derived from
+    // the THREAD, every re-run is a new thread, so the pod boots on a fresh
+    // `sandbox/thread-<new-id>` branch and the daemon's HEAD-based shutdown
+    // push publishes THAT — a second pull request for the same task. One task
+    // reached four open PRs this way, all with the same title.
+    //
+    // Pinning the PR's head branch makes the sandbox boot on it, so the same
+    // push updates the same PR. Best-effort: a null head ref (GitHub
+    // unreachable, PR already closed/merged) falls back to today's behavior
+    // rather than pinning a ref we can't confirm exists.
+    const pinnedRef =
+      getSettings().taskBoardRerunReusesPrBranch && opts?.pr
+        ? await resolveRerunBranch(ctx, task, opts.pr.number)
+        : null;
+
     // Sandbox-hosted claude-code takes every task that has a repo it could work
     // in — bound before dispatch when there's exactly one, otherwise chosen
     // mid-run with `TASK_ADD_REPO` (see `claude-code-task-run.ts`). An org with
@@ -153,6 +192,7 @@ export async function enqueueSuperAgentForTask(
       const repo = "repo" in choice ? choice.repo : null;
       await enqueueAgentRunForTask(ctx, task, {
         title: `Super Agent: ${task.title}`,
+        ...(pinnedRef ? { pinnedRef } : {}),
         prompt: buildClaudeCodeTaskPrompt(task, repo, {
           ...opts,
           // Names the candidates in the prompt so the run doesn't spend its first
@@ -170,6 +210,7 @@ export async function enqueueSuperAgentForTask(
       title: `Super Agent: ${task.title}`,
       prompt: buildSuperAgentTaskPrompt(task, opts),
       temperature: 0.5,
+      ...(pinnedRef ? { pinnedRef } : {}),
     });
   } catch (err) {
     // Nothing was dispatched — no thread exists to ever trigger the

--- a/apps/api/src/tools/task-board/enqueue-task-run.ts
+++ b/apps/api/src/tools/task-board/enqueue-task-run.ts
@@ -40,6 +40,13 @@ export async function enqueueAgentRunForTask(
      * them; a Decopilot fallback run must carry its persona in the prompt.
      */
     agent?: { instructions?: string; disallowedTools?: string[] };
+    /**
+     * A real git ref this run must land on instead of its own derived branch —
+     * the head branch of the pull request a re-run has to update. Without it
+     * every re-run gets a fresh `thread:<id>` key, forks a new branch off the
+     * default, and opens a SECOND pull request for the same task.
+     */
+    pinnedRef?: string | null;
   },
 ): Promise<{ threadId: string }> {
   const organizationId = task.organizationId;
@@ -73,6 +80,9 @@ export async function enqueueAgentRunForTask(
   const metadata = {
     ...(thread.metadata ?? {}),
     ...(harnessRunsInSandbox(harnessId) ? { read_only: true } : {}),
+    // Read back by `resolveSandboxBranch` at provision time (via the thread, so
+    // a durable re-dispatch resolves the same pod). See `pinnedRef` above.
+    ...(opts.pinnedRef ? { pinnedRef: opts.pinnedRef } : {}),
     ...(opts.repo
       ? {
           githubRepo: {
@@ -91,11 +101,13 @@ export async function enqueueAgentRunForTask(
   // different repos into one pod. The bare `thread:<id>` key is what
   // `resolveSandboxBranch` holds onto for the whole run even once a repo lands,
   // so the claim handle can't move out from under the live pod.
-  const sandboxBranch = opts.repo
-    ? threadBranch(thread.id, opts.repo.connectionId)
-    : harnessRunsInSandbox(harnessId)
-      ? threadBranch(thread.id)
-      : null;
+  const sandboxBranch = opts.pinnedRef
+    ? opts.pinnedRef
+    : opts.repo
+      ? threadBranch(thread.id, opts.repo.connectionId)
+      : harnessRunsInSandbox(harnessId)
+        ? threadBranch(thread.id)
+        : null;
   await ctx.storage.threads.update(thread.id, {
     metadata,
     ...(sandboxBranch ? { branch: sandboxBranch } : {}),

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -800,3 +800,53 @@ export const TASK_BOARD_ITEM_PRS_GET = defineTool({
     return { prs };
   },
 });
+
+/**
+ * The PR's head branch name (`head.ref`), or null when GitHub can't be reached.
+ *
+ * Read live rather than stored on the row deliberately: `task_board_item_prs`
+ * is written from three places (the MCP `onPrOpened` hook, a bash-output scan,
+ * and the sweeper's closing-message scan) and only one of them ever knows the
+ * branch. GitHub always does. Null is a first-class answer — the caller falls
+ * back to today's fresh-branch behavior rather than guessing a ref and pushing
+ * work somewhere nobody is looking.
+ */
+export async function fetchPrHeadRef(
+  ctx: StudioContext,
+  orgId: string,
+  pr: TaskBoardItemPrRef,
+): Promise<string | null> {
+  const conn = await resolveGithubConnection(ctx, orgId, pr.connectionId, {
+    owner: pr.repoOwner,
+    name: pr.repoName,
+  });
+  if (!conn) return null;
+  const client = await clientFromConnection(conn, ctx, true);
+  try {
+    const obj = toolResultJson(
+      await client.callTool(
+        {
+          name: "pull_request_read",
+          arguments: {
+            method: "get",
+            owner: pr.repoOwner,
+            repo: pr.repoName,
+            pullNumber: pr.number,
+          },
+        },
+        undefined,
+        { timeout: PR_FETCH_TIMEOUT_MS },
+      ),
+    );
+    // Only an OPEN PR's branch is worth reusing: pushing to a merged or closed
+    // PR's branch updates nothing anyone will look at, and the re-run's work
+    // would be invisible.
+    if (!obj || obj.state !== "open") return null;
+    const ref = (obj.head as { ref?: unknown } | undefined)?.ref;
+    return typeof ref === "string" && ref.length > 0 ? ref : null;
+  } catch {
+    return null;
+  } finally {
+    await client.close().catch(() => {});
+  }
+}


### PR DESCRIPTION
## Summary

One task on a live board had **four open pull requests** with the same title, on branches `sandbox/thread-<a>`, `sandbox/thread-<b>`, `sandbox/thread-<c>`, `sandbox/thread-<d>`. Across the board: 54 PRs for 45 cards.

The re-run prompt has always instructed `gh pr checkout <n>` and "push to the SAME pull request — do NOT open a new one". **It cannot work on its own.** The sandbox isolation key is derived from the *thread*, every re-run creates a *new* thread, so the pod boots on a fresh `sandbox/thread-<new-id>` branch and the daemon's HEAD-based shutdown push publishes that branch. A second PR, regardless of what the model was told. Prompt instruction vs. branch derivation — the derivation wins every time.

So pin the branch rather than asking for it:

- `resolveSandboxBranch` gains `pinnedRef`, a real git ref that wins over every derivation below it. Carried on the thread as `metadata.pinnedRef` so a durable re-dispatch resolves the same pod.
- `enqueueSuperAgentForTask` sets it to the head branch of the PR it is re-running, read live from GitHub via the new `fetchPrHeadRef`. Live rather than stored on the row on purpose: `task_board_item_prs` is written from three places (the MCP `onPrOpened` hook, a bash-output scan, the sweeper's closing-message scan) and only one of them ever knows the branch — GitHub always does.

Two re-runs of the same task now share one sandbox. That is correct: they share a branch, and sharing beats two pods force-pushing over each other.

## Safety

- **Null is a first-class answer.** GitHub unreachable, or a PR already closed/merged, falls back to exactly today's behavior rather than pinning a ref we can't confirm exists. Never wrong, just costs another PR — the status quo.
- **Both derivation sites read the pin** (the dispatch path *and* the decopilot fs tools). They must agree exactly; a pin visible to only one would provision a second pod for one thread, which is the failure the shared-derivation comment in that file warns about.
- **Behind `TASK_BOARD_RERUN_REUSES_PR_BRANCH`, default off.** It changes which sandbox a dispatch resolves to — a boot/dispatch hot path gets its own flag.
- The prompt's `gh pr checkout` instruction stays as belt and braces.

## Testing

- `bun run --cwd=apps/api check` — clean
- `bun run lint` — 0 errors
- 3 new unit tests on the pure resolver, covering: pin beats a thread-bound repo, pin beats the bare thread key and the ephemeral fallback, and an absent pin changes nothing (`null` / `undefined` / `""`).
- `bun test src/tools src/settings src/harnesses` from `apps/api`: 1023 → 1026 pass, with the same 16 pre-existing failures as `main` (verified against a clean checkout).

## Note

Since the flag ships off, enabling it in staging on a task with an open PR is the real verification — the unit tests pin the derivation, not the daemon's push behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-runs now update the existing PR by pinning the PR’s branch on the thread, preventing duplicate PRs and sharing a single sandbox per PR. Falls back to today’s behavior when the PR branch can’t be confirmed.

- **Bug Fixes**
  - Added `pinnedRef` to `resolveSandboxBranch`, stored as `thread.metadata.pinnedRef` and respected in both dispatch and `decopilot` tools.
  - On task re-run, fetch the PR’s head branch live from GitHub (`fetchPrHeadRef`) and pin it; if unreachable or the PR isn’t open, use the derived branch.
  - Guarded by `TASK_BOARD_RERUN_REUSES_PR_BRANCH` (default off) and `Settings.taskBoardRerunReusesPrBranch`.
  - Added unit tests to verify `pinnedRef` precedence and no-op when absent.

<sup>Written for commit bc3113a050c3e29ade1eac9c58e51ca1f7fbebef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

