### PR TITLE
fix(virtual): keep a repo connection a thread still points at

### DIFF
--- a/apps/api/src/storage/connection.integration.test.ts
+++ b/apps/api/src/storage/connection.integration.test.ts
@@ -552,4 +552,48 @@ describe("ConnectionStorage", () => {
       expect(updated.bindings).toEqual(["CHAT"]);
     });
   });
+
+  describe("isReferencedByThread", () => {
+    it("reports a thread pinned to the connection as its repo", async () => {
+      const connection = await storage.create({
+        organization_id: "org_123",
+        created_by: "user_123",
+        title: "GitHub: acme/site",
+        connection_type: "HTTP",
+        connection_url: "https://github.test/mcp",
+      });
+
+      expect(await storage.isReferencedByThread(connection.id)).toBe(false);
+
+      const now = new Date().toISOString();
+      await database.db
+        .insertInto("threads")
+        .values({
+          id: `thrd_ref_${connection.id}`,
+          organization_id: "org_123",
+          title: "demo",
+          description: null,
+          status: "in_progress",
+          message_storage_version: 2,
+          virtual_mcp_id: "",
+          created_at: now,
+          updated_at: now,
+          created_by: "user_123",
+          metadata: JSON.stringify({
+            githubRepo: {
+              url: "https://github.com/acme/site",
+              owner: "acme",
+              name: "site",
+              connectionId: connection.id,
+            },
+          }),
+        })
+        .execute();
+
+      // The guard that keeps a live thread from being stranded on a deleted
+      // repo connection (see VIRTUAL_MCP_DELETE).
+      expect(await storage.isReferencedByThread(connection.id)).toBe(true);
+      expect(await storage.isReferencedByThread("conn_unrelated")).toBe(false);
+    });
+  });
 });

--- a/apps/api/src/storage/connection.ts
+++ b/apps/api/src/storage/connection.ts
@@ -410,6 +410,24 @@ export class ConnectionStorage implements ConnectionStoragePort {
     return connection;
   }
 
+  /**
+   * Is any thread pinned to this connection as its repo?
+   *
+   * `threads.metadata.githubRepo.connectionId` is a pointer with no FK behind
+   * it, so deleting the connection strands every thread that holds it — the
+   * sandbox can never boot again. Callers that tear a repo connection down
+   * must check this first.
+   */
+  async isReferencedByThread(id: string): Promise<boolean> {
+    const row = await this.db
+      .selectFrom("threads")
+      .select("id")
+      .where(sql<boolean>`metadata -> 'githubRepo' ->> 'connectionId' = ${id}`)
+      .limit(1)
+      .executeTakeFirst();
+    return row !== undefined;
+  }
+
   async delete(id: string): Promise<void> {
     await this.db.deleteFrom("connections").where("id", "=", id).execute();
   }

--- a/apps/api/src/tools/sandbox/thread-repo.test.ts
+++ b/apps/api/src/tools/sandbox/thread-repo.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
 import type { GithubRepo } from "@decocms/shared/sdk";
 import {
+  repointedRepoBinding,
   resolveSandboxBranch,
   syntheticBranchToGitRef,
   threadBranch,
@@ -154,4 +155,69 @@ test("a repo-less run pinned to its own bare key does not join the ephemeral poo
       runBranch: "thread:t1",
     }),
   ).toBe("thread:t1");
