### PR TITLE
fix(commerce-onboarding): open the report's per-source connect dialog in place

### DIFF
--- a/apps/web/src/i18n/en/commerce-onboarding.ts
+++ b/apps/web/src/i18n/en/commerce-onboarding.ts
@@ -20,6 +20,9 @@ export const commerceOnboarding = {
   "commerceOnboarding.companionCard.editConfiguration": "Edit configuration",
   "commerceOnboarding.companionCard.finishSetup": "Finish setup",
   "commerceOnboarding.companionCard.required": "Required",
+  "commerceOnboarding.connectSourceDialog.connecting": "Connecting {title}...",
+  "commerceOnboarding.connectSourceDialog.loading": "Loading...",
+  "commerceOnboarding.connectSourceDialog.title": "Connect data source",
   "commerceOnboarding.githubConfigForm.cancel": "Cancel",
   "commerceOnboarding.githubConfigForm.failedToSave":
     "Couldn't save the configuration",

--- a/apps/web/src/i18n/pt-br/commerce-onboarding.ts
+++ b/apps/web/src/i18n/pt-br/commerce-onboarding.ts
@@ -22,6 +22,9 @@ export const commerceOnboarding = {
   "commerceOnboarding.companionCard.editConfiguration": "Editar configuração",
   "commerceOnboarding.companionCard.finishSetup": "Concluir configuração",
   "commerceOnboarding.companionCard.required": "Obrigatório",
+  "commerceOnboarding.connectSourceDialog.connecting": "Conectando {title}...",
+  "commerceOnboarding.connectSourceDialog.loading": "Carregando...",
+  "commerceOnboarding.connectSourceDialog.title": "Conectar fonte de dados",
   "commerceOnboarding.githubConfigForm.cancel": "Cancelar",
   "commerceOnboarding.githubConfigForm.failedToSave":
     "Não foi possível salvar a configuração",

--- a/apps/web/src/layouts/main-panel-tabs/connect-sources-tab.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/connect-sources-tab.tsx
@@ -1,23 +1,21 @@
 /**
  * ConnectSourcesTab — reopens the commerce-onboarding connect flow for a
  * client who already finished onboarding but skipped one or more data
- * sources (GA4/GSC/VTEX/GitHub). Opened via the report app's
+ * sources (GA4/GSC/VTEX/GitHub). Opened via the report app's generic
  * `studio://navigate?main=connect-sources` resource link (see
  * project-app-navigate.ts) — a dismissable overlay tab, unlike the blocking
  * onboarding step (CommerceConnectModal), sharing the same provider-card UI
  * and chrome (ConnectLayout) so the two don't drift.
  *
- * An optional `&field=<id>` on that same link (see CONNECT_SOURCE_FIELDS in
- * project-app-navigate.ts) narrows this to exactly one companion's card,
- * auto-triggering its connect/config dialog on arrival — the report already
- * knows which source is missing, so it skips the 4-card grid entirely.
+ * A `&field=<id>` on that same link targets one specific source and does NOT
+ * come here — project-app-view.tsx opens that source's connect dialog in
+ * place (ConnectSourceDialog) instead of swapping the panel.
  */
-import { useMutation, useSuspenseQuery } from "@tanstack/react-query";
-import { useNavigate, useSearch } from "@tanstack/react-router";
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
 import { Suspense, useState } from "react";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { useT } from "@/i18n/use-t.ts";
-import { KEYS } from "@/lib/query-keys";
 import {
   SELF_MCP_ALIAS_ID,
   useMCPClient,
@@ -28,6 +26,7 @@ import {
   CompanionMcpsSection,
   CompanionMcpsSectionSkeleton,
 } from "@/routes/commerce-onboarding/companion-mcps-section.tsx";
+import { useCommerceDiscoverySiteUrl } from "@/routes/commerce-onboarding/use-commerce-companions.ts";
 import {
   ConnectFooterButton,
   ConnectLayout,
@@ -47,12 +46,6 @@ function ConnectSourcesTabError({ onClose }: { onClose: () => void }) {
 
 export function ConnectSourcesTab() {
   const navigate = useNavigate();
-  // Set only by the report's per-card "Connect" click (studio://navigate?
-  // main=connect-sources&field=<id>) — skips the grid straight to that one
-  // companion's own dialog. Absent for the generic "connect-sources" entry
-  // (e.g. from the autopilot card, which doesn't know which analytics source
-  // the user will pick), which still shows the full 4-card grid.
-  const { field } = useSearch({ strict: false }) as { field?: string };
   const close = () =>
     navigate({
       to: ".",
@@ -75,11 +68,7 @@ export function ConnectSourcesTab() {
             </ConnectLayout>
           }
         >
-          <ConnectSourcesTabContent
-            onDone={close}
-            onClose={close}
-            focusFieldKey={field}
-          />
+          <ConnectSourcesTabContent onDone={close} onClose={close} />
         </Suspense>
       </ErrorBoundary>
     </div>
@@ -89,11 +78,9 @@ export function ConnectSourcesTab() {
 function ConnectSourcesTabContent({
   onDone,
   onClose,
-  focusFieldKey,
 }: {
   onDone: () => void;
   onClose: () => void;
-  focusFieldKey?: string;
 }) {
   const t = useT();
   const { org } = useProjectContext();
@@ -104,24 +91,11 @@ function ConnectSourcesTabContent({
     orgSlug: org.slug,
   });
 
-  const connectionQuery = useSuspenseQuery({
-    queryKey: KEYS.commerceDiscoveryConnection(org.id, connectionId),
-    queryFn: async () => {
-      const result = await selfClient.callTool({
-        name: "COLLECTION_CONNECTIONS_GET",
-        arguments: { id: connectionId },
-      });
-      return parseSelfToolResult<{
-        item: { metadata?: Record<string, unknown> | null } | null;
-      }>(result);
-    },
-    retry: false,
+  const siteUrl = useCommerceDiscoverySiteUrl({
+    selfClient,
+    org,
+    cdConnectionId: connectionId,
   });
-  const item = connectionQuery.data.item;
-  const siteUrl =
-    typeof item?.metadata?.siteUrl === "string"
-      ? (item.metadata.siteUrl as string)
-      : undefined;
 
   // Starts false (unlike the onboarding modal, which fails open): here the
   // client is already past onboarding, so there's no forced-continue path —
@@ -186,7 +160,6 @@ function ConnectSourcesTabContent({
           org={org}
           cdConnectionId={connectionId}
           siteUrl={siteUrl}
-          focusFieldKey={focusFieldKey}
           onReadinessChange={setHasConnectedSource}
         />
       </div>

--- a/apps/web/src/layouts/shell-layout.tsx
+++ b/apps/web/src/layouts/shell-layout.tsx
@@ -190,11 +190,10 @@ export function usePanelActions() {
     setTaskId(newId, targetVmcp);
   };
 
-  const openTab = (tabId: string, extraSearch?: Record<string, string>) =>
+  const openTab = (tabId: string) =>
     navWith(currentTaskId || crypto.randomUUID(), (prev) => ({
       ...prev,
       main: tabId,
-      ...extraSearch,
     }));
 
   return {

--- a/apps/web/src/routes/commerce-onboarding/companion-card.tsx
+++ b/apps/web/src/routes/commerce-onboarding/companion-card.tsx
@@ -103,24 +103,6 @@ function UnlinkButton({
   );
 }
 
-/**
- * Renders nothing; fires `onConnect` exactly once when mounted — the "no
- * panel in between" deep link's not-yet-linked case (see `autoOpen` on
- * {@link CompanionCard}). Mirrors `CmsAutoOpen` (sandbox/preview/preview.tsx):
- * a state-guarded render-time call instead of a mount effect (no useEffect
- * in this codebase), deferred with `queueMicrotask` to land post-commit.
- * The caller only renders this while the trigger condition holds, so it
- * stops appearing — and can't re-fire — the instant that condition flips.
- */
-function AutoConnectOnce({ onConnect }: { onConnect: () => void }) {
-  const [fired, setFired] = useState(false);
-  if (!fired) {
-    setFired(true);
-    queueMicrotask(onConnect);
-  }
-  return null;
-}
-
 export function CompanionCard({
   card,
   connecting,
@@ -133,7 +115,6 @@ export function CompanionCard({
   siteUrl,
   autoOpenConfigFieldKey,
   onAutoOpenConfigHandled,
-  autoOpen,
 }: {
   card: CompanionCardModel;
   connecting: boolean;
@@ -146,14 +127,6 @@ export function CompanionCard({
   siteUrl?: string;
   autoOpenConfigFieldKey: string | null;
   onAutoOpenConfigHandled: () => void;
-  /** Skip the click: immediately open this card's connect/config dialog on
-   *  mount. Used by the "no panel in between" deep link from the commerce
-   *  report (see focusFieldKey in companion-mcps-section.tsx) — forces the
-   *  OAuth/config-form `handleConnect` for a not-yet-linked card, the SA
-   *  dialog directly (below), or the config-form for a satisfied-but-
-   *  unconfigured one (needsConfig doesn't auto-open it on its own — only a
-   *  same-session `autoOpenConfigFieldKey` match does). */
-  autoOpen?: boolean;
 }) {
   const linkedConnectionId = card.linkedConnectionId;
   // GA4/GSC use the shared-SA lane by default; only fall back to the OAuth gear
@@ -167,14 +140,6 @@ export function CompanionCard({
   // can hit this; SA bindings are configured the moment they verify.
   const needsConfig = card.satisfied && !card.configured;
 
-  // Not-yet-linked + autoOpen: trigger the OAuth/config-form connect flow
-  // immediately instead of waiting for a click. The SA lane's own dialog
-  // handles its `autoOpen` prop directly (below) since its "connect" click
-  // only opens a local dialog rather than calling this handler. Renders only
-  // while the trigger condition holds, so it stops appearing (and can't
-  // re-fire) the instant `card.satisfied` flips true.
-  const triggerAutoConnect = autoOpen && !useSaFlow && !card.satisfied;
-
   const action =
     useSaFlow && saProvider ? (
       <SaConnectAction
@@ -187,7 +152,6 @@ export function CompanionCard({
         disabled={disabled}
         connecting={connecting}
         primary={card.required}
-        autoOpen={autoOpen && !card.satisfied}
       />
     ) : card.satisfied && linkedConnectionId ? (
       needsConfig ? (
@@ -201,13 +165,10 @@ export function CompanionCard({
               contextSiteUrl={siteUrl}
               variant="configure"
               disabled={disabled}
-              autoOpen={
-                autoOpen ||
-                shouldAutoOpenCompanionConfig({
-                  autoOpenFieldKey: autoOpenConfigFieldKey,
-                  card,
-                })
-              }
+              autoOpen={shouldAutoOpenCompanionConfig({
+                autoOpenFieldKey: autoOpenConfigFieldKey,
+                card,
+              })}
               onAutoOpenHandled={onAutoOpenConfigHandled}
             />
           </Suspense>
@@ -265,7 +226,6 @@ export function CompanionCard({
 
   return (
     <>
-      {triggerAutoConnect && <AutoConnectOnce onConnect={onConnect} />}
       <CompanionCardView
         icon={card.icon}
         title={card.title}
@@ -293,7 +253,6 @@ function SaConnectAction({
   disabled,
   connecting,
   primary,
-  autoOpen,
 }: {
   card: CompanionCardModel;
   provider: BindProvider;
@@ -304,18 +263,9 @@ function SaConnectAction({
   disabled: boolean;
   connecting: boolean;
   primary?: boolean;
-  /** Open the binding dialog immediately instead of waiting for a click — the
-   *  "no panel in between" deep link from the commerce report. */
-  autoOpen?: boolean;
 }) {
   const t = useT();
-  const [open, setOpen] = useState(autoOpen ?? false);
-  const [savePending, setSavePending] = useState(false);
-
-  const handleOpenChange = (next: boolean) => {
-    if (!next && savePending) return; // don't close mid-verify
-    setOpen(next);
-  };
+  const [open, setOpen] = useState(false);
 
   return (
     <>
@@ -349,45 +299,88 @@ function SaConnectAction({
         />
       )}
 
-      <Dialog open={open} onOpenChange={handleOpenChange}>
-        {/* No DialogDescription: the numbered steps immediately below the title
-            are the description, so `aria-describedby` is opted out explicitly
-            rather than left dangling. */}
-        <DialogContent
-          aria-describedby={undefined}
-          className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-lg"
-        >
-          <DialogHeader className="flex-row items-center gap-3 space-y-0 text-left">
-            <IntegrationIcon
-              icon={card.icon}
-              name={card.title}
-              size="sm"
-              fit="contain"
-              className="p-1"
-            />
-            <DialogTitle className="min-w-0 flex-1">{card.title}</DialogTitle>
-          </DialogHeader>
-          <SaBindingForm
-            provider={provider}
-            siteUrl={siteUrl}
-            siteHost={siteUrlToHost(siteUrl)}
-            selfClient={selfClient}
-            org={org}
-            initialResourceId={card.boundResource ?? undefined}
-            onDone={() => setOpen(false)}
-            onIsPendingChange={setSavePending}
-            onOAuthInstead={
-              card.satisfied
-                ? undefined
-                : () => {
-                    setOpen(false);
-                    onOAuthInstead();
-                  }
-            }
-          />
-        </DialogContent>
-      </Dialog>
+      <SaBindingDialog
+        card={card}
+        provider={provider}
+        org={org}
+        selfClient={selfClient}
+        siteUrl={siteUrl}
+        open={open}
+        onOpenChange={setOpen}
+        onOAuthInstead={
+          card.satisfied
+            ? undefined
+            : () => {
+                setOpen(false);
+                onOAuthInstead();
+              }
+        }
+      />
     </>
+  );
+}
+
+/** The shared-SA binding dialog (step-by-step grant + resource id form) as a
+ *  controlled component, so both the card's connect action and the report's
+ *  deep-link dialog (connect-source-dialog.tsx) open the exact same thing. */
+export function SaBindingDialog({
+  card,
+  provider,
+  org,
+  selfClient,
+  siteUrl,
+  open,
+  onOpenChange,
+  onOAuthInstead,
+}: {
+  card: CompanionCardModel;
+  provider: BindProvider;
+  org: { id: string; slug: string };
+  selfClient: Client;
+  siteUrl?: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onOAuthInstead?: () => void;
+}) {
+  const [savePending, setSavePending] = useState(false);
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next && savePending) return; // don't close mid-verify
+    onOpenChange(next);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      {/* No DialogDescription: the numbered steps immediately below the title
+          are the description, so `aria-describedby` is opted out explicitly
+          rather than left dangling. */}
+      <DialogContent
+        aria-describedby={undefined}
+        className="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-lg"
+      >
+        <DialogHeader className="flex-row items-center gap-3 space-y-0 text-left">
+          <IntegrationIcon
+            icon={card.icon}
+            name={card.title}
+            size="sm"
+            fit="contain"
+            className="p-1"
+          />
+          <DialogTitle className="min-w-0 flex-1">{card.title}</DialogTitle>
+        </DialogHeader>
+        <SaBindingForm
+          provider={provider}
+          siteUrl={siteUrl}
+          siteHost={siteUrlToHost(siteUrl)}
+          selfClient={selfClient}
+          org={org}
+          initialResourceId={card.boundResource ?? undefined}
+          onDone={() => onOpenChange(false)}
+          onIsPendingChange={setSavePending}
+          onOAuthInstead={onOAuthInstead}
+        />
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -425,16 +418,8 @@ function CompanionConfiguration({
   onAutoOpenHandled,
 }: CompanionConfigurationProps) {
   const t = useT();
-  const companionClient = useMCPClient({
-    connectionId,
-    orgId: org.id,
-    orgSlug: org.slug,
-  });
   const [dialogOpen, setDialogOpen] = useState(autoOpen);
-  const [isSavePending, setIsSavePending] = useState(false);
-  const queryClient = useQueryClient();
 
-  const FormComponent = COMPANION_CONFIG_FORMS[card.bindingType];
   const savedConfigEntries = getConfigurationSummaryEntries(
     card.configurationState,
     t,
@@ -447,44 +432,10 @@ function CompanionConfiguration({
     }
   };
 
-  const handleDialogOpenChange = (open: boolean) => {
-    if (!open && isSavePending) {
-      return;
-    }
-    if (!open) {
-      closeDialog();
-      return;
-    }
-    setDialogOpen(true);
-  };
-
-  const disconnectMutation = useMutation({
-    mutationFn: async () => {
-      await selfClient.callTool({
-        name: "COLLECTION_CONNECTIONS_DELETE",
-        arguments: { id: connectionId, force: true },
-      });
-    },
-    onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: KEYS.commerceDiscoveryCompanionConnectionsPrefix(org.id),
-      });
-      toast.success(
-        t("commerceOnboarding.companionCard.disconnectedSuccess", {
-          title: card.title,
-        }),
-      );
-      closeDialog();
-    },
-    onError: () => {
-      toast.error(t("commerceOnboarding.companionCard.disconnectError"));
-    },
-  });
-
   // No config form for this binding → nothing to open. A "configure" variant
   // still needs a visible trigger, so it degrades to a quiet gear-less noop
   // only when there's genuinely nothing to configure.
-  if (!FormComponent) {
+  if (!COMPANION_CONFIG_FORMS[card.bindingType]) {
     return null;
   }
 
@@ -518,38 +469,118 @@ function CompanionConfiguration({
     <>
       {trigger}
 
-      <Dialog open={dialogOpen} onOpenChange={handleDialogOpenChange}>
-        <DialogContent className="sm:max-w-lg">
-          <DialogHeader className="flex-row items-center gap-3 space-y-0 text-left">
-            <IntegrationIcon
-              icon={card.icon}
-              name={card.title}
-              size="sm"
-              fit="contain"
-              className="p-1"
-            />
-            <div className="flex min-w-0 flex-1 flex-col gap-1">
-              <DialogTitle>{card.title}</DialogTitle>
-              <DialogDescription>
-                {t("commerceOnboarding.companionCard.configureDescription", {
-                  title: card.title,
-                })}
-              </DialogDescription>
-            </div>
-          </DialogHeader>
-          <FormComponent
-            card={card}
-            connectionId={connectionId}
-            companionClient={companionClient}
-            selfClient={selfClient}
-            org={org}
-            contextSiteUrl={contextSiteUrl}
-            onDone={closeDialog}
-            onDisconnect={() => disconnectMutation.mutate()}
-            onIsPendingChange={setIsSavePending}
-          />
-        </DialogContent>
-      </Dialog>
+      <CompanionConfigDialog
+        card={card}
+        org={org}
+        selfClient={selfClient}
+        connectionId={connectionId}
+        contextSiteUrl={contextSiteUrl}
+        open={dialogOpen}
+        onOpenChange={(open) => (open ? setDialogOpen(true) : closeDialog())}
+      />
     </>
+  );
+}
+
+/** The companion's config-form dialog (repo/property/credentials picker) as a
+ *  controlled component, so both the card's gear/finish-setup triggers and the
+ *  report's deep-link dialog (connect-source-dialog.tsx) open the same thing.
+ *  Suspends while the companion MCP client connects — callers own the
+ *  Suspense boundary. */
+export function CompanionConfigDialog({
+  card,
+  org,
+  selfClient,
+  connectionId,
+  contextSiteUrl,
+  open,
+  onOpenChange,
+}: {
+  card: CompanionCardModel;
+  org: { id: string; slug: string };
+  selfClient: Client;
+  connectionId: string;
+  contextSiteUrl?: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const t = useT();
+  const companionClient = useMCPClient({
+    connectionId,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+  const [isSavePending, setIsSavePending] = useState(false);
+  const queryClient = useQueryClient();
+
+  const FormComponent = COMPANION_CONFIG_FORMS[card.bindingType];
+
+  const disconnectMutation = useMutation({
+    mutationFn: async () => {
+      await selfClient.callTool({
+        name: "COLLECTION_CONNECTIONS_DELETE",
+        arguments: { id: connectionId, force: true },
+      });
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: KEYS.commerceDiscoveryCompanionConnectionsPrefix(org.id),
+      });
+      toast.success(
+        t("commerceOnboarding.companionCard.disconnectedSuccess", {
+          title: card.title,
+        }),
+      );
+      onOpenChange(false);
+    },
+    onError: () => {
+      toast.error(t("commerceOnboarding.companionCard.disconnectError"));
+    },
+  });
+
+  if (!FormComponent) {
+    return null;
+  }
+
+  const handleDialogOpenChange = (next: boolean) => {
+    if (!next && isSavePending) {
+      return;
+    }
+    onOpenChange(next);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleDialogOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader className="flex-row items-center gap-3 space-y-0 text-left">
+          <IntegrationIcon
+            icon={card.icon}
+            name={card.title}
+            size="sm"
+            fit="contain"
+            className="p-1"
+          />
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <DialogTitle>{card.title}</DialogTitle>
+            <DialogDescription>
+              {t("commerceOnboarding.companionCard.configureDescription", {
+                title: card.title,
+              })}
+            </DialogDescription>
+          </div>
+        </DialogHeader>
+        <FormComponent
+          card={card}
+          connectionId={connectionId}
+          companionClient={companionClient}
+          selfClient={selfClient}
+          org={org}
+          contextSiteUrl={contextSiteUrl}
+          onDone={() => onOpenChange(false)}
+          onDisconnect={() => disconnectMutation.mutate()}
+          onIsPendingChange={setIsSavePending}
+        />
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/web/src/routes/commerce-onboarding/companion-mcps-section.tsx
+++ b/apps/web/src/routes/commerce-onboarding/companion-mcps-section.tsx
@@ -92,10 +92,6 @@ export function CompanionMcpsSection(props: {
   /** Called once cards resolve with whether at least one is connected (or
    *  none are required). Lets the report CTA above this section gate on it. */
   onReadinessChange?: (hasConnectedSource: boolean) => void;
-  /** Render (and auto-trigger) only this one companion's card instead of the
-   *  full grid — the "no panel in between" deep link from the commerce
-   *  report, which already knows exactly which source is missing. */
-  focusFieldKey?: string;
 }) {
   return (
     <QueryErrorResetBoundary>
@@ -124,13 +120,11 @@ function CompanionMcpsSectionContent({
   cdConnectionId,
   siteUrl,
   onReadinessChange,
-  focusFieldKey,
 }: {
   org: CompanionOrg;
   cdConnectionId: string;
   siteUrl?: string;
   onReadinessChange?: (hasConnectedSource: boolean) => void;
-  focusFieldKey?: string;
 }) {
   const t = useT();
   const { data: session } = authClient.useSession();
@@ -230,7 +224,6 @@ function CompanionMcpsSectionContent({
             current === card.fieldKey ? null : current,
           )
         }
-        autoOpen={focusFieldKey === card.fieldKey}
         onConnect={() => void handleConnect()}
         onDisconnect={() => void disconnect(card)}
       />
@@ -265,14 +258,9 @@ function CompanionMcpsSectionContent({
           </p>
         )}
         {/* Single list, required source(s) first — the "Obrigatório" pill on the
-            card carries the must-vs-optional distinction (no section headers).
-            focusFieldKey narrows this to exactly one card — the "no panel in
-            between" deep link from the commerce report. */}
+            card carries the must-vs-optional distinction (no section headers). */}
         <div className="flex flex-col gap-4 pt-3">
-          {(focusFieldKey
-            ? cards.filter((c) => c.fieldKey === focusFieldKey)
-            : [...requiredCards, ...enhancedCards]
-          ).map(renderCard)}
+          {[...requiredCards, ...enhancedCards].map(renderCard)}
         </div>
       </ScrollReveal>
     </div>

--- a/apps/web/src/routes/commerce-onboarding/connect-source-dialog.tsx
+++ b/apps/web/src/routes/commerce-onboarding/connect-source-dialog.tsx
@@ -1,0 +1,285 @@
+/**
+ * ConnectSourceDialog — the report app's per-source "Connect" deep link
+ * (`studio://navigate?main=connect-sources&field=<id>`, intercepted in
+ * project-app-view.tsx) rendered as a plain modal over the report, instead of
+ * swapping the main panel to the onboarding-style connect-sources tab. Opens
+ * the exact same SA-binding / OAuth+config dialogs as the companion cards:
+ *   - GA4/GSC on the shared-SA lane → SaBindingDialog
+ *   - already linked (or just linked) → CompanionConfigDialog
+ *   - OAuth lane, not linked yet → run the OAuth connect immediately behind a
+ *     small progress dialog; once linked the card flips and the config dialog
+ *     renders on the next pass.
+ */
+import { siteUrlToHost } from "@decocms/shared/reports/site-url";
+import { Suspense, useState, type ReactNode } from "react";
+import { ErrorBoundary } from "@/components/error-boundary";
+import { authClient } from "@/lib/auth-client";
+import { useT } from "@/i18n/use-t.ts";
+import {
+  SELF_MCP_ALIAS_ID,
+  useMCPClient,
+  useProjectContext,
+  WellKnownOrgMCPId,
+} from "@/sdk";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@deco/ui/components/dialog.tsx";
+import { Button } from "@deco/ui/components/button.tsx";
+import { Loading01 } from "@untitledui/icons";
+import { IntegrationIcon } from "@/components/integration-icon";
+import { CompanionConfigDialog, SaBindingDialog } from "./companion-card.tsx";
+import type { CompanionCardModel } from "./companions-core.ts";
+import {
+  type BindProvider,
+  PROVIDER_BY_BINDING_TYPE,
+} from "./companion-forms/sa-binding-copy.ts";
+import {
+  useCommerceCompanions,
+  useCommerceDiscoverySiteUrl,
+} from "./use-commerce-companions.ts";
+import { useConnectCompanion } from "./use-connect-companion.ts";
+
+/** Minimal modal for the loading / error shells around the real dialogs. */
+function StatusDialog({
+  onClose,
+  children,
+}: {
+  onClose: () => void;
+  children: ReactNode;
+}) {
+  const t = useT();
+  return (
+    <Dialog open onOpenChange={(open) => !open && onClose()}>
+      <DialogContent aria-describedby={undefined} className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            {t("commerceOnboarding.connectSourceDialog.title")}
+          </DialogTitle>
+        </DialogHeader>
+        {children}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function SpinnerRow({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-2 py-2 text-sm text-muted-foreground">
+      <Loading01 size={16} className="animate-spin" />
+      <span>{label}</span>
+    </div>
+  );
+}
+
+export function ConnectSourceDialog({
+  field,
+  onClose,
+}: {
+  field: string;
+  onClose: () => void;
+}) {
+  const t = useT();
+  return (
+    <ErrorBoundary
+      fallback={() => (
+        <StatusDialog onClose={onClose}>
+          <p className="text-sm text-muted-foreground">
+            {t("routes.commerceOnboarding.connectModal.loadError")}
+          </p>
+        </StatusDialog>
+      )}
+    >
+      <Suspense
+        fallback={
+          <StatusDialog onClose={onClose}>
+            <SpinnerRow
+              label={t("commerceOnboarding.connectSourceDialog.loading")}
+            />
+          </StatusDialog>
+        }
+      >
+        <ConnectSourceDialogContent field={field} onClose={onClose} />
+      </Suspense>
+    </ErrorBoundary>
+  );
+}
+
+function ConnectSourceDialogContent({
+  field,
+  onClose,
+}: {
+  field: string;
+  onClose: () => void;
+}) {
+  const t = useT();
+  const { org } = useProjectContext();
+  const cdConnectionId = WellKnownOrgMCPId.COMMERCE_DISCOVERY(org.id);
+  const selfClient = useMCPClient({
+    connectionId: SELF_MCP_ALIAS_ID,
+    orgId: org.id,
+    orgSlug: org.slug,
+  });
+  const { data: session } = authClient.useSession();
+  const userId = session?.user?.id ?? "";
+
+  const siteUrl = useCommerceDiscoverySiteUrl({
+    selfClient,
+    org,
+    cdConnectionId,
+  });
+  const { cards } = useCommerceCompanions({
+    selfClient,
+    org,
+    cdConnectionId,
+    siteUrl,
+  });
+  const { connect, connectingFieldKey, error } = useConnectCompanion({
+    selfClient,
+    org,
+    userId,
+    cdConnectionId,
+    domain: siteUrlToHost(siteUrl) ?? undefined,
+    siteUrl,
+  });
+
+  const card = cards.find((c) => c.fieldKey === field);
+  if (!card) {
+    return (
+      <StatusDialog onClose={onClose}>
+        <p className="text-sm text-muted-foreground">
+          {t("routes.commerceOnboarding.connectModal.loadError")}
+        </p>
+      </StatusDialog>
+    );
+  }
+
+  // Same lane rule as CompanionCard's action branching: GA4/GSC default to the
+  // shared-SA dialog unless they were actually satisfied via OAuth.
+  const saProvider = PROVIDER_BY_BINDING_TYPE[card.bindingType] as
+    | BindProvider
+    | undefined;
+  if (saProvider && card.boundVia !== "oauth") {
+    return (
+      <SaBindingDialog
+        card={card}
+        provider={saProvider}
+        org={org}
+        selfClient={selfClient}
+        siteUrl={siteUrl}
+        open
+        onOpenChange={(open) => !open && onClose()}
+        onOAuthInstead={card.satisfied ? undefined : () => void connect(card)}
+      />
+    );
+  }
+
+  if (card.satisfied && card.linkedConnectionId) {
+    return (
+      <Suspense
+        fallback={
+          <StatusDialog onClose={onClose}>
+            <SpinnerRow
+              label={t("commerceOnboarding.connectSourceDialog.loading")}
+            />
+          </StatusDialog>
+        }
+      >
+        <CompanionConfigDialog
+          card={card}
+          org={org}
+          selfClient={selfClient}
+          connectionId={card.linkedConnectionId}
+          contextSiteUrl={siteUrl}
+          open
+          onOpenChange={(open) => !open && onClose()}
+        />
+      </Suspense>
+    );
+  }
+
+  return (
+    <OauthConnectDialog
+      card={card}
+      connecting={connectingFieldKey === card.fieldKey}
+      error={error}
+      onConnect={() => void connect(card)}
+      onClose={onClose}
+    />
+  );
+}
+
+/**
+ * OAuth-lane connect in progress: fires `connect` once on mount (popup OAuth +
+ * link write), showing a small progress dialog meanwhile. On success the
+ * invalidations flip the card to linked and the parent re-renders straight
+ * into the config dialog; on failure the error + retry stay here. Render-time
+ * one-shot instead of a mount effect (no useEffect in this codebase), same
+ * pattern as CmsAutoOpen in sandbox/preview/preview.tsx.
+ */
+function OauthConnectDialog({
+  card,
+  connecting,
+  error,
+  onConnect,
+  onClose,
+}: {
+  card: CompanionCardModel;
+  connecting: boolean;
+  error: string | null;
+  onConnect: () => void;
+  onClose: () => void;
+}) {
+  const t = useT();
+  const [started, setStarted] = useState(false);
+  if (!started) {
+    setStarted(true);
+    queueMicrotask(onConnect);
+  }
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open && connecting) return; // don't close mid-OAuth
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent aria-describedby={undefined} className="sm:max-w-lg">
+        <DialogHeader className="flex-row items-center gap-3 space-y-0 text-left">
+          <IntegrationIcon
+            icon={card.icon}
+            name={card.title}
+            size="sm"
+            fit="contain"
+            className="p-1"
+          />
+          <DialogTitle className="min-w-0 flex-1">{card.title}</DialogTitle>
+        </DialogHeader>
+        {error ? (
+          <div className="flex flex-col gap-3">
+            <p role="alert" className="text-sm text-destructive">
+              {error}
+            </p>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="self-start"
+              onClick={onConnect}
+            >
+              {t("routes.commerceOnboarding.companionSection.retry")}
+            </Button>
+          </div>
+        ) : (
+          <SpinnerRow
+            label={t("commerceOnboarding.connectSourceDialog.connecting", {
+              title: card.title,
+            })}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/routes/commerce-onboarding/use-commerce-companions.ts
+++ b/apps/web/src/routes/commerce-onboarding/use-commerce-companions.ts
@@ -297,3 +297,32 @@ export function useCommerceCompanions({
 
   return { cards, saStatusUnavailable };
 }
+
+/** The commerce-discovery connection's stored site URL (metadata.siteUrl).
+ *  Shared by the connect-sources tab and the report's per-source deep-link
+ *  dialog so both read it through the same query key. Suspends. */
+export function useCommerceDiscoverySiteUrl({
+  selfClient,
+  org,
+  cdConnectionId,
+}: {
+  selfClient: Client;
+  org: CompanionOrg;
+  cdConnectionId: string;
+}): string | undefined {
+  const query = useSuspenseQuery({
+    queryKey: KEYS.commerceDiscoveryConnection(org.id, cdConnectionId),
+    queryFn: async () => {
+      const result = await selfClient.callTool({
+        name: "COLLECTION_CONNECTIONS_GET",
+        arguments: { id: cdConnectionId },
+      });
+      return unwrapToolResult<{
+        item: { metadata?: Record<string, unknown> | null } | null;
+      }>(result);
+    },
+    retry: false,
+  });
+  const siteUrl = query.data.item?.metadata?.siteUrl;
+  return typeof siteUrl === "string" ? siteUrl : undefined;
+}

--- a/apps/web/src/routes/project-app-navigate.ts
+++ b/apps/web/src/routes/project-app-navigate.ts
@@ -7,10 +7,12 @@ import { OVERLAY_TABS } from "@/layouts/main-panel-tabs/tab-id";
 // OVERLAY_TABS so a message can't drive arbitrary navigation.
 const NAVIGATE_SCHEME = "studio://navigate";
 
-// `field=<key>` deep-links `main=connect-sources` straight to one companion's
-// own connect/config dialog (skipping the card grid) — the commerce report
-// already knows exactly which source it's missing. Allowlisted the same way
-// as OVERLAY_TABS; meaningless (and ignored) for any other tab.
+// `field=<key>` on `main=connect-sources` targets one specific source — the
+// commerce report already knows exactly which one it's missing. The caller
+// (project-app-view.tsx) opens that source's connect/config dialog in place
+// over the app view (ConnectSourceDialog) instead of swapping the panel to
+// the connect-sources tab. Allowlisted the same way as OVERLAY_TABS;
+// meaningless (and ignored) for any other tab.
 const CONNECT_SOURCE_FIELDS = new Set(["vtex", "ga4", "gsc", "github"]);
 
 /**

--- a/apps/web/src/routes/project-app-view.tsx
+++ b/apps/web/src/routes/project-app-view.tsx
@@ -25,6 +25,8 @@ import {
 import { useChatStream, useChatPrefs } from "@/components/chat/context.tsx";
 import { usePanelActions } from "@/layouts/shell-layout";
 import { resolveAppNavigateTarget } from "@/routes/project-app-navigate.ts";
+import { ConnectSourceDialog } from "@/routes/commerce-onboarding/connect-source-dialog.tsx";
+import { useState } from "react";
 
 const EMPTY_TOOL_INPUT: Record<string, unknown> = {};
 
@@ -52,6 +54,12 @@ function AppRenderer({
   const { setAppContext, clearAppContext } = useChatPrefs();
   const { openSidePanel, openTab } = usePanelActions();
   const sourceId = `${connectionId}:${tool.name}`;
+  // A `field`-carrying connect-sources navigate opens the source's connect
+  // dialog right here, over the app view — swapping the whole panel to the
+  // onboarding-style tab just to show one dialog reads as broken.
+  const [connectSourceField, setConnectSourceField] = useState<string | null>(
+    null,
+  );
 
   const handleRequestDisplayMode = (
     mode: McpUiDisplayMode,
@@ -84,11 +92,13 @@ function AppRenderer({
     // it into chat; any other message falls through to the normal path.
     const navigateResult = resolveAppNavigateTarget(params.content);
     if (navigateResult.isNavigate) {
-      if (navigateResult.tab) {
-        openTab(
-          navigateResult.tab,
-          navigateResult.field ? { field: navigateResult.field } : undefined,
-        );
+      // A specific source to connect → just open its connect dialog in place;
+      // only the generic (field-less) connect-sources request still opens the
+      // full card-grid tab.
+      if (navigateResult.tab === "connect-sources" && navigateResult.field) {
+        setConnectSourceField(navigateResult.field);
+      } else if (navigateResult.tab) {
+        openTab(navigateResult.tab);
       }
       return;
     }
@@ -100,22 +110,30 @@ function AppRenderer({
   };
 
   return (
-    <MCPAppRenderer
-      resourceURI={resourceURI}
-      orgId={orgId}
-      toolInfo={{ tool: strippedTool }}
-      toolInput={toolInput}
-      toolResult={toolResult}
-      displayMode="fullscreen"
-      minHeight={MCP_APP_DISPLAY_MODES.fullscreen.minHeight}
-      maxHeight={MCP_APP_DISPLAY_MODES.fullscreen.maxHeight}
-      client={client}
-      onMessage={handleAppMessage}
-      onUpdateModelContext={(params) => setAppContext(sourceId, params)}
-      onTeardown={() => clearAppContext(sourceId)}
-      onRequestDisplayMode={handleRequestDisplayMode}
-      className="h-full"
-    />
+    <>
+      <MCPAppRenderer
+        resourceURI={resourceURI}
+        orgId={orgId}
+        toolInfo={{ tool: strippedTool }}
+        toolInput={toolInput}
+        toolResult={toolResult}
+        displayMode="fullscreen"
+        minHeight={MCP_APP_DISPLAY_MODES.fullscreen.minHeight}
+        maxHeight={MCP_APP_DISPLAY_MODES.fullscreen.maxHeight}
+        client={client}
+        onMessage={handleAppMessage}
+        onUpdateModelContext={(params) => setAppContext(sourceId, params)}
+        onTeardown={() => clearAppContext(sourceId)}
+        onRequestDisplayMode={handleRequestDisplayMode}
+        className="h-full"
+      />
+      {connectSourceField && (
+        <ConnectSourceDialog
+          field={connectSourceField}
+          onClose={() => setConnectSourceField(null)}
+        />
+      )}
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary

The report app's per-source **Connect** deep link (`studio://navigate?main=connect-sources&field=<ga4|gsc|github|vtex>`) used to swap the whole main panel to the onboarding-style connect-sources tab (breadcrumb, quote panel, refresh CTA) showing a single card, then auto-open that card's dialog on top — reading as a dialog bizarrely rendered inside a panel, and hiding the report behind it.

Now `project-app-view` intercepts a `field`-carrying navigate and opens that source's connect dialog **in place, over the report**, which stays mounted behind it. Closing the dialog returns straight to the report. The generic (field-less) `connect-sources` navigate still opens the full card-grid tab.

## Changes

- **`connect-source-dialog.tsx` (new)** — standalone flow for one source, reusing the exact dialogs the companion cards open:
  - GA4/GSC on the shared-SA lane → `SaBindingDialog`
  - already linked source → `CompanionConfigDialog` (repo/property/credentials)
  - OAuth lane not linked yet → runs the OAuth connect immediately behind a small progress dialog; once linked it flips into the config dialog. Errors show inline with a retry.
- **`companion-card.tsx`** — extracted the two dialogs that lived inside the cards (`SaBindingDialog`, `CompanionConfigDialog`) as controlled components so the card and the deep link can't drift.
- **Dead-code cleanup of the old path**: removed the `field` search param handling in `ConnectSourcesTab`, the `focusFieldKey`/`autoOpen` plumbing through `CompanionMcpsSection`/`CompanionCard`, `AutoConnectOnce`, and `openTab`'s now-unused `extraSearch` param.
- Extracted `useCommerceDiscoverySiteUrl` so the tab and the dialog read the CD connection's site URL through the same query key.
- 3 new i18n strings (en + pt-br).

## Testing

- `bun run check` passes across all workspaces; `bun run lint` has no warnings on touched files; `bun run fmt` applied; knip reports nothing for touched files.
- Unit tests for the touched areas pass (`project-app-navigate`, `companions-core`, `self-tool-result`, `loading-state` — 66 tests). The full `bun test apps/web` has 103 pre-existing failures, identical with this change stashed.

## Notes

- The old tab had a "refresh report" CTA (`COMMERCE_DISCOVERY_RUN`) after connecting; the dialog intentionally doesn't — statuses invalidate on connect and the report app refreshes through its own data. Easy follow-up if we want to auto-trigger a run after a successful deep-link connect.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Open the report’s per-source Connect link in place so it shows the source’s connect dialog as a modal over the report, instead of switching to the connect-sources tab. This fixes the awkward “dialog inside a panel” experience and keeps the report visible.

- **Bug Fixes**
  - Intercept `studio://navigate?main=connect-sources&field=<id>` in `project-app-view` and render the new `ConnectSourceDialog` over the report.
  - Reuse the same dialogs as the cards (shared-SA binding, OAuth + config) so behavior is consistent.
  - Field-less `connect-sources` still opens the full card grid tab.

- **Refactors**
  - Extracted `SaBindingDialog` and `CompanionConfigDialog` from the card into controlled components and reused them in the deep link flow.
  - Removed the old deep-link plumbing: `field` handling in `ConnectSourcesTab`, `focusFieldKey`/`autoOpen`, `AutoConnectOnce`, and `openTab`’s `extraSearch`.
  - Added `useCommerceDiscoverySiteUrl` so the tab and dialog share the same site URL query.
  - Added new i18n strings for the connect dialog (en and pt-br).

<sup>Written for commit 2a026bc27847b1d9e265cb58a678fac2e89b124e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

