### PR TITLE
fix(task-board): stop the review sweeper exhausting the GitHub rate limit

### DIFF
--- a/apps/api/migrations/166-task-board-last-swept-at.ts
+++ b/apps/api/migrations/166-task-board-last-swept-at.ts
@@ -1,0 +1,40 @@
+import { type Kysely, sql } from "kysely";
+
+/**
+ * When a card was last reconciled by the review sweeper.
+ *
+ * The sweeper's rate was a product of its own timer (`setInterval`, per pod)
+ * rather than of anything about the cards, and that had two consequences in
+ * prod, both measured: every API replica ran its own timer over the same work
+ * list, so the GitHub cost was multiplied by the replica count; and a card whose
+ * checks never go green never leaves `listItemsPendingReview`, so it was
+ * re-fetched every 60s forever. 32 such cards in one org held a steady ~370
+ * `pull_request_read` calls/min for 17 hours and exhausted the GitHub App's
+ * installation rate limit (93% of the calls came back 429).
+ *
+ * Stamping the interval on the CARD instead of the pod fixes both with one
+ * mechanism: replicas share the stamp, so a card is swept once per interval no
+ * matter how many pods are running, and a permanently-parked card costs one
+ * sweep per interval instead of one per tick. It also stays correct if the
+ * replica count changes, which a leader lock would not.
+ *
+ * NULL means never swept — those sort first and are always due, so existing
+ * cards are picked up on the next tick with no backfill.
+ *
+ * Deliberately NOT `updated_at`: a sweep is not a user-visible edit, and reusing
+ * `updated_at` would churn the keyset cursor this table is paged by and make
+ * every parked card look freshly edited in the UI.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE task_board_items
+      ADD COLUMN last_swept_at timestamptz
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE task_board_items
+      DROP COLUMN last_swept_at
+  `.execute(db);
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -164,6 +164,7 @@ import * as migration162claudesubscriptions from "./162-claude-subscriptions.ts"
 import * as migration163taskboarditemdismissed from "./163-task-board-item-dismissed.ts";
 import * as migration164perorgtaskquota from "./164-per-org-task-quota.ts";
 import * as migration165taskboardpendingreviewindex from "./165-task-board-pending-review-index.ts";
+import * as migration166taskboardlastsweptat from "./166-task-board-last-swept-at.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -356,6 +357,7 @@ const migrations: Record<string, Migration> = {
   "164-per-org-task-quota": migration164perorgtaskquota,
   "165-task-board-pending-review-index":
     migration165taskboardpendingreviewindex,
+  "166-task-board-last-swept-at": migration166taskboardlastsweptat,
 };
 
 export default migrations;

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/vm-tools/schemas.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/vm-tools/schemas.ts
@@ -9,9 +9,10 @@ export const ReadInputSchema = z.object({
   path: z
     .string()
     .describe(
-      "File path. Relative paths resolve against the project root (e.g. " +
-        "'src/index.ts'); absolute paths are accepted for files outside the " +
-        "project (e.g. '/home/sandbox/deck.thumbnail.jpg').",
+      "File path. Prefer relative paths — they resolve against the project " +
+        "root (e.g. 'src/index.ts'). Absolute paths are accepted but only " +
+        "for files you already know exist outside the project; do not guess " +
+        "one.",
     ),
   offset: z
     .number()
@@ -140,7 +141,10 @@ export const GLOB_DESCRIPTION =
 
 export const BASH_DESCRIPTION =
   "Execute a shell command in the VM's project directory. " +
-  "Working directory is the project root. Timeout default 30s, max 2min.\n\n" +
+  "Working directory is already the project root — the git checkout, when " +
+  "the agent has a repo. Never `cd` to an absolute path you guessed " +
+  "(there is no `/home/sandbox` project dir); run git and build commands " +
+  "as-is from the default cwd. Timeout default 30s, max 2min.\n\n" +
   "The organization filesystem is mounted at `org/`:\n" +
   "- `org/home/` — the org's shared home folder (editable, " +
   "shared across runs). Organize it " +

--- a/apps/api/src/storage/task-board-pending-review.integration.test.ts
+++ b/apps/api/src/storage/task-board-pending-review.integration.test.ts
@@ -247,4 +247,105 @@ describe("listItemsPendingReview (real Postgres)", () => {
       expect(seen.slice().sort()).toEqual(ids.slice().sort());
     });
   });
+
+  // The sweep budget that bounds the sweeper's GitHub cost. Before it, a card
+  // whose checks never go green was re-fetched on every tick of every replica —
+  // 4 `pull_request_read` calls x 32 cards x 3 pods / 60s = ~370 calls/min for 17
+  // hours in prod, 93% of them answered 429 by GitHub. Real Postgres because the
+  // whole mechanism is one NULL-aware SQL predicate plus one narrow UPDATE.
+  describe("due filter (last_swept_at)", () => {
+    const ORG_DUE = "org_pending_due";
+
+    beforeAll(async () => {
+      await database.db
+        .insertInto("organization")
+        .values({
+          id: ORG_DUE,
+          name: ORG_DUE,
+          slug: "org-pending-due",
+          createdAt: new Date().toISOString(),
+        })
+        .execute();
+    });
+
+    const sweptAt = async (id: string, iso: string) => {
+      await database.db
+        .updateTable("task_board_items")
+        .set({ last_swept_at: iso })
+        .where("id", "=", id)
+        .execute();
+    };
+
+    const dueIds = async (dueBefore: Date) =>
+      (await taskBoard.listItemsPendingReview(50, null, dueBefore))
+        .filter((r) => r.organizationId === ORG_DUE)
+        .map((r) => r.id);
+
+    // A never-swept card must be due, or the filter would exclude every card
+    // that existed before the column did and the sweeper would go permanently
+    // idle after deploy.
+    it("treats a never-swept card as due", async () => {
+      const fresh = await card({ org: ORG_DUE, title: "never swept" });
+      expect(await dueIds(new Date())).toContain(fresh.id);
+    });
+
+    it("excludes a card swept inside the interval and returns it once outside", async () => {
+      const item = await card({ org: ORG_DUE, title: "recently swept" });
+      await sweptAt(item.id, "2026-01-01T00:05:00.000Z");
+
+      // Interval boundary just before the sweep — not due yet.
+      expect(await dueIds(new Date("2026-01-01T00:00:00.000Z"))).not.toContain(
+        item.id,
+      );
+      // Boundary past the sweep — due again.
+      expect(await dueIds(new Date("2026-01-01T00:10:00.000Z"))).toContain(
+        item.id,
+      );
+    });
+
+    // This is the fix for the replica amplification: pod A's stamp is what makes
+    // the card disappear from pod B's work list, so three pods cost what one
+    // costs. Also asserts the stamp does NOT move `updated_at` — that column is
+    // the keyset cursor and the UI's "edited" signal, and churning it on every
+    // sweep would reorder the backlog under the cursor.
+    it("markSwept claims the interval without touching updated_at", async () => {
+      const item = await card({ org: ORG_DUE, title: "claimed" });
+      const before = await database.db
+        .selectFrom("task_board_items")
+        .select(["updated_at", "last_swept_at"])
+        .where("id", "=", item.id)
+        .executeTakeFirstOrThrow();
+      expect(before.last_swept_at).toBeNull();
+
+      await taskBoard.markSwept(item.id, ORG_DUE);
+
+      const after = await database.db
+        .selectFrom("task_board_items")
+        .select(["updated_at", "last_swept_at"])
+        .where("id", "=", item.id)
+        .executeTakeFirstOrThrow();
+      expect(after.last_swept_at).not.toBeNull();
+      expect(new Date(after.updated_at).toISOString()).toBe(
+        new Date(before.updated_at).toISOString(),
+      );
+      // And the freshly-stamped card is no longer due this interval.
+      expect(await dueIds(new Date(Date.now() - 60_000))).not.toContain(
+        item.id,
+      );
+    });
+
+    // Org-scoped like every other write here: a task id alone must not let one
+    // org's sweep stamp another org's card.
+    it("markSwept will not stamp a card from another org", async () => {
+      const item = await card({ org: ORG_DUE, title: "other org" });
+      await taskBoard.markSwept(item.id, ORG_A);
+
+      const row = await database.db
+        .selectFrom("task_board_items")
+        .select("last_swept_at")
+        .where("id", "=", item.id)
+        .executeTakeFirstOrThrow();
+      expect(row.last_swept_at).toBeNull();
+    });
+  });
 });

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -493,9 +493,19 @@ export class TaskBoardStorage {
    * them is ever swept again. Paging across ticks bounds each tick's work
    * without bounding what the sweep can ever reach.
    */
