### PR TITLE
fix(sections-editor): disambiguate sibling props that share a schema title

### DIFF
--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -12,6 +12,7 @@ import {
   normalizeBreadcrumbLabel,
   resolveActiveFieldKey,
   resolveArrayItemSelection,
+  siblingFieldLabel,
   isBreadcrumbInsideObject,
 } from "./schema-form-breadcrumb";
 import { getArrayItemLabels } from "./array-item-display";
@@ -79,6 +80,125 @@ describe("fieldDisplayLabel", () => {
     expect(fieldDisplayLabel("backgroundColor", {} as SchemaProperty)).toBe(
       "Background Color",
     );
+  });
+});
+
+describe("siblingFieldLabel", () => {
+  test("falls back to humanized key when siblings share a title", () => {
+    // Both props `$ref` the same interface, so both inherit its title.
+    const properties = {
+      shelfProps: { title: "ProductShelfProps" } as SchemaProperty,
+      shelfPropsOffer: { title: "ProductShelfProps" } as SchemaProperty,
+    };
+    const keys = Object.keys(properties);
+    expect(siblingFieldLabel("shelfProps", keys, properties)).toBe(
+      "Shelf Props",
+    );
+    expect(siblingFieldLabel("shelfPropsOffer", keys, properties)).toBe(
+      "Shelf Props Offer",
+    );
+  });
+
+  test("keeps the title when siblings are distinct", () => {
+    const properties = {
+      alpha: { title: "Alpha" } as SchemaProperty,
+      beta: { title: "Beta" } as SchemaProperty,
+    };
+    expect(
+      siblingFieldLabel("alpha", Object.keys(properties), properties),
+    ).toBe("Alpha");
+  });
+
+  test("keeps the title for a lone property", () => {
+    const properties = { cards: { title: "Cards" } as SchemaProperty };
+    expect(siblingFieldLabel("cards", ["cards"], properties)).toBe("Cards");
+  });
+});
+
+describe("resolveActiveFieldKey — sibling props with identical titles", () => {
+  // Mirrors ProductShelfTimedOffers: `shelfProps` and `shelfPropsOffer` both
+  // `$ref` `ProductShelfProps`, so both share the title and an identical nested
+  // `cardLayout.productTags` shape. Item labels come from the `label` field.
+  const shelf = {
+    type: "object",
+    title: "ProductShelfProps",
+    properties: {
+      cardLayout: {
+        type: "object",
+        title: "CardLayout",
+        properties: {
+          productTags: {
+            type: "array",
+            title: "ProductTags",
+            items: {
+              type: "object",
+              properties: { label: { type: "string" } },
+            },
+          },
+        },
+      },
+    },
+  } satisfies SchemaProperty;
+  const properties = { shelfProps: shelf, shelfPropsOffer: shelf };
+  const keys = Object.keys(properties);
+  const objValue = {
+    shelfProps: {
+      cardLayout: {
+        productTags: [
+          { label: "OFERTAS 8.8" },
+          { label: "Frete grátis geral" },
+        ],
+      },
+    },
+    shelfPropsOffer: {
+      cardLayout: {
+        productTags: [
+          { label: "OFERTAS 7.7" },
+          { label: "Frete grátis geral" },
+        ],
+      },
+    },
+  };
+
+  test("a unique item label resolves to its owning sibling", () => {
+    expect(
+      resolveActiveFieldKey(keys, properties, objValue, ["OFERTAS 7.7"]),
+    ).toBe("shelfPropsOffer");
+    expect(
+      resolveActiveFieldKey(keys, properties, objValue, ["OFERTAS 8.8"]),
+    ).toBe("shelfProps");
+  });
+
+  test("a disambiguated ancestor crumb focuses the right sibling for a shared item", () => {
+    expect(
+      resolveActiveFieldKey(keys, properties, objValue, [
+        "Shelf Props Offer",
+        "Frete grátis geral",
+      ]),
+    ).toBe("shelfPropsOffer");
+    expect(
+      resolveActiveFieldKey(keys, properties, objValue, [
+        "Shelf Props",
+        "Frete grátis geral",
+      ]),
+    ).toBe("shelfProps");
+  });
+
+  test("an ambiguous shared crumb without an ancestor returns null (shows both)", () => {
+    expect(
+      resolveActiveFieldKey(keys, properties, objValue, ["Frete grátis geral"]),
+    ).toBeNull();
+  });
+
+  test("breadcrumbPathForActiveField strips the disambiguated ancestor crumb", () => {
+    expect(
+      breadcrumbPathForActiveField(
+        "shelfPropsOffer",
+        shelf,
+        ["Shelf Props Offer", "Frete grátis geral"],
+        "Shelf Props Offer",
+      ),
+    ).toEqual(["Frete grátis geral"]);
   });
 });
 

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -10,6 +10,7 @@ import {
   findBreadcrumbLabelIndex,
   isArrayDrillDownField,
   normalizeBreadcrumbLabel,
+  prependCrumbIfAbsent,
   resolveActiveFieldKey,
   resolveArrayItemSelection,
   siblingFieldLabel,
@@ -115,10 +116,31 @@ describe("siblingFieldLabel", () => {
   });
 });
 