+});
+
+const DEAD_REPO: GithubRepo = {
+  url: "https://github.com/deco-sites/demo-storefront",
+  owner: "deco-sites",
+  name: "demo-storefront",
+  connectionId: "conn_dead",
+  installationId: 1,
+};
+
+const repoConnection = (
+  id: string,
+  owner: string,
+  repo: string,
+  extra: Record<string, unknown> = {},
+) => ({
+  id,
+  status: "active",
+  metadata: {
+    repoScope: {
+      owner,
+      repo,
+      installationId: 42,
+      permissions: { contents: "write" },
+    },
+    ...extra,
+  },
+});
+
+test("repointedRepoBinding picks a live connection for the same repo", () => {
+  const healed = repointedRepoBinding(DEAD_REPO, [
+    repoConnection("conn_other", "deco-sites", "another-site"),
+    repoConnection("conn_live", "deco-sites", "demo-storefront"),
+  ]);
+  expect(healed).toEqual({
+    ...DEAD_REPO,
+    connectionId: "conn_live",
+    installationId: 42,
+  });
+});
+
+test("repointedRepoBinding prefers the org-shared connection", () => {
+  const healed = repointedRepoBinding(DEAD_REPO, [
+    repoConnection("conn_agent", "deco-sites", "demo-storefront"),
+    repoConnection("conn_shared", "deco-sites", "demo-storefront", {
+      orgShared: true,
+    }),
+  ]);
+  expect(healed?.connectionId).toBe("conn_shared");
+});
+
+test("repointedRepoBinding returns null when nothing matches the repo", () => {
+  expect(
+    repointedRepoBinding(DEAD_REPO, [
+      repoConnection("conn_other", "deco-sites", "another-site"),
+    ]),
+  ).toBeNull();
+});
+
+test("repointedRepoBinding is a no-op when the binding is already live", () => {
+  expect(
+    repointedRepoBinding(DEAD_REPO, [
+      repoConnection("conn_dead", "deco-sites", "demo-storefront"),
+    ]),
+  ).toBeNull();
 });