+  /**
+   * The review sweeper's work list: Super Agent cards parked In Review that are
+   * DUE a sweep, i.e. never swept or last swept before `dueBefore`.
+   *
+   * That predicate is what bounds the sweeper's GitHub cost. Without it the same
+   * cards came back on every tick of every replica — a card whose checks never
+   * go green never leaves this set — so the cost was (cards x replicas x ticks)
+   * rather than (cards x intervals). See migration 166.
+   */
   async listItemsPendingReview(
     limit: number,
     after?: { updatedAt: string; id: string } | null,
+    dueBefore?: Date,
   ): Promise<{ id: string; organizationId: string; updatedAt: string }[]> {
     let query = this.db
       .selectFrom("task_board_items")
@@ -503,6 +513,15 @@ export class TaskBoardStorage {
       .where("status", "=", "in_review")
       .where("assignee_id", "=", SUPER_AGENT_ASSIGNEE_ID)
       .where("dismissed_at", "is", null);
+    if (dueBefore) {
+      // A never-swept card (NULL) is always due — `<` alone would exclude it.
+      query = query.where((eb) =>
+        eb.or([
+          eb("last_swept_at", "is", null),
+          eb("last_swept_at", "<", dueBefore),
+        ]),
+      );
+    }
     if (after) {
       // `updated_at` is a timestamptz, so the cursor's ISO string has to go back
       // to a Date — comparing it as text would collate lexically, not
@@ -531,6 +550,26 @@ export class TaskBoardStorage {
           ? row.updated_at.toISOString()
           : String(row.updated_at),
     }));
+  }
+
+  /**
+   * Stamp a card as swept. Claims the card's next interval for whichever replica
+   * got there first, so the stamp must be written for every card the sweeper
+   * LOOKS at, not only the ones it dispatches a reviewer for — a card that has no
+   * PR, or whose checks are still pending, is exactly the card that otherwise
+   * comes back on every tick forever.
+   *
+   * Writes `last_swept_at` alone, on purpose: it does not go through `update()`
+   * (whose column whitelist is for user edits) and it must not touch
+   * `updated_at`, which is this table's keyset cursor and its UI "edited" signal.
+   */
+  async markSwept(id: string, organizationId: string): Promise<void> {
+    await this.db
+      .updateTable("task_board_items")
+      .set({ last_swept_at: new Date() })
+      .where("id", "=", id)
+      .where("organization_id", "=", organizationId)
+      .execute();
   }
 
   async linkedTaskIds(

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -1612,6 +1612,17 @@ export interface TaskBoardItemTable {
   >;
   /** Manual drag-to-reorder position within a lane, ascending. */
   sort_order: ColumnType<number, number | undefined, number>;
+  /** When the review sweeper last reconciled this card. Null = never, which is
+   *  always due. The sweeper's interval hangs off this column rather than off
+   *  its own timer so that every replica shares one budget and a permanently
+   *  parked card costs one GitHub round-trip per interval, not one per tick —
+   *  see `migrations/166-task-board-last-swept-at.ts`. Not `updated_at`: a
+   *  sweep is not a user-visible edit. */
+  last_swept_at: ColumnType<
+    Date | null,
+    Date | string | null | undefined,
+    Date | string | null
+  >;
   created_by: string;
   created_at: ColumnType<Date, Date | string | undefined, never>;
   updated_by: string;

--- a/apps/api/src/tools/task-board/review-sweeper.ts
+++ b/apps/api/src/tools/task-board/review-sweeper.ts
@@ -31,6 +31,18 @@
  * `enqueueEnabledReviewers` claims per (task, reviewer, cycle), so re-running
  * every tick cannot spawn duplicate reviewer runs.
  *
+ * Idempotent is not the same as terminating, though, and conflating the two is
+ * what took out the GitHub App's rate limit: a card whose checks never go green
+ * never leaves `listItemsPendingReview`, so re-running was free of duplicate
+ * REVIEWS but not free of duplicate GITHUB CALLS. Each card costs four
+ * `pull_request_read` calls per sweep, and the sweep rate was this class's own
+ * `setInterval` — per pod. 32 parked cards x 4 calls x 3 replicas / 60s held a
+ * steady ~370 calls/min for 17 hours, 93% of them answered 429, until the pods
+ * happened to restart. So the sweep budget now lives on the CARD
+ * (`task_board_items.last_swept_at`, migration 166): replicas share it, and a
+ * parked card costs one sweep per `DEFAULT_ITEM_SWEEP_INTERVAL_MS` instead of one
+ * per tick. `DEFAULT_BATCH_SIZE` remains the ceiling on any single tick.
+ *
  * Deliberately NOT a replacement for the instant paths. `TASK_BOARD_ITEM_PRS_GET`
  * still does this on the dialog's poll, and the projector hook still fires — the
  * sweeper is the floor that guarantees it happens without a human, not the only
@@ -43,10 +55,18 @@ import { extractPrFromText } from "./pr-extract";
 import { enqueueEnabledReviewers } from "./enqueue-reviewer";
 import { fetchPrLiveState, prReadyForReview } from "./prs-get";
 
-/** How often to reconcile. A minute is well under the time a human would take
- *  to notice a stuck card, and the work list is one index scan when idle
- *  (`idx_task_board_items_pending_review`). */
+/** How often to LOOK for due cards. A minute is well under the time a human
+ *  would take to notice a stuck card, and the work list is one index scan when
+ *  idle (`idx_task_board_items_pending_review`). This is not the rate a card is
+ *  swept at — see `DEFAULT_ITEM_SWEEP_INTERVAL_MS`. */
 const DEFAULT_SWEEP_INTERVAL_MS = 60 * 1000;
+
+/** How often a single card may cost a GitHub round-trip (four
+ *  `pull_request_read` calls). Five minutes, not the tick interval, because this
+ *  sweeper is the floor rather than the fast path — the projector hook and the
+ *  dialog poll still react immediately, so five minutes of extra latency on the
+ *  recovery path is invisible next to the CI run the card waits on anyway. */
+const DEFAULT_ITEM_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
 
 /** Items per tick. Bounds one tick's work: each item costs a `getById`, up to
  *  one `linkPr` per thread, and a GitHub round-trip per linked PR. Not a bound
@@ -57,6 +77,8 @@ const DEFAULT_BATCH_SIZE = 50;
 export interface TaskBoardReviewSweeperOptions {
   intervalMs?: number;
   batchSize?: number;
+  /** Minimum age of a card's last sweep before it is due again. */
+  itemIntervalMs?: number;
 }
 
 export class TaskBoardReviewSweeper {
@@ -90,9 +112,12 @@ export class TaskBoardReviewSweeper {
     let dispatched = 0;
     try {
       const batchSize = this.options.batchSize ?? DEFAULT_BATCH_SIZE;
+      const itemInterval =
+        this.options.itemIntervalMs ?? DEFAULT_ITEM_SWEEP_INTERVAL_MS;
       const pending = await this.taskBoard.listItemsPendingReview(
         batchSize,
         this.cursor,
+        new Date(Date.now() - itemInterval),
       );
       // A short page means the backlog is exhausted — wrap around so cards that
       // moved back into In Review behind the cursor get picked up again.
@@ -127,6 +152,12 @@ export class TaskBoardReviewSweeper {
   ): Promise<boolean> {
     const item = await this.taskBoard.getById(id, organizationId);
     if (!item) return false;
+
+    // Claim the interval BEFORE the GitHub work, not after: that is what makes a
+    // second replica skip this card, and what stops a card that comes back
+    // rate-limited from being retried on the very next tick. A pod crashing
+    // mid-sweep costs one interval of delay — the right trade for a slow floor.
+    await this.taskBoard.markSwept(id, organizationId);
 
     // Same recovery `TASK_BOARD_ITEM_PRS_GET` does: the agent's closing summary
     // reliably prints the URL ("Opened PR #309 https://github.com/…/pull/309").


### PR DESCRIPTION
## Summary

We were getting 429s from GitHub across unrelated features. The source is the review sweeper (`review-sweeper.ts`, shipped in #5775), not any user action.

Measured in `studio.studio_monitoring_logs`:

| hour (UTC) | `pull_request_read` | /min | errors |
|---|---|---|---|
| Jul 30 – Aug 5 20:00 | 30–430/h | 1–7 | few |
| **Aug 5 21:00** (#5775 deployed 21:44) | 5,494 | 92 | 5,253 |
| Aug 5 22:00 → Aug 6 13:00 | ~37k/h each | **585–632** | ~90% |

554,056 of the errors are `too many requests`; the rest are `403 API rate limit exceeded for installation`. It only stopped when the pods happened to restart, and would have climbed straight back.

## Root cause

The sweeper's GitHub cost was a product of its own timer rather than of the cards it sweeps, and both halves multiplied:

1. **Per-pod timer.** `start()` arms a bare `setInterval` per process. Prod runs 3 API replicas, so three timers swept the same work list — a flat 3× on every call. Nothing coordinated them; `this.running` only guards a pod against itself.
2. **The work set never drains.** A card whose checks never go green never leaves `listItemsPendingReview`, so it was re-fetched every tick, forever. `linkPr` and `enqueueEnabledReviewers` are idempotent — which the file's header leans on — but idempotent is not terminating. Re-running was free of duplicate *reviews*, not of duplicate *GitHub calls*.

Each sweep of a card costs 4 `pull_request_read` calls (`get`, `get_status`, `get_check_runs`, `get_comments`). The arithmetic matches the telemetry:

| | predicted | measured |
|---|---|---|
| global | 3 pods × 50 batch × 4 / min = **600/min** | p50 **615/min** |
| worst org (32 parked cards) | 32 × 4 × 3 = **384/min** | **351–378/min** |
| calls per request | **4** | **4.05** |

`uniqExact(prs)` sat dead flat at 32 for 17 hours — the signature of re-polling a fixed set, not of new work.

## Fix

Move the sweep budget off the timer and onto the card: `task_board_items.last_swept_at` (migration 166). One mechanism fixes both faults — replicas share the stamp, so 3 pods cost what 1 pod costs, and a parked card costs one sweep per interval instead of one per tick. It also stays correct if the replica count changes, which a leader lock would not.

- Per-card interval **5 minutes**. This sweeper is the floor that guarantees the hand-off happens without a human, not the fast path — the projector hook and the dialog poll still react immediately — so the added latency on the recovery path is invisible next to the CI run the card is waiting on. The 60s tick stays as "look for due cards" (one partial-index scan), and `DEFAULT_BATCH_SIZE` still caps any single tick.
- The stamp is written **before** the GitHub work, so a second replica skips the card and a rate-limited card is not retried on the next tick. Cost: a pod crashing mid-sweep delays that card one interval, which is the right trade for a slow floor.
- `markSwept` writes `last_swept_at` alone — not through `update()` (whose column whitelist is for user edits), and never touching `updated_at`, which is this table's keyset cursor and the UI's "edited" signal.

Net effect on the measured incident: **~615 calls/min → ~41**.

## Deliberately not in this PR

- **A separate 429 backoff.** Stamping before the work already means a rate-limited card waits a full interval, and `DEFAULT_BATCH_SIZE` is a hard global ceiling per tick. A dedicated backoff would be a second mechanism for a bound the first one already provides. Worth revisiting if the parked-card count ever grows enough that `batch × 4 / tick` is itself too much.
- **Dropping `get_comments` from the sweeper path.** It only feeds `previewUrl`, which the sweeper never reads, so it is a wasted call — but it is a 25% shave on an already-fixed number and would mean threading an option through `fetchPrLiveState`, which the dialog shares. Left alone on purpose.
- **The unrelated `403 Resource not accessible by integration`** on `get_status` for `wolycasa/WolyCasa` and `deco-sites/cuttermanhml` (~6k errors) — a real permissions gap burning quota for nothing, but a different bug.

## Testing

`bun run fmt`, `bun run lint` (0 errors), `bun run --cwd=apps/api check` (0 errors), `bunx knip` (clean).

Migration 166 applies clean on a fresh `postgres:16`. `bun test apps/api/src/storage/ apps/api/src/tools/task-board/` → **404 pass, 0 fail**.

New real-Postgres coverage in `task-board-pending-review.integration.test.ts` (real PG because the whole mechanism is one NULL-aware predicate plus one narrow UPDATE — an in-memory fake would accept both):

- a never-swept card (NULL) is due, so cards predating the column are picked up with no backfill
- the interval boundary in both directions
- `markSwept` claims the interval **without moving `updated_at`**
- `markSwept` is org-scoped

Both new branches verified by mutation — removing the `IS NULL` arm and removing the org filter each fail exactly one of the new tests.

Note on the wider suite: `bun test apps/api` shows 50 pre-existing failures on this branch (S3, credential-vault, OAuth-URL, task-board-import routes) — all env/service-dependent suites unrelated to these files. I did not get a clean baseline comparison on the base commit, so treat that count as unverified rather than as confirmed-pre-existing; CI is the check that matters.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stopped the review sweeper from exhausting the GitHub rate limit by moving throttling from a per-pod timer to a per-card timestamp. This cuts `pull_request_read` traffic from ~615/min to ~41/min and avoids 429/403 errors.

- **Bug Fixes**
  - Added `task_board_items.last_swept_at` and sweep only due cards (NULL or older than 5 minutes).
  - Stamp is written before GitHub calls so replicas share the budget and rate-limited cards wait a full interval.
  - New `markSwept` updates only `last_swept_at` (keeps `updated_at` unchanged) and is org-scoped.
  - Sweeper now passes a due-before time to `listItemsPendingReview`; keeps a 60s scan and a 50-item batch cap.
  - Added real-Postgres tests for NULL-as-due, interval boundary, `updated_at` unchanged on sweep, and org scoping.

<sup>Written for commit 5a418b345e7937bede36de55130ae1ed90177c44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

