### PR TITLE
fix(reports): remove scroll from scan-loading screen

### DIFF
--- a/apps/web/src/routes/reports/scan-gate.tsx
+++ b/apps/web/src/routes/reports/scan-gate.tsx
@@ -134,7 +134,7 @@ function ScanScreen({
 
   return (
     <div
-      className="fixed inset-0 overflow-y-auto"
+      className="fixed inset-0 overflow-hidden"
       style={{
         color: DECK.ink,
         fontFamily: "Switzer, 'Inter var', Helvetica, Arial, sans-serif",
@@ -157,10 +157,10 @@ function ScanScreen({
         )}
       </div>
 
-      <div className="relative z-10 flex min-h-full flex-col items-center justify-center px-3 py-4 sm:px-5 sm:py-16">
+      <div className="relative z-10 flex h-full flex-col items-center justify-center px-3 py-4 sm:px-5 sm:py-8">
         {isActive && (
           <div
-            className="w-full max-w-[460px] rounded-2xl sm:rounded-3xl px-5 pt-5 pb-6 sm:px-8 sm:pt-8 sm:pb-9"
+            className="max-h-full w-full max-w-[460px] overflow-y-auto rounded-2xl sm:rounded-3xl px-5 pt-5 pb-6 sm:px-8 sm:pt-8 sm:pb-9"
             style={{
               background: "#fff",
               boxShadow:
@@ -297,7 +297,7 @@ function ScanScreen({
                 </a>
               </p>
             ) : (
-              <ReportSocialProof />
+              <ReportSocialProof compact />
             )}
           </div>
         )}


### PR DESCRIPTION
## What is this contribution about?
The "your report is being prepared" scan-loading card (`apps/web/src/routes/reports/scan-gate.tsx`) overflowed the viewport on shorter screens, forcing the whole page to scroll. Switched the outer shell to a fixed, non-scrolling layout, made the card itself internally scrollable only as a fallback for very short viewports, tightened vertical padding, and used the existing `compact` variant of the social-proof logo strip.

## How did you verify your code works?
Verified manually: rendered the real `ScanScreen` component in a local dev build (via a throwaway preview route, removed before this commit) and confirmed the loading card fits the viewport at both desktop and shorter window heights without triggering page scroll.

## Screenshots/Demonstration
See attached image of the previous broken state (page-level scrollbar visible around the card).

## How to Test
1. Open a report URL while a scan is in progress (`/report/<domain>`).
2. Resize the browser window to a shorter height.
3. Expected outcome: the card fits within the viewport with no page-level scrollbar; the tracker/social-proof content is visible without scrolling on typical screen sizes.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the scan-loading screen so it no longer triggers page scroll on short viewports. Uses a fixed layout with an internally scrollable card and tighter spacing.

- **Bug Fixes**
  - Outer wrapper: `overflow-hidden` to stop page-level scroll.
  - Center container: `h-full` and reduced vertical padding.
  - Card: `max-h-full` and `overflow-y-auto` for very short screens.
  - Social proof: use `compact` variant.

<sup>Written for commit 7042fd6da4147c0d47336a10367fa654048aa45b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