--- a/apps/api/src/tools/sandbox/thread-repo.ts
+++ b/apps/api/src/tools/sandbox/thread-repo.ts
@@ -18,6 +18,10 @@ import type {
 } from "@decocms/shared/sdk";
 import type { SandboxProviderKind } from "@decocms/sandbox/provider";
 import {
+  findReusableRepoConnection,
+  getRepoScope,
+} from "@decocms/shared/github-repo-scope";
+import {
   deleteSandboxMapEntry,
   mergeSandboxMapEntry,
   readSandboxMap,
@@ -158,13 +162,82 @@ export async function setThreadHeadRef(
     .catch((err) => console.warn("[thread-repo] setThreadHeadRef failed", err));
 }
 
-/** Read the repo bound to a thread, or null. Never throws. */
+/**
+ * The repo binding to use when the one recorded on the thread points at a
+ * connection that is gone, or null when nothing in the org can stand in.
+ *
+ * Repo connections are not immortal: deleting the agent that owned one tears
+ * it down (`VIRTUAL_MCP_DELETE`), and re-importing a repo mints a new id. A
+ * thread pinned to the dead id can never boot a sandbox again even though the
+ * org still has a perfectly good connection for the same repository — so
+ * re-point it at that one instead. Pure so the choice is testable without a DB.
+ */
+export function repointedRepoBinding(
+  repo: GithubRepo,
+  connections: {
+    id: string;
+    status?: string;
+    metadata: Record<string, unknown> | null;
+  }[],
+): GithubRepo | null {
+  const replacement = findReusableRepoConnection(
+    connections,
+    repo.owner,
+    repo.name,
+  );
+  if (!replacement || replacement.id === repo.connectionId) return null;
+  const scope = getRepoScope(replacement);
+  return {
+    ...repo,
+    connectionId: replacement.id,
+    ...(scope?.installationId ? { installationId: scope.installationId } : {}),
+  };
+}
+
+/**
+ * Read the repo bound to a thread, or null. Never throws.
+ *
+ * Self-heals a dangling `connectionId` (see {@link repointedRepoBinding}) and
+ * persists the repoint, so every consumer — sandbox provisioning, the fs tools,
+ * dispatch — agrees on the live connection. When no replacement exists the
+ * dead binding is returned untouched and SANDBOX_START fails with
+ * `GITHUB_CONNECTION_MISSING`, which tells the user to link the repo again.
+ *
+ * Note: the sandbox branch embeds the connection id (`threadBranch`), so a
+ * repoint yields a fresh sandbox. The old one was unusable anyway.
+ */
 export async function getThreadGithubRepo(
   ctx: StudioContext,
   threadId: string | undefined | null,
 ): Promise<GithubRepo | null> {
   const meta = await getThreadMeta(ctx, threadId);
-  return (meta as { githubRepo?: GithubRepo } | null)?.githubRepo ?? null;
+  const repo = (meta as { githubRepo?: GithubRepo } | null)?.githubRepo ?? null;
+  if (!threadId || !meta || !repo?.connectionId) return repo;
+
+  try {
+    // The org the thread was just read under — `ctx.organization` is unset on
+    // some dispatch paths, this binding never is.
+    const orgId = ctx.storage.threads.getOrganizationId();
+    if (!orgId) return repo;
+    if (await ctx.storage.connections.findById(repo.connectionId, orgId)) {
+      return repo;
+    }
+    const { items } = await ctx.storage.connections.list(orgId);
+    const repointed = repointedRepoBinding(repo, items);
+    if (!repointed) return repo;
+    await ctx.storage.threads.update(threadId, {
+      metadata: { ...meta, githubRepo: repointed },
+    });
+    console.warn("[thread-repo] re-pointed thread at a live repo connection", {
+      threadId,
+      from: repo.connectionId,
+      to: repointed.connectionId,
+    });
+    return repointed;
+  } catch (err) {
+    console.warn("[thread-repo] repoint check failed", err);
+    return repo;
+  }
 }
 
 /**

--- a/apps/api/src/tools/virtual/delete.ts
+++ b/apps/api/src/tools/virtual/delete.ts
@@ -131,6 +131,10 @@ export const COLLECTION_VIRTUAL_MCP_DELETE = defineTool({
         // Both checks run BEFORE the revoke. Relying on the ON DELETE RESTRICT
         // FK to stop the delete is not enough: the token would already have
         // been revoked by then, leaving a live connection with a dead grant.
+        //  - a thread pinned to it (`metadata.githubRepo.connectionId`, set by
+        //    `load_repo` / the repo picker) keeps working long after the agent
+        //    that minted the connection is gone. Deleting it stranded 152
+        //    prod threads on a sandbox that can never boot again.
         const heldBySomeoneElse =
           child &&
           (isOrgSharedConnection(child) ||
@@ -139,7 +143,10 @@ export const COLLECTION_VIRTUAL_MCP_DELETE = defineTool({
                 organization.id,
                 childConnectionId,
               )
-            ).length > 0);
+            ).length > 0 ||
+            (await ctx.storage.connections.isReferencedByThread(
+              childConnectionId,
+            )));
         if (child && getRepoScope(child) && !heldBySomeoneElse) {
           const tokenStorage = new DownstreamTokenStorage(ctx.db, ctx.vault);
           const tok = await tokenStorage.get(childConnectionId);


### PR DESCRIPTION
Stacked on #5808 (which is stacked on #5807). Third and last of the series — this one makes the failure *impossible* rather than survivable.

## Problem

`VIRTUAL_MCP_DELETE` deletes the agent's repo-scoped GitHub connection when no other **agent** holds it. But threads hold it too: `threads.metadata.githubRepo.connectionId` (set by `load_repo` / the repo picker) is a pointer with no FK behind it, and it long outlives the agent that minted the connection. Deleting anyway stranded 152 prod threads on a sandbox that can never boot again.

## Change

- `ConnectionStorage.isReferencedByThread(id)` — one indexed-jsonb lookup.
- `VIRTUAL_MCP_DELETE`'s `heldBySomeoneElse` now counts a referencing thread as a holder, alongside org-shared and other agents' aggregations. The connection (and its token) survives; only the agent goes.

Worst case is an orphan connection whose token self-expires — the same trade-off the existing guards already accept, and strictly better than a permanently dead thread.

## Testing

- New real-Postgres integration test in `connection.integration.test.ts`: false before a thread points at it, true after, false for an unrelated id.
- `bun test apps/api/src/tools/virtual`, `bun run check`, `bun run fmt`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent deleting repo-scoped GitHub connections when any thread still points to them. This avoids stranding threads and breaking sandboxes after agent cleanup.

- **Bug Fixes**
  - Added `ConnectionStorage.isReferencedByThread` to detect thread references via `threads.metadata.githubRepo.connectionId`.
  - Updated `VIRTUAL_MCP_DELETE` to treat referencing threads as holders, preserving the connection and its token while removing only the agent.
  - Added a Postgres integration test for the new guard.

<sup>Written for commit 634fa0fc1b22f1d08deac8dbf0dbf57017181617. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

