### PR TITLE
feat(sandbox): ask for the L2 golden store's volume instead of naming a cloud

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,6 +9,18 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
+# 0.11.0: this chart now OWNS the L2 store's PV/PVC. `depsCache.remote` takes
+# `bucketName` (the terraform-provisioned bucket) and renders a mountpoint-S3 PV
+# + PVC named per release, each mounted under `prefix=<envName>/`. Previously
+# those objects were created by terraform under one namespace-wide name, which
+# made every release share a single bucket root — so stg could publish an archive
+# that prod then restored. `pvcName` survives as an escape hatch for a claim this
+# chart does not manage, and is now mutually exclusive with `bucketName`; setting
+# neither fails the render instead of mounting an empty claimName. Minor bump:
+# `pvcName` stops being the only way in, and a consumer pointing it at the
+# terraform-created `sandbox-golden-ro` must switch to `bucketName` before those
+# objects are removed on the terraform side. Still default off — no change unless
+# enabled.
 # 0.10.7: opt-in node placeholder / "balloon" (nodePlaceholder.*, default off)
 # — low-priority pods that reserve warm NODE capacity on the sandbox NodePool
 # so warm-pool refill / KEDA scale-up / cold claims schedule onto an already-up
@@ -67,7 +79,7 @@ type: application
 # 0.8.0: org-fs sidecar (orgFs.*) — privileged rclone mounter + main-container
 # mounts. NOTE: the publish workflow skips existing versions, so this MUST
 # stay ahead of the latest published chart (0.7.5 at time of writing).
-version: 0.10.19
+version: 0.11.0
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "1.42.0"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,18 +9,21 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
-# 0.11.0: this chart now OWNS the L2 store's PV/PVC. `depsCache.remote` takes
-# `bucketName` (the terraform-provisioned bucket) and renders a mountpoint-S3 PV
-# + PVC named per release, each mounted under `prefix=<envName>/`. Previously
-# those objects were created by terraform under one namespace-wide name, which
-# made every release share a single bucket root — so stg could publish an archive
-# that prod then restored. `pvcName` survives as an escape hatch for a claim this
-# chart does not manage, and is now mutually exclusive with `bucketName`; setting
-# neither fails the render instead of mounting an empty claimName. Minor bump:
-# `pvcName` stops being the only way in, and a consumer pointing it at the
-# terraform-created `sandbox-golden-ro` must switch to `bucketName` before those
-# objects are removed on the terraform side. Still default off — no change unless
-# enabled.
+# 0.11.0: this chart now asks for the L2 store's volume instead of having it
+# handed over. `depsCache.remote` takes exactly one of three sources:
+# `storageClassName` (dynamic — renders only a PVC, so any RWX CSI driver works
+# and nothing here names a cloud), `volume.{driver,attributes,mountOptions}`
+# (static — renders PV + PVC, required for a driver with no provisioner, which
+# is why mountpoint-S3 is the default), or `pvcName` (an existing claim, as
+# before). Two set fails the render as ambiguous; none set fails instead of
+# leaving a PVC Pending forever with neither a StorageClass nor a volumeName.
+# Those objects used to be created by terraform under one namespace-wide name,
+# which made every release share a single store root — so stg could publish an
+# archive that prod then restored; both are now envName-suffixed, and the static
+# path keys each release under its own `prefix`. Minor bump: `pvcName` stops
+# being the only way in, and a consumer pointing it at the terraform-created
+# `sandbox-golden-ro` must move to one of the other two before those objects are
+# removed on the terraform side. Still default off — no change unless enabled.
 # 0.10.7: opt-in node placeholder / "balloon" (nodePlaceholder.*, default off)
 # — low-priority pods that reserve warm NODE capacity on the sandbox NodePool
 # so warm-pool refill / KEDA scale-up / cold claims schedule onto an already-up

--- a/deploy/helm/sandbox-env/templates/_helpers.tpl
+++ b/deploy/helm/sandbox-env/templates/_helpers.tpl
@@ -360,20 +360,29 @@ that cannot mount, or one that silently mounts nothing:
   - remote without the node-local tier is incoherent: an L2 hit seeds L1 via
     the same pendingGolden path, and the daemon reads DEPS_CACHE_ROOT either
     way.
-  - exactly one source: a bucket for this chart to provision a PV over, or a
-    pre-existing PVC. Both set is ambiguous (which one is authoritative?),
-    neither set would render a volume with an empty claimName.
+  - exactly ONE volume source. The three are mutually exclusive by
+    construction (each implies a different set of objects to render), so two
+    set is ambiguous authority and zero set would render a claim with neither
+    a StorageClass nor a volumeName — Pending forever, silently.
 */}}
 {{- define "sandbox-env.validateGoldenRemote" -}}
 {{- if .Values.depsCache.remote.enabled }}
