### PR TITLE
fix(org-fs): retry the manifest write so a torn write can't truncate mounts

### DIFF
--- a/apps/api/src/file-storage/org-fs.ts
+++ b/apps/api/src/file-storage/org-fs.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { retry } from "@decocms/shared/std";
 import type { BoundObjectStorage } from "../object-storage/bound-object-storage";
 import { detectContentType } from "../object-storage/key-utils";
 import type {
@@ -454,16 +455,34 @@ export class OrgFs {
       contentType: opts.contentType ?? detectContentType(normalized),
     });
 
-    return this.manifest.putFile({
-      organizationId: this.organizationId,
-      volume,
-      path: normalized,
-      parent: parentOf(normalized),
-      contentHash: sha256(bytes),
-      size: bytes.byteLength,
-      actor: opts.actor,
-      threadId: opts.threadId ?? null,
-    });
+    // The bytes are already committed; if the manifest write is lost the entry
+    // keeps the PREVIOUS size, and that stale size is what the mount serves as
+    // WebDAV `getcontentlength` — so every sandbox reads a silently truncated
+    // prefix of a file the browser shows in full. `putFile` is an idempotent
+    // upsert, so retry it rather than let a transient DB blip tear the two.
+    try {
+      return await retry(() =>
+        this.manifest.putFile({
+          organizationId: this.organizationId,
+          volume,
+          path: normalized,
+          parent: parentOf(normalized),
+          contentHash: sha256(bytes),
+          size: bytes.byteLength,
+          actor: opts.actor,
+          threadId: opts.threadId ?? null,
+        }),
+      );
+    } catch (err) {
+      console.error("org-fs manifest write lost after object put", {
+        organizationId: this.organizationId,
+        volume,
+        path: normalized,
+        size: bytes.byteLength,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      throw err;
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Reported as "the agent can't read the file" — a Library file the browser rendered in full (704 rows) that every sandbox agent saw as empty.

The bytes and the metadata disagreed:

| | value |
|---|---|
| R2 object `_fs/home/references/references.md` | **120,526 bytes** |
| `org_fs_entry.size` | **256** — frozen at the first write, `seq` never bumped |

`packages/sandbox/orgfs/webdav.ts:60` serves `node.size` as WebDAV `getcontentlength`, so rclone sized the mounted file at 256 bytes and the sandbox read a prefix cut mid-sentence. The Library viewer streams bytes straight from S3 (`/fs/:volume/read`, uncapped) so it showed everything — while its "256 B" label came from `/stat`, the same stale row. Agent and browser were each telling the truth about a different source.

## Cause

`OrgFs.write` does `storage.put(...)` then `manifest.putFile(...)` as two unguarded awaits. The bytes landed; the manifest write never did. The unbumped `seq` proves the row was inserted once and never updated, so this was a lost metadata write, not a racing overwrite. The log for that moment was gone, so the trigger (DB blip vs. torn request) is inferred, not proven.

## Fix

`putFile` is an idempotent upsert — wrap it in `retry` from `@decocms/shared/std`, and `console.error` if it still fails so the inconsistency stops being invisible.

## Blast radius

Scanned all **1,846** live org-fs files across **127** orgs against R2: **1 drifted, 0 missing.** Rare, but silent and severe when it hits.

## Prod repair (already done, out of band)

The one drifted row had `size`/`content_hash` recomputed from the object and `seq` bumped so the mount's change-feed invalidator drops its cache. No code in this PR performs it.

## Deliberately not done

- No manifest-vs-object reconciliation on read — that's a HEAD per stat on the mount hot path. Not worth it at 1-in-1846.
- No periodic sweeper. Add one if that new error line ever fires.
- No test: a lost-DB-write path needs mocks, which per `TESTING.md` disqualifies it from the unit tier, and it isn't reachable black-box from e2e.

## Testing

`bun run fmt` and `bun run --cwd=apps/api check` pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retry the manifest write in org-fs to prevent stale sizes that truncate mounted files. If retries fail, log the error so drift is visible.

- **Bug Fixes**
  - Wrap `manifest.putFile` in `retry` from `@decocms/shared/std` to handle transient failures safely.
  - Log a detailed error (org, volume, path, size) and rethrow if retries exhaust.

<sup>Written for commit cffc7a4cb770924537b0735ada6609588a6a0e9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

