### PR TITLE
feat(sandbox): park on no cluster capacity, and finish work before starting more

### DIFF
--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -2201,6 +2201,13 @@ export async function createApp(options: CreateAppOptions = {}) {
     await DBOS.registerQueue(THREAD_GATE_QUEUE, {
       partitionQueue: true,
       concurrency: THREAD_GATE_PARTITION_CONCURRENCY,
+      // Let an enqueue state its class (`enqueueOptions.priority`, lower first
+      // — see dispatch-queue/run-priority.ts). Scoped honestly: partitions are
+      // per-thread with concurrency 1, so this orders MESSAGES QUEUED ON THE
+      // SAME THREAD, not one thread against another. Cross-run ordering is the
+      // pod's admission gate (hosted-run-concurrency.ts), because DBOS has no
+      // global cap on a partitioned queue to order against.
+      priorityEnabled: true,
     });
     // Hosted-harness child workflow queue. Partition key = threadId, concurrency 1
     // (mirrors THREAD_GATE_QUEUE: one active run per thread, different threads
@@ -2208,6 +2215,8 @@ export async function createApp(options: CreateAppOptions = {}) {
     await DBOS.registerQueue(HOSTED_HARNESS_QUEUE, {
       partitionQueue: true,
       concurrency: HOSTED_HARNESS_PARTITION_CONCURRENCY,
+      // Same scope caveat as the gate queue above.
+      priorityEnabled: true,
     });
     // Slow backgroundable built-ins (generate_image) run here, partitioned by
     // orgId for per-org fairness. The reaction turn hops to the thread-gate.

--- a/apps/api/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/api/src/dbos/workflow-source-guard.snapshot.json
@@ -1,8 +1,8 @@
 {
   "auth/install-studio-pack-workflow.ts": "e284b2fd9950d5cc803d66a3b79e86258968b7d9a124cf2746363f8a4f7513a3",
   "automations/dbos-workflow.ts": "dd8535f7577bbd3c0270c60f14f480d4fb42e366666245c3efa77f0ce73a9da2",
-  "dispatch-queue/hosted-harness-workflow.ts": "aae8038ed00ed1838e7e6fa21c716ef2d6957150d0b822bd2f74df5cc4183f5e",
-  "dispatch-queue/thread-gate-workflow.ts": "f0e942d6f3f12dca92e4e793202dd38a3488a0a82c114b26d86967b663a394e9",
+  "dispatch-queue/hosted-harness-workflow.ts": "f5d4a8168c366575bbf7218b87fab17ea7aa749195e7a19d47abca2673a28eca",
+  "dispatch-queue/thread-gate-workflow.ts": "28823d1de22256bda37c50da051e9e9b32d9e48365410a6fd752def8530345f1",
   "file-storage/dbos-public-sets-sync.ts": "efd9c4bfd9ae29b13970e6b1072e067f43f151b3530d552efc1b4daf038bea7e",
   "harnesses/decopilot/background-tool-workflow.ts": "9febb699f45b63b418481ed998aee0ec8251c97cb5c409d54d714eb365a08fd0",
   "monitoring/dbos-retention-workflow.ts": "757e9999af900d9395c6629d4966b84c723512d0a5a8e488f70b7ba634752bd8"

--- a/apps/api/src/dispatch-queue/hosted-harness-workflow.ts
+++ b/apps/api/src/dispatch-queue/hosted-harness-workflow.ts
@@ -86,6 +86,7 @@ import type { StudioContext } from "@/core/studio-context";
 export { HOSTED_HARNESS_QUEUE } from "./queue-names";
 import { HOSTED_HARNESS_QUEUE } from "./queue-names";
 import { acquireHostedRunSlot } from "./hosted-run-concurrency";
+import { runPriority } from "./run-priority";
 import {
   advanceTaskBoardForRun,
   reopenTasksOnThreadRun,
@@ -231,7 +232,13 @@ export async function runHostedHarness(
     emit: () => publishWaitingCapacity(rt, input),
   });
   const releaseSlot = await acquireHostedRunSlot(
-    { harnessId: request.harnessId },
+    // Finish before you start: a reviewer or a retry outranks a brand-new task
+    // for the next slot (see run-priority.ts). Ordering only — a run already
+    // holding a slot is never preempted.
+    {
+      harnessId: request.harnessId,
+      priority: runPriority(request.runMetadata),
+    },
     () => {
       parked = true;
       void publishWaitingCapacity(rt, input);

--- a/apps/api/src/dispatch-queue/hosted-run-concurrency.ts
+++ b/apps/api/src/dispatch-queue/hosted-run-concurrency.ts
@@ -121,7 +121,11 @@ export const HOSTED_RUN_CAPS: { inProcess: number; sandboxed: number } = {
  * `hosted-harness-workflow.ts`'s `runHostedHarness`).
  */
 export const acquireHostedRunSlot = (
-  args: { harnessId: string | null | undefined },
+  args: {
+    harnessId: string | null | undefined;
+    /** See `runPriority` — lower goes first. Omit for FIFO. */
+    priority?: number;
+  },
   onPark?: () => void,
 ): Promise<() => void> => {
   // Which budget this run spends: its own sandbox pod's, or this pod's memory.
@@ -136,8 +140,9 @@ export const acquireHostedRunSlot = (
       pending: chosen.pending,
       max,
       sandboxed,
+      priority: args.priority ?? 0,
     });
     onPark?.();
   }
-  return chosen.acquire();
+  return chosen.acquire(args.priority);
 };

--- a/apps/api/src/dispatch-queue/run-priority.test.ts
+++ b/apps/api/src/dispatch-queue/run-priority.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+import {
+  RUN_CLASS_METADATA_KEY,
+  RUN_PRIORITY,
+  runPriority,
+} from "./run-priority";
+
+describe("runPriority", () => {
+  // The ordering this whole change exists for: a card one verdict from Done, or
+  // a retry with a budget, must not queue behind a task nothing is waiting on.
+  test("finish before you start", () => {
+    expect(RUN_PRIORITY.interactive).toBeLessThan(RUN_PRIORITY.reviewer);
+    expect(RUN_PRIORITY.reviewer).toBeLessThan(RUN_PRIORITY.retry);
+    expect(RUN_PRIORITY.retry).toBeLessThan(RUN_PRIORITY.new_task);
+  });
+
+  test("reads the class off runMetadata", () => {
+    expect(runPriority({ [RUN_CLASS_METADATA_KEY]: "reviewer" })).toBe(
+      RUN_PRIORITY.reviewer,
+    );
+    expect(runPriority({ [RUN_CLASS_METADATA_KEY]: "retry" })).toBe(
+      RUN_PRIORITY.retry,
+    );
+    expect(runPriority({ [RUN_CLASS_METADATA_KEY]: "new_task" })).toBe(
+      RUN_PRIORITY.new_task,
+    );
+  });
+
+  // An unmarked run is a person waiting on a stream (a chat turn). Sending those
+  // to the back of the queue would be the regression this change must not cause.
+  test("an unmarked or unknown run is treated as interactive", () => {
+    expect(runPriority(undefined)).toBe(RUN_PRIORITY.interactive);
+    expect(runPriority({})).toBe(RUN_PRIORITY.interactive);
+    expect(runPriority({ [RUN_CLASS_METADATA_KEY]: "nonsense" })).toBe(
+      RUN_PRIORITY.interactive,
+    );
+  });
+
+  // DBOS's scale: 1..2^31-1, lower dequeues first. Same numbers are handed to
+  // `enqueueOptions.priority`, so they have to be legal there.
+  test("values are legal DBOS priorities", () => {
+    for (const p of Object.values(RUN_PRIORITY)) {
+      expect(p).toBeGreaterThanOrEqual(1);
+      expect(p).toBeLessThan(2 ** 31 - 1);
+    }
+  });
+});

--- a/apps/api/src/dispatch-queue/run-priority.ts
+++ b/apps/api/src/dispatch-queue/run-priority.ts
@@ -1,0 +1,54 @@
+/**
+ * Which run gets the next slot when a pod is at its cap.
+ *
+ * Admission used to be first-come-first-served, which is the wrong order for a
+ * board: a brand-new task takes a slot while the card ahead of it is In Review
+ * waiting for a reviewer that can't get one. Nothing finishes, everything is
+ * half-done, and every unfinished card is holding a PR nobody has ruled on.
+ *
+ * So the ordering is "finish before you start":
+ *
+ *   interactive  — a human is watching this stream. Always first.
+ *   reviewer     — a QA / code-review run. The card is one verdict from Done.
+ *   retry        — a re-dispatch of work that already failed once. It has a
+ *                  budget; spending it behind new work wastes it.
+ *   new task     — the only class where nothing is waiting on the outcome yet.
+ *
+ * Deliberately NOT a hard precondition ("no new task while any card is In
+ * Review"). That reads as stricter and is worse: three cards sat In Review for
+ * 40 minutes with reviewers that couldn't get a pod, and a hard rule would have
+ * frozen the whole board instead of just ordering it. Priority starves nothing
+ * permanently — a new task waits behind in-flight work and then runs.
+ *
+ * Values are DBOS's convention (1..2^31-1, lower dequeues first) so the same
+ * numbers can be handed to `enqueueOptions.priority` without a second scale.
+ */
+
+/** How a run was started — set in `runMetadata.runClass` at enqueue. */
+export type RunClass = "interactive" | "reviewer" | "retry" | "new_task";
+
+export const RUN_PRIORITY: Record<RunClass, number> = {
+  interactive: 10,
+  reviewer: 20,
+  retry: 30,
+  new_task: 40,
+};
+
+/** Metadata key carrying the class. A free-form `runMetadata` string, so adding
+ *  it changes no schema and no DBOS step I/O. */
+export const RUN_CLASS_METADATA_KEY = "runClass";
+
+/**
+ * The priority for a run, from its metadata. An unmarked run is interactive:
+ * every dispatch that isn't a board-driven background run is a person waiting on
+ * a stream, and defaulting those to the back of the queue would be a visible
+ * regression. Pure — unit-tested.
+ */
+export function runPriority(
+  runMetadata: Record<string, string> | undefined,
+): number {
+  const cls = runMetadata?.[RUN_CLASS_METADATA_KEY];
+  return cls && cls in RUN_PRIORITY
+    ? RUN_PRIORITY[cls as RunClass]
+    : RUN_PRIORITY.interactive;
+}

--- a/apps/api/src/dispatch-queue/thread-gate-workflow.ts
+++ b/apps/api/src/dispatch-queue/thread-gate-workflow.ts
@@ -38,6 +38,7 @@ import { consumeRunProjection } from "@/api/routes/decopilot/consume-run-project
 
 export { THREAD_GATE_QUEUE } from "./queue-names";
 import { THREAD_GATE_QUEUE } from "./queue-names";
+import { runPriority } from "./run-priority";
 import { startHostedHarness } from "./hosted-harness-workflow";
 
 /**
@@ -446,7 +447,12 @@ export async function enqueueThreadRun(
   assertHarnessRunsInCluster(ctx.request.harnessId);
   const handle = await DBOS.startWorkflow(threadGateWorkflow, {
     queueName: THREAD_GATE_QUEUE,
-    enqueueOptions: { queuePartitionKey: ctx.threadId },
+    enqueueOptions: {
+      queuePartitionKey: ctx.threadId,
+      // Orders messages queued on THIS thread (the partition). Cross-run
+      // ordering is the pod's admission gate — see run-priority.ts.
+      priority: runPriority(ctx.request.runMetadata),
+    },
     workflowID: opts?.workflowID,
   })(ctx);
   return { workflowID: handle.workflowID };

--- a/apps/api/src/harnesses/decopilot/built-in-tools/concurrency-priority.test.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/concurrency-priority.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+import { createConcurrencyGate } from "./subagent-concurrency";
+
+describe("createConcurrencyGate priority", () => {
+  // Ordering the WAITERS is the whole mechanism: the slot holder is never
+  // preempted, so a low-priority run that started is never killed for a
+  // high-priority one.
+  test("a higher-priority waiter takes the freed slot first", async () => {
+    const gate = createConcurrencyGate(1);
+    const release = await gate.acquire();
+    const order: string[] = [];
+
+    const low = gate.acquire(40).then((r) => {
+      order.push("low");
+      r();
+    });
+    const high = gate.acquire(20).then((r) => {
+      order.push("high");
+      r();
+    });
+    // Let both park before the slot frees.
+    await Promise.resolve();
+    release();
+    await Promise.all([low, high]);
+
+    expect(order).toEqual(["high", "low"]);
+  });
+
+  test("equal priorities keep arrival order", async () => {
+    const gate = createConcurrencyGate(1);
+    const release = await gate.acquire();
+    const order: number[] = [];
+    const waits = [1, 2, 3].map((n) =>
+      gate.acquire(30).then((r) => {
+        order.push(n);
+        r();
+      }),
+    );
+    await Promise.resolve();
+    release();
+    await Promise.all(waits);
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  test("omitting priority still works (plain FIFO)", async () => {
+    const gate = createConcurrencyGate(1);
+    const release = await gate.acquire();
+    const order: string[] = [];
+    const a = gate.acquire().then((r) => {
+      order.push("a");
+      r();
+    });
+    const b = gate.acquire().then((r) => {
+      order.push("b");
+      r();
+    });
+    await Promise.resolve();
+    release();
+    await Promise.all([a, b]);
+    expect(order).toEqual(["a", "b"]);
+  });
+});

--- a/apps/api/src/harnesses/decopilot/built-in-tools/concurrency-priority.test.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/concurrency-priority.test.ts
@@ -18,7 +18,7 @@ describe("createConcurrencyGate priority", () => {
       order.push("high");
       r();
     });
-    // Let both park before the slot frees.
+    // Let both park before the slot frees
     await Promise.resolve();
     release();
     await Promise.all([low, high]);

--- a/apps/api/src/harnesses/decopilot/built-in-tools/subagent-concurrency.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/subagent-concurrency.ts
@@ -45,7 +45,8 @@ export function createConcurrencyGate(max: number): ConcurrencyGate {
   // the queue is bounded by how many runs one pod can have in flight (tens), so
   // an O(n) insert is free and a heap would be code to maintain for nothing.
   let arrivals = 0;
-  const waiters: Array<{ priority: number; seq: number; wake: () => void }> = [];
+  const waiters: Array<{ priority: number; seq: number; wake: () => void }> =
+    [];
 
   return {
     async acquire(priority = 0) {

--- a/apps/api/src/harnesses/decopilot/built-in-tools/subagent-concurrency.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/subagent-concurrency.ts
@@ -21,8 +21,13 @@ export interface ConcurrencyGate {
   /**
    * Acquire a slot, waiting if at capacity. Returns a release function; call it
    * exactly once (idempotent) when the work is done, including on error/abort.
+   *
+   * `priority` orders the WAITERS only (lower goes first, ties keep arrival
+   * order) — it never preempts a slot already held, so a low-priority run that
+   * started is never killed to make room. Omit for FIFO, which is what every
+   * caller that doesn't care gets.
    */
-  acquire(): Promise<() => void>;
+  acquire(priority?: number): Promise<() => void>;
   /** Slots currently held (testing/observability). */
   readonly active: number;
   /** Callers waiting for a slot (testing/observability). */
@@ -36,16 +41,27 @@ export function createConcurrencyGate(max: number): ConcurrencyGate {
   // of the intended cap.
   const limit = Number.isFinite(max) ? Math.max(1, max) : 1;
   let active = 0;
-  const waiters: Array<() => void> = [];
+  // Sorted by (priority, arrival). A plain array + insertion scan, not a heap:
+  // the queue is bounded by how many runs one pod can have in flight (tens), so
+  // an O(n) insert is free and a heap would be code to maintain for nothing.
+  let arrivals = 0;
+  const waiters: Array<{ priority: number; seq: number; wake: () => void }> = [];
 
   return {
-    async acquire() {
+    async acquire(priority = 0) {
       if (active < limit) {
         active++;
       } else {
         // Parked: the eventual release() hands this slot off directly
         // (active is never decremented for it), so no increment here either.
-        await new Promise<void>((resolve) => waiters.push(resolve));
+        await new Promise<void>((wake) => {
+          const entry = { priority, seq: arrivals++, wake };
+          // Last index whose priority is <= ours — insert after it, so equal
+          // priorities stay FIFO.
+          let i = waiters.length;
+          while (i > 0 && waiters[i - 1]!.priority > priority) i--;
+          waiters.splice(i, 0, entry);
+        });
       }
 
       let released = false;
@@ -54,7 +70,7 @@ export function createConcurrencyGate(max: number): ConcurrencyGate {
         released = true;
         const next = waiters.shift();
         if (next) {
-          next();
+          next.wake();
         } else {
           active--;
         }

--- a/apps/api/src/storage/task-board-advance-review.integration.test.ts
+++ b/apps/api/src/storage/task-board-advance-review.integration.test.ts
@@ -260,7 +260,9 @@ describe("failed runs never reach In Review (real Postgres)", () => {
 
     await taskBoard.advanceLinkedTasksToReviewOnThreadFinish(thread.id, ORG2);
 
-    expect((await taskBoard.getById(task.id, ORG2))?.status).toBe("in_progress");
+    expect((await taskBoard.getById(task.id, ORG2))?.status).toBe(
+      "in_progress",
+    );
   });
 
   it("reads the failure kind and the run's error text together", async () => {
@@ -356,7 +358,12 @@ describe("failed runs never reach In Review (real Postgres)", () => {
       .set({ assignee_id: "super-agent" })
       .where("id", "=", task.id)
       .execute();
-    await taskBoard.scheduleRunRetry(task.id, ORG2, 1, new Date(Date.now() + 60_000));
+    await taskBoard.scheduleRunRetry(
+      task.id,
+      ORG2,
+      1,
+      new Date(Date.now() + 60_000),
+    );
 
     const stuck = await taskBoard.listItemsStuckAfterFailure(10, new Date());
 

--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -22,6 +22,7 @@ import {
   type SandboxProviderKind,
   type Workload,
 } from "@decocms/sandbox/provider";
+import { sleep } from "@decocms/shared/std";
 import { defineTool } from "../../core/define-tool";
 import {
   getUserId,
@@ -577,6 +578,16 @@ async function provisionSandbox(
     }
   }
 
+  // Ask before claiming: a sandbox the cluster cannot place sits `Pending`
+  // (`FailedScheduling: Insufficient memory`) until the 180s readiness timeout
+  // fails the run. On a node with room for 4, an 8-card auto-fix produced 4
+  // failures that way, and each retry re-entered the same full node. Waiting
+  // here turns over-admission into a queue. Bounded well under the readiness
+  // timeout this call already tolerates, so it adds no new liveness risk; past
+  // the bound the error is phrased for the task-board retry to recognize as
+  // infrastructure. No-op for a provider that can't answer.
+  await waitForSchedulableCapacity(runner);
+
   const sandbox = await runner.ensure(
     { userId: sandboxUserId, projectRef },
     {
@@ -699,4 +710,49 @@ async function persistDetectedRuntime(
       runtime: { selected: packageManager, port: devPort },
     } as VirtualMCPUpdateData["metadata"],
   });
+}
+
+/** How long `ensureSandbox` waits for the cluster to have room. Deliberately
+ *  under `waitForSandboxReady`'s own 180s: this call's callers already tolerate
+ *  that much, so staying inside it means the wait can't trip a liveness window
+ *  that the readiness wait wouldn't have tripped anyway. A cluster still full
+ *  after this needs nodes, not patience — the run fails and the task-board
+ *  retry re-dispatches it with backoff. */
+const CAPACITY_WAIT_MS = 150_000;
+/** Re-ask this often. The provider caches its answer (3s), so this is the poll
+ *  rate that matters. */
+const CAPACITY_POLL_MS = 5_000;
+
+/**
+ * Park until the provider says another sandbox can actually be scheduled.
+ *
+ * The signal is the scheduler's own verdict on pods it already refused to place
+ * (see `capacity.ts`), so it is lagging by one admission: the first
+ * over-subscribed claim is still made, and it is what makes this false for
+ * everyone behind it. That is the trade — one run pays the readiness timeout
+ * instead of every run in the burst.
+ */
+async function waitForSchedulableCapacity(
+  runner: SandboxProvider,
+): Promise<void> {
+  if (!runner.hasSchedulableCapacity) return;
+  const deadline = Date.now() + CAPACITY_WAIT_MS;
+  let logged = false;
+  while (!(await runner.hasSchedulableCapacity())) {
+    if (Date.now() >= deadline) {
+      // Phrased so the task-board's `isTransientRunFailure` recognizes it: this
+      // is capacity, not the task's fault, so the card must be retried.
+      throw new Error(
+        "sandbox provisioning failed: the cluster has had no room to schedule " +
+          `another sandbox for ${Math.round(CAPACITY_WAIT_MS / 1000)}s`,
+      );
+    }
+    if (!logged) {
+      logged = true;
+      console.warn(
+        "[ensureSandbox] waiting for cluster capacity — a sandbox pod cannot be scheduled right now",
+      );
+    }
+    await sleep(CAPACITY_POLL_MS);
+  }
 }

--- a/apps/api/src/tools/task-board/enqueue-reviewer.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.ts
@@ -312,6 +312,9 @@ async function enqueueReviewerForTask(
 
   // Create + link the reviewer thread and dispatch its run (shared plumbing).
   await enqueueAgentRunForTask(ctx, task, {
+    // A verdict is the last thing between this card and Done — it outranks
+    // starting a new task for the next slot.
+    runClass: "reviewer",
     title: `${REVIEWER_LABEL[kind]}: ${task.title}`,
     prompt,
     temperature: 0.3,

--- a/apps/api/src/tools/task-board/enqueue-super-agent.ts
+++ b/apps/api/src/tools/task-board/enqueue-super-agent.ts
@@ -8,6 +8,7 @@ import {
 } from "../../billing/task-quota";
 import { getSettings } from "@/settings";
 import { enqueueAgentRunForTask } from "./enqueue-task-run";
+import type { RunClass } from "@/dispatch-queue/run-priority";
 import { fetchPrHeadRef } from "./prs-get";
 import {
   buildClaudeCodeTaskPrompt,
@@ -58,6 +59,10 @@ export type SuperAgentPromptOpts = {
    *  `pr` — without it the conflict lead is skipped (a conflict instruction
    *  is meaningless with no PR to check out). */
   resolveConflict?: boolean;
+  /** Admission class for the dispatched run — `"retry"` for a re-dispatch of
+   *  work that already failed, so it outranks a brand-new task for the next
+   *  slot. Defaults to a new task. See `dispatch-queue/run-priority.ts`. */
+  runClass?: RunClass;
 };
 
 /**
@@ -192,6 +197,7 @@ export async function enqueueSuperAgentForTask(
       const repo = "repo" in choice ? choice.repo : null;
       await enqueueAgentRunForTask(ctx, task, {
         title: `Super Agent: ${task.title}`,
+        ...(opts?.runClass ? { runClass: opts.runClass } : {}),
         ...(pinnedRef ? { pinnedRef } : {}),
         prompt: buildClaudeCodeTaskPrompt(task, repo, {
           ...opts,
@@ -208,6 +214,7 @@ export async function enqueueSuperAgentForTask(
 
     await enqueueAgentRunForTask(ctx, task, {
       title: `Super Agent: ${task.title}`,
+      ...(opts?.runClass ? { runClass: opts.runClass } : {}),
       prompt: buildSuperAgentTaskPrompt(task, opts),
       temperature: 0.5,
       ...(pinnedRef ? { pinnedRef } : {}),

--- a/apps/api/src/tools/task-board/enqueue-task-run.ts
+++ b/apps/api/src/tools/task-board/enqueue-task-run.ts
@@ -1,4 +1,8 @@
 import { taskRunMetadata } from "../../billing/subsidized-runs";
+import {
+  RUN_CLASS_METADATA_KEY,
+  type RunClass,
+} from "@/dispatch-queue/run-priority";
 import type { StudioContext } from "@/core/studio-context";
 import type { TaskBoardItem } from "@/storage/types";
 import { resolveTier } from "@/core/resolve-tier";
@@ -47,6 +51,8 @@ export async function enqueueAgentRunForTask(
      * default, and opens a SECOND pull request for the same task.
      */
     pinnedRef?: string | null;
+    /** Admission class for this run. See `dispatch-queue/run-priority.ts`. */
+    runClass?: RunClass;
   },
 ): Promise<{ threadId: string }> {
   const organizationId = task.organizationId;
@@ -163,7 +169,14 @@ export async function enqueueAgentRunForTask(
       taskId: thread.id,
       // Reports tasks carry the subscription-billing stamp: their AI usage
       // is included in the org subscription (billing/subsidized-runs.ts).
-      runMetadata: taskRunMetadata(task),
+      // `runClass` orders admission when the pod is at its cap — a reviewer or
+      // a retry outranks a brand-new task (see dispatch-queue/run-priority.ts).
+      // A free-form metadata string, so it changes no schema and no DBOS step
+      // I/O. Defaults to a new task: the class that nothing is waiting on.
+      runMetadata: {
+        ...taskRunMetadata(task),
+        [RUN_CLASS_METADATA_KEY]: opts.runClass ?? "new_task",
+      },
     },
   });
 

--- a/apps/api/src/tools/task-board/review-sweeper.ts
+++ b/apps/api/src/tools/task-board/review-sweeper.ts
@@ -269,7 +269,9 @@ export class TaskBoardReviewSweeper {
           item.assignedBy ?? item.createdBy,
         );
         if (!ctx) continue;
-        await enqueueSuperAgentForTask(ctx, item);
+        // A retry is work that already failed once and has a budget — it
+        // outranks a brand-new task for the next slot.
+        await enqueueSuperAgentForTask(ctx, item, { runClass: "retry" });
         count++;
         console.warn(
           `[task-board-review-sweeper] re-dispatched ${id} after a failure ` +

--- a/packages/sandbox/server/provider/agent-sandbox/capacity.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/capacity.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+import { hasUnschedulablePod } from "./capacity";
+
+describe("hasUnschedulablePod", () => {
+  // The exact verdict that failed eight tasks: the scheduler could not place the
+  // pod, so the sandbox never became ready and the run died after 180s.
+  test("true for a pod the scheduler refused to place", () => {
+    expect(
+      hasUnschedulablePod({
+        items: [
+          {
+            status: {
+              phase: "Pending",
+              conditions: [
+                {
+                  type: "PodScheduled",
+                  status: "False",
+                  reason: "Unschedulable",
+                },
+              ],
+            },
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  // A Pending pod that HAS a node (pulling its image, running an init container)
+  // is not a capacity problem — counting it would park runs the cluster could
+  // have taken.
+  test("false for a Pending pod that was already scheduled", () => {
+    expect(
+      hasUnschedulablePod({
+        items: [
+          {
+            status: {
+              phase: "Pending",
+              conditions: [{ type: "PodScheduled", status: "True" }],
+            },
+          },
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  test("false for a running namespace and for an empty list", () => {
+    expect(hasUnschedulablePod({ items: [{ status: { phase: "Running" } }] })).toBe(
+      false,
+    );
+    expect(hasUnschedulablePod({ items: [] })).toBe(false);
+    expect(hasUnschedulablePod({})).toBe(false);
+  });
+});

--- a/packages/sandbox/server/provider/agent-sandbox/capacity.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/capacity.test.ts
@@ -44,9 +44,9 @@ describe("hasUnschedulablePod", () => {
   });
 
   test("false for a running namespace and for an empty list", () => {
-    expect(hasUnschedulablePod({ items: [{ status: { phase: "Running" } }] })).toBe(
-      false,
-    );
+    expect(
+      hasUnschedulablePod({ items: [{ status: { phase: "Running" } }] }),
+    ).toBe(false);
     expect(hasUnschedulablePod({ items: [] })).toBe(false);
     expect(hasUnschedulablePod({})).toBe(false);
   });

--- a/packages/sandbox/server/provider/agent-sandbox/capacity.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/capacity.ts
@@ -1,0 +1,98 @@
+/**
+ * "Can the cluster place another sandbox right now?"
+ *
+ * The honest answer comes from the scheduler, and it only ever says so about
+ * pods it has already tried to place: a pod it cannot fit stays `Pending` with
+ * an `Unschedulable` condition (`FailedScheduling: 0/1 nodes are available: 1
+ * Insufficient memory`). So the probe is "is anything currently unplaceable?",
+ * not a capacity forecast — forecasting would mean summing requests against
+ * allocatable across every node and re-implementing the scheduler's own
+ * accounting, which would be wrong in a different way every release.
+ *
+ * Reading an already-failing pod is a lagging signal by one admission: the first
+ * over-subscribed claim still gets made and still `Pending`s. That claim is what
+ * makes the probe true for everyone behind it, which is the point — one run pays
+ * the 180s timeout instead of eight.
+ *
+ * Cached, because this sits on the run-admission path and a burst asks the same
+ * question N times in the same second.
+ */
+
+import type { KubeConfig } from "@kubernetes/client-node";
+import { kubeFetch } from "./client";
+
+/** How long an answer is reused. Short: a pod becoming schedulable is exactly
+ *  the event a parked run is waiting for, and 3s is well under the time a node
+ *  takes to free 2Gi. */
+const CACHE_TTL_MS = 3_000;
+
+/** Treat a probe failure as "capacity available" and admit. A broken probe must
+ *  never become a global stop on running work — that would trade a bounded,
+ *  retriable failure for a total outage. */
+const FAIL_OPEN = true;
+
+interface PodList {
+  items?: Array<{
+    status?: {
+      phase?: string;
+      conditions?: Array<{ type?: string; reason?: string; status?: string }>;
+    };
+  }>;
+}
+
+/**
+ * True when at least one pod in `namespace` is Pending because the scheduler
+ * could not place it. Exported for the unit test: the shape-reading is the part
+ * worth pinning, since `PodScheduled=False/Unschedulable` is the contract here
+ * (a pod Pending while pulling an image is NOT this — it has a node).
+ */
+export function hasUnschedulablePod(list: PodList): boolean {
+  return (list.items ?? []).some((pod) => {
+    if (pod.status?.phase !== "Pending") return false;
+    return (pod.status?.conditions ?? []).some(
+      (c) =>
+        c.type === "PodScheduled" &&
+        c.status === "False" &&
+        c.reason === "Unschedulable",
+    );
+  });
+}
+
+export function createCapacityProbe(
+  kc: KubeConfig,
+  namespace: string,
+): () => Promise<boolean> {
+  let cachedAt = 0;
+  let cached = true;
+  let inFlight: Promise<boolean> | null = null;
+
+  const read = async (): Promise<boolean> => {
+    try {
+      const resp = await kubeFetch(kc, {
+        method: "GET",
+        path:
+          `/api/v1/namespaces/${encodeURIComponent(namespace)}/pods` +
+          // Only Pending pods can be unschedulable, so let the API server filter
+          // — a busy namespace's Running pods are the bulk of the payload.
+          `?fieldSelector=status.phase%3DPending`,
+      });
+      if (!resp.ok) return FAIL_OPEN;
+      const list = (await resp.json()) as PodList;
+      return !hasUnschedulablePod(list);
+    } catch {
+      return FAIL_OPEN;
+    }
+  };
+
+  return async () => {
+    const now = Date.now();
+    if (now - cachedAt < CACHE_TTL_MS) return cached;
+    // Coalesce a burst: N runs admitting in the same tick share one API call.
+    inFlight ??= read().finally(() => {
+      inFlight = null;
+    });
+    cached = await inFlight;
+    cachedAt = Date.now();
+    return cached;
+  };
+}

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -27,6 +27,7 @@ import { createHash, randomBytes, randomUUID } from "node:crypto";
 import * as net from "node:net";
 import { PassThrough } from "node:stream";
 import { sleep } from "@decocms/shared/std";
+import { createCapacityProbe } from "./capacity";
 import {
   type KubeConfig,
   KubeConfig as KubeConfigClass,
@@ -408,6 +409,8 @@ export class AgentSandboxProvider implements SandboxProvider {
   private readonly stateStore: RunnerStateStore | null;
   private readonly previewUrlPattern: string | null;
   private readonly kubeConfig: KubeConfig;
+  /** Lazily built so a provider instance that never admits a run pays nothing. */
+  private capacityProbe?: () => Promise<boolean>;
   private readonly portForward: PortForward;
   private readonly namespace: string;
   private readonly sandboxTemplateName: string;
@@ -577,6 +580,18 @@ export class AgentSandboxProvider implements SandboxProvider {
       claimName: handle,
       signal,
     });
+  }
+
+  /**
+   * Can the cluster place another sandbox right now? See `capacity.ts` — the
+   * answer is "nothing is currently unschedulable", read from the scheduler's
+   * own verdict rather than forecast from node capacity. The admission gate
+   * parks on `false` instead of claiming a sandbox that would sit `Pending`
+   * until the 180s readiness timeout fails the run.
+   */
+  hasSchedulableCapacity(): Promise<boolean> {
+    this.capacityProbe ??= createCapacityProbe(this.kubeConfig, this.namespace);
+    return this.capacityProbe();
   }
 
   async getPreviewUrl(handle: string): Promise<string | null> {

--- a/packages/sandbox/server/provider/types.ts
+++ b/packages/sandbox/server/provider/types.ts
@@ -214,6 +214,26 @@ export interface SandboxProvider {
    */
   forgetHandle?(handle: string): Promise<void>;
 
+  /**
+   * Can the backing infrastructure schedule another sandbox right now?
+   *
+   * `false` means "do not ask for one yet" — the caller parks instead of
+   * claiming a sandbox that cannot be placed. Without it, over-admission is only
+   * discovered by waiting out `waitForSandboxReady` (180s) and failing the run,
+   * which is how one over-subscribed node turned an 8-card auto-fix into 4
+   * failed tasks: their pods sat `Pending` with
+   * `FailedScheduling: Insufficient memory`, and Studio's only limit was a fixed
+   * per-pod number that cannot see a cluster.
+   *
+   * `true` is not a reservation, just "nothing is currently unplaceable". A race
+   * between two admissions is fine: the loser fails and is retried, which is the
+   * pre-existing behavior.
+   *
+   * Optional: a provider that cannot answer omits it and callers admit
+   * immediately, preserving today's behavior exactly.
+   */
+  hasSchedulableCapacity?(): Promise<boolean>;
+
   /** Null when no workload was requested or the sandbox isn't running. */
   getPreviewUrl(handle: string): Promise<string | null>;
 


### PR DESCRIPTION
Follow-on to #5825 (PR linking) and #5826 (failure recovery), both merged. Those two made a full node *survivable*; this one stops over-subscribing it in the first place, and stops new work from jumping the queue ahead of work that's nearly done.

## 1. Nothing asked whether a sandbox could be placed

The only limit on sandbox admission was `SANDBOX_MAX_CONCURRENT_HOSTED_RUNS`: a fixed per-pod number that cannot see a cluster. Measured on the node that produced the incident:

```
allocatable memory : 9.7 Gi          → room for 4 sandboxes
one sandbox pod    : 2 Gi + 128 Mi (sandbox + orgfs-sidecar)
result of 8 runs   : 4 Running, 4 Pending
                     FailedScheduling: 0/1 nodes are available: 1 Insufficient memory
```

Those 4 died on `Sandbox did not become ready within 180 seconds`, and each retry re-entered the same full node.

Now `SandboxProvider.hasSchedulableCapacity?()` answers "can another sandbox be placed right now", and **`ensureSandbox` parks on `false`** instead of claiming one that can't be.

- **The signal is the scheduler's own verdict** — a Pending pod with `PodScheduled=False/Unschedulable` — not a forecast from node allocatable. Forecasting means re-implementing the scheduler's accounting and being wrong in a new way every release.
- **Cached 3s and coalesced**: a burst asks the same question N times in one tick.
- **Capped at 150s, inside the 180s readiness timeout this call already tolerates**, so it adds no liveness risk the readiness wait didn't already carry. Past the cap the error is worded for #5826's `isTransientRunFailure` to classify as infrastructure → the card is re-dispatched with backoff.
- **Optional on the interface**: a provider without the probe admits immediately, so `user-desktop` and every existing test are unchanged.

Residual, stated plainly: the signal **lags by one admission**. The first over-subscribed claim is still made, and that claim is what makes the probe false for everyone behind it. One run pays the timeout instead of eight. A true reservation would need the scheduler to answer before the pod exists, which it won't.

## 2. Admission was first-come-first-served

A brand-new task took the slot a reviewer needed to finish the card ahead of it. Three cards sat In Review for 40 minutes with reviewers that couldn't get a pod, while new work kept starting.

Runs now carry `runMetadata.runClass`, and the pod's gate orders its **waiters** by it:

| Class | Priority | Why |
|---|---|---|
| interactive | 10 | a human is watching this stream |
| reviewer | 20 | the card is one verdict from Done |
| retry | 30 | already failed once, and its budget is finite |
| new_task | 40 | nothing is waiting on the outcome yet |

- **Ordering, never preemption** — a run holding a slot is never killed to make room.
- **An unmarked run is interactive**: every non-board dispatch is a person waiting on a stream, and defaulting those to the back would be a visible regression.
- `runClass` is a free-form `runMetadata` string → **no schema change, no DBOS step I/O change**.

**Deliberately not the hard rule** ("no new task while a card is In Review waiting on reviewers"). It reads stricter but is worse: during the incident the blocking cards were themselves waiting on capacity, so a hard gate would have frozen the whole board instead of ordering it. Priority starves nothing permanently.

## On DBOS priority

`priorityEnabled: true` is set on both queues and the priority is passed at enqueue — with an explicit comment about its scope: **partitions are per-thread with concurrency 1**, so DBOS priority orders messages on the *same thread*, not one thread against another. There's no global cap on a partitioned queue for it to order against, which is why cross-run ordering has to live in the pod's admission gate.

## Version safety

**No `DBOS_WORKFLOW_VERSION` bump.** Both workflow-file edits are inside a step's body (the slot acquire — the existing comments already document it as living inside `runHostedHarness`) and in enqueue options; no step sequence changed. The source-guard snapshot is re-baselined for that reason, and the guard is what forced the question.

## Testing

- `run-priority.test.ts` — the ordering invariant, metadata parsing, the interactive default, and that the values are legal DBOS priorities.
- `capacity.test.ts` — `PodScheduled=False/Unschedulable` is true; a Pending pod that *was* scheduled (pulling an image) is **false**, since counting it would park runs the cluster could have taken.
- `concurrency-priority.test.ts` — a higher-priority waiter takes the freed slot, equal priorities stay FIFO, and `acquire()` with no argument is unchanged FIFO (the subagent gate shares this factory).
- `bun run --cwd=apps/api check`, `--cwd=packages/sandbox check`, `fmt`, `lint`, and the workflow source guard all pass.

## Also included

`selfhost/examples/dev-hybrid/.env` gets `SANDBOX_MAX_CONCURRENT_HOSTED_RUNS=3` and `DATABASE_POOL_MAX=20`, with the node arithmetic behind each number in comments. That's the stopgap; the probe is the actual fix, since it needs no per-machine tuning.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a capacity gate for sandbox admission and run prioritization so reviewers and retries finish before new tasks. This avoids over-subscribing the cluster and reduces failed runs on full nodes.

- **New Features**
  - Capacity gate: `ensureSandbox` waits up to 150s when `hasSchedulableCapacity` is false; agent-sandbox probes Kubernetes `PodScheduled=False/Unschedulable` with a 3s cache and coalesced calls; providers without the probe admit immediately.
  - Admission priority: runs carry `runMetadata.runClass`; waiters are ordered interactive < reviewer < retry < new_task with no preemption. `THREAD_GATE_QUEUE` and `HOSTED_HARNESS_QUEUE` have `priorityEnabled` (per-thread scope); `enqueue-reviewer`, `review-sweeper` (retry), and `enqueue-super-agent` tag classes; unmarked runs default to interactive. Subagent/pod gates order by (priority, arrival); `enqueueThreadRun` and `runHostedHarness` pass the computed priority.

<sup>Written for commit 0ed8ae3483b7e36c0bd31166dd0d12e84510ffc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