+{{- $r := .Values.depsCache.remote -}}
 {{- if not .Values.depsCache.enabled }}
 {{- fail "sandbox-env: depsCache.remote.enabled=true requires depsCache.enabled=true — the L2 archive restores into the node-local store, so there is nothing for it to seed otherwise." -}}
 {{- end }}
-{{- if and .Values.depsCache.remote.bucketName .Values.depsCache.remote.pvcName }}
-{{- fail "sandbox-env: set exactly one of depsCache.remote.bucketName (this chart provisions the PV/PVC over that S3 bucket) or depsCache.remote.pvcName (mount a claim this chart does not manage) — both are set, so which one is authoritative is ambiguous." -}}
+{{- $sources := list -}}
+{{- if ne (default "" $r.storageClassName) "" }}{{- $sources = append $sources "storageClassName" -}}{{- end }}
+{{- if $r.volume.attributes }}{{- $sources = append $sources "volume.attributes" -}}{{- end }}
+{{- if ne (default "" $r.pvcName) "" }}{{- $sources = append $sources "pvcName" -}}{{- end }}
+{{- if gt (len $sources) 1 }}
+{{- fail (printf "sandbox-env: depsCache.remote takes exactly ONE volume source, got %d (%s). storageClassName = dynamic (this chart renders only the PVC); volume.attributes = static (renders PV + PVC, for a driver with no provisioner such as mountpoint-S3); pvcName = mount an existing claim this chart does not manage." (len $sources) (join ", " $sources)) -}}
 {{- end }}
