### PR TITLE
fix(task-board): stop the reviewer bounce loop after 5 rounds

### DIFF
--- a/apps/api/src/tools/task-board/review-decision.ts
+++ b/apps/api/src/tools/task-board/review-decision.ts
@@ -4,9 +4,11 @@ import { requireAuth } from "@/core/studio-context";
 import type { StudioContext } from "@/core/studio-context";
 import {
   allReviewersApproved,
+  MAX_REVIEW_BOUNCES,
   REVIEWER_FLAG,
   REVIEWER_KINDS,
   REVIEWER_LABEL,
+  reviewBounceLimitReached,
 } from "@decocms/shared/task-board";
 import { TaskBoardItemStatusSchema } from "./schema";
 import { recordTaskActivity } from "./activity";
@@ -126,6 +128,53 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
     const verified = claim?.reviewer === reviewer;
 
     if (decision === "request_changes") {
+      // Break a runaway review loop BEFORE bouncing. A reviewer that keeps
+      // finding something keeps finding something, and each round costs a
+      // sandbox run — one board logged 179 change-requests against 68
+      // approvals. Past the cap the verdict is still recorded (it is the
+      // reviewer's most useful output) but the task stops going back to the
+      // Super Agent and is handed to a person instead.
+      //
+      // Checked BEFORE `claimReviewChangesBounce`, not after: that call moves
+      // the card to In Progress, and skipping the dispatch afterwards would
+      // leave it sitting In Progress with nothing running — the
+      // delegated-but-idle state this codebase goes out of its way to avoid.
+      const history = await ctx.storage.taskBoard.listActivity(
+        taskBoardItemId,
+        organizationId,
+      );
+      if (reviewBounceLimitReached(history)) {
+        await recordTaskActivity(ctx, {
+          taskBoardItemId,
+          action: "review_changes_requested",
+          actorId: null,
+          data: { reviewer, notes, verified, bounceLimitReached: true },
+        });
+        console.warn(
+          `[task-board] ${taskBoardItemId}: ${MAX_REVIEW_BOUNCES} review ` +
+            `bounces reached — unassigning the Super Agent, needs a human`,
+        );
+        // Unassign so the card reads as a person's problem rather than an
+        // agent's, and so nothing downstream re-dispatches it. It stays In
+        // Review with the reviewer's notes: that is where a human wants to
+        // pick it up, and the ship button stays hidden because nothing is
+        // approved.
+        const handed = await ctx.storage.taskBoard.update(
+          taskBoardItemId,
+          organizationId,
+          { assigneeId: null },
+          item.updatedBy,
+        );
+        await recordTaskActivity(ctx, {
+          taskBoardItemId,
+          action: "assignee_changed",
+          actorId: null,
+          data: { from: item.assigneeId, to: null },
+        });
+        emitTaskBoardUpdated(organizationId, handed);
+        return { status: handed.status, merged: false };
+      }
+
       // Any reviewer requesting changes bounces the task straight back to the
       // Super Agent with the feedback in its re-run prompt — no need to wait on
       // the other reviewer. Pull it back to In Progress and re-enqueue directly.

--- a/packages/shared/src/task-board.test.ts
+++ b/packages/shared/src/task-board.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "bun:test";
 import {
   allReviewersApproved,
   isReviewerThreadTitle,
+  MAX_REVIEW_BOUNCES,
+  reviewBounceLimitReached,
   reviewCycleStart,
   reviewCycleVerdicts,
   type ReviewCycleActivity,
@@ -144,5 +146,77 @@ describe("allReviewersApproved", () => {
     ).toBe(false);
     // The human ship button (no verifiedOnly) still sees both as approved.
     expect(allReviewersApproved(forged, ["qa", "code_review"])).toBe(true);
+  });
+});
+
+// The runaway-loop guard. It counts ACROSS review cycles on purpose — each
+// bounce starts a new cycle, so a per-cycle count is always 1 and would never
+// trip, which is exactly how a board reached 179 change-requests.
+
+function bounce(at: string): ReviewCycleActivity {
+  return {
+    action: "review_changes_requested",
+    data: { reviewer: "code_review" },
+    occurredAt: at,
+  };
+}
+
+describe("reviewBounceLimitReached", () => {
+  it("allows the first bounces through", () => {
+    expect(reviewBounceLimitReached([])).toBe(false);
+    expect(
+      reviewBounceLimitReached([
+        bounce("2026-01-01T00:00:00.000Z"),
+        bounce("2026-01-01T01:00:00.000Z"),
+        bounce("2026-01-01T02:00:00.000Z"),
+      ]),
+    ).toBe(false);
+  });
+
+  it("trips on the bounce that would reach the limit, counting the pending one", () => {
+    const four = Array.from({ length: 4 }, (_, i) =>
+      bounce(`2026-01-01T0${i}:00:00.000Z`),
+    );
+    expect(four).toHaveLength(MAX_REVIEW_BOUNCES - 1);
+    expect(reviewBounceLimitReached(four)).toBe(true);
+  });
+
+  it("counts bounces from earlier review cycles, not just the current one", () => {
+    const acrossCycles: ReviewCycleActivity[] = [
+      bounce("2026-01-01T00:00:00.000Z"),
+      {
+        action: "status_changed",
+        data: { to: "in_review" },
+        occurredAt: "2026-01-01T00:30:00.000Z",
+      },
+      bounce("2026-01-01T01:00:00.000Z"),
+      {
+        action: "status_changed",
+        data: { to: "in_review" },
+        occurredAt: "2026-01-01T01:30:00.000Z",
+      },
+      bounce("2026-01-01T02:00:00.000Z"),
+      {
+        action: "status_changed",
+        data: { to: "in_review" },
+        occurredAt: "2026-01-01T02:30:00.000Z",
+      },
+      bounce("2026-01-01T03:00:00.000Z"),
+    ];
+    expect(reviewBounceLimitReached(acrossCycles)).toBe(true);
+  });
+
+  it("ignores approvals and unrelated activity", () => {
+    expect(
+      reviewBounceLimitReached([
+        {
+          action: "review_approved",
+          data: { reviewer: "qa" },
+          occurredAt: "2026-01-01T00:00:00.000Z",
+        },
+        { action: "created", occurredAt: "2026-01-01T00:00:00.000Z" },
+        bounce("2026-01-01T01:00:00.000Z"),
+      ]),
+    ).toBe(false);
   });
 });

