### PR TITLE
fix(task-board): render task comments as markdown

### DIFF
--- a/apps/web/src/layouts/task-board/task-comments.tsx
+++ b/apps/web/src/layouts/task-board/task-comments.tsx
@@ -30,6 +30,7 @@ import {
   X,
 } from "@untitledui/icons";
 import { cn } from "@deco/ui/lib/utils.ts";
+import { MemoizedMarkdown } from "@/components/chat/markdown";
 import { SuperAgentIcon } from "@/components/super-agent-icon";
 import { getInitials } from "@/lib/get-initials";
 import { formatTimeAgo } from "@/lib/format-time";
@@ -245,12 +246,12 @@ function CommentEntry({
         className={cn(
           // Same size as the task's description: a comment is body prose, not
           // metadata like the name and timestamp above it.
-          "whitespace-pre-wrap text-[15px] leading-relaxed text-foreground",
+          "text-[15px] leading-relaxed text-foreground",
           // Avatar (24px) + gap (8px), so a reply's text starts at the name.
           isReply && "pl-8",
         )}
       >
-        {comment.body}
+        <MemoizedMarkdown id={comment.id} text={comment.body} />
       </div>
     </div>
   );


### PR DESCRIPTION
## What is this contribution about?
Task comment bodies (from both org members and the Super Agent) were rendered as plain text, so markdown formatting like lists, code blocks, and links showed up as raw syntax. This renders comment bodies through the same `MemoizedMarkdown` component already used for the task description and PR summaries.

## How did you verify your code works?
Ran `bun run check` (no new type errors) and manually verified in the dev UI: seeded a task with a Super Agent comment containing headings, bold/italic, a bullet list, a numbered list, a code block, a link, and a blockquote, and confirmed it renders formatted instead of as raw markdown text.

## Screenshots/Demonstration
N/A — verified manually via local dev server, no screenshot captured.

## How to Test
1. Open any task in the task board and add a comment containing markdown (e.g. `**bold**`, a \`\`\`code block\`\`\`, or a bullet list).
2. Submit the comment.
3. Expected outcome: the comment renders formatted markdown instead of raw text.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render task comment bodies as markdown using the existing `MemoizedMarkdown` component, so lists, code blocks, links, and other formatting display correctly instead of raw syntax. This matches the formatting used for task descriptions and PR summaries.

<sup>Written for commit f9850a52ca5130e3997571fd982e470bc6f5357b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

