### PR TITLE
fix(task-board): dedup imported findings by title when no externalKey is sent

### DIFF
--- a/apps/api/src/api/routes/task-board-import.test.ts
+++ b/apps/api/src/api/routes/task-board-import.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { importBodySchema } from "./task-board-import";
+import { importBodySchema, normalizeTitleKey } from "./task-board-import";
 
 describe("importBodySchema", () => {
   it("accepts a minimal batch and fills nothing in", () => {
@@ -52,5 +52,40 @@ describe("importBodySchema", () => {
     expect(
       importBodySchema.safeParse({ items: items.slice(0, 100) }).success,
     ).toBe(true);
+  });
+});
+
+// The fallback finding identity for producers that send no `externalKey` — the
+// case that let one board accumulate 19 cards for 8 findings, each duplicate
+// spawning its own agent run and its own pull request.
+describe("normalizeTitleKey", () => {
+  it("flattens case and whitespace differences", () => {
+    expect(normalizeTitleKey("  Adicionar um H1 na home  ")).toBe(
+      normalizeTitleKey("adicionar um h1 na home"),
+    );
+    expect(normalizeTitleKey("Adicionar   um\tH1\nna home")).toBe(
+      "adicionar um h1 na home",
+    );
+  });
+
+  it("keeps genuinely different findings apart", () => {
+    // Two real findings off the same board. They differ by a few words and are
+    // NOT the same check — merging them would silently drop one, which is why
+    // the match is exact rather than fuzzy.
+    expect(
+      normalizeTitleKey(
+        "Habilitar compressão gzip ou brotli no servidor para respostas de texto",
+      ),
+    ).not.toBe(
+      normalizeTitleKey(
+        "Habilitar compressão gzip ou brotli nas respostas de texto da home",
+      ),
+    );
+  });
+
+  it("does not collapse distinct URLs in a title", () => {
+    expect(normalizeTitleKey("Adicionar alt à imagem em /a.png")).not.toBe(
+      normalizeTitleKey("Adicionar alt à imagem em /b.png"),
+    );
   });
 });

--- a/apps/api/src/api/routes/task-board-import.ts
+++ b/apps/api/src/api/routes/task-board-import.ts
@@ -39,6 +39,14 @@ import { bearerToken, isVaultServiceToken } from "./credential-vault";
  *   recurring diagnostic runs converge on the same card. A done item is NOT
  *   matched — a regression creates a fresh card. Refreshes never re-trigger
  *   the Super Agent delegation.
+ *   When an item carries NO externalKey, its normalized title stands in as the
+ *   finding identity. `externalKey` is optional and at least one real producer
+ *   never sends it, so the dedup above was simply never reached: one board
+ *   accumulated 8 duplicated findings (19 cards that should have been 8), each
+ *   duplicate spawning its own agent run and its own pull request. Matching is
+ *   EXACT on the normalized title (case, surrounding and repeated whitespace) —
+ *   deliberately not fuzzy, because two findings that differ by a few words are
+ *   usually two findings, and wrongly merging them loses one silently.
  *
  * A DISMISSED key (`dismissed_at` set) is skipped and counted in `dismissed`.
  *
@@ -53,6 +61,15 @@ import { bearerToken, isVaultServiceToken } from "./credential-vault";
 type Variables = {
   studioContext: StudioContext;
 };
+
+/**
+ * Finding identity for an item that carries no `externalKey`: the title with
+ * case and whitespace differences flattened. Nothing more aggressive — see the
+ * module docstring on why matching stays exact.
+ */
+export function normalizeTitleKey(title: string): string {
+  return title.trim().replace(/\s+/g, " ").toLowerCase();
+}
 
 export const importBodySchema = z.object({
   items: z
@@ -170,6 +187,32 @@ export const createTaskBoardImportRoutes = () => {
       const keys = items.flatMap((i) => i.externalKey ?? []);
       const openByKey = new Map<string, string>();
       const dismissed = new Set<string>();
+
+      // Title-keyed fallback for items with no externalKey. Scoped to the org's
+      // non-done cards and only paid for when some item actually lacks a key.
+      const openByTitle = new Map<string, string>();
+      const dismissedTitles = new Set<string>();
+      if (items.some((i) => !i.externalKey)) {
+        const rows = await trx
+          .selectFrom("task_board_items")
+          .select(["id", "title", "status", "dismissed_at"])
+          .where("organization_id", "=", organizationId)
+          .where((eb) =>
+            eb.or([
+              eb("dismissed_at", "is not", null),
+              eb("status", "!=", "done"),
+            ]),
+          )
+          .execute();
+        for (const row of rows) {
+          const key = normalizeTitleKey(row.title);
+          if (row.dismissed_at) dismissedTitles.add(key);
+          else if (row.status !== "done" && !openByTitle.has(key)) {
+            openByTitle.set(key, row.id);
+          }
+        }
+      }
+
       if (keys.length > 0) {
         const rows = await trx
           .selectFrom("task_board_items")
@@ -199,13 +242,17 @@ export const createTaskBoardImportRoutes = () => {
       let updated = 0;
       let skipped = 0;
       for (const item of items) {
-        if (item.externalKey && dismissed.has(item.externalKey)) {
+        const titleKey = normalizeTitleKey(item.title);
+        const isDismissed = item.externalKey
+          ? dismissed.has(item.externalKey)
+          : dismissedTitles.has(titleKey);
+        if (isDismissed) {
           skipped++;
           continue;
         }
         const existingId = item.externalKey
           ? openByKey.get(item.externalKey)
-          : undefined;
+          : openByTitle.get(titleKey);
         if (existingId) {
           // Refresh the finding's card: new evidence + severity. Title,
           // status and assignee stay — a human may have touched them, and a
@@ -246,6 +293,7 @@ export const createTaskBoardImportRoutes = () => {
         });
         // A within-batch duplicate key folds into the row just created.
         if (item.externalKey) openByKey.set(item.externalKey, row.id);
+        else openByTitle.set(titleKey, row.id);
         touched.push(row);
         created++;
         if (toSuperAgent) delegations.push(row);


### PR DESCRIPTION
## Summary

The import route dedups recurring findings on `item.externalKey`. That field is **optional**, and at least one live producer never sends it — **zero of the 63 cards** on the board I investigated had one. So the dedup path was never reached: every re-import created a fresh card for a finding that already had one.

That board carried **8 duplicated findings — 19 cards that should have been 8**:

| normalized title | cards |
|---|---|
| adicionar texto alternativo à imagem em … | 3 |
| aumentar o contraste de cor do texto 'hurry, offer ends soon…' | 3 |
| criar arquivo /.well-known/security.txt … | 3 |
| configurar a página de erro para retornar status 404 … | 2 |
| habilitar compressão gzip ou brotli no servidor para respostas de texto | 2 |
| remover o header x-powered-by da página de erro … | 2 |
| adicionar um h1 na home | 2 |
| remover ou ofuscar o header x-powered-by … | 2 |

Because reports tasks auto-delegate to the Super Agent, **each duplicate spawned its own run and its own pull request.**

## Change

Fall back to the normalized title as the finding identity when no `externalKey` is supplied. Same open/done/dismissed semantics the key path already has, including "a done item is not matched — a regression gets a fresh card" and "a dismissed finding stays suppressed".

## Why exact and not fuzzy

Matching flattens case and whitespace, nothing more. Two of the real duplicates on that board are near-misses that are **genuinely different checks**:

- `Habilitar compressão gzip ou brotli no servidor para respostas de texto`
- `Habilitar compressão gzip ou brotli nas respostas de texto da home`

Fuzzy matching would merge those and silently drop one. The exact rule catches all 8 groups above without that risk. There is a test pinning both directions.

## Cost

The extra query is scoped to the org's non-done cards and only runs when some item in the batch actually lacks a key. It stays inside the existing import transaction.

## Testing

- `bun run --cwd=apps/api check` — clean
- `bun run lint` — 0 errors; `knip` clean on `apps/api`
- 3 new unit tests: whitespace/case flattening, keeping the two near-miss findings apart, and not collapsing distinct URLs in a title. `bun test src/api/routes/task-board-import.test.ts` — 8/8.

## Follow-up worth doing separately

The real fix is the producer sending a stable `externalKey` (`diag:{domain}:{check_id}`, as the schema documents). This is the defensive net for producers that don't — it should not be a reason to stop asking them to.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes task-board import deduplication by falling back to a normalized title when `externalKey` is missing. Prevents duplicate cards, Super Agent runs, and PRs.

- **Bug Fixes**
  - When `externalKey` is absent, dedup by exact match on a normalized title (trimmed, single-spaced, lowercased).
  - Preserve existing semantics: done items aren’t matched; dismissed items stay suppressed.
  - Scope the extra lookup to the org’s non-done and dismissed cards, only when any batch item lacks a key.
  - Export `normalizeTitleKey` and add tests for normalization, keeping near-miss findings separate, and not collapsing distinct URLs.

<sup>Written for commit e7e863e6d50ffd98c4ce12e5a1e49025b2d1e942. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

