### PR TITLE
simplify(task-board): single priority-picked agent row on task cards

### DIFF
--- a/apps/web/src/components/code-reviewer-icon.tsx
+++ b/apps/web/src/components/code-reviewer-icon.tsx
@@ -1,8 +1,10 @@
 import { cn } from "@deco/ui/lib/utils.ts";
-import { CODE_REVIEWER_ICON_URL } from "@/sdk";
+import { CODE_REVIEWER_COLOR, CODE_REVIEWER_ICON_URL } from "@/sdk";
 
-/** The Code Reviewer glyph, rendered as a round avatar so its review thread
- *  sits alongside the Super Agent and QA Agent on the task card. */
+/** The Code Reviewer glyph, rendered as a round avatar badge — a light tint
+ *  of its own brand color with the glyph centered inside, matching the Super
+ *  Agent capybara avatar's weight — so its review thread sits alongside the
+ *  Super Agent and QA Agent on the task card. */
 export function CodeReviewerIcon({
   size = 16,
   className,
@@ -11,13 +13,22 @@ export function CodeReviewerIcon({
   className?: string;
 }) {
   return (
-    <img
-      src={CODE_REVIEWER_ICON_URL}
-      alt="Code Reviewer"
-      width={size}
-      height={size}
-      style={{ width: size, height: size }}
-      className={cn("shrink-0 rounded-full object-cover", className)}
-    />
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center rounded-full",
+        className,
+      )}
+      style={{
+        width: size,
+        height: size,
+        backgroundColor: `${CODE_REVIEWER_COLOR}26`,
+      }}
+    >
+      <img
+        src={CODE_REVIEWER_ICON_URL}
+        alt="Code Reviewer"
+        style={{ width: size * 0.6, height: size * 0.6 }}
+      />
+    </span>
   );
 }

--- a/apps/web/src/components/qa-agent-icon.tsx
+++ b/apps/web/src/components/qa-agent-icon.tsx
@@ -1,9 +1,12 @@
 import { cn } from "@deco/ui/lib/utils.ts";
-import { QA_AGENT_ICON_URL } from "@/sdk";
+import { QA_AGENT_COLOR, QA_AGENT_ICON_URL } from "@/sdk";
 import { useT } from "@/i18n/use-t.ts";
 
-/** The QA Agent glyph, rendered as a round avatar so it sits alongside the
- *  Super Agent and member avatars in the assignee picker. */
+/** The QA Agent glyph, rendered as a round avatar badge — a light tint of its
+ *  own brand color with the glyph centered inside — so it reads with the same
+ *  visual weight as the Super Agent capybara avatar instead of a bare line
+ *  icon, and sits alongside the Super Agent and member avatars in the
+ *  assignee picker. */
 export function QaAgentIcon({
   size = 16,
   className,
@@ -13,13 +16,22 @@ export function QaAgentIcon({
 }) {
   const t = useT();
   return (
-    <img
-      src={QA_AGENT_ICON_URL}
-      alt={t("taskBoard.taskDialog.qaAgentLabel")}
-      width={size}
-      height={size}
-      style={{ width: size, height: size }}
-      className={cn("shrink-0 rounded-full object-cover", className)}
-    />
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center justify-center rounded-full",
+        className,
+      )}
+      style={{
+        width: size,
+        height: size,
+        backgroundColor: `${QA_AGENT_COLOR}26`,
+      }}
+    >
+      <img
+        src={QA_AGENT_ICON_URL}
+        alt={t("taskBoard.taskDialog.qaAgentLabel")}
+        style={{ width: size * 0.6, height: size * 0.6 }}
+      />
+    </span>
   );
 }

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useRef, useState } from "react";
-import type { CSSProperties, ReactNode } from "react";
+import type { CSSProperties } from "react";
 import { createPortal } from "react-dom";
 import {
   DndContext,
@@ -118,7 +118,7 @@ import { AssigneePickerContent } from "./assignee-picker";
 import { SubscriptionPaywallDialog } from "./subscription-paywall-dialog";
 import { RerunDialog } from "./rerun-dialog";
 import { subscriptionErrorKind } from "@/components/task-board/is-subscription-error";
-import { isReportsTask } from "@decocms/shared/task-board";
+import { isReportsTask, type ReviewerKind } from "@decocms/shared/task-board";
 import { useFlipLanes } from "./use-flip-lanes";
 import { Calendar as DayPickerCalendar } from "@deco/ui/components/calendar.tsx";
 import { buildTaskChatContext } from "./build-task-chat-context";
@@ -1823,34 +1823,94 @@ function TaskCard({
       )}
 
       {mainThread && (
-        <div className="-mx-3 flex flex-col gap-1.5 border-t border-border px-3 pt-3">
-          <AgentThreadFooterRow
-            icon={<SuperAgentIcon size={14} />}
-            name={t("taskBoard.taskDialog.superAgentDefaultName")}
-            thread={mainThread}
-          />
-          {reviewThreads.map(({ kind, thread }) => (
-            <AgentThreadFooterRow
-              key={thread.threadId}
-              icon={
-                kind === "qa" ? (
-                  <QaAgentIcon size={14} />
-                ) : (
-                  <CodeReviewerIcon size={14} />
-                )
-              }
-              name={t(
-                kind === "qa"
-                  ? "taskBoard.taskDialog.qaAgentLabel"
-                  : "taskBoard.taskDialog.codeReviewerLabel",
-              )}
-              thread={thread}
-            />
-          ))}
-        </div>
+        <AgentReviewFooter
+          mainThread={mainThread}
+          reviewThreads={reviewThreads}
+        />
       )}
     </button>
   );