--- a/packages/shared/src/task-board.ts
+++ b/packages/shared/src/task-board.ts
@@ -127,6 +127,39 @@ export function allReviewersApproved(
 }
 
 /**
+ * How many times a task may be bounced back to the Super Agent by a reviewer
+ * before the loop is broken and a human takes over.
+ *
+ * The reviewer → fix → re-review cycle has no natural fixed point: a reviewer
+ * that keeps finding something will keep finding something, and each round
+ * costs a sandbox run and (before the PR-branch pin) an extra pull request. One
+ * live board logged 179 change-requests against 68 approvals, with a single
+ * task rejected five times in an hour by the same reviewer on the same PR.
+ *
+ * Five is chosen to be clearly past "the reviewer had a point" and clearly
+ * short of "we are burning runs on a disagreement a person should settle".
+ */
+export const MAX_REVIEW_BOUNCES = 5;
+
+/**
+ * True when this task has already been handed back to the Super Agent
+ * `MAX_REVIEW_BOUNCES` times, counting the change-request about to be recorded.
+ *
+ * Deliberately counts across ALL review cycles, not the current one: the
+ * runaway loop IS the cycles: each bounce starts a fresh cycle, so a per-cycle
+ * count is always 1 and would never trip.
+ */
+export function reviewBounceLimitReached(
+  activity: ReviewCycleActivity[],
+  limit: number = MAX_REVIEW_BOUNCES,
+): boolean {
+  const bounces = activity.filter(
+    (a) => a.action === "review_changes_requested",
+  ).length;
+  return bounces + 1 >= limit;
+}
+
+/**
  * Org-scoped SSE event pushed on `sseHub` whenever a Super Agent run advances a
  * task board item's status (enqueued→todo, executing→in_progress, PR→in_review).
  * Its `data` is the full updated `TaskBoardItem`; the web board patches its


### PR DESCRIPTION
## Summary

The reviewer → fix → re-review cycle has no fixed point. A reviewer that keeps finding something keeps finding something, and every round costs a sandbox run and (before #5802) another pull request.

On a live board: **179 change-requests against 68 approvals.** One task was rejected five times in an hour by the same reviewer on the same PR, each rejection spawning a fresh Super Agent run.

Cap it at five bounces. Past the cap:

- the verdict is **still recorded** — it is the reviewer's most useful output, and a human is about to read it;
- the task **stops going back to the Super Agent**;
- the card is **unassigned**, so it reads as a person's problem and nothing downstream re-dispatches it;
- it stays **In Review** with the notes attached, which is where a human wants to pick it up. The ship button stays hidden because nothing is approved.

## Two details worth reviewing

**The check runs *before* `claimReviewChangesBounce`.** That call moves the card to In Progress. Checking the cap afterwards and skipping the dispatch would leave the card sitting In Progress with nothing running — the delegated-but-idle state this codebase avoids everywhere else.

**`reviewBounceLimitReached` counts across ALL review cycles, not the current one.** Each bounce *starts* a fresh cycle, so a per-cycle count is always 1 and would never trip. That is exactly how a board reached 179. There is a test pinning this.

## Scope

No new activity action, so **no migration** — the existing `assignee_changed` entry already renders the hand-off in the timeline. This keeps the PR independent of #5801, which does add one.

## Testing

- `bun run --cwd=apps/api check`, `bun run --cwd=apps/web check` — clean
- `bun run lint` — 0 errors
- 4 new unit tests in `packages/shared`: under-limit, the trip (counting the pending change-request), counting across cycles, and ignoring approvals/unrelated activity. `bun test src/task-board.test.ts` — 12/12.

## Judgement call

Five is a guess, deliberately past "the reviewer had a point" and short of "we are burning runs on a disagreement a person should settle". It is a single exported constant (`MAX_REVIEW_BOUNCES`) if you want a different number.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the reviewer → fix → re-review bounce loop by capping Super Agent re-runs at five. When the cap hits, we record the verdict, tag it, unassign the agent, keep the card In Review, and do not re-dispatch.

- **Bug Fixes**
  - Added `MAX_REVIEW_BOUNCES = 5` and `reviewBounceLimitReached` in `packages/shared` to count bounces across cycles.
  - In `apps/api`, check the cap before `claimReviewChangesBounce`; on limit: record `review_changes_requested` with `bounceLimitReached: true`, unassign, record `assignee_changed`, emit update, and skip the re-run.
  - Added unit tests in `packages/shared` for under-limit, trip-at-limit, cross-cycle counting, and ignoring approvals. No migration needed.

<sup>Written for commit 3e55134b2392897134460ae3435821431daafce7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