+describe("prependCrumbIfAbsent", () => {
+  test("prepends the label when the trail doesn't start with it", () => {
+    expect(
+      prependCrumbIfAbsent("Shelf Props Offer", ["Free shipping"]),
+    ).toEqual(["Shelf Props Offer", "Free shipping"]);
+  });
+
+  test("prepends onto an empty trail", () => {
+    expect(prependCrumbIfAbsent("Shelf Props Offer", [])).toEqual([
+      "Shelf Props Offer",
+    ]);
+  });
+
+  test("is a no-op when the label is already the head (NFC-insensitive)", () => {
+    const trail = ["café", "Free shipping"];
+    // Same crumb in composed form must be recognized as already present.
+    expect(prependCrumbIfAbsent("café", trail)).toBe(trail);
+  });
+});
+
 describe("resolveActiveFieldKey — sibling props with identical titles", () => {
-  // Mirrors ProductShelfTimedOffers: `shelfProps` and `shelfPropsOffer` both
-  // `$ref` `ProductShelfProps`, so both share the title and an identical nested
-  // `cardLayout.productTags` shape. Item labels come from the `label` field.
+  // Mirrors the general shape that triggers the bug: two props that `$ref` the
+  // same interface, so both share the title and an identical nested
+  // `cardLayout.tags` shape. Item labels come from the `label` field. Fixture
+  // labels are neutral placeholders — not tied to any real store's content.
   const shelf = {
     type: "object",
     title: "ProductShelfProps",
@@ -127,9 +149,9 @@ describe("resolveActiveFieldKey — sibling props with identical titles", () => 
         type: "object",
         title: "CardLayout",
         properties: {
-          productTags: {
+          tags: {
             type: "array",
-            title: "ProductTags",
+            title: "Tags",
             items: {
               type: "object",
               properties: { label: { type: "string" } },
@@ -144,28 +166,22 @@ describe("resolveActiveFieldKey — sibling props with identical titles", () => 
   const objValue = {
     shelfProps: {
       cardLayout: {
-        productTags: [
-          { label: "OFERTAS 8.8" },
-          { label: "Frete grátis geral" },
-        ],
+        tags: [{ label: "Summer Sale" }, { label: "Free shipping" }],
       },
     },
     shelfPropsOffer: {
       cardLayout: {
-        productTags: [
-          { label: "OFERTAS 7.7" },
-          { label: "Frete grátis geral" },
-        ],
+        tags: [{ label: "Winter Sale" }, { label: "Free shipping" }],
       },
     },
   };
 
   test("a unique item label resolves to its owning sibling", () => {
     expect(
-      resolveActiveFieldKey(keys, properties, objValue, ["OFERTAS 7.7"]),
+      resolveActiveFieldKey(keys, properties, objValue, ["Winter Sale"]),
     ).toBe("shelfPropsOffer");
     expect(
-      resolveActiveFieldKey(keys, properties, objValue, ["OFERTAS 8.8"]),
+      resolveActiveFieldKey(keys, properties, objValue, ["Summer Sale"]),
     ).toBe("shelfProps");
   });
 
@@ -173,20 +189,27 @@ describe("resolveActiveFieldKey — sibling props with identical titles", () => 
     expect(
       resolveActiveFieldKey(keys, properties, objValue, [
         "Shelf Props Offer",
-        "Frete grátis geral",
+        "Free shipping",
       ]),
     ).toBe("shelfPropsOffer");
     expect(
       resolveActiveFieldKey(keys, properties, objValue, [
         "Shelf Props",
-        "Frete grátis geral",
+        "Free shipping",
       ]),
+    ).toBe("shelfProps");
+  });
+
+  test("a single matching object sibling still resolves (not null)", () => {
+    // Only `shelfProps` has a "Summer Sale" tag → one match, returns it.
+    expect(
+      resolveActiveFieldKey(keys, properties, objValue, ["Summer Sale"]),
     ).toBe("shelfProps");
   });
 
   test("an ambiguous shared crumb without an ancestor returns null (shows both)", () => {
     expect(
-      resolveActiveFieldKey(keys, properties, objValue, ["Frete grátis geral"]),
+      resolveActiveFieldKey(keys, properties, objValue, ["Free shipping"]),
     ).toBeNull();
   });
 
@@ -195,10 +218,10 @@ describe("resolveActiveFieldKey — sibling props with identical titles", () => 
       breadcrumbPathForActiveField(
         "shelfPropsOffer",
         shelf,
-        ["Shelf Props Offer", "Frete grátis geral"],
+        ["Shelf Props Offer", "Free shipping"],
         "Shelf Props Offer",
       ),
-    ).toEqual(["Frete grátis geral"]);
+    ).toEqual(["Free shipping"]);
   });
 });
 

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -15,6 +15,21 @@ export function normalizeBreadcrumbLabel(label: string): string {
   return label.normalize("NFC").trim();
 }
 
+/**
+ * Prepend `label` to a breadcrumb `trail` unless it's already the head crumb
+ * (NFC-insensitive). Used to stamp the disambiguated ancestor label onto a drill
+ * trail so the resolver can tell same-titled sibling props apart.
+ */
+export function prependCrumbIfAbsent(label: string, trail: string[]): string[] {
+  if (
+    trail.length > 0 &&
+    normalizeBreadcrumbLabel(trail[0]!) === normalizeBreadcrumbLabel(label)
+  ) {
+    return trail;
+  }
+  return [label, ...trail];
+}
+
 function labelsMatch(a: string, b: string): boolean {
   return normalizeBreadcrumbLabel(a) === normalizeBreadcrumbLabel(b);
 }
@@ -341,7 +356,7 @@ function resolveActiveFieldKeyInScope(
   // Collect every object sibling that owns the trail rather than returning the
   // first. Two siblings that `$ref` the same interface (e.g. `shelfProps` /
   // `shelfPropsOffer`, both `ProductShelfProps`) have identical nested shapes,
-  // so a shared crumb ("Frete grátis geral", or a field-level "Card Layout")
+  // so a shared crumb ("Free shipping", or a field-level "Card Layout")
   // matches BOTH. First-match-wins would silently narrow to the first and drill
   // the wrong prop; if the trail can't tell them apart, return null so the panel
   // keeps both visible instead of editing the wrong sibling. A crumb carrying the

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -131,9 +131,10 @@ export function breadcrumbPathForActiveField(
   activeKey: string,
   schema: SchemaProperty,
   breadcrumbPath: string[],
+  overrideLabel?: string,
 ): string[] {
   if (breadcrumbPath.length === 0) return breadcrumbPath;
-  const label = fieldDisplayLabel(activeKey, schema);
+  const label = overrideLabel ?? fieldDisplayLabel(activeKey, schema);
   const head = breadcrumbPath[0]!;
   if (labelsMatch(head, label) || labelsMatch(head, activeKey)) {
     return breadcrumbPath.slice(1);
@@ -143,6 +144,30 @@ export function breadcrumbPathForActiveField(
 
 export function fieldDisplayLabel(key: string, schema: SchemaProperty): string {
   return schema.title ?? humanize(key);
+}
+
+/**
+ * Display label for a property within its sibling group, disambiguated by key
+ * when two siblings share the same {@link fieldDisplayLabel} (e.g. `shelfProps`
+ * and `shelfPropsOffer` both `$ref` the `ProductShelfProps` interface, so both
+ * inherit its `title`). A collision falls back to `humanize(key)` so the fields
+ * stay distinguishable in the panel AND the breadcrumb resolver can tell which
+ * sibling a crumb belongs to. No-op (returns the plain label) when unique.
+ */
+export function siblingFieldLabel(
+  key: string,
+  keys: string[],
+  properties: Record<string, SchemaProperty>,
+): string {
+  const schema = properties[key];
+  if (!schema) return humanize(key);
+  const base = fieldDisplayLabel(key, schema);
+  const collides = keys.some((k) => {
+    if (k === key) return false;
+    const other = properties[k];
+    return other != null && fieldDisplayLabel(k, other) === base;
+  });
+  return collides ? humanize(key) : base;
 }
 
 /**
@@ -293,7 +318,7 @@ function resolveActiveFieldKeyInScope(
   for (const key of keys) {
     const schema = properties[key];
     if (!schema || !isArrayDrillDownField(schema, objValue[key])) continue;
-    const label = fieldDisplayLabel(key, schema);
+    const label = siblingFieldLabel(key, keys, properties);
     if (labelsMatch(head, label) || labelsMatch(head, key)) return key;
     if (
       breadcrumbPath.some(
@@ -313,33 +338,48 @@ function resolveActiveFieldKeyInScope(
     if (labels.some((label) => labelsMatch(label, head))) return key;
   }
 
+  // Collect every object sibling that owns the trail rather than returning the
+  // first. Two siblings that `$ref` the same interface (e.g. `shelfProps` /
+  // `shelfPropsOffer`, both `ProductShelfProps`) have identical nested shapes,
+  // so a shared crumb ("Frete grátis geral", or a field-level "Card Layout")
+  // matches BOTH. First-match-wins would silently narrow to the first and drill
+  // the wrong prop; if the trail can't tell them apart, return null so the panel
+  // keeps both visible instead of editing the wrong sibling. A crumb carrying the
+  // disambiguated ancestor label (its `siblingFieldLabel`) matches exactly one.
+  let objMatch: string | null = null;
+  let objAmbiguous = false;
   for (const key of keys) {
     const schema = properties[key];
     if (schema?.type !== "object" || !schema.properties) continue;
     const childKeys = Object.keys(schema.properties);
     const childObj = asObjectRecord(objValue[key]);
-    const label = fieldDisplayLabel(key, schema);
+    const label = siblingFieldLabel(key, keys, properties);
 
-    const direct = resolveActiveFieldKeyInScope(
-      childKeys,
-      schema.properties,
-      childObj,
-      breadcrumbPath,
-      decofile,
-    );
-    if (direct) return key;
-
-    if (labelsMatch(head, label) || labelsMatch(head, key)) {
-      const viaLabel = resolveActiveFieldKeyInScope(
+    let matched =
+      resolveActiveFieldKeyInScope(
         childKeys,
         schema.properties,
         childObj,
-        breadcrumbPath.slice(1),
+        breadcrumbPath,
         decofile,
-      );
-      if (viaLabel) return key;
+      ) != null;
+
+    if (!matched && (labelsMatch(head, label) || labelsMatch(head, key))) {
+      matched =
+        resolveActiveFieldKeyInScope(
+          childKeys,
+          schema.properties,
+          childObj,
+          breadcrumbPath.slice(1),
+          decofile,
+        ) != null;
     }
+
+    if (!matched) continue;
+    if (objMatch === null) objMatch = key;
+    else objAmbiguous = true;
   }
+  if (objMatch !== null) return objAmbiguous ? null : objMatch;
 
   // Inline-union fields ("A or B" plain-data unions) store the chosen branch's
   // fields flat on the value, so a nested array inside a branch (e.g.
@@ -401,6 +441,9 @@ function resolveActiveFieldKeyInScope(
   for (const key of keys) {
     const schema = properties[key];
     if (schema?.type !== "block-ref") continue;
+    // NB: keep the plain label here — this branch disambiguates same-titled
+    // block-refs (e.g. two "Section" loaders) by VALUE ownership, so it must
+    // still match the shared title crumb, not a key-disambiguated one.
     const fieldLabel = fieldDisplayLabel(key, schema);
     if (head !== fieldLabel && head !== key) {
       // The crumb isn't the loader's own label, but the drilled item may live

--- a/apps/web/src/components/sections-editor/schema-form.tsx
+++ b/apps/web/src/components/sections-editor/schema-form.tsx
@@ -30,7 +30,7 @@ import {
   consumedBreadcrumbPrefix,
   fieldDisplayLabel,
   isArrayDrillDownField,
-  normalizeBreadcrumbLabel,
+  prependCrumbIfAbsent,
   resolveActiveFieldKey,
   siblingFieldLabel,
 } from "./schema-form-breadcrumb";
@@ -579,8 +579,8 @@ export function SchemaForm({
         // When two siblings share a title (e.g. `shelfProps`/`shelfPropsOffer`,
         // both `ProductShelfProps`), a descendant drill reports a bare
         // `[itemLabel]` trail with no ancestor crumb — the resolver then can't
-        // tell which sibling a shared crumb ("Frete grátis geral") came from. In
-        // the non-focused view (both rendered together, `consumedPrefix` empty)
+        // tell which sibling a shared crumb ("Free shipping") came from. In the
+        // non-focused view (both rendered together, `consumedPrefix` empty)
         // prepend this field's disambiguated label so the trail identifies the
         // sibling. In the focused view `consumedPrefix` already carries it.
         const plainLabel = fieldDisplayLabel(key, propSchema);
@@ -597,13 +597,7 @@ export function SchemaForm({
         const fieldOnBreadcrumbChangeForKey =
           collidesWithSibling && fieldOnBreadcrumbChange
             ? (next: string[]) =>
-                fieldOnBreadcrumbChange(
-                  next.length > 0 &&
-                    normalizeBreadcrumbLabel(next[0]!) ===
-                      normalizeBreadcrumbLabel(label)
-                    ? next
-                    : [label, ...next],
-                )
+                fieldOnBreadcrumbChange(prependCrumbIfAbsent(label, next))
             : fieldOnBreadcrumbChange;
 
         return renderField({

--- a/apps/web/src/components/sections-editor/schema-form.tsx
+++ b/apps/web/src/components/sections-editor/schema-form.tsx
@@ -30,7 +30,9 @@ import {
   consumedBreadcrumbPrefix,
   fieldDisplayLabel,
   isArrayDrillDownField,
+  normalizeBreadcrumbLabel,
   resolveActiveFieldKey,
+  siblingFieldLabel,
 } from "./schema-form-breadcrumb";
 import {
   blockRefArrayItemSchemaFromRefs,
@@ -541,7 +543,12 @@ export function SchemaForm({
   const visibleKeys = activeKey && activeSchema ? [activeKey] : keys;
   const fieldBreadcrumbPath =
     activeKey && activeSchema
-      ? breadcrumbPathForActiveField(activeKey, activeSchema, breadcrumbPath)
+      ? breadcrumbPathForActiveField(
+          activeKey,
+          activeSchema,
+          breadcrumbPath,
+          siblingFieldLabel(activeKey, keys, properties),
+        )
       : breadcrumbPath;
   // `breadcrumbPathForActiveField` hands the active field a breadcrumb RELATIVE
   // to itself (the crumbs it consumed are dropped from the front). The child
@@ -567,7 +574,37 @@ export function SchemaForm({
         const propSchema = properties[key];
         if (!propSchema) return null;
         const fieldPath = basePath ? `${basePath}.${key}` : key;
-        const label = fieldDisplayLabel(key, propSchema);
+        const label = siblingFieldLabel(key, keys, properties);
+
+        // When two siblings share a title (e.g. `shelfProps`/`shelfPropsOffer`,
+        // both `ProductShelfProps`), a descendant drill reports a bare
+        // `[itemLabel]` trail with no ancestor crumb — the resolver then can't
+        // tell which sibling a shared crumb ("Frete grátis geral") came from. In
+        // the non-focused view (both rendered together, `consumedPrefix` empty)
+        // prepend this field's disambiguated label so the trail identifies the
+        // sibling. In the focused view `consumedPrefix` already carries it.
+        const plainLabel = fieldDisplayLabel(key, propSchema);
+        const collidesWithSibling =
+          consumedPrefix.length === 0 &&
+          keys.some((k) => {
+            const other = properties[k];
+            return (
+              k !== key &&
+              other != null &&
+              fieldDisplayLabel(k, other) === plainLabel
+            );
+          });
+        const fieldOnBreadcrumbChangeForKey =
+          collidesWithSibling && fieldOnBreadcrumbChange
+            ? (next: string[]) =>
+                fieldOnBreadcrumbChange(
+                  next.length > 0 &&
+                    normalizeBreadcrumbLabel(next[0]!) ===
+                      normalizeBreadcrumbLabel(label)
+                    ? next
+                    : [label, ...next],
+                )
+            : fieldOnBreadcrumbChange;
 
         return renderField({
           schema: propSchema,
@@ -576,7 +613,7 @@ export function SchemaForm({
           path: fieldPath,
           label,
           breadcrumbPath: fieldBreadcrumbPath,
-          onBreadcrumbChange: fieldOnBreadcrumbChange,
+          onBreadcrumbChange: fieldOnBreadcrumbChangeForKey,
           hasSiblingDrillDownFields,
           meta,
           decofile,


### PR DESCRIPTION
## What is this contribution about?
Two section props that `$ref` the same interface (e.g. `shelfProps` / `shelfPropsOffer`, both `ProductShelfProps` in `ProductShelfTimedOffers`) inherit the same schema `title`, so the sections-editor form rendered them with an identical label and the breadcrumb resolver narrowed to the first sibling on any shared crumb — drilling into the second prop silently opened the first, so users edited the wrong prop (e.g. edited the "8.8" shelf while the site rendered the stale "7.7" one). This adds `siblingFieldLabel` (falls back to `humanize(key)` on a title collision), prepends the disambiguated ancestor label into the drill breadcrumb so the correct sibling is focused, and makes the object branch of `resolveActiveFieldKeyInScope` return `null` (show both) instead of first-match-wins when siblings are ambiguous.

## How did you verify your code works?
Added unit tests in `schema-form-breadcrumb.test.ts` for `siblingFieldLabel` (collision → distinct humanized labels) and `resolveActiveFieldKey` with identical-titled siblings (unique item → correct sibling; ancestor-prefixed shared crumb → correct sibling; bare shared crumb → `null`), plus a `breadcrumbPathForActiveField` override case. `bun test` on the sections-editor suite passes 581/581; `bun run --cwd=apps/web check`, `bun run fmt`, and `bun run lint` (0 errors) are clean.

## Screenshots/Demonstration
N/A (behavior verified via unit tests; manual editor check pending on a real section with two same-typed props).

## How to Test
1. Open a section whose schema has two sibling props of the same TS type (e.g. `ProductShelfTimedOffers` with `shelfProps` + `shelfPropsOffer`) in the sections editor.
2. Confirm the two fields now render with distinct labels ("Shelf Props" vs "Shelf Props Offer").
3. Drill into the second prop's nested content and confirm you edit that prop (not the first).

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a sections-editor bug where sibling props sharing the same schema title opened the wrong field when drilling down. Labels and breadcrumbs are now disambiguated so the correct sibling is focused.

- **Bug Fixes**
  - Added `siblingFieldLabel` to fall back to humanized keys when titles collide; used for rendering and breadcrumb matching.
  - Introduced `prependCrumbIfAbsent` and wired the form to prefix the ancestor label only when needed; `breadcrumbPathForActiveField` can strip it via an override.
  - Updated resolver to return null when a shared crumb matches multiple object siblings and to keep unique matches; expanded tests to cover crumb prefixing, neutral fixtures, and a single-object-match regression.

<sup>Written for commit 6faa72bfa3441845498a9c25e174ecba39c55533. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