-{{- if not (or .Values.depsCache.remote.bucketName .Values.depsCache.remote.pvcName) }}
-{{- fail "sandbox-env: depsCache.remote.enabled=true requires depsCache.remote.bucketName (preferred: this chart provisions the mountpoint-S3 PV/PVC) or depsCache.remote.pvcName (an existing claim). Neither is set, which would mount a volume with an empty claimName." -}}
+{{- if eq (len $sources) 0 }}
+{{- fail "sandbox-env: depsCache.remote.enabled=true requires one volume source — storageClassName (dynamic provisioning: bring your own RWX CSI driver and StorageClass), volume.attributes (static: e.g. bucketName for mountpoint-S3, which has no dynamic provisioner), or pvcName (an existing claim). With none set the PVC would have neither a StorageClass nor a volumeName and stay Pending forever." -}}
+{{- end }}
+{{- if and $r.volume.attributes (eq (default "" $r.volume.driver) "") }}
+{{- fail "sandbox-env: depsCache.remote.volume.attributes is set but volume.driver is empty — the static path renders a PV, whose csi.driver must name the installed CSI driver (e.g. s3.csi.aws.com)." -}}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/sandbox-env/templates/_helpers.tpl
+++ b/deploy/helm/sandbox-env/templates/_helpers.tpl
@@ -327,3 +327,53 @@ Sentinel token. Priority order:
 {{- end -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+Name of the chart-managed L2 golden PV and PVC. envName-suffixed like every
+other resource here: the PV is CLUSTER-scoped, so two releases installing
+without the suffix would collide outright, and the PVC shares
+agent-sandbox-system with every other release.
+*/}}
+{{- define "sandbox-env.goldenRemoteName" -}}
+{{- printf "studio-sandbox-golden-%s" (include "sandbox-env.envName" .) -}}
+{{- end }}
+
+{{/*
+Claim the sandbox pod mounts for the L2 store. An explicit
+`depsCache.remote.pvcName` wins and nothing is rendered by
+sandbox-golden-remote.yaml — that is the escape hatch for a volume this chart
+does not manage (a different backend, or one provisioned by hand). Otherwise
+the claim is the chart's own, created alongside its PV from
+`depsCache.remote.bucketName`.
+*/}}
+{{- define "sandbox-env.goldenRemoteClaimName" -}}
+{{- if .Values.depsCache.remote.pvcName -}}
+{{- .Values.depsCache.remote.pvcName -}}
+{{- else -}}
+{{- include "sandbox-env.goldenRemoteName" . -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Validate the L2 remote block. Fail at template time rather than shipping a pod
+that cannot mount, or one that silently mounts nothing:
+  - remote without the node-local tier is incoherent: an L2 hit seeds L1 via
+    the same pendingGolden path, and the daemon reads DEPS_CACHE_ROOT either
+    way.
+  - exactly one source: a bucket for this chart to provision a PV over, or a
+    pre-existing PVC. Both set is ambiguous (which one is authoritative?),
+    neither set would render a volume with an empty claimName.
+*/}}
+{{- define "sandbox-env.validateGoldenRemote" -}}
+{{- if .Values.depsCache.remote.enabled }}
+{{- if not .Values.depsCache.enabled }}
+{{- fail "sandbox-env: depsCache.remote.enabled=true requires depsCache.enabled=true — the L2 archive restores into the node-local store, so there is nothing for it to seed otherwise." -}}
+{{- end }}
+{{- if and .Values.depsCache.remote.bucketName .Values.depsCache.remote.pvcName }}
+{{- fail "sandbox-env: set exactly one of depsCache.remote.bucketName (this chart provisions the PV/PVC over that S3 bucket) or depsCache.remote.pvcName (mount a claim this chart does not manage) — both are set, so which one is authoritative is ambiguous." -}}
+{{- end }}
+{{- if not (or .Values.depsCache.remote.bucketName .Values.depsCache.remote.pvcName) }}
+{{- fail "sandbox-env: depsCache.remote.enabled=true requires depsCache.remote.bucketName (preferred: this chart provisions the mountpoint-S3 PV/PVC) or depsCache.remote.pvcName (an existing claim). Neither is set, which would mount a volume with an empty claimName." -}}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/sandbox-env/templates/sandbox-golden-remote.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-golden-remote.yaml
@@ -1,83 +1,87 @@
-{{- if and .Values.depsCache.enabled .Values.depsCache.remote.enabled .Values.depsCache.remote.bucketName }}
+{{- if and .Values.depsCache.enabled .Values.depsCache.remote.enabled (not .Values.depsCache.remote.pvcName) }}
 {{- /*
-L2 golden archive store, exposed to sandbox pods as a statically-provisioned
-mountpoint-S3 volume.
+Claim (and, for static drivers, the volume) backing the L2 golden archive
+store.
 
-OWNED HERE, not by terraform. The bucket is a cloud resource and stays in
-terraform-eks-cluster (eks-setup/s3-sandbox-golden.tf); the PV/PVC pair is
-workload config and belongs with the pod that mounts it, for three reasons:
+OWNED HERE, not by terraform. Installing the CSI driver is infrastructure and
+stays in terraform; asking for a volume is workload config and belongs with the
+pod that mounts it, for three reasons:
 
   - `agent-sandbox-system` is shared by every release of this chart, so a
-    single namespace-wide PVC name would make prod and stg mount the same
-    bucket root — stg could publish an archive prod then restores. Names are
-    envName-suffixed like every other resource here, and each release gets its
-    own key prefix.
-  - a PVC created elsewhere is an unenforced contract: rename it there and
+    single namespace-wide claim name would make prod and stg mount the same
+    store — stg could publish an archive prod then restores. Names are
+    envName-suffixed like every other resource here, and the static path also
+    keys each release under its own prefix.
+  - a claim created elsewhere is an unenforced contract: rename it there and
     `helm template` still passes while the pod fails at mount time.
   - this chart is delivered by Argo, so a foreign-owned PVC sits outside
     self-heal, prune, and the UI next to the workload it serves.
 
-Set `depsCache.remote.pvcName` instead to point at a PVC this chart does not
-create (another backend, or a hand-provisioned volume); then nothing here
-renders.
+Two shapes, because CSI drivers differ on provisioning:
+
+  - `storageClassName` set — DYNAMIC. Only the PVC is rendered; the
+    provisioner creates the volume. Cloud-agnostic, and the right shape when
+    self-hosting: bring any RWX driver, this template never names it.
+  - otherwise — STATIC, from `volume.*`. Required for drivers with no dynamic
+    provisioner. mountpoint-S3 is one, which is why it's the default here:
+    there is no StorageClass to claim against, so the PV must be declared.
 */ -}}
+{{- $r := .Values.depsCache.remote -}}
+{{- $name := include "sandbox-env.goldenRemoteName" . -}}
+{{- $dynamic := ne (default "" $r.storageClassName) "" -}}
+{{- if not $dynamic }}
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: {{ include "sandbox-env.goldenRemoteName" . }}
+  name: {{ $name }}
   labels:
     {{- include "sandbox-env.labels" . | nindent 4 }}
 spec:
   capacity:
-    # Ignored by mountpoint (S3 is unbounded); required by the PV schema.
-    storage: {{ .Values.depsCache.remote.capacity }}
+    # Ignored by object-store drivers; required by the schema.
+    storage: {{ $r.capacity }}
   accessModes:
     - ReadWriteMany
-  # The bucket outlives any release: reclaiming would only delete the PV
-  # object, but Retain also keeps a released PV from being recycled by an
-  # unrelated claim.
+  # The store outlives any release. Retain also keeps a released PV from
+  # being recycled by an unrelated claim.
   persistentVolumeReclaimPolicy: Retain
   # Empty (not absent) so no default StorageClass is injected and the claim
   # binds statically by volumeName.
   storageClassName: ""