+}
+
+/** An agent thread paired with its glyph kind and display name, for the card footer. */
+type FooterAgent = {
+  kind: "main" | ReviewerKind;
+  name: string;
+  thread: TaskBoardItemThread;
+};
+
+/** Rank for picking which agent's row the card footer shows — lower wins. A
+ *  running/awaiting-input agent is always the most important thing on the
+ *  card; once nothing is running, a failure is the most important thing;
+ *  otherwise (everything `completed`) the most recently run agent wins. */
+function statusPriority(status: TaskBoardItemThread["status"]): number {
+  if (status === "in_progress" || status === "requires_action") return 0;
+  if (status === "failed") return 1;
+  return 2;
+}
+
+/**
+ * The card footer shows a single row for whichever agent thread — the Super
+ * Agent's own run, or a QA/code-review thread — matters most right now:
+ * something running or awaiting input beats everything else, an error beats
+ * a clean run, and among equals the most recently run agent wins. Stacking
+ * all three threads (one row each, or a row plus a collapsed icon strip)
+ * cost more space than it was worth for a card whose job is a quick glance —
+ * full activity detail already lives one click away in the task dialog.
+ */
+function AgentReviewFooter({
+  mainThread,
+  reviewThreads,
+}: {
+  mainThread: TaskBoardItemThread;
+  reviewThreads: { kind: ReviewerKind; thread: TaskBoardItemThread }[];
+}) {
+  const t = useT();
+  const agents: FooterAgent[] = [
+    {
+      kind: "main",
+      name: t("taskBoard.taskDialog.superAgentDefaultName"),
+      thread: mainThread,
+    },
+    ...reviewThreads.map(({ kind, thread }) => ({
+      kind,
+      name: t(
+        kind === "qa"
+          ? "taskBoard.taskDialog.qaAgentLabel"
+          : "taskBoard.taskDialog.codeReviewerLabel",
+      ),
+      thread,
+    })),
+  ];
+  const featuredAgent = agents.reduce((best, agent) => {
+    const rank = statusPriority(agent.thread.status);
+    const bestRank = statusPriority(best.thread.status);
+    if (rank !== bestRank) return rank < bestRank ? agent : best;
+    return agent.thread.createdAt > best.thread.createdAt ? agent : best;
+  });
+
+  return (
+    <div className="-mx-3 flex flex-col gap-1.5 border-t border-border px-3 pt-3">
+      <AgentThreadFooterRow {...featuredAgent} />
+    </div>
+  );
+}
+
+/** An agent's glyph — the Super Agent capybara, or the QA/Code Reviewer badge. */
+function AgentGlyph({
+  kind,
+  size,
+  className,
+}: {
+  kind: FooterAgent["kind"];
+  size: number;
+  className?: string;
+}) {
+  if (kind === "qa") return <QaAgentIcon size={size} className={className} />;
+  if (kind === "code_review") {
+    return <CodeReviewerIcon size={size} className={className} />;
+  }
+  return <SuperAgentIcon size={size} className={className} />;
 }
 
 /**
@@ -1859,21 +1919,13 @@ function TaskCard({
  * thread's last message. A condensed version of `ThreadActivityItem`'s status
  * row in the task dialog.
  */
