### PR TITLE
fix(sandbox): re-point a thread at a live GitHub connection when its own is gone

### DIFF
--- a/apps/api/src/tools/sandbox/thread-repo.test.ts
+++ b/apps/api/src/tools/sandbox/thread-repo.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 import type { GithubRepo } from "@decocms/shared/sdk";
 import {
+  repointedRepoBinding,
   resolveSandboxBranch,
   syntheticBranchToGitRef,
   threadBranch,
@@ -154,4 +155,69 @@ test("a repo-less run pinned to its own bare key does not join the ephemeral poo
       runBranch: "thread:t1",
     }),
   ).toBe("thread:t1");
+});
+
+const DEAD_REPO: GithubRepo = {
+  url: "https://github.com/deco-sites/demo-storefront",
+  owner: "deco-sites",
+  name: "demo-storefront",
+  connectionId: "conn_dead",
+  installationId: 1,
+};
+
+const repoConnection = (
+  id: string,
+  owner: string,
+  repo: string,
+  extra: Record<string, unknown> = {},
+) => ({
+  id,
+  status: "active",
+  metadata: {
+    repoScope: {
+      owner,
+      repo,
+      installationId: 42,
+      permissions: { contents: "write" },
+    },
+    ...extra,
+  },
+});
+
+test("repointedRepoBinding picks a live connection for the same repo", () => {
+  const healed = repointedRepoBinding(DEAD_REPO, [
+    repoConnection("conn_other", "deco-sites", "another-site"),
+    repoConnection("conn_live", "deco-sites", "demo-storefront"),
+  ]);
+  expect(healed).toEqual({
+    ...DEAD_REPO,
+    connectionId: "conn_live",
+    installationId: 42,
+  });
+});
+
+test("repointedRepoBinding prefers the org-shared connection", () => {
+  const healed = repointedRepoBinding(DEAD_REPO, [
+    repoConnection("conn_agent", "deco-sites", "demo-storefront"),
+    repoConnection("conn_shared", "deco-sites", "demo-storefront", {
+      orgShared: true,
+    }),
+  ]);
+  expect(healed?.connectionId).toBe("conn_shared");
+});
+
+test("repointedRepoBinding returns null when nothing matches the repo", () => {
+  expect(
+    repointedRepoBinding(DEAD_REPO, [
+      repoConnection("conn_other", "deco-sites", "another-site"),
+    ]),
+  ).toBeNull();
+});
+
+test("repointedRepoBinding is a no-op when the binding is already live", () => {
+  expect(
+    repointedRepoBinding(DEAD_REPO, [
+      repoConnection("conn_dead", "deco-sites", "demo-storefront"),
+    ]),
+  ).toBeNull();
 });