+  {{- with $r.volume.mountOptions }}
+  # Driver-specific syntax — see the annotated defaults in values.yaml. Each
+  # entry goes through `tpl` so it can reference chart helpers (the default
+  # `prefix` uses envName for per-release key isolation).
   mountOptions:
-    # Read-only at the MOUNT, not only at the pod's volumeMount below —
-    # defence in depth if a consumer ever forgets `readOnly: true`.
-    - read-only
-    # Mountpoint synthesises ownership: without these, every object presents
-    # as root-owned and the sandbox uid cannot open it. Publish is best-effort
-    # and swallows the resulting EACCES, so the failure surfaces as "the cache
-    # never hits" rather than as a permission error. Verified the hard way.
-    #
-    # Must track the sandbox pod's securityContext in sandbox-template.yaml,
-    # which pins runAsUser/runAsGroup to 1000.
-    - uid=1000
-    - gid=1000
-    # Required for a non-root process to touch a FUSE mount it did not create.
-    - allow-other
-    # Per-release key prefix, so releases sharing agent-sandbox-system cannot
-    # read or overwrite each other's archives. Trailing slash is significant.
-    - prefix={{ include "sandbox-env.envName" . }}/
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
   csi:
-    driver: s3.csi.aws.com
+    driver: {{ $r.volume.driver | quote }}
     # An identifier, not a path — must be unique per PV in the cluster.
-    volumeHandle: {{ include "sandbox-env.goldenRemoteName" . }}
+    volumeHandle: {{ $name }}
     volumeAttributes:
-      bucketName: {{ .Values.depsCache.remote.bucketName | quote }}
+      {{- toYaml $r.volume.attributes | nindent 6 }}
 ---
+{{- end }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ include "sandbox-env.goldenRemoteName" . }}
+  name: {{ $name }}
   namespace: agent-sandbox-system
   labels:
     {{- include "sandbox-env.labels" . | nindent 4 }}
 spec:
   accessModes:
     - ReadWriteMany
+  {{- if $dynamic }}
+  storageClassName: {{ $r.storageClassName | quote }}
+  {{- else }}
+  # Empty + volumeName: bind to this chart's PV above, never to a default
+  # StorageClass.
   storageClassName: ""
-  volumeName: {{ include "sandbox-env.goldenRemoteName" . }}
+  volumeName: {{ $name }}
+  {{- end }}
   resources:
     requests:
-      storage: {{ .Values.depsCache.remote.capacity }}
+      storage: {{ $r.capacity }}
 {{- end }}