-function AgentThreadFooterRow({
-  icon,
-  name,
-  thread,
-}: {
-  icon: ReactNode;
-  name: string;
-  thread: TaskBoardItemThread;
-}) {
+function AgentThreadFooterRow({ kind, name, thread }: FooterAgent) {
   const t = useT();
   const state = thread.status ? threadStatusStyle(thread.status, t) : null;
 
   return (
     <div className="flex items-center gap-1.5">
-      {icon}
+      <AgentGlyph kind={kind} size={16} />
       <span className="shrink-0 text-xs font-medium text-foreground">
         {name}
       </span>

--- a/packages/shared/src/sdk/lib/constants.ts
+++ b/packages/shared/src/sdk/lib/constants.ts
@@ -271,16 +271,20 @@ export const parseDevConnectionId = devConnectionPrefix.is;
 export const SUPER_AGENT_ICON_URL =
   "https://assets.decocache.com/decocms/fd07a578-6b1c-40f1-bc05-88a3b981695d/f7fc4ffa81aec04e37ae670c3cd4936643a7b269.png";
 
+/** The QA Agent's brand color — shared by its glyph and its avatar badge tint. */
+export const QA_AGENT_COLOR = "#f59e0b";
+
 /** The QA Agent glyph — a bug/testing magnifier, distinguishing its review
  *  thread from the Super Agent capybara on the task card. Deliberately NOT a
  *  checkmark/shield-check: that glyph read as "already verified" even while
  *  the QA run was still in progress or had failed. */
-export const QA_AGENT_ICON_URL =
-  "https://api.iconify.design/lucide:bug.svg?color=%23f59e0b";
+export const QA_AGENT_ICON_URL = `https://api.iconify.design/lucide:bug.svg?color=${encodeURIComponent(QA_AGENT_COLOR)}`;
+
+/** The Code Reviewer's brand color — shared by its glyph and its avatar badge tint. */
+export const CODE_REVIEWER_COLOR = "#6366f1";
 
 /** The Code Reviewer glyph — a code-inspection magnifier. */
-export const CODE_REVIEWER_ICON_URL =
-  "https://api.iconify.design/lucide:file-search.svg?color=%236366f1";
+export const CODE_REVIEWER_ICON_URL = `https://api.iconify.design/lucide:file-search.svg?color=${encodeURIComponent(CODE_REVIEWER_COLOR)}`;
 
 export function getWellKnownDecopilotVirtualMCP(
   organizationId: string,


### PR DESCRIPTION
## What is this contribution about?
The task card footer used to render one row per linked agent thread (Super Agent, QA, Code Reviewer), which crowded the card with duplicated visual weight. It now shows a single row for whichever agent thread matters most: a running/awaiting-input agent wins over everything, an unresolved error wins over a clean run, and otherwise the most recently run agent is shown. QA Agent and Code Reviewer glyphs also got an avatar-badge treatment (a light tint of their own brand color behind the glyph) so they read with the same visual weight as the Super Agent capybara avatar instead of a bare line icon.

## How did you verify your code works?
`bun run --cwd apps/web check` and `bun run lint` both pass with no new errors. Verified manually against the running local dev server: inserted a mock task with three linked threads (Super Agent completed, QA Agent failed, Code Reviewer completed, in that creation order) and confirmed the card surfaces the QA Agent error row rather than the later, clean Code Reviewer run — exercising the priority order end to end.

## Screenshots/Demonstration
Before: three stacked rows (Super Agent / QA Agent / Code Reviewer), each with name, status, and message preview.
After: a single row — e.g. "QA Agent · Error · I'll start by finding th..." — chosen by priority (running/awaiting-input > error > most recent).

## How to Test
1. Open a task board card that has a Super Agent thread plus QA/Code Reviewer reviewer threads.
2. If any thread is `in_progress` or `requires_action`, confirm the card shows that thread's row.
3. Otherwise, if any thread is `failed`, confirm the card shows that thread's row (even if a later reviewer thread completed cleanly).
4. Otherwise, confirm the card shows the most recently created thread's row, with `Completed` status.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplified task card footers to show a single, priority-picked agent row (Super Agent, QA, or Code Reviewer) for faster scanning. Updated QA and Code Reviewer icons to colored avatar badges for visual parity with the Super Agent avatar.

- New Features
  - Picks one row by status: in_progress/requires_action > failed > most recent completed.
  - Adds avatar badges for QA and Code Reviewer using `QA_AGENT_COLOR` and `CODE_REVIEWER_COLOR`.
  - Introduces a compact footer row that shows agent glyph, name, status, and last message preview.

<sup>Written for commit 3f02b1c732f060ceac657fd983aaf3cc4b92ecbb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