--- a/apps/api/src/tools/sandbox/thread-repo.ts
+++ b/apps/api/src/tools/sandbox/thread-repo.ts
@@ -18,6 +18,10 @@ import type {
 } from "@decocms/shared/sdk";
 import type { SandboxProviderKind } from "@decocms/sandbox/provider";
 import {
+  findReusableRepoConnection,
+  getRepoScope,
+} from "@decocms/shared/github-repo-scope";
+import {
   deleteSandboxMapEntry,
   mergeSandboxMapEntry,
   readSandboxMap,
@@ -158,13 +162,82 @@ export async function setThreadHeadRef(
     .catch((err) => console.warn("[thread-repo] setThreadHeadRef failed", err));
 }
 
-/** Read the repo bound to a thread, or null. Never throws. */
+/**
+ * The repo binding to use when the one recorded on the thread points at a
+ * connection that is gone, or null when nothing in the org can stand in.
+ *
+ * Repo connections are not immortal: deleting the agent that owned one tears
+ * it down (`VIRTUAL_MCP_DELETE`), and re-importing a repo mints a new id. A
+ * thread pinned to the dead id can never boot a sandbox again even though the
+ * org still has a perfectly good connection for the same repository — so
+ * re-point it at that one instead. Pure so the choice is testable without a DB.
+ */
+export function repointedRepoBinding(
+  repo: GithubRepo,
+  connections: {
+    id: string;
+    status?: string;
+    metadata: Record<string, unknown> | null;
+  }[],
+): GithubRepo | null {
+  const replacement = findReusableRepoConnection(
+    connections,
+    repo.owner,
+    repo.name,
+  );
+  if (!replacement || replacement.id === repo.connectionId) return null;
+  const scope = getRepoScope(replacement);
+  return {
+    ...repo,
+    connectionId: replacement.id,
+    ...(scope?.installationId ? { installationId: scope.installationId } : {}),
+  };
+}
+
+/**
+ * Read the repo bound to a thread, or null. Never throws.
+ *
+ * Self-heals a dangling `connectionId` (see {@link repointedRepoBinding}) and
+ * persists the repoint, so every consumer — sandbox provisioning, the fs tools,
+ * dispatch — agrees on the live connection. When no replacement exists the
+ * dead binding is returned untouched and SANDBOX_START fails with
+ * `GITHUB_CONNECTION_MISSING`, which tells the user to link the repo again.
+ *
+ * Note: the sandbox branch embeds the connection id (`threadBranch`), so a
+ * repoint yields a fresh sandbox. The old one was unusable anyway.
+ */
 export async function getThreadGithubRepo(
   ctx: StudioContext,
   threadId: string | undefined | null,
 ): Promise<GithubRepo | null> {
   const meta = await getThreadMeta(ctx, threadId);
-  return (meta as { githubRepo?: GithubRepo } | null)?.githubRepo ?? null;
+  const repo = (meta as { githubRepo?: GithubRepo } | null)?.githubRepo ?? null;
+  if (!threadId || !meta || !repo?.connectionId) return repo;
+
+  try {
+    // The org the thread was just read under — `ctx.organization` is unset on
+    // some dispatch paths, this binding never is.
+    const orgId = ctx.storage.threads.getOrganizationId();
+    if (!orgId) return repo;
+    if (await ctx.storage.connections.findById(repo.connectionId, orgId)) {
+      return repo;
+    }
+    const { items } = await ctx.storage.connections.list(orgId);
+    const repointed = repointedRepoBinding(repo, items);
+    if (!repointed) return repo;
+    await ctx.storage.threads.update(threadId, {
+      metadata: { ...meta, githubRepo: repointed },
+    });
+    console.warn("[thread-repo] re-pointed thread at a live repo connection", {
+      threadId,
+      from: repo.connectionId,
+      to: repointed.connectionId,
+    });
+    return repointed;
+  } catch (err) {
+    console.warn("[thread-repo] repoint check failed", err);
+    return repo;
+  }
 }
 
 /**


### PR DESCRIPTION
Stacked on #5807 (merge that first; this PR's base is its branch).

## Problem

`threads.metadata.githubRepo.connectionId` pins a specific mcp-github connection, but those aren't immortal:

- `VIRTUAL_MCP_DELETE` tears down the agent's repo-scoped child connection;
- re-importing a repo mints a **new** connection id.

Either way every thread pinned to the old id is permanently un-startable, even when the org still has a perfectly good connection for the *same repository*. Prod today: **152 threads** reference a connection id that no longer exists (e.g. `thrd_sUNCH2u3kuYEdSE4mb5Ca` → `conn_JLu7_P8GYpTVtsx6sUHQ_`).

## Change

`getThreadGithubRepo` — the single read every consumer goes through (sandbox provisioning, fs tools, dispatch) — now, when the pinned connection is missing:

1. looks for a live connection granting the same `owner/repo` via the existing `findReusableRepoConnection` (org-shared wins, same rule as import);
2. returns the re-pointed binding and persists it to the thread metadata;
3. falls back to the dead binding untouched when nothing matches, so the user still gets `GITHUB_CONNECTION_MISSING` (#5807) telling them to link the repo again.

Best-effort: any failure logs and returns the original binding. The choice itself is a pure function, `repointedRepoBinding`.

Note: the sandbox branch embeds the connection id (`threadBranch`), so a repoint yields a fresh sandbox — the old one was unusable anyway.

## Testing

- 4 new unit tests on `repointedRepoBinding` (match, org-shared preference, no match, already-live no-op)
- `bun run check`, `bun run fmt`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically re-points a thread’s GitHub repo binding to a live connection for the same owner/repo when its pinned `connectionId` no longer exists, and persists the fix. Falls back to the original binding so users still see `GITHUB_CONNECTION_MISSING` when no replacement is available.

- **Bug Fixes**
  - Added `repointedRepoBinding` to pick a live repo connection (prefers org-shared via `findReusableRepoConnection`) and update `getThreadGithubRepo`.
  - Persist the new binding in thread metadata so sandbox, fs tools, and dispatch all use the same live connection; repointing yields a fresh sandbox branch.
  - Best‑effort behavior: on errors or no match, keep the old binding and surface `GITHUB_CONNECTION_MISSING`.
  - Added 4 unit tests for `repointedRepoBinding` (match, org-shared preference, no match, already-live no-op).

<sup>Written for commit b5dc1a59ffb15fc215d75ecc6867a90af90b32be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