--- a/deploy/helm/sandbox-env/templates/sandbox-golden-remote.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-golden-remote.yaml
@@ -1,0 +1,83 @@
+{{- if and .Values.depsCache.enabled .Values.depsCache.remote.enabled .Values.depsCache.remote.bucketName }}
+{{- /*
+L2 golden archive store, exposed to sandbox pods as a statically-provisioned
+mountpoint-S3 volume.
+
+OWNED HERE, not by terraform. The bucket is a cloud resource and stays in
+terraform-eks-cluster (eks-setup/s3-sandbox-golden.tf); the PV/PVC pair is
+workload config and belongs with the pod that mounts it, for three reasons:
+
+  - `agent-sandbox-system` is shared by every release of this chart, so a
+    single namespace-wide PVC name would make prod and stg mount the same
+    bucket root — stg could publish an archive prod then restores. Names are
+    envName-suffixed like every other resource here, and each release gets its
+    own key prefix.
+  - a PVC created elsewhere is an unenforced contract: rename it there and
+    `helm template` still passes while the pod fails at mount time.
+  - this chart is delivered by Argo, so a foreign-owned PVC sits outside
+    self-heal, prune, and the UI next to the workload it serves.
+
+Set `depsCache.remote.pvcName` instead to point at a PVC this chart does not
+create (another backend, or a hand-provisioned volume); then nothing here
+renders.
+*/ -}}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "sandbox-env.goldenRemoteName" . }}
+  labels:
+    {{- include "sandbox-env.labels" . | nindent 4 }}
+spec:
+  capacity:
+    # Ignored by mountpoint (S3 is unbounded); required by the PV schema.
+    storage: {{ .Values.depsCache.remote.capacity }}
+  accessModes:
+    - ReadWriteMany
+  # The bucket outlives any release: reclaiming would only delete the PV
+  # object, but Retain also keeps a released PV from being recycled by an
+  # unrelated claim.
+  persistentVolumeReclaimPolicy: Retain
+  # Empty (not absent) so no default StorageClass is injected and the claim
+  # binds statically by volumeName.
+  storageClassName: ""
+  mountOptions:
+    # Read-only at the MOUNT, not only at the pod's volumeMount below —
+    # defence in depth if a consumer ever forgets `readOnly: true`.
+    - read-only
+    # Mountpoint synthesises ownership: without these, every object presents
+    # as root-owned and the sandbox uid cannot open it. Publish is best-effort
+    # and swallows the resulting EACCES, so the failure surfaces as "the cache
+    # never hits" rather than as a permission error. Verified the hard way.
+    #
+    # Must track the sandbox pod's securityContext in sandbox-template.yaml,
+    # which pins runAsUser/runAsGroup to 1000.
+    - uid=1000
+    - gid=1000
+    # Required for a non-root process to touch a FUSE mount it did not create.
+    - allow-other
+    # Per-release key prefix, so releases sharing agent-sandbox-system cannot
+    # read or overwrite each other's archives. Trailing slash is significant.
+    - prefix={{ include "sandbox-env.envName" . }}/
+  csi:
+    driver: s3.csi.aws.com
+    # An identifier, not a path — must be unique per PV in the cluster.
+    volumeHandle: {{ include "sandbox-env.goldenRemoteName" . }}
+    volumeAttributes:
+      bucketName: {{ .Values.depsCache.remote.bucketName | quote }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "sandbox-env.goldenRemoteName" . }}
+  namespace: agent-sandbox-system
+  labels:
+    {{- include "sandbox-env.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  volumeName: {{ include "sandbox-env.goldenRemoteName" . }}
+  resources:
+    requests:
+      storage: {{ .Values.depsCache.remote.capacity }}
+{{- end }}

--- a/deploy/helm/sandbox-env/templates/sandbox-template.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-template.yaml
@@ -384,7 +384,7 @@ spec:
         {{- if .Values.depsCache.remote.enabled }}
         - name: golden-remote
           persistentVolumeClaim:
-            claimName: {{ required "depsCache.remote.pvcName is required when depsCache.remote.enabled" .Values.depsCache.remote.pvcName }}
+            claimName: {{ include "sandbox-env.goldenRemoteClaimName" . }}
             readOnly: true
         {{- end }}
         {{- end }}

--- a/deploy/helm/sandbox-env/templates/validations.yaml
+++ b/deploy/helm/sandbox-env/templates/validations.yaml
@@ -13,6 +13,7 @@ only really matters for Helm's own bookkeeping.
 {{- include "sandbox-env.validateWarmPoolAutoscaling" . -}}
 {{- include "sandbox-env.validateWarmPoolSize" . -}}
 {{- include "sandbox-env.validateNodePlaceholder" . -}}
+{{- include "sandbox-env.validateGoldenRemote" . -}}
 {{- /* Force envName validation to run at template time even when no
 resource references it directly (pure-validation render). Discard the
 return value into a local so it doesn't leak into the rendered YAML. */ -}}

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -379,18 +379,67 @@ depsCache:
   # pays one full install and republishes.
   remote:
     enabled: false
-    # S3 bucket holding the archives — the `sandbox_golden_bucket` output of
-    # the terraform above. This chart then provisions the mountpoint-S3 PV
-    # and its PVC (see templates/sandbox-golden-remote.yaml), named per
-    # release so they can coexist in agent-sandbox-system.
+    mountPath: /golden-cache
+    # Ignored by object-store CSI drivers (the store is unbounded) but
+    # required by the PV and PVC schemas, and the claim's request must not
+    # exceed the volume's capacity.
+    capacity: 1200Gi
+
+    # ── where the volume comes from: pick exactly ONE of the three ──────
     #
-    # Mounted read-only and whole-volume: warm-pool pods are bound before
-    # they know their repo, so a per-repo subPath can't be picked at mount
-    # time. The daemon reads only its own <repoHash>/ prefix by convention.
-    bucketName: ""
-    # Escape hatch: mount a claim this chart does NOT manage (another
-    # backend, or one provisioned by hand). Mutually exclusive with
-    # bucketName; when set, no PV/PVC is rendered here.
+    # Mounted read-only and whole-volume in every case: warm-pool pods are
+    # bound before they know their repo, so a per-repo subPath can't be
+    # picked at mount time. The daemon reads only its own <repoHash>/ prefix
+    # by convention, not by enforcement (see CROSS-REPO READS above).
+
+    # (1) DYNAMIC — the chart renders only a PVC and lets your provisioner
+    # create the volume. The idiomatic path when self-hosting: install
+    # whichever RWX CSI driver you run (EFS, gcsfuse, Azure Blob, NFS,
+    # JuiceFS, ...), create a StorageClass, name it here, and this chart
+    # stays cloud-agnostic. Nothing below is used.
+    storageClassName: ""
+
+    # (2) STATIC — the chart renders a PV *and* its PVC. Needed for drivers
+    # with no dynamic provisioner, which is the AWS case: mountpoint-S3 is
+    # static-provisioning only, so there is no StorageClass to claim against
+    # and the PV has to be declared. Active when `attributes` is non-empty.
+    #
+    # Both objects are named per release and, via the default `prefix`
+    # option, keyed per release — so two environments sharing
+    # agent-sandbox-system cannot read or overwrite each other's archives.
+    volume:
+      driver: s3.csi.aws.com
+      # Verbatim into the PV's csi.volumeAttributes. For mountpoint-S3 that
+      # is the bucket from terraform (`sandbox_golden_bucket` output).
+      attributes: {}
+        # bucketName: eks-serverless-sandbox-golden
+      #
+      # These defaults are MOUNTPOINT-S3 SYNTAX. For any other driver,
+      # replace the list wholesale — option names are not portable. Each
+      # entry is passed through `tpl`, so chart helpers are available.
+      #
+      # Why each one is load-bearing:
+      #   read-only     at the mount, not only at the pod's volumeMount, so
+      #                 a consumer that forgets `readOnly: true` still can't
+      #                 write.
+      #   uid/gid 1000  mountpoint synthesises ownership; without these every
+      #                 object reads as root-owned and the sandbox uid cannot
+      #                 open it. Publish is best-effort and swallows the
+      #                 EACCES, so the symptom is "the cache never hits", not
+      #                 a permission error. Must track the pod
+      #                 securityContext in sandbox-template.yaml.
+      #   allow-other   required for a non-root process to touch a FUSE
+      #                 mount it did not create.
+      #   prefix        per-release key isolation (trailing slash matters).
+      mountOptions:
+        - read-only
+        - uid=1000
+        - gid=1000
+        - allow-other
+        - prefix={{ include "sandbox-env.envName" . }}/
+
+    # (3) EXISTING CLAIM — mount a PVC this chart neither creates nor
+    # manages. Nothing above is used.
     #
     # PROVISION THAT VOLUME'S ROOT YOURSELF — this chart cannot. A freshly
     # provisioned volume comes up root-owned, and nothing here can fix it:
@@ -399,12 +448,9 @@ depsCache:
     # trusted writer must be able to create `<mountPath>/golden/`. Verified
     # the hard way — publish fails with `EACCES: mkdir '/golden-cache/golden'`
     # and, publish being best-effort, every restore then misses silently and
-    # forever. (The bucketName path handles this via mountOptions instead.)
+    # forever. Paths (1) and (2) handle ownership for you: (2) via
+    # mountOptions, (1) via your StorageClass / access point.
     pvcName: ""
-    mountPath: /golden-cache
-    # Ignored by mountpoint (S3 is unbounded) but required by the PV and PVC
-    # schemas, and the claim's request must not exceed the volume's capacity.
-    capacity: 1200Gi
 
 # ── sentinel token ─────────────────────────────────────────────────────
 sentinel:

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -327,10 +327,18 @@ depsCache:
   # ── L2: cross-node golden archive (opt-in, off) ──────────────────────
   # The golden above is NODE-LOCAL: it only hits when the pod lands on a
   # node already warm for its repo. This tier removes that dependency by
-  # keeping a per-(repo, lockfile) tar.zst on an RWX volume (EFS), so any
-  # node in any zone can restore it. Requires `zstd` in the sandbox image.
+  # keeping a per-(repo, lockfile) tar.zst on an RWX volume, so any node in
+  # any zone can restore it. Requires `zstd` in the sandbox image.
   #
-  # STORE A TARBALL, NEVER MOUNT node_modules HERE. EFS/NFS charges
+  # Backed by S3 through the mountpoint CSI driver, not EFS: the tier stores
+  # one large blob and adding an EFS addon would have cost a filesystem, a
+  # mount target per AZ, a security group and ~13x the per-GB price, while
+  # `aws-mountpoint-s3-csi-driver` is already installed on the sandbox
+  # cluster. The bucket itself is a cloud resource and lives in terraform
+  # (decocms/terraform-eks-cluster eks-setup/s3-sandbox-golden.tf); pass its
+  # name as `bucketName` below and this chart provisions the PV/PVC over it.
+  #
+  # STORE A TARBALL, NEVER MOUNT node_modules HERE. A blob store charges
   # per-operation metadata latency: fatal across ~100k small files, a
   # non-issue for one large sequential blob. The per-file cost is paid by
   # the local extract.
@@ -353,36 +361,50 @@ depsCache:
   # tenant can tamper with. What flips that: a repo installing from a private
   # registry ships proprietary package source inside node_modules, which this
   # store would then expose fleet-wide. Do not enable remote for such repos
-  # without per-repo enforcement (an EFS access point per repo — which needs
-  # the repo known at mount time, i.e. it costs the warm pool).
+  # without per-repo enforcement (which needs the repo known at mount time,
+  # i.e. it costs the warm pool).
   #
-  # GROWTH: bounded, unlike the two caches above — the daemon prunes each
-  # repo's archives after a successful publish (untouched >7d, then newest 5
-  # kept; a restore touches mtime so a live lockfile never ages out). But
-  # prune runs only where publish does, and the tenant mount is read-only —
-  # so until a trusted writer exists NOTHING prunes, and a filesystem
-  # lifecycle policy is the only reaper.
+  # Cross-RELEASE reads are NOT possible, though: each release mounts the
+  # bucket under its own `prefix=<envName>/`, so stg cannot publish an
+  # archive that prod then restores.
+  #
+  # GROWTH: the daemon prunes each repo's archives after a successful publish
+  # (untouched >7d, then newest 5 kept) — but prune runs only where publish
+  # does, and the tenant mount is read-only, so until a trusted writer exists
+  # NOTHING prunes from here. The bucket's own lifecycle policy is the only
+  # reaper, and on mountpoint it is the only one that CAN be: there is no
+  # utimes, so the mtime-touch that keeps a live lockfile from ageing out
+  # elsewhere does not work. Expiry counts from object creation, so an archive
+  # in active use still expires (14d in terraform today) and the next boot
+  # pays one full install and republishes.
   remote:
     enabled: false
-    # Existing RWX PVC backed by the shared filesystem. Required when
-    # enabled. Mounted read-only; the daemon reads only its own
-    # <repoHash>/ prefix. Whole-volume (not a per-repo subPath) because
-    # warm-pool pods are bound before they know their repo.
+    # S3 bucket holding the archives — the `sandbox_golden_bucket` output of
+    # the terraform above. This chart then provisions the mountpoint-S3 PV
+    # and its PVC (see templates/sandbox-golden-remote.yaml), named per
+    # release so they can coexist in agent-sandbox-system.
+    #
+    # Mounted read-only and whole-volume: warm-pool pods are bound before
+    # they know their repo, so a per-repo subPath can't be picked at mount
+    # time. The daemon reads only its own <repoHash>/ prefix by convention.
+    bucketName: ""
+    # Escape hatch: mount a claim this chart does NOT manage (another
+    # backend, or one provisioned by hand). Mutually exclusive with
+    # bucketName; when set, no PV/PVC is rendered here.
+    #
+    # PROVISION THAT VOLUME'S ROOT YOURSELF — this chart cannot. A freshly
+    # provisioned volume comes up root-owned, and nothing here can fix it:
+    # the tenant mount is read-only by design and fsGroup does not apply. So
+    # uid 1000 must already be able to traverse and read the root, and the
+    # trusted writer must be able to create `<mountPath>/golden/`. Verified
+    # the hard way — publish fails with `EACCES: mkdir '/golden-cache/golden'`
+    # and, publish being best-effort, every restore then misses silently and
+    # forever. (The bucketName path handles this via mountOptions instead.)
     pvcName: ""
     mountPath: /golden-cache
-    #
-    # PROVISION THE VOLUME'S ROOT DIRECTORY YOURSELF — this chart cannot.
-    # A freshly-provisioned volume comes up root-owned, and nothing here can
-    # fix that: the tenant mount is read-only by design, and fsGroup does not
-    # apply to it. So the sandbox uid (1000) must already be able to traverse
-    # and read the root, and the trusted writer must be able to create
-    # `<mountPath>/golden/`. Verified the hard way on a bare RWX volume —
-    # publish fails with `EACCES: mkdir '/golden-cache/golden'` and every
-    # restore then misses, silently, forever.
-    #
-    # On EFS that means an access point with a RootDirectory CreationInfo
-    # granting uid/gid 1000 (or 0755 with a readable path), not the
-    # filesystem root.
+    # Ignored by mountpoint (S3 is unbounded) but required by the PV and PVC
+    # schemas, and the claim's request must not exceed the volume's capacity.
+    capacity: 1200Gi
 
 # ── sentinel token ─────────────────────────────────────────────────────
 sentinel:


### PR DESCRIPTION
`depsCache.remote` now **asks** for a volume instead of having one handed over by terraform. Chart `0.11.0`. Still default off.

Infra side: decocms/terraform-eks-cluster#92 (merged) removes the four `kubectl_manifest` resources and keeps the bucket.

## Why move them here

Those objects were created by terraform (decocms/terraform-eks-cluster#88) under one namespace-wide name, `sandbox-golden-ro`. `agent-sandbox-system` holds a release per environment, so that made prod and stg mount **the same store root** — stg could publish an archive that prod then restored, and stg is where broken builds live. Only this chart knows the release, so only this chart can name the objects apart and scope their keys.

It also closes an unenforced contract: `pvcName` pointed at an object this chart did not own, so a rename on the terraform side left `helm template` passing while the pod failed at mount time. And since this chart is delivered by Argo, a foreign-owned PVC sat outside self-heal, prune, and the UI next to the workload it serves.

The split is now clean: **installing a CSI driver is infrastructure; asking for a volume is workload config.**

## Three sources, exactly one

| value | chart renders | when |
|---|---|---|
| `storageClassName` | PVC only | driver with dynamic provisioning — **the self-host path** |
| `volume.{driver,attributes,mountOptions}` | PV + PVC | driver with no provisioner — the AWS path, default |
| `pvcName` | nothing | a claim managed elsewhere |

**Why the static path has to exist.** mountpoint-S3 is static-provisioning only — the cluster has no StorageClass for `s3.csi.aws.com` and the driver ships no provisioner, so there is nothing to claim against and the PV must be declared by hand. The PV is what names the driver, which is the one genuinely cloud-specific part of the whole feature; everything else was already agnostic (the daemon writes a tarball to a path via `GOLDEN_CACHE_REMOTE`).

**Why the dynamic path is the self-host answer.** It renders only a PVC, so nothing in the template names a cloud. Bring EFS, gcsfuse, Azure Blob, NFS CSI, JuiceFS — install the driver, create a StorageClass, name it here.

Two sources set fails the render as ambiguous authority. None set fails too, rather than emitting a PVC with neither a StorageClass nor a `volumeName` — that would sit `Pending` forever with no obvious cause. (Previously the `required` on `pvcName` covered this; dropping it without a replacement would have regressed into a silent failure.)

## mountOptions are load-bearing, and not portable

Mountpoint synthesises ownership, so a PV without `uid=1000` / `gid=1000` presents every object as root-owned and the sandbox uid cannot open it. Publish is best-effort and swallows the resulting `EACCES`, so the symptom is "the cache never hits" rather than a permission error — this already cost a debug cycle on the terraform version. `allow-other` is required for a non-root process to touch a FUSE mount it didn't create. `read-only` is set at the mount as well as at the pod's `volumeMount`, so a consumer that forgets `readOnly: true` still cannot write.

Option *names* are per-driver, though, so the defaults are documented as mountpoint syntax and meant to be replaced wholesale rather than extended. Each entry passes through `tpl`, so a driver can express per-release scoping in its own syntax — the default is `prefix={{ envName }}/`, which is what stops two releases from reading each other's archives.

uid/gid are hardcoded to 1000 with a comment tracking the pod `securityContext` in `sandbox-template.yaml`, which hardcodes them too. Not worth a value until something needs to disagree.

## Docs refresh

The `depsCache.remote` block still described EFS throughout, and claimed the daemon's prune keeps a live lockfile alive because "a restore touches mtime". True on EFS, false on mountpoint — there is no `utimes`, so the store's own lifecycle policy is the only reaper and an archive in active use still expires (14d in terraform today), costing one cold install before it republishes.

Kept as-is: the CROSS-REPO READS note. That trade-off was already stated and accepted, and this change doesn't move it — the mount still exposes the whole store, because warm-pool pods are bound before they know their repo. What it does add is that cross-*release* reads are now impossible.

## Verification

`helm template`, every path:

| case | result |
|---|---|
| default (off) | nothing rendered |
| static, `envName=prod` | PV + PVC `studio-sandbox-golden-prod`, `driver: s3.csi.aws.com`, bucket, `prefix=prod/` |
| static, `envName=stg` | `studio-sandbox-golden-stg`, `prefix=stg/` — distinct from prod |
| dynamic | PVC only, `storageClassName: "efs-sc"`, **no driver named anywhere** |
| `pvcName` | neither rendered, `claimName: legacy` |

All four validation failures produce their intended message: remote without `depsCache.enabled`, two sources, zero sources, `attributes` without `driver`. `helm lint` clean.

**Not validated on a real pod.** Enabling this is gated on a first mountpoint mount actually working on the sandbox NodePool — that pool carries `decocms.com/sandbox=true:NoSchedule`, and no mountpoint volume has ever been mounted in that cluster (the `mount-s3` namespace is empty), so whether the driver's Mountpoint Pod tolerates the taint is unverified. That test comes before flipping `enabled`, not in this PR.