### PR TITLE
fix(thread): add aria-label to icon-only GitHub header action buttons

### DIFF
--- a/apps/web/src/components/thread/github/header-actions.tsx
+++ b/apps/web/src/components/thread/github/header-actions.tsx
@@ -529,6 +529,7 @@ function HeaderButtonRenderer(props: {
           size="sm"
           variant={button.variant}
           disabled={disabled}
+          aria-label={button.label}
           // Only anchor the tour's "submit for review" step when the button is
           // actually in that state. In neutral states (e.g. "Up to date", which
           // is disabled and has no action) the step would point at an unrelated
@@ -567,6 +568,7 @@ function HeaderButtonRenderer(props: {
             data-tour={TOUR_ANCHORS.publish}
             disabled={props.githubActionPending || !props.publishGate.allowed}
             onClick={props.onPublishSide}
+            aria-label={t("thread.headerActions.publish")}
           >
             {props.publishGate.pending ? (
               <Spinner size="xs" variant="default" />
@@ -599,7 +601,13 @@ function SyncButton({
 }) {
   return (
     <WithTooltip label={t("thread.headerActions.syncTooltip")}>
-      <Button size="sm" variant="default" disabled={busy} onClick={onClick}>
+      <Button
+        size="sm"
+        variant="default"
+        disabled={busy}
+        onClick={onClick}
+        aria-label={t("thread.headerActions.sync")}
+      >
         <RefreshCw01 className="size-4 shrink-0 @3xl/panel-header:hidden" />
         <span className="@max-3xl/panel-header:hidden">
           {t("thread.headerActions.sync")}


### PR DESCRIPTION
The GitHub-thread header action buttons (primary next-action button, Sync button, and the persistent green Publish button) collapse to icon-only below `@3xl/panel-header` width — their text `<span>` gets `@max-3xl/panel-header:hidden`, which is `display:none`, removing it from the accessibility tree entirely. On narrow panels these buttons had no accessible name at all (a screen reader announces just "button"); the tooltip doesn't supply one since Radix tooltips attach `aria-describedby`, not a label.

**Fix**: add `aria-label` (using the same translated label already shown as text) to all three buttons in `header-actions.tsx`, so the accessible name survives the icon-only collapse.

**How to verify**: `bunx tsc --noEmit` in `apps/web`, `bunx oxlint apps/web/src/components/thread/github/header-actions.tsx` — both clean. No behavior change otherwise (labels are cosmetic-hidden already; this only restores the a11y name).

Locally ran: `bun run fmt`, targeted `tsc --noEmit`, and `oxlint` on the changed file. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add aria-labels to the icon-only GitHub thread header buttons so they keep accessible names when text is hidden on narrow panels. Screen readers now announce correct labels for the next-action, Sync, and Publish buttons; no behavior change.

<sup>Written for commit 78865c72ce1a1d3d00bfd2f24af3c34097c32e9a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

