### PR TITLE
fix(task-board): keep sticky title above timeline avatars

### DIFF
--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -305,8 +305,10 @@ export function TaskBoardItemDialog({
               gap above the properties; fills the column on desktop. */}
           <div className="flex min-w-0 flex-col sm:flex-1 sm:overflow-y-auto">
             {/* Sticky so a long description never scrolls the title out of
-                view — the title is the one thing that should stay put. */}
-            <div className="sticky top-0 z-10 bg-background p-6 pb-0 sm:p-8 sm:pb-0">
+                view — the title is the one thing that should stay put. z-20
+                keeps it above the activity timeline's avatars (z-10), which
+                would otherwise paint over it once scrolled underneath. */}
+            <div className="sticky top-0 z-20 bg-background p-6 pb-0 sm:p-8 sm:pb-0">
               <textarea
                 ref={(el) => {
                   if (!el) return;


### PR DESCRIPTION
## What is this contribution about?
In the task detail modal, the sticky task-title header and the activity timeline's avatar icons both used `z-10` with no stacking context between them. Once a timeline avatar (e.g. "created the task") scrolled underneath the sticky title, it painted on top of the title text instead of staying behind it. Bumped the title header to `z-20` so it always wins regardless of any `z-10` usage further down the feed.

## How did you verify your code works?
Verified manually in a local dev build: opened a task with a long description and several activity/comment entries, scrolled the activity feed, and confirmed an avatar rendered directly over the sticky title before the fix (confirmed via `elementFromPoint` at the overlapping coordinates) and no longer does after bumping the z-index.

## Screenshots/Demonstration
Before: a purple "R" avatar renders on top of the task title text once scrolled underneath it. After: the title stays clean while timeline avatars scroll normally beneath it.

## How to Test
1. Open a task in the task board with a long description and a few comments/activity events.
2. Open the task dialog and scroll the activity feed down, then back up slowly.
3. Expected outcome: the task title stays fully legible and no avatar/icon renders over it.

## Migration Notes
None.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a visual overlap in the task dialog where activity timeline avatars rendered over the sticky task title. Raised the title header to z-20 so the title always stays above the feed.

<sup>Written for commit 51053c2d9f50caa362c5a873542995d9ce1a709d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

