### PR TITLE
i18n(commerce-onboarding): translate saved-config field labels

### DIFF
--- a/apps/web/src/i18n/en/commerce-onboarding.ts
+++ b/apps/web/src/i18n/en/commerce-onboarding.ts
@@ -1,4 +1,9 @@
 export const commerceOnboarding = {
+  "commerceOnboarding.companionCard.configField.accountName": "Account name",
+  "commerceOnboarding.companionCard.configField.appKey": "App Key",
+  "commerceOnboarding.companionCard.configField.appToken": "App Token",
+  "commerceOnboarding.companionCard.configField.propertyId": "Property",
+  "commerceOnboarding.companionCard.configField.siteUrl": "Site",
   "commerceOnboarding.companionCard.configure": "Configure",
   "commerceOnboarding.companionCard.configureAriaLabel": "Configure {title}",
   "commerceOnboarding.companionCard.configureDescription":

--- a/apps/web/src/i18n/pt-br/commerce-onboarding.ts
+++ b/apps/web/src/i18n/pt-br/commerce-onboarding.ts
@@ -1,6 +1,11 @@
 import type { commerceOnboarding as commerceOnboardingEn } from "../en/commerce-onboarding.ts";
 
 export const commerceOnboarding = {
+  "commerceOnboarding.companionCard.configField.accountName": "Nome da conta",
+  "commerceOnboarding.companionCard.configField.appKey": "App Key",
+  "commerceOnboarding.companionCard.configField.appToken": "App Token",
+  "commerceOnboarding.companionCard.configField.propertyId": "Propriedade",
+  "commerceOnboarding.companionCard.configField.siteUrl": "Site",
   "commerceOnboarding.companionCard.configure": "Configurar",
   "commerceOnboarding.companionCard.configureAriaLabel": "Configurar {title}",
   "commerceOnboarding.companionCard.configureDescription":

--- a/apps/web/src/routes/commerce-onboarding/companion-card.tsx
+++ b/apps/web/src/routes/commerce-onboarding/companion-card.tsx
@@ -437,6 +437,7 @@ function CompanionConfiguration({
   const FormComponent = COMPANION_CONFIG_FORMS[card.bindingType];
   const savedConfigEntries = getConfigurationSummaryEntries(
     card.configurationState,
+    t,
   );
 
   const closeDialog = () => {

--- a/apps/web/src/routes/commerce-onboarding/companions-core.test.ts
+++ b/apps/web/src/routes/commerce-onboarding/companions-core.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, it } from "bun:test";
+import { en } from "@/i18n/en/index.ts";
+import { interpolate, type InterpolationVars } from "@/i18n/interpolate.ts";
 import {
   buildCompanionCards,
   buildRegistryWhere,
@@ -79,27 +81,36 @@ describe("mergeBindingValue", () => {
   });
 });
 
+const t = (key: keyof typeof en, vars?: InterpolationVars) =>
+  interpolate(en[key], vars);
+
 describe("getConfigurationSummaryEntries", () => {
   it("returns displayable non-empty config entries and hides internal fields", () => {
     expect(
-      getConfigurationSummaryEntries({
-        __type: "vtex",
-        accountName: "electrolux",
-        propertyId: null,
-        currency: "",
-      }),
+      getConfigurationSummaryEntries(
+        {
+          __type: "vtex",
+          accountName: "electrolux",
+          propertyId: null,
+          currency: "",
+        },
+        t,
+      ),
     ).toEqual([
-      { key: "accountName", label: "Nome da conta", value: "electrolux" },
+      { key: "accountName", label: "Account name", value: "electrolux" },
     ]);
   });
 
   it("humanizes keys with no curated label (camelCase and snake/kebab-case)", () => {
     expect(
-      getConfigurationSummaryEntries({
-        storeDomain: "electrolux",
-        api_key: "abc",
-        "sales-channel": "1",
-      }),
+      getConfigurationSummaryEntries(
+        {
+          storeDomain: "electrolux",
+          api_key: "abc",
+          "sales-channel": "1",
+        },
+        t,
+      ),
     ).toEqual([
       { key: "storeDomain", label: "Store Domain", value: "electrolux" },
       { key: "api_key", label: "Api Key", value: "abc" },
@@ -109,7 +120,7 @@ describe("getConfigurationSummaryEntries", () => {
 
   it("stringifies non-scalar values as JSON", () => {
     expect(
-      getConfigurationSummaryEntries({ scopes: ["read", "write"] }),
+      getConfigurationSummaryEntries({ scopes: ["read", "write"] }, t),
     ).toEqual([{ key: "scopes", label: "Scopes", value: '["read","write"]' }]);
   });
 });

--- a/apps/web/src/routes/commerce-onboarding/companions-core.ts
+++ b/apps/web/src/routes/commerce-onboarding/companions-core.ts
@@ -4,6 +4,8 @@ import {
   getStudioMcpMetadata,
   type StudioMcpMetadataContainer,
 } from "@decocms/shared/registry/metadata";
+import type { TFunction } from "@/i18n/use-t.ts";
+import type { TranslationKey } from "@/i18n/en/index.ts";
 import type { CompanionCopy } from "./companions.ts";
 
 export interface BindingRequirement {
@@ -265,15 +267,17 @@ function isMeaningfulConfigValue(value: unknown): boolean {
   return false;
 }
 
-function formatConfigurationKey(key: string): string {
-  const labels: Record<string, string> = {
-    accountName: "Nome da conta",
-    appKey: "App Key",
-    appToken: "App Token",
-    propertyId: "Propriedade",
-    siteUrl: "Site",
-  };
-  if (labels[key]) return labels[key];
+const CONFIG_FIELD_LABEL_KEYS: Record<string, TranslationKey> = {
+  accountName: "commerceOnboarding.companionCard.configField.accountName",
+  appKey: "commerceOnboarding.companionCard.configField.appKey",
+  appToken: "commerceOnboarding.companionCard.configField.appToken",
+  propertyId: "commerceOnboarding.companionCard.configField.propertyId",
+  siteUrl: "commerceOnboarding.companionCard.configField.siteUrl",
+};
+
+function formatConfigurationKey(key: string, t: TFunction): string {
+  const labelKey = CONFIG_FIELD_LABEL_KEYS[key];
+  if (labelKey) return t(labelKey);
 
   return key
     .replace(/[_-]+/g, " ")
@@ -292,13 +296,14 @@ function stringifyConfigurationValue(value: unknown): string | null {
 
 export function getConfigurationSummaryEntries(
   state: Record<string, unknown> | null | undefined,
+  t: TFunction,
 ): Array<{ key: string; label: string; value: string }> {
   if (!state) return [];
   return Object.entries(state).flatMap(([key, value]) => {
     if (key.startsWith("__")) return [];
     const stringValue = stringifyConfigurationValue(value);
     if (!stringValue) return [];
-    return [{ key, label: formatConfigurationKey(key), value: stringValue }];
+    return [{ key, label: formatConfigurationKey(key, t), value: stringValue }];
   });
 }
 


### PR DESCRIPTION
**Source:** bug found while auditing the commerce-onboarding companion card/config UI (focus area: companion-core + card-view screens).

**Payoff:** `formatConfigurationKey` in `companions-core.ts` hardcoded Portuguese labels ("Nome da conta", "App Key", "App Token", "Propriedade", "Site") for the saved-configuration summary shown in the companion config dialog (`companion-card.tsx`'s `CompanionConfiguration`), regardless of the active language preference. An English-language user connecting VTEX/Shopify/GA4/GSC would see these Portuguese field labels in the saved-config summary — the one hardcoded-string leak in an otherwise fully-i18n'd component.

**Fix:** moved the 5 labels into the `commerceOnboarding` i18n dictionary (en + pt-BR) and threaded the `TFunction` through `getConfigurationSummaryEntries`/`formatConfigurationKey` so the label resolves per active locale, same pattern already used elsewhere in this file (`useT()` in the caller). The camelCase/snake-case humanizing fallback for uncurated keys is unchanged.

**Failure scenario before the fix:** switch language to English, connect VTEX, open "Edit configuration" — the saved account name row is labeled "Nome da conta" instead of "Account name".

**Verify:** `bun test apps/web/src/routes/commerce-onboarding/companions-core.test.ts` (updated to pass a stub `t` and assert the English label). 

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/web), the targeted test file above, and `bunx oxlint` on every changed file — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localized the saved-configuration field labels in the commerce onboarding companion so they follow the user’s language. Fixes English users seeing Portuguese labels for VTEX/Shopify/GA4/GSC.

- **Bug Fixes**
  - Moved five labels into the `commerceOnboarding` i18n dictionary (en, pt-BR).
  - Threaded `t` through `getConfigurationSummaryEntries` and `formatConfigurationKey`.
  - Updated the companion card to pass `t`; kept the humanizing fallback.
  - Adjusted tests to use a stub `t` and assert English labels.

<sup>Written for commit e9a09cc6bd1a23e65a97c77334a8f6a0659d6f9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

