### PR TITLE
fix(github): drop list_pull_requests from publish & submit-for-review

### DIFF
--- a/apps/web/src/components/thread/github/github-pr-api.test.ts
+++ b/apps/web/src/components/thread/github/github-pr-api.test.ts
@@ -5,9 +5,9 @@ import {
   pullRequestFromToolText,
 } from "./extract-tool-json.ts";
 import {
-  findOpenPullRequestForBranch,
   openPullRequestForBranch,
   parseCreatedPullRequestResult,
+  PULL_REQUEST_ALREADY_EXISTS_MESSAGE,
   squashMergePullRequest,
 } from "./github-pr-api.ts";
 
@@ -84,49 +84,6 @@ describe("parseCreatedPullRequestResult", () => {
   });
 });
 
-describe("findOpenPullRequestForBranch", () => {
-  test("uses head filter and does not scan unfiltered PR list", async () => {
-    const calls: Record<string, unknown>[] = [];
-    const client = {
-      callTool: async (req: {
-        name: string;
-        arguments: Record<string, unknown>;
-      }) => {
-        calls.push(req.arguments);
-        if (req.arguments.head === "owner:feat/x") {
-          return {
-            content: [
-              {
-                type: "text",
-                text: JSON.stringify([
-                  {
-                    number: 5,
-                    html_url: "https://github.com/o/r/pull/5",
-                    head: { ref: "feat/x" },
-                  },
-                ]),
-              },
-            ],
-          };
-        }
-        return { content: [{ type: "text", text: "[]" }] };
-      },
-    };
-
-    const pr = await findOpenPullRequestForBranch(client, {
-      owner: "owner",
-      repo: "repo",
-      branch: "feat/x",
-    });
-
-    expect(pr).toEqual({
-      number: 5,
-      htmlUrl: "https://github.com/o/r/pull/5",
-    });
-    expect(calls.every((c) => c.head != null)).toBe(true);
-  });
-});
-
 describe("squashMergePullRequest", () => {
   test("requires merged === true in response", async () => {
     const client = {
@@ -173,16 +130,15 @@ describe("squashMergePullRequest", () => {
 });
 
 describe("openPullRequestForBranch", () => {
-  test("does not create a co-author-only PR body", async () => {
+  test("creates a PR and never calls list_pull_requests", async () => {
+    const names: string[] = [];
     let args: Record<string, unknown> | undefined;
     const client = {
       callTool: async (req: {
         name: string;
         arguments: Record<string, unknown>;
       }) => {
-        if (req.name === "list_pull_requests") {
-          return { content: [{ type: "text", text: "[]" }] };
-        }
+        names.push(req.name);
         args = req.arguments;
         return {
           content: [
@@ -197,7 +153,7 @@ describe("openPullRequestForBranch", () => {
       },
     };
 
-    await openPullRequestForBranch(client, {
+    const pr = await openPullRequestForBranch(client, {
       owner: "o",
       repo: "r",
       branch: "feat/x",
@@ -206,6 +162,72 @@ describe("openPullRequestForBranch", () => {
       coAuthor: { userName: "Jane Doe", userEmail: "jane@example.com" },
     });
 
+    expect(pr).toEqual({ number: 2, htmlUrl: "https://github.com/o/r/pull/2" });
+    // No co-author-only body should be created.
     expect(args?.body).toBeUndefined();
+    expect(names).toEqual(["create_pull_request"]);
+    expect(names).not.toContain("list_pull_requests");
+  });
+
+  test("reuses an existing PR without listing or creating", async () => {
+    const names: string[] = [];
+    const client = {
+      callTool: async (req: {
+        name: string;
+        arguments: Record<string, unknown>;
+      }) => {
+        names.push(req.name);
+        return { content: [{ type: "text", text: "{}" }] };
+      },
+    };
+
+    const pr = await openPullRequestForBranch(client, {
+      owner: "o",
+      repo: "r",
+      branch: "feat/x",
+      title: "feat: x",
+      body: "already open",
+      base: "main",
+      existing: { number: 9, htmlUrl: "https://github.com/o/r/pull/9" },
+      coAuthor: { userName: "Jane Doe", userEmail: "jane@example.com" },
+    });
+
+    expect(pr).toEqual({ number: 9, htmlUrl: "https://github.com/o/r/pull/9" });
+    // Only a best-effort co-author body update — never list/create.
+    expect(names).not.toContain("list_pull_requests");
+    expect(names).not.toContain("create_pull_request");
+  });
+
+  test("surfaces a retry message when create reports a duplicate PR", async () => {
+    const names: string[] = [];
+    const client = {
+      callTool: async (req: {
+        name: string;
+        arguments: Record<string, unknown>;
+      }) => {
+        names.push(req.name);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text",
+              text: "A pull request already exists for o:feat/x.",
+            },
+          ],
+        };
+      },
+    };
+
+    await expect(
+      openPullRequestForBranch(client, {
+        owner: "o",
+        repo: "r",
+        branch: "feat/x",
+        title: "feat: x",
+        base: "main",
+      }),
+    ).rejects.toThrow(PULL_REQUEST_ALREADY_EXISTS_MESSAGE);
+    // We must NOT fall back to list_pull_requests to recover the PR.
+    expect(names).not.toContain("list_pull_requests");
   });
 });

--- a/apps/web/src/components/thread/github/github-pr-api.ts
+++ b/apps/web/src/components/thread/github/github-pr-api.ts
@@ -36,7 +36,23 @@ export interface OpenPullRequestArgs {
   body?: string;
   base: string;
   coAuthor?: CoAuthorIdentity;
+  /**
+   * The branch's already-known open PR, supplied by the caller from its polled
+   * PR state. When present we reuse it directly instead of calling
+   * `list_pull_requests` — keeping that rate-limit-heavy call out of the
+   * publish/submit path.
+   */
+  existing?: CreatedPullRequest;
 }
+
+/**
+ * Thrown when `create_pull_request` reports a PR already exists for the branch
+ * but the caller had no `existing` PR to reuse (its polled state was stale).
+ * Retrying once the PR panel refreshes resolves it — see
+ * {@link openPullRequestForBranch}.
+ */
+export const PULL_REQUEST_ALREADY_EXISTS_MESSAGE =
+  "A pull request already exists for this branch. Refresh and try again.";
 
 function assertGithubToolSuccess(result: unknown): void {
   const message = toolErrorMessage(result);
@@ -71,20 +87,6 @@ function pickNumber(
   return undefined;
 }
 
-function headRefFromListItem(pr: Record<string, unknown>): string | null {
-  const head = pr.head as Record<string, unknown> | undefined;
-  const ref = head?.ref;
-  return typeof ref === "string" && ref.length > 0 ? ref : null;
-}
-
-function pullRequestMatchesBranch(
-  pr: Record<string, unknown>,
-  branch: string,
-): boolean {
-  const headRef = headRefFromListItem(pr);
-  return headRef === branch;
-}
-
 export function extractPullRequestList(
   result: unknown,
 ): Record<string, unknown>[] {
@@ -110,16 +112,6 @@ export function extractPullRequestList(
   return [];
 }
 
-function toCreatedPullRequest(
-  pr: Record<string, unknown>,
-): CreatedPullRequest | null {
-  const htmlUrl = pickString(pr, ["html_url", "htmlUrl", "url", "URL"]);
-  const number =
-    pickNumber(pr, ["number", "pullNumber"]) ?? pullNumberFromUrl(htmlUrl);
-  if (!number || !htmlUrl) return null;
-  return { number, htmlUrl };
-}
-
 /** github-mcp-server create_pull_request returns MinimalResponse `{ id, url }`. */
 export function parseCreatedPullRequestResult(
   result: unknown,
@@ -142,49 +134,6 @@ export function parseCreatedPullRequestResult(
 
 function pullRequestAlreadyExists(message: string): boolean {
   return /already exists|pull request already/i.test(message);
-}
-
-async function listOpenPullRequests(
-  client: GithubMcpClient,
-  args: { owner: string; repo: string; head?: string },
-): Promise<Record<string, unknown>[]> {
-  const result = await client.callTool({
-    name: "list_pull_requests",
-    arguments: {
-      owner: args.owner,
-      repo: args.repo,
-      state: "open",
-      ...(args.head ? { head: args.head } : {}),
-      perPage: 10,
-    },
-  });
-
-  assertGithubToolSuccess(result);
-  return extractPullRequestList(result);
-}
-
-export async function findOpenPullRequestForBranch(
-  client: GithubMcpClient,
-  args: {
-    owner: string;
-    repo: string;
-    branch: string;
-  },
-): Promise<CreatedPullRequest | null> {
-  const headFilters = [`${args.owner}:${args.branch}`, args.branch];
-
-  for (const head of headFilters) {
-    const prs = await listOpenPullRequests(client, {
-      owner: args.owner,
-      repo: args.repo,
-      head,
-    });
-    const match = prs.find((pr) => pullRequestMatchesBranch(pr, args.branch));
-    const created = match ? toCreatedPullRequest(match) : null;
-    if (created) return created;
-  }
-
-  return null;
 }
 
 async function ensureExistingPullRequestCoAuthor(
@@ -249,25 +198,29 @@ async function createPullRequest(
   return parseCreatedPullRequestResult(result);
 }
 
-/** Returns an open PR for the branch, or creates one if none exists. */
+/**
+ * Reuses the branch's open PR when the caller already knows it (`args.existing`,
+ * from its polled PR state), otherwise creates one. This path deliberately does
+ * NOT call `list_pull_requests`: on GitHub's hosted MCP that list is a top
+ * rate-limit contributor, and the publish/submit flows run inside it. If no
+ * `existing` PR is supplied and `create_pull_request` reports a duplicate, we
+ * surface {@link PULL_REQUEST_ALREADY_EXISTS_MESSAGE} rather than listing to
+ * recover it — the PR panel repopulates `existing` on its next poll, so a retry
+ * succeeds without us adding another list call here.
+ */
 export async function openPullRequestForBranch(
   client: GithubMcpClient,
   args: OpenPullRequestArgs,
 ): Promise<CreatedPullRequest> {
-  const existing = await findOpenPullRequestForBranch(client, {
-    owner: args.owner,
-    repo: args.repo,
-    branch: args.branch,
-  });
-  if (existing) {
+  if (args.existing) {
     await ensureExistingPullRequestCoAuthor(client, {
       owner: args.owner,
       repo: args.repo,
-      pullNumber: existing.number,
+      pullNumber: args.existing.number,
       body: args.body,
       coAuthor: args.coAuthor,
     });
-    return existing;
+    return args.existing;
   }
 
   try {
@@ -282,13 +235,9 @@ export async function openPullRequestForBranch(
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    if (!pullRequestAlreadyExists(message)) throw err;
-    const found = await findOpenPullRequestForBranch(client, {
-      owner: args.owner,
-      repo: args.repo,
-      branch: args.branch,
-    });
-    if (found) return found;
+    if (pullRequestAlreadyExists(message)) {
+      throw new Error(PULL_REQUEST_ALREADY_EXISTS_MESSAGE);
+    }
     throw err;
   }
 }

--- a/apps/web/src/components/thread/github/header-actions.tsx
+++ b/apps/web/src/components/thread/github/header-actions.tsx
@@ -449,13 +449,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
               ? effectiveBranchMeta.headSha
               : null
           }
-          openPullRequest={
-            publishDialogIntent === "publish-only"
-              ? null
-              : pr?.state === "open"
-                ? pr
-                : null
-          }
+          openPullRequest={pr?.state === "open" ? pr : null}
           onPullRequestChanged={refreshPrState}
           onPublished={switchToFreshBranch}
         />

--- a/apps/web/src/components/thread/github/publish-dialog.tsx
+++ b/apps/web/src/components/thread/github/publish-dialog.tsx
@@ -155,6 +155,13 @@ function PublishDialogBody({
   const coAuthor = coAuthorFromSessionUser(session?.user);
 
   const commitToOpenPr = openPullRequest?.state === "open";
+  // The branch's already-known open PR (from the header's polled PR state).
+  // Passed to openPullRequestForBranch so it reuses this PR instead of calling
+  // list_pull_requests to rediscover it.
+  const existingOpenPr =
+    openPullRequest?.state === "open"
+      ? { number: openPullRequest.number, htmlUrl: openPullRequest.htmlUrl }
+      : undefined;
   const openPrFromCommits = dialogIntent === "open-pr" && !commitToOpenPr;
   /** Side "Publish" button — direct publish to base, single green button. */
   const isPublishOnly = dialogIntent === "publish-only";
@@ -382,6 +389,7 @@ function PublishDialogBody({
           body: prBody,
           base: baseBranch,
           coAuthor,
+          existing: existingOpenPr,
         });
       } catch (error) {
         throw new PublishFlowError(
@@ -516,6 +524,7 @@ function PublishDialogBody({
         body: prBody,
         base: baseBranch,
         coAuthor,
+        existing: existingOpenPr,
       });
 
       toast.success(


### PR DESCRIPTION
## Summary

The **"Publicar em produção"** and **"Enviar para revisão"** flows both go through `openPullRequestForBranch`, which **pre-checked for an existing PR via `list_pull_requests`** (up to 2 calls, one per head filter) **plus a further recovery listing** in the `already exists` catch — **2–4 `list_pull_requests` calls per action, before the PR was even created**.

On GitHub's hosted MCP (`api.githubcopilot.com/mcp`) this list is a top rate-limit contributor and was surfacing to users as:

- `failed to list pull requests: GitHub API rate limit exceeded. Retry after 1m52s.`
- `Streamable HTTP error: Error POSTing to endpoint: too many requests`

Both are the same GitHub connection being hammered — the second is just the transport-level 429 instead of the tool-level result error.

## Change

- **Reuse the branch's already-known open PR** instead of listing. The header already polls the PR (`usePrByBranch`) and passes it into the dialog as `openPullRequest`; we thread it down as `existing`. When present, `openPullRequestForBranch` skips straight to the co-author/body update and returns it — **zero `list_pull_requests` calls**.
- **No `existing` → create directly.** If `create_pull_request` reports a duplicate and no `existing` was supplied (stale polled state), we surface a retry message (`PULL_REQUEST_ALREADY_EXISTS_MESSAGE`) **instead of listing to recover it**. The PR panel repopulates `existing` on its next poll, so a retry succeeds without adding a list call here.
- **`header-actions.tsx`** now passes the known open PR for the `publish-only` intent too (previously always `null`), so direct publish reuses/merges an existing PR without listing.
- Removes the now-dead `findOpenPullRequestForBranch`, `listOpenPullRequests`, and the `toCreatedPullRequest` / `pullRequestMatchesBranch` / `headRefFromListItem` helpers.

## Behavior trade-off

The old code silently recovered from a stale-poll race by re-listing. Now that rare case shows a "refresh and try again" error instead. This is intentional: the common path drops from 2–4 list calls to **0**, and the race resolves itself on the next panel poll (≤60s). Flagged here for reviewer visibility.

## Testing

- `bun test apps/web/src/components/thread/github/github-pr-api.test.ts` ✅ (10 pass)
  - Inverted the test that asserted the head-filtered `list_pull_requests` scan.
  - Added coverage: creates without ever calling `list_pull_requests`; reuses `existing` without list/create; surfaces the retry message on a duplicate without falling back to list.
- `bun run --cwd=apps/web check` (tsc) ✅
- `bun run lint` ✅ (0 errors) · `bun run knip` ✅ (no new dead code) · `bun run fmt` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `list_pull_requests` from Publish and Submit for Review by reusing the already-polled open PR or creating directly. This drops 2–4 list calls per action to zero and prevents GitHub MCP rate limit errors.

- **Refactors**
  - Thread the known open PR into `openPullRequestForBranch` via `existing`; reuse it and only update co-author/body.
  - If `create_pull_request` reports a duplicate and no `existing` is provided, show a retry message instead of listing.
  - `header-actions.tsx` now passes the open PR for publish-only; removed `findOpenPullRequestForBranch`, `listOpenPullRequests`, and related helpers; tests updated for reuse and duplicate paths.

<sup>Written for commit f1a215e905c05ffe939ebeb9739ea05e49d0f55a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

