### PR TITLE
fix(reports): sign-out popover stacking and logo carousel CLS

### DIFF
--- a/apps/web/src/routes/reports/report-social-proof.tsx
+++ b/apps/web/src/routes/reports/report-social-proof.tsx
@@ -75,7 +75,7 @@ function LogoCol({
   return (
     <div
       ref={cycleRef}
-      className="flex flex-1 items-center justify-center overflow-hidden py-3"
+      className="flex min-w-0 flex-1 items-center justify-center overflow-hidden py-3"
       style={{
         borderRight: last ? undefined : `1px solid ${DECK.border}`,
         borderTop: bottomRow ? `1px solid ${DECK.border}` : undefined,

--- a/apps/web/src/routes/reports/signal-deck.tsx
+++ b/apps/web/src/routes/reports/signal-deck.tsx
@@ -586,7 +586,7 @@ export default function SignalDeck({
                 </button>
                 {userMenuOpen && (
                   <div
-                    className="absolute right-0 top-full z-50 mt-2 min-w-[180px] overflow-hidden rounded-xl border shadow-xl"
+                    className="absolute right-0 top-full z-[60] mt-2 min-w-[180px] overflow-hidden rounded-xl border shadow-xl"
                     style={{
                       background: DECK.surface,
                       borderColor: DECK.border,


### PR DESCRIPTION
## What is this contribution about?
Two small UI bugs in the report deck (`/report/:domain`):
1. The sign-out popover in the deck header used `z-50`, which tied with slide content also at `z-50` (e.g. the cover slide's score-methodology tooltip). Ties resolve by DOM order, and the slide content renders after the header, so it painted on top and intercepted clicks — the popover appeared but "Sign out" wasn't clickable on any slide. Bumped it to `z-[60]`, safely above every `z-*` value used in the report templates.
2. The "Already received by" logo carousel columns are flex items that default to `min-width: auto`. As logos cycled through with different rendered widths, a wider logo forced its column (and the whole row) to grow past its even share, then shrink back — visible layout shift. Added `min-w-0` so each column stays pinned to its equal `flex-1` share.

## How did you verify your code works?
Verified manually in the browser: opened `/report/:domain`, confirmed the sign-out popover renders above slide content and "Sign out" is clickable on the cover slide and other slides; watched the logo carousel cycle through several rounds and confirmed the container width no longer shifts.

## Screenshots/Demonstration
N/A — see linked bug report screenshots for before state.

## How to Test
1. Visit `/report/:domain` while signed in and open the account popover in the header.
2. On the cover slide (and other slides), click "Sign out" — it should sign out instead of being unresponsive.
3. Watch the "Already received by" logo strip cycle for ~10s — the surrounding box width should stay constant.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two UI issues in the report deck: the account popover now stacks above slide content, and the logo carousel no longer causes layout shifts. This makes "Sign out" clickable on all slides and keeps the carousel width stable.

- **Bug Fixes**
  - Raised header popover z-index to `z-[60]` so it renders above slide tooltips and accepts clicks.
  - Set logo column `min-w-0` to prevent flex item growth and stop CLS during logo cycles.

<sup>Written for commit cd0ececdb65307b54190d5ae21365f548af1337a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

