### PR TITLE
feat(sandbox): reimplement the L2 golden tier in the Go daemon

### DIFF
--- a/packages/sandbox/daemon-go/internal/setup/orchestrator.go
+++ b/packages/sandbox/daemon-go/internal/setup/orchestrator.go
@@ -146,6 +146,12 @@ func (o *Orchestrator) PublishPendingGolden() {
 	pending.Log = func(m string) { o.rawChunk(m + "\r\n") }
 	PublishGolden(*pending)
 	PruneGoldens("")
+	// L2 last: it is the slow one (compress + read-back over the network), and a
+	// no-op both when the key already exists — the common case after an L2
+	// restore — and when GOLDEN_CACHE_REMOTE is unset. The store is read-only in
+	// a tenant pod, so today this only ever logs a failure to write; that changes
+	// when a trusted publisher gets the writable mount.
+	PublishRemoteGolden(RemoteGoldenFrom(*pending))
 }
 
 func (o *Orchestrator) enqueue(step Step) {
@@ -420,6 +426,23 @@ func (o *Orchestrator) stepInstallInner() bool {
 		o.pendingGolden = nil // restored an existing golden — nothing to publish
 		o.mu.Unlock()
 		EmitDepsRestore(RestoreL1, cloneUrl, elapsedMs(), bootId)
+		o.markInstallSucceeded(cfg)
+		return true
+	}
+
+	// L2: the same lockfile may already be archived on the shared store even
+	// though this node has never built it. Extracting it beats installing, and it
+	// is the only tier that helps a pod that landed in a cold zone.
+	//
+	// A hit leaves pendingGolden set, so the healthy-boot transition seeds THIS
+	// node's L1 from the extracted tree — the next pod here gets the reflink
+	// instead of another extract. PublishRemoteGolden no-ops on an existing key,
+	// so it is safe that the same transition also runs the L2 publish.
+	if TryRestoreRemoteGolden(RemoteGoldenFrom(golden)) {
+		o.mu.Lock()
+		o.pendingGolden = &golden
+		o.mu.Unlock()
+		EmitDepsRestore(RestoreL2, cloneUrl, elapsedMs(), bootId)
 		o.markInstallSucceeded(cfg)
 		return true
 	}

--- a/packages/sandbox/daemon-go/internal/setup/remotegolden.go
+++ b/packages/sandbox/daemon-go/internal/setup/remotegolden.go
@@ -1,0 +1,394 @@
+package setup
+
+// L2: the cross-node golden tier.
+//
+// The node-local golden (golden.go) only hits when the pod lands on a node
+// already warm for its repo. The sandbox pool churns ~170 nodes a day across
+// three AZs with ~80% fresh pods, so a large share of boots land somewhere cold
+// and pay a full install, and cross-zone a node-local cache cannot help at all.
+// This tier removes the same-node dependency: one archive per
+// (repo, pm, lockfile) on a shared store, restorable on ANY node in ANY zone.
+//
+// ONE HARD RULE: a compressed ARCHIVE on the shared store, never the
+// node_modules TREE. A shared store charges per-operation metadata latency —
+// fatal across ~100k small files, a non-issue for a single large sequential
+// blob. The per-file cost is paid by the local extract, on local disk. Mounting
+// a tree here would be slower than no cache at all.
+//
+// The store is S3 through the mountpoint CSI driver, and this code assumes only
+// that a path can be read and written sequentially. It does NOT assume rename
+// or utimes, because mountpoint has neither — see PublishRemoteGolden for what
+// losing rename costs, and pruneRemoteGoldens for why the bucket's own
+// lifecycle policy is the real reaper.
+//
+// Dormant without GOLDEN_CACHE_REMOTE: absent → every entry point returns
+// immediately and the boot path is exactly L1-then-install, as today.
+//
+// Ported from the TypeScript daemon's setup/remote-golden.ts, which was deleted
+// with that daemon in #5575 before this tier ever ran in a deployed config.
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	remoteEnabledEnvVar = "GOLDEN_CACHE_REMOTE"
+	remoteArchiveSuffix = ".tar.zst"
+	// Longest single stderr line kept for a log message. A tar failure can
+	// repeat per member, so this is a log line, not a transcript.
+	remoteStderrMax = 200
+)
+
+// zstd level for publish. -3 is the speed/ratio knee: measured on a 2.3 GB /
+// 168k-file tree it produced 450 MB in 26s, where -19 spent 85s to reach
+// 332 MB. Publish is off the critical path but not free, and restore-side
+// decompression is ~1.6s either way, so the extra 59s buys nothing that
+// matters. -T0 uses all available cores.
+var zstdPublishArgs = []string{"-3", "-T0"}
+
+// RemoteGoldenParams identifies the shared archive for one install step. Mirrors
+// GoldenParams so the orchestrator can derive one from the other — the two tiers
+// are keyed identically on purpose (same credential-stripped repo hash, same
+// lockfile hash), so they can never disagree about what a key means.
+type RemoteGoldenParams struct {
+	RemoteRoot  string
+	CloneUrl    string
+	InstallRoot string
+	Pm          string
+	Log         func(msg string)
+}
+
+func (p RemoteGoldenParams) log(msg string) {
+	if p.Log != nil {
+		p.Log(msg)
+	}
+}
+
+// RemoteGoldenFrom derives the L2 params for an L1 golden, so a caller cannot
+// accidentally key the two tiers differently.
+func RemoteGoldenFrom(g GoldenParams) RemoteGoldenParams {
+	return RemoteGoldenParams{
+		CloneUrl:    g.CloneUrl,
+		InstallRoot: g.InstallRoot,
+		Pm:          g.Pm,
+		Log:         g.Log,
+	}
+}
+
+// RemoteEnabled is an independent kill switch, separate from
+// GOLDEN_CACHE_ENABLED: L2 puts a shared store on the boot path and must be
+// enableable — and revocable — without touching L1.
+func RemoteEnabled() bool {
+	return os.Getenv(remoteEnabledEnvVar) != ""
+}
+
+// RemoteGoldenArchivePath is the archive path for a (repo, pm, lockfile) triple,
+// or empty when L2 cannot apply.
+func RemoteGoldenArchivePath(remoteRoot, cloneUrl, pm, lockHash string) string {
+	if remoteRoot == "" || cloneUrl == "" || lockHash == "" {
+		return ""
+	}
+	return filepath.Join(remoteRoot, "golden", repoCacheKey(cloneUrl),
+		pm+"-"+lockHash+remoteArchiveSuffix)
+}
+
+func (p RemoteGoldenParams) resolve() (string, bool) {
+	if !RemoteEnabled() {
+		return "", false
+	}
+	root := p.RemoteRoot
+	if root == "" {
+		root = os.Getenv(remoteEnabledEnvVar)
+	}
+	archive := RemoteGoldenArchivePath(root, p.CloneUrl, p.Pm,
+		LockfileHash(p.InstallRoot, p.Pm))
+	if archive == "" {
+		return "", false
+	}
+	return archive, true
+}
+
+// pipeResult carries the exit code plus the first stderr line from either side.
+// The message is the whole point: "tar exit 2" alone is unactionable — it took a
+// hand-run of the pipe to learn it meant "Unexpected EOF in archive", i.e. a
+// truncated archive rather than a permissions or disk problem.
+type pipeResult struct {
+	code   int
+	stderr string
+}
+
+// runPiped streams producer | consumer to completion, reporting failure if
+// EITHER side fails — the shell's `pipefail` semantics. Without that, a failed
+// `tar -c` feeding a happy `zstd` would look like a successful publish.
+//
+// An explicit pipe rather than tar's own compressor flags, because those are not
+// portable and fail in DIFFERENT ways per flavor: this image ships GNU tar, but
+// a macOS host runner has bsdtar, where `-I` means `--include` (so `-I zstd`
+// silently looks for a file named "zstd") and `--use-compress-program` is
+// rejected on read with "Unrecognized archive format". `zstd -dc | tar -xf -`
+// behaves identically everywhere.
+//
+// The kernel owns the pipe: os.Pipe gives both children one real fd pair, so a
+// multi-GB tree never traverses this process. That matters twice — the daemon's
+// health probe must keep answering while this runs (Studio tears the pod down on
+// a single miss), and a relayed copy is what corrupted this transfer in the
+// TypeScript version, where the runtime pumped the bytes through the event loop
+// and raced the consumer. Using os/exec's StdoutPipe here would reintroduce
+// exactly that relay.
+func runPiped(producer, consumer *exec.Cmd) pipeResult {
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		return pipeResult{code: 1, stderr: err.Error()}
+	}
+	var perr, cerr bytes.Buffer
+	producer.Stdout = pw
+	producer.Stderr = &perr
+	consumer.Stdin = pr
+	consumer.Stderr = &cerr
+
+	if err := producer.Start(); err != nil {
+		pw.Close()
+		pr.Close()
+		return pipeResult{code: 1, stderr: err.Error()}
+	}
+	if err := consumer.Start(); err != nil {
+		pw.Close()
+		pr.Close()
+		_ = producer.Wait()
+		return pipeResult{code: 1, stderr: err.Error()}
+	}
+	// Drop the parent's ends: the consumer must see EOF when the producer exits,
+	// which cannot happen while this process still holds the write side.
+	pw.Close()
+	pr.Close()
+
+	prodErr := producer.Wait()
+	consErr := consumer.Wait()
+
+	// Consumer first: its message is the one that explains a corrupt archive.
+	for _, c := range []struct {
+		err error
+		buf *bytes.Buffer
+	}{{consErr, &cerr}, {prodErr, &perr}} {
+		if c.err == nil {
+			continue
+		}
+		code := 1
+		var exitErr *exec.ExitError
+		if errors.As(c.err, &exitErr) {
+			code = exitErr.ExitCode()
+		}
+		return pipeResult{code: code, stderr: firstLine(c.buf.String())}
+	}
+	return pipeResult{code: 0}
+}
+
+func firstLine(s string) string {
+	line := strings.TrimSpace(s)
+	if i := strings.IndexByte(line, '\n'); i >= 0 {
+		line = line[:i]
+	}
+	if len(line) > remoteStderrMax {
+		line = line[:remoteStderrMax]
+	}
+	return line
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// TryRestoreRemoteGolden extracts the shared archive into the repo's
+// node_modules, skipping install. True only when node_modules is now populated
+// from the archive.
+//
+// Extraction lands in a staging dir and is then renamed into place. A tar
+// interrupted halfway (pod killed, archive truncated) would otherwise leave a
+// partial node_modules that later code reads as complete — the boot would skip
+// install and fail later, somewhere unrelated.
+func TryRestoreRemoteGolden(p RemoteGoldenParams) bool {
+	archive, ok := p.resolve()
+	if !ok || !fileExists(archive) {
+		return false
+	}
+
+	target := filepath.Join(p.InstallRoot, "node_modules")
+	staging := filepath.Join(p.InstallRoot, fmt.Sprintf(".node_modules.l2.%d", os.Getpid()))
+	os.RemoveAll(staging)
+	if err := os.MkdirAll(staging, 0o755); err != nil {
+		p.log("[golden-l2] restore skipped: " + err.Error())
+		return false
+	}
+	// The archive stores a `node_modules/` prefix, so it lands at
+	// <staging>/node_modules.
+	r := runPiped(
+		exec.Command("zstd", "-dc", archive),
+		exec.Command("tar", "-xf", "-", "-C", staging),
+	)
+	if r.code != 0 {
+		p.log(fmt.Sprintf("[golden-l2] restore failed (exit %d: %s) — falling back to install", r.code, r.stderr))
+		os.RemoveAll(staging)
+		return false
+	}
+	// A partial tree from an interrupted earlier boot would make the rename land
+	// inside it rather than replacing it.
+	os.RemoveAll(target)
+	if err := os.Rename(filepath.Join(staging, "node_modules"), target); err != nil {
+		p.log("[golden-l2] restore skipped: " + err.Error())
+		os.RemoveAll(staging)
+		return false
+	}
+	os.RemoveAll(staging)
+
+	// Best-effort recently-used marker. On a POSIX store this is what keeps a
+	// TTL sweep from reaping a lockfile that repos are still booting on. On
+	// mountpoint there is no utimes, so this fails and the bucket's lifecycle
+	// policy is the only reaper — expiry counts from object creation there, so an
+	// in-use archive does expire and the next boot republishes it.
+	now := time.Now()
+	os.Chtimes(archive, now, now)
+	p.log("[golden-l2] restored node_modules from shared cache (skipped install)")
+	return true
+}
+
+// PublishRemoteGolden publishes a node_modules as the shared archive for its
+// lockfile.
+//
+// Callers must only invoke this for a boot whose dev server came up healthy —
+// the same rule as L1, and it matters more here: a broken install published to
+// the shared store poisons every node in the fleet, not just this one.
+//
+// Best-effort and idempotent: a no-op once the archive exists, and the archive
+// is read back before this reports success, so a truncated write never survives
+// as a permanently-broken key.
+func PublishRemoteGolden(p RemoteGoldenParams) {
+	archive, ok := p.resolve()
+	if !ok {
+		return
+	}
+	source := filepath.Join(p.InstallRoot, "node_modules")
+	if !fileExists(source) {
+		return
+	}
+	if fileExists(archive) {
+		return // already published for this lockfile
+	}
+	// Best-effort: a blob store has no real directories, so creating the prefix
+	// is a no-op there and may not be supported at all. Writing the key below is
+	// what creates it.
+	os.MkdirAll(filepath.Dir(archive), 0o755)
+
+	// Written straight to its final key, NOT to a temp name plus rename. The
+	// shared store is a blob store and rename does not exist there. Nothing is
+	// lost by dropping it: an object becomes visible only once its upload
+	// completes, so a publisher killed mid-write leaves no readable object —
+	// the same guarantee the rename was providing.
+	//
+	// Porting this to a POSIX store would need the temp+rename back, because
+	// there a partial file IS visible to a concurrent reader.
+	tarArgs := []string{"-cf", "-", "-C", p.InstallRoot}
+	for _, d := range runtimeCacheDirs {
+		// Pod-local caches churn per boot and would bloat every download.
+		tarArgs = append(tarArgs, "--exclude=node_modules/"+d)
+	}
+	tarArgs = append(tarArgs, "node_modules")
+
+	zstdArgs := append(append([]string{}, zstdPublishArgs...), "-q", "-o", archive)
+	if r := runPiped(exec.Command("tar", tarArgs...), exec.Command("zstd", zstdArgs...)); r.code != 0 {
+		p.log(fmt.Sprintf("[golden-l2] publish failed (exit %d: %s)", r.code, r.stderr))
+		os.Remove(archive)
+		return
+	}
+	// A bad archive here is PERMANENT: publish no-ops once the key exists, so
+	// every node in the fleet would keep failing its restore and paying a full
+	// install, with nothing to repair it. Read it back and drop it if it does not
+	// parse — publish already runs after the boot is healthy, off the critical
+	// path, and this is one sequential pass.
+	//
+	// Because the write went to the live key, this reads back over the network
+	// rather than off local disk. That is the cost of losing rename; it buys the
+	// same protection, and the alternative — staging the archive in the pod
+	// first — would spend the tenant's /app quota on a file that can be several
+	// hundred MB.
+	if check := runPiped(
+		exec.Command("zstd", "-dc", archive),
+		exec.Command("tar", "-tf", "-"),
+	); check.code != 0 {
+		p.log(fmt.Sprintf("[golden-l2] publish discarded — archive failed read-back (%s)", check.stderr))
+		os.Remove(archive)
+		return
+	}
+	p.log("[golden-l2] published node_modules to shared cache")
+	pruneRemoteGoldens(p.remoteRootOrEnv(), GoldenTTL, GoldenMaxPerRepo, time.Now(), p.log)
+}
+
+func (p RemoteGoldenParams) remoteRootOrEnv() string {
+	if p.RemoteRoot != "" {
+		return p.RemoteRoot
+	}
+	return os.Getenv(remoteEnabledEnvVar)
+}
+
+// pruneRemoteGoldens bounds shared-store growth with the same rule as the
+// node-local store: per repo, drop archives untouched for longer than the TTL,
+// then keep only the newest maxPerRepo.
+//
+// Opportunistic (after a successful publish) and best-effort, so it only ever
+// runs where publish does — i.e. wherever the store is writable. A tenant pod
+// holds a read-only mount and cannot delete, which is the point. Racing a
+// concurrent restore is safe: the reader either finished its extract or falls
+// back to install.
+//
+// On mountpoint this prunes nothing useful, because there is no utimes for
+// restore to touch and every archive's mtime is its creation time. The bucket
+// lifecycle policy is the reaper there. Kept because it is correct on a POSIX
+// store and free otherwise.
+func pruneRemoteGoldens(remoteRoot string, ttl time.Duration, maxPerRepo int, now time.Time, log func(string)) {
+	if remoteRoot == "" {
+		return
+	}
+	root := filepath.Join(remoteRoot, "golden")
+	repos, err := os.ReadDir(root)
+	if err != nil {
+		return // nothing published yet
+	}
+	for _, repo := range repos {
+		repoDir := filepath.Join(root, repo.Name())
+		names, err := os.ReadDir(repoDir)
+		if err != nil {
+			continue
+		}
+		type entry struct {
+			path  string
+			mtime time.Time
+		}
+		var entries []entry
+		for _, name := range names {
+			if !strings.HasSuffix(name.Name(), remoteArchiveSuffix) {
+				continue
+			}
+			info, err := name.Info()
+			if err != nil {
+				continue
+			}
+			entries = append(entries, entry{filepath.Join(repoDir, name.Name()), info.ModTime()})
+		}
+		sort.Slice(entries, func(i, j int) bool { return entries[i].mtime.After(entries[j].mtime) })
+		for i, e := range entries {
+			if i >= maxPerRepo || now.Sub(e.mtime) > ttl {
+				if err := os.Remove(e.path); err == nil && log != nil {
+					log("[golden-l2] pruned " + e.path)
+				}
+			}
+		}
+	}
+}

--- a/packages/sandbox/daemon-go/internal/setup/remotegolden_test.go
+++ b/packages/sandbox/daemon-go/internal/setup/remotegolden_test.go
@@ -1,0 +1,430 @@
+package setup
+
+// Real files, real tar/zstd, no mocks — the whole point of this tier is that a
+// tree survives a compress/decompress round trip through a store the daemon does
+// not control, and a mocked pipe proves nothing about that.
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// requireTools skips rather than fails when the host lacks zstd: the sandbox
+// image ships it, a contributor's machine may not, and a red suite there would
+// train people to ignore it.
+func requireTools(t *testing.T) {
+	t.Helper()
+	for _, bin := range []string{"tar", "zstd"} {
+		if _, err := exec.LookPath(bin); err != nil {
+			t.Skipf("%s not on PATH", bin)
+		}
+	}
+}
+
+// installRootWithTree builds an install root holding a node_modules with enough
+// shape to prove the round trip: nested dirs, a file per dir, and one of the
+// pod-local caches that must NOT travel.
+func installRootWithTree(t *testing.T, pkgs int) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "bun.lock"), []byte("lockfile-v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < pkgs; i++ {
+		dir := filepath.Join(root, "node_modules", fmt.Sprintf("pkg-%d", i), "dist")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		body := fmt.Sprintf("module.exports = %d;", i)
+		if err := os.WriteFile(filepath.Join(dir, "index.js"), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cache := filepath.Join(root, "node_modules", ".vite")
+	if err := os.MkdirAll(cache, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cache, "junk"), []byte("pod-local"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func params(remoteRoot, installRoot string) RemoteGoldenParams {
+	return RemoteGoldenParams{
+		RemoteRoot:  remoteRoot,
+		CloneUrl:    "https://github.com/acme/site.git",
+		InstallRoot: installRoot,
+		Pm:          "bun",
+	}
+}
+
+func TestRemoteGoldenArchivePath(t *testing.T) {
+	t.Run("keyed by repo, pm and lockfile", func(t *testing.T) {
+		got := RemoteGoldenArchivePath("/store", "https://github.com/acme/site.git", "bun", "abc")
+		want := filepath.Join("/store", "golden", repoCacheKey("https://github.com/acme/site.git"), "bun-abc.tar.zst")
+		if got != want {
+			t.Fatalf("got %q want %q", got, want)
+		}
+	})
+	t.Run("credentials do not change the key", func(t *testing.T) {
+		bare := RemoteGoldenArchivePath("/store", "https://github.com/acme/site.git", "bun", "abc")
+		creds := RemoteGoldenArchivePath("/store", "https://user:tok@github.com/acme/site.git", "bun", "abc")
+		if bare != creds {
+			t.Fatalf("credential-stripping broken:\n bare  %q\n creds %q", bare, creds)
+		}
+	})
+	t.Run("empty when a component is missing", func(t *testing.T) {
+		for _, c := range [][4]string{
+			{"", "url", "bun", "hash"},
+			{"/store", "", "bun", "hash"},
+			{"/store", "url", "bun", ""},
+		} {
+			if got := RemoteGoldenArchivePath(c[0], c[1], c[2], c[3]); got != "" {
+				t.Fatalf("expected empty for %v, got %q", c, got)
+			}
+		}
+	})
+	t.Run("two repos never share an archive", func(t *testing.T) {
+		a := RemoteGoldenArchivePath("/store", "https://github.com/acme/a.git", "bun", "same")
+		b := RemoteGoldenArchivePath("/store", "https://github.com/acme/b.git", "bun", "same")
+		if a == b {
+			t.Fatal("distinct repos collided on one archive — bun does not re-verify cache content")
+		}
+	})
+}
+
+func TestRemoteEnabled(t *testing.T) {
+	t.Setenv(remoteEnabledEnvVar, "")
+	if RemoteEnabled() {
+		t.Fatal("must be off when unset")
+	}
+	t.Setenv(remoteEnabledEnvVar, "/golden-cache")
+	if !RemoteEnabled() {
+		t.Fatal("must be on when set to a path")
+	}
+}
+
+// The tier's whole purpose: a tree published where one pod ran is restored where
+// another one runs, with no node-local state in common.
+func TestRemoteGoldenPublishOnOneNodeRestoreOnAnother(t *testing.T) {
+	requireTools(t)
+	store := t.TempDir()
+	t.Setenv(remoteEnabledEnvVar, store)
+
+	nodeA := installRootWithTree(t, 12)
+	PublishRemoteGolden(params(store, nodeA))
+
+	// A cold node: same lockfile, no node_modules at all.
+	nodeB := t.TempDir()
+	if err := os.WriteFile(filepath.Join(nodeB, "bun.lock"), []byte("lockfile-v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !TryRestoreRemoteGolden(params(store, nodeB)) {
+		t.Fatal("restore reported no hit on a cold node")
+	}
+
+	got, err := os.ReadFile(filepath.Join(nodeB, "node_modules", "pkg-7", "dist", "index.js"))
+	if err != nil {
+		t.Fatalf("restored tree missing a package: %v", err)
+	}
+	if string(got) != "module.exports = 7;" {
+		t.Fatalf("restored contents wrong: %q", got)
+	}
+	// Pod-local caches must not travel in a shared archive.
+	if _, err := os.Stat(filepath.Join(nodeB, "node_modules", ".vite")); err == nil {
+		t.Fatal(".vite travelled in the archive — every consumer pays for pod-local churn")
+	}
+	// No staging left behind.
+	entries, _ := os.ReadDir(nodeB)
+	for _, e := range entries {
+		if len(e.Name()) > 15 && e.Name()[:15] == ".node_modules.l" {
+			t.Fatalf("staging dir survived: %s", e.Name())
+		}
+	}
+}
+
+// A tree big enough that the transfer cannot complete inside one pipe buffer —
+// this is the case that caught a truncating implementation in the TypeScript
+// version, where a 1 KB fixture passed and a multi-MB one did not.
+func TestRemoteGoldenRoundTripsUnderBackpressure(t *testing.T) {
+	requireTools(t)
+	store := t.TempDir()
+	t.Setenv(remoteEnabledEnvVar, store)
+
+	nodeA := installRootWithTree(t, 40)
+	// ~8 MB of incompressible payload, well past any pipe buffer.
+	big := make([]byte, 8<<20)
+	for i := range big {
+		big[i] = byte(i * 7)
+	}
+	if err := os.WriteFile(filepath.Join(nodeA, "node_modules", "pkg-0", "dist", "big.bin"), big, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	PublishRemoteGolden(params(store, nodeA))
+
+	nodeB := t.TempDir()
+	if err := os.WriteFile(filepath.Join(nodeB, "bun.lock"), []byte("lockfile-v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !TryRestoreRemoteGolden(params(store, nodeB)) {
+		t.Fatal("restore reported no hit")
+	}
+	back, err := os.ReadFile(filepath.Join(nodeB, "node_modules", "pkg-0", "dist", "big.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(back) != len(big) {
+		t.Fatalf("payload truncated: got %d bytes want %d", len(back), len(big))
+	}
+	for i := range back {
+		if back[i] != big[i] {
+			t.Fatalf("payload corrupted at byte %d", i)
+		}
+	}
+}
+
+// Discriminating counterpart: without this, the tests above would pass even if
+// the code ignored its configuration and restored from somewhere else.
+func TestRemoteGoldenDormantWhenUnconfigured(t *testing.T) {
+	requireTools(t)
+	store := t.TempDir()
+
+	t.Setenv(remoteEnabledEnvVar, "")
+	nodeA := installRootWithTree(t, 4)
+	PublishRemoteGolden(params("", nodeA))
+	if entries, _ := os.ReadDir(store); len(entries) != 0 {
+		t.Fatal("published with the tier disabled")
+	}
+
+	nodeB := t.TempDir()
+	if err := os.WriteFile(filepath.Join(nodeB, "bun.lock"), []byte("lockfile-v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if TryRestoreRemoteGolden(params("", nodeB)) {
+		t.Fatal("restored with the tier disabled")
+	}
+	if _, err := os.Stat(filepath.Join(nodeB, "node_modules")); err == nil {
+		t.Fatal("created node_modules with the tier disabled")
+	}
+}
+
+// A truncated archive must fail closed. A partial node_modules that later code
+// reads as complete is worse than a miss: the boot skips install and fails
+// somewhere unrelated.
+func TestRemoteGoldenTruncatedArchiveFailsClosed(t *testing.T) {
+	requireTools(t)
+	store := t.TempDir()
+	t.Setenv(remoteEnabledEnvVar, store)
+
+	nodeA := installRootWithTree(t, 20)
+	PublishRemoteGolden(params(store, nodeA))
+
+	archive := RemoteGoldenArchivePath(store, "https://github.com/acme/site.git", "bun",
+		LockfileHash(nodeA, "bun"))
+	full, err := os.ReadFile(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(archive, full[:len(full)/2], 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	nodeB := t.TempDir()
+	if err := os.WriteFile(filepath.Join(nodeB, "bun.lock"), []byte("lockfile-v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if TryRestoreRemoteGolden(params(store, nodeB)) {
+		t.Fatal("reported success on a truncated archive")
+	}
+	if _, err := os.Stat(filepath.Join(nodeB, "node_modules")); err == nil {
+		t.Fatal("left a partial node_modules behind")
+	}
+	entries, _ := os.ReadDir(nodeB)
+	for _, e := range entries {
+		if len(e.Name()) > 15 && e.Name()[:15] == ".node_modules.l" {
+			t.Fatalf("staging dir survived a failed restore: %s", e.Name())
+		}
+	}
+}
+
+// Publish no-ops once the key exists. It matters because the store has no
+// rename: a second publisher rewriting a live key would expose a partial object
+// to concurrent readers.
+func TestRemoteGoldenPublishIsIdempotent(t *testing.T) {
+	requireTools(t)
+	store := t.TempDir()
+	t.Setenv(remoteEnabledEnvVar, store)
+
+	nodeA := installRootWithTree(t, 6)
+	PublishRemoteGolden(params(store, nodeA))
+	archive := RemoteGoldenArchivePath(store, "https://github.com/acme/site.git", "bun",
+		LockfileHash(nodeA, "bun"))
+	first, err := os.Stat(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Change the tree so a rewrite would be observable, then publish again.
+	if err := os.WriteFile(filepath.Join(nodeA, "node_modules", "pkg-0", "dist", "index.js"),
+		[]byte("module.exports = 'rewritten';"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	PublishRemoteGolden(params(store, nodeA))
+
+	second, err := os.Stat(archive)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first.ModTime().Equal(second.ModTime()) || first.Size() != second.Size() {
+		t.Fatal("republished over an existing key")
+	}
+}
+
+// Garbage at the key — not a truncated archive but never-valid bytes — is also a
+// miss, not a crash and not a partial tree.
+//
+// NOTE: this exercises the RESTORE side only. Publish's read-back guard (drop the
+// object when `zstd -dc | tar -tf -` rejects what was just written) is not
+// covered: publish no-ops on an existing key, so a corrupt object cannot be
+// planted ahead of it, and making zstd emit a bad archive on demand would mean
+// faking the pipe, which defeats the point of testing against real tools.
+func TestRemoteGoldenRestoreRejectsCorruptArchive(t *testing.T) {
+	requireTools(t)
+	store := t.TempDir()
+	t.Setenv(remoteEnabledEnvVar, store)
+
+	nodeB := t.TempDir()
+	if err := os.WriteFile(filepath.Join(nodeB, "bun.lock"), []byte("lockfile-v1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	archive := RemoteGoldenArchivePath(store, "https://github.com/acme/site.git", "bun",
+		LockfileHash(nodeB, "bun"))
+	if err := os.MkdirAll(filepath.Dir(archive), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(archive, []byte("not a zstd stream"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if TryRestoreRemoteGolden(params(store, nodeB)) {
+		t.Fatal("restored from a corrupt archive")
+	}
+	if _, err := os.Stat(filepath.Join(nodeB, "node_modules")); err == nil {
+		t.Fatal("left a node_modules behind after a corrupt archive")
+	}
+}
+
+func TestPruneRemoteGoldens(t *testing.T) {
+	now := time.Date(2026, 8, 6, 12, 0, 0, 0, time.UTC)
+	write := func(t *testing.T, dir, name string, age time.Duration) string {
+		t.Helper()
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		stamp := now.Add(-age)
+		if err := os.Chtimes(p, stamp, stamp); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	t.Run("absent store is a no-op", func(t *testing.T) {
+		pruneRemoteGoldens("", GoldenTTL, GoldenMaxPerRepo, now, nil)
+		pruneRemoteGoldens(filepath.Join(t.TempDir(), "absent"), GoldenTTL, GoldenMaxPerRepo, now, nil)
+	})
+
+	t.Run("drops archives past the TTL", func(t *testing.T) {
+		store := t.TempDir()
+		repo := filepath.Join(store, "golden", "repo-a")
+		fresh := write(t, repo, "bun-fresh.tar.zst", time.Hour)
+		stale := write(t, repo, "bun-stale.tar.zst", 8*24*time.Hour)
+		pruneRemoteGoldens(store, GoldenTTL, GoldenMaxPerRepo, now, nil)
+		if _, err := os.Stat(fresh); err != nil {
+			t.Fatal("pruned an archive inside the TTL")
+		}
+		if _, err := os.Stat(stale); err == nil {
+			t.Fatal("kept an archive past the TTL")
+		}
+	})
+
+	t.Run("keeps only the newest per repo", func(t *testing.T) {
+		store := t.TempDir()
+		repo := filepath.Join(store, "golden", "repo-a")
+		var paths []string
+		for i := 0; i < GoldenMaxPerRepo+3; i++ {
+			paths = append(paths, write(t, repo, fmt.Sprintf("bun-%d.tar.zst", i), time.Duration(i)*time.Minute))
+		}
+		pruneRemoteGoldens(store, GoldenTTL, GoldenMaxPerRepo, now, nil)
+		for i, p := range paths {
+			_, err := os.Stat(p)
+			if i < GoldenMaxPerRepo && err != nil {
+				t.Fatalf("pruned archive %d, inside the cap", i)
+			}
+			if i >= GoldenMaxPerRepo && err == nil {
+				t.Fatalf("kept archive %d, past the cap", i)
+			}
+		}
+	})
+
+	t.Run("leaves non-archive entries alone", func(t *testing.T) {
+		store := t.TempDir()
+		repo := filepath.Join(store, "golden", "repo-a")
+		other := write(t, repo, "README", 8*24*time.Hour)
+		pruneRemoteGoldens(store, GoldenTTL, GoldenMaxPerRepo, now, nil)
+		if _, err := os.Stat(other); err != nil {
+			t.Fatal("pruned something that is not an archive")
+		}
+	})
+
+	t.Run("one repo's cap does not affect another", func(t *testing.T) {
+		store := t.TempDir()
+		a := filepath.Join(store, "golden", "repo-a")
+		b := filepath.Join(store, "golden", "repo-b")
+		for i := 0; i < GoldenMaxPerRepo+2; i++ {
+			write(t, a, fmt.Sprintf("bun-%d.tar.zst", i), time.Duration(i)*time.Minute)
+		}
+		only := write(t, b, "bun-only.tar.zst", time.Minute)
+		pruneRemoteGoldens(store, GoldenTTL, GoldenMaxPerRepo, now, nil)
+		if _, err := os.Stat(only); err != nil {
+			t.Fatal("pruned another repo's only archive")
+		}
+	})
+}
+
+// A successful publish prunes, so the store stays bounded wherever it is
+// writable without anything having to walk it on a schedule.
+func TestRemoteGoldenPublishPrunes(t *testing.T) {
+	requireTools(t)
+	store := t.TempDir()
+	t.Setenv(remoteEnabledEnvVar, store)
+
+	nodeA := installRootWithTree(t, 4)
+	repoDir := filepath.Dir(RemoteGoldenArchivePath(store, "https://github.com/acme/site.git", "bun",
+		LockfileHash(nodeA, "bun")))
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stale := filepath.Join(repoDir, "bun-ancient.tar.zst")
+	if err := os.WriteFile(stale, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-30 * 24 * time.Hour)
+	if err := os.Chtimes(stale, old, old); err != nil {
+		t.Fatal(err)
+	}
+
+	PublishRemoteGolden(params(store, nodeA))
+
+	if _, err := os.Stat(stale); err == nil {
+		t.Fatal("publish did not prune a stale archive")
+	}
+}

--- a/packages/sandbox/daemon-go/main.go
+++ b/packages/sandbox/daemon-go/main.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"os/exec"
 	"os/signal"
 	"path/filepath"
 	"strconv"
@@ -698,11 +699,13 @@ func main() {
 		slog.Warn("ORGFS_CONFIG is set but this daemon does not mount org volumes " +
 			"(cluster sidecar path only) — org files will not appear in the workspace")
 	}
-	// Same rule for the golden cache's remote tier: the pod may be configured for
-	// L2, but this daemon implements L1 only. Boots stay correct, just slower.
-	if os.Getenv("GOLDEN_CACHE_REMOTE") != "" {
-		slog.Warn("GOLDEN_CACHE_REMOTE is set but this daemon implements the " +
-			"node-local golden tier only — remote restore/publish is skipped")
+	// The golden cache's remote tier needs `zstd` in the image; without it every
+	// restore and publish fails into a normal install, silently apart from this.
+	if setup.RemoteEnabled() {
+		if _, err := exec.LookPath("zstd"); err != nil {
+			slog.Warn("GOLDEN_CACHE_REMOTE is set but zstd is not on PATH — " +
+				"the shared golden tier will miss on every boot")
+		}
 	}
 
 	catalogSync := toolscatalog.NewCoalescer(


### PR DESCRIPTION
The cross-node golden tier has no implementation. This restores one.

## What happened

The tier was written in TypeScript (#5351, #5399) and **deleted with that daemon** in #5575, before it ever ran in a deployed config. Nothing replaced it — the Go daemon logged

```
GOLDEN_CACHE_REMOTE is set but this daemon implements the node-local golden tier only
```

and installed from scratch. Meanwhile the infrastructure kept being built around it: the bucket (decocms/terraform-eks-cluster#88), the PV/PVC ownership refactor (#92, decocms/studio#5806) and the rollout (decocms/deco-apps-cd#203). So prod today has the volume mounted at `/golden-cache` with nothing on either end of it. The `RestoreL2` metric constant in `depmetrics.go` survived too — only the code was gone.

## What this does

Ports restore, publish and prune to Go, keyed **identically** to L1 (same credential-stripped repo hash, same lockfile hash) so the two tiers can never disagree about what a key means. A test asserts credentials do not change the key and that two repos never collide — bun does not re-verify cache content, so per-repo isolation is the boundary both tiers rely on.

**Orchestrator wiring:** L1 reflink → L2 extract → install. An L2 hit leaves `pendingGolden` set, so the healthy-boot transition seeds *this* node's L1 from the extracted tree and the next pod here gets the reflink instead of another extract. That same transition runs the L2 publish, which no-ops on an existing key, so the two are safe together.

## Two deliberate departures from the original

**The pipe is `os.Pipe`, not `bash -c` with `pipefail`.** Both children get one real kernel fd pair, so a multi-GB tree never traverses this process. That matters twice: the health probe must keep answering (Studio tears the pod down on a single miss), and a *relayed* copy is exactly what truncated this transfer in the TS version — using `os/exec`'s `StdoutPipe` here would reintroduce that relay. It also drops the bash dependency and the shell quoting it required.

**No shell means no `pipefail`,** so both exit codes are checked explicitly — consumer first, because its stderr is the line that explains a corrupt archive. `tar exit 2` alone is unactionable; it took a hand-run of the pipe to learn it meant "Unexpected EOF in archive".

## Kept, because they are load-bearing

- **An archive, never the tree.** Per-operation metadata latency is fatal across ~100k files, a non-issue for one sequential blob. The per-file cost is paid by the local extract.
- **Extract into staging, then rename.** An interrupted tar would otherwise leave a partial `node_modules` that later code reads as complete — the boot skips install and fails somewhere unrelated.
- **Write straight to the final key, not temp+rename.** A blob store has no rename and does not need one: an object becomes visible only once its upload completes, which is the same guarantee. A POSIX store would need it back, and the comment says so.
- **Read the archive back before reporting success.** Publish no-ops on an existing key, so a corrupt object would make every node in the fleet miss forever with nothing to repair it.

`zstd` is already in the sandbox image (`packages/sandbox/image/Dockerfile:42`) — it survived the TS deletion. `main.go` now warns when it is *missing* instead of warning that the tier is unimplemented.

## Testing

Real files, real `tar`/`zstd`, no mocks:

| test | why it exists |
|---|---|
| publish on one root, restore on another | the point of the tier: a cold root with no `node_modules` gets a complete tree, contents verified |
| ~8 MB payload | past any pipe buffer — the case that caught a truncating implementation in TS, where a 1 KB fixture passed |
| dormant when unconfigured | discriminating counterpart; without it the two above would pass even if the code ignored its configuration |
| truncated archive | fails closed: no partial tree, no staging left behind |
| corrupt (never-valid) archive | same, for bytes that were never an archive |
| idempotent publish | a second publish does not rewrite a live key — which matters because there is no rename to hide a partial object behind |
| prune | TTL, per-repo cap, non-archive entries left alone, repos independent |
| `.vite` excluded | pod-local churn must not travel in a shared archive |

`go build ./...`, `go vet`, `gofmt` clean; the full `internal/setup` suite passes. Tests skip rather than fail when `zstd` is absent, so a contributor without it does not get a red suite that trains them to ignore it.

**Not covered:** publish's read-back guard. Publish no-ops on an existing key so a corrupt object cannot be planted ahead of it, and making `zstd` emit a bad archive on demand would mean faking the pipe — which defeats testing against real tools. Noted in the test file rather than papered over.

## Not validated on a real pod, and it cannot be yet

The tenant mount is **read-only** by design, so publish always fails there and the store stays empty. Restore needs something to have published first.

So this PR makes the tier *possible*, not *live*: with a seeded store, sandboxes will restore from it and `sandbox.deps.restore{source="l2"}` starts reporting. The remaining piece is a trusted seeder holding the writable mount — deliberately not a sidecar in the sandbox pod, since a package manager installs cached content as-is and write access to a shared store would turn a node-local RCE surface into a fleet-wide one.

Per the repo norm, "done" means a tailed pod showing an L2 hit. This is not that yet.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reimplements the cross-node L2 golden cache in the Go daemon to restore, publish, and prune shared `tar`+`zstd` archives, cutting cold-node installs and wiring L2 before install in the orchestrator.

- **New Features**
  - L2 restore/publish/prune keyed exactly like L1 (credential-stripped repo hash + lockfile hash).
  - Orchestrator tries L2 before install; on hit, seeds this node’s L1, emits `sandbox.deps.restore{source="l2"}`, marks install success; after healthy boot it runs L2 publish and prune.
  - Restore extracts to staging then renames; no partial trees on failure.
  - Publish is idempotent, writes directly to the final key, validates by reading back the archive; excludes pod-local caches like `.vite`.
  - Prune by TTL and per-repo cap; safe post-publish; no-ops on read-only mounts.
  - Robust streaming via `os.Pipe` with explicit exit checks; large streams never traverse the daemon process.
  - Dormant unless `GOLDEN_CACHE_REMOTE` is set; `main.go` warns when `zstd` is missing.

- **Migration**
  - Seed the shared store from a trusted publisher with a writable mount; tenant pods stay read-only. Once seeded, sandboxes restore from L2 automatically or fall back to install.

<sup>Written for commit 2f539d6edc011f19d28f6b5fb3ebcf614a9fa85a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

