### PR TITLE
fix(task-board): recognize Vercel/VTEX preview hosts

### DIFF
--- a/apps/api/src/storage/task-board-advance-review.integration.test.ts
+++ b/apps/api/src/storage/task-board-advance-review.integration.test.ts
@@ -260,7 +260,9 @@ describe("failed runs never reach In Review (real Postgres)", () => {
 
     await taskBoard.advanceLinkedTasksToReviewOnThreadFinish(thread.id, ORG2);
 
-    expect((await taskBoard.getById(task.id, ORG2))?.status).toBe("in_progress");
+    expect((await taskBoard.getById(task.id, ORG2))?.status).toBe(
+      "in_progress",
+    );
   });
 
   it("reads the failure kind and the run's error text together", async () => {
@@ -356,7 +358,12 @@ describe("failed runs never reach In Review (real Postgres)", () => {
       .set({ assignee_id: "super-agent" })
       .where("id", "=", task.id)
       .execute();
-    await taskBoard.scheduleRunRetry(task.id, ORG2, 1, new Date(Date.now() + 60_000));
+    await taskBoard.scheduleRunRetry(
+      task.id,
+      ORG2,
+      1,
+      new Date(Date.now() + 60_000),
+    );
 
     const stuck = await taskBoard.listItemsStuckAfterFailure(10, new Date());
 

--- a/apps/api/src/tools/task-board/checks-status.test.ts
+++ b/apps/api/src/tools/task-board/checks-status.test.ts
@@ -321,19 +321,50 @@ describe("extractPreviewUrlFromComments", () => {
     ).toBeNull();
   });
 
-  it("prefers the newest comment by created_at over array order, so a stale re-deploy comment doesn't win", () => {
+  it("prefers the newest comment by updated_at over array order, so a stale re-deploy comment doesn't win", () => {
     const staleVercelBody =
       "[Preview](https://electrolux-git-old-stale-deploy-deco13.vercel.app)";
     const fresh = extractPreviewUrlFromComments([
-      { body: staleVercelBody, created_at: "2026-08-01T00:00:00Z" },
-      { body: vercelBody, created_at: "2026-08-06T22:32:55Z" },
+      {
+        body: staleVercelBody,
+        created_at: "2026-08-01T00:00:00Z",
+        updated_at: "2026-08-01T00:00:00Z",
+      },
+      {
+        body: vercelBody,
+        created_at: "2026-08-06T22:32:55Z",
+        updated_at: "2026-08-06T22:32:55Z",
+      },
     ]);
     expect(fresh).toBe(
       "https://electrolux-git-fix-pdp-focus-order-mobile-menu-deco13.vercel.app",
     );
   });
 
-  it("falls back to array order when created_at is missing", () => {
+  it("prefers a comment's updated_at over its created_at, so a sticky comment edited in place beats an unrelated later comment", () => {
+    // Vercel/Cloudflare edit a single sticky comment on each push — created_at
+    // stays frozen at the FIRST post, only updated_at moves forward. A human
+    // comment posted in between (with a coincidentally-matching host) must
+    // NOT outrank the bot's freshly-edited comment just because its
+    // created_at is later.
+    const stickyBotComment = {
+      body: vercelBody,
+      created_at: "2026-08-01T00:00:00Z", // first posted early in the PR
+      updated_at: "2026-08-06T22:32:55Z", // edited in place on the latest push
+    };
+    const laterUnrelatedComment = {
+      body: "unrelated review note, check https://some-other.vercel.app for reference",
+      created_at: "2026-08-03T00:00:00Z", // posted after the bot's first post...
+      updated_at: "2026-08-03T00:00:00Z", // ...but never edited again
+    };
+    expect(
+      extractPreviewUrlFromComments([stickyBotComment, laterUnrelatedComment]),
+    ).toBe(
+      "https://electrolux-git-fix-pdp-focus-order-mobile-menu-deco13.vercel.app",
+    );
+  });
+
+  it("falls back to created_at, then array order, when updated_at is missing", () => {
     expect(
       extractPreviewUrlFromComments([
         { body: decobotBody },

--- a/apps/api/src/tools/task-board/checks-status.test.ts
+++ b/apps/api/src/tools/task-board/checks-status.test.ts
@@ -8,7 +8,7 @@ import {
   conflictFromPrGet,
   extractPreviewUrl,
   extractPreviewUrlFromComments,
-  isDecoPreviewHost,
+  isTrustedPreviewHost,
   mergeChecksStatus,
   parseCheckRuns,
   toCheckRunsStatus,
@@ -226,27 +226,46 @@ describe("mergeChecksStatus", () => {
   });
 });
 
-describe("isDecoPreviewHost", () => {
+describe("isTrustedPreviewHost", () => {
   it("accepts the real deco preview hosts", () => {
     expect(
-      isDecoPreviewHost("https://envs-montecarlo--c8xgrn.decocdn.com/"),
+      isTrustedPreviewHost("https://envs-montecarlo--c8xgrn.decocdn.com/"),
     ).toBe(true);
     expect(
-      isDecoPreviewHost(
+      isTrustedPreviewHost(
         "https://fix-home-247-decocms-tanstack.deco-cx.workers.dev/",
       ),
     ).toBe(true);
-    expect(isDecoPreviewHost("https://acme.deco.site/")).toBe(true);
-    expect(isDecoPreviewHost("https://deco.site")).toBe(true);
+    expect(isTrustedPreviewHost("https://acme.deco.site/")).toBe(true);
+    expect(isTrustedPreviewHost("https://deco.site")).toBe(true);
+  });
+
+  it("accepts Vercel preview subdomains but not the bare apex", () => {
+    expect(
+      isTrustedPreviewHost(
+        "https://electrolux-git-fix-pdp-focus-order-mobile-menu-deco13.vercel.app",
+      ),
+    ).toBe(true);
+    expect(isTrustedPreviewHost("https://vercel.app/")).toBe(false);
+    expect(isTrustedPreviewHost("https://vercel.app.evil.com/")).toBe(false);
+    expect(isTrustedPreviewHost("https://evilvercel.app/")).toBe(false);
+  });
+
+  it("accepts VTEX preview subdomains but not other vtex.app hosts", () => {
+    expect(isTrustedPreviewHost("https://acme.preview.vtex.app/")).toBe(true);
+    expect(isTrustedPreviewHost("https://acme.vtex.app/")).toBe(false);
+    expect(isTrustedPreviewHost("https://preview.vtex.app.evil.com/")).toBe(
+      false,
+    );
   });
 
   it("rejects a decoy where the deco host is only in the path/query (injection)", () => {
     expect(
-      isDecoPreviewHost("https://evil.example.com/login?x=.decocdn.com"),
+      isTrustedPreviewHost("https://evil.example.com/login?x=.decocdn.com"),
     ).toBe(false);
-    expect(isDecoPreviewHost("https://decocdn.com.evil.com/")).toBe(false);
-    expect(isDecoPreviewHost("https://not-deco.site.evil.com/")).toBe(false);
-    expect(isDecoPreviewHost("not a url")).toBe(false);
+    expect(isTrustedPreviewHost("https://decocdn.com.evil.com/")).toBe(false);
+    expect(isTrustedPreviewHost("https://not-deco.site.evil.com/")).toBe(false);
+    expect(isTrustedPreviewHost("not a url")).toBe(false);
   });
 });
 
@@ -261,6 +280,11 @@ describe("extractPreviewUrlFromComments", () => {
   const decobotBody =
     "**deco Deployment** · commit `1059e10`\n\n| Name | Preview |\n| - | - |\n" +
     "| montecarlo | [Visit Preview](https://envs-montecarlo--c8xgrn.decocdn.com) |";
+  // Real Vercel bot comment shape (trimmed, from deco-sites/electrolux#10).
+  const vercelBody =
+    "| Project | Deployment | Actions | Updated (UTC) |\n| :--- | :----- | :------ | :------ |\n" +
+    "| [electrolux](https://vercel.com/deco13/electrolux) | ![Ready](https://vercel.com/static/status/ready.svg) [Ready](https://vercel.com/deco13/electrolux/GoTyhNUVcQSf7yKLG2yFtWjJ4sZA) | " +
+    "[Preview](https://electrolux-git-fix-pdp-focus-order-mobile-menu-deco13.vercel.app) | Aug 6, 2026 10:47pm |";
 
   it("prefers the Cloudflare Branch Preview URL over the commit one", () => {
     expect(extractPreviewUrlFromComments([{ body: cloudflareBody }])).toBe(
@@ -271,6 +295,12 @@ describe("extractPreviewUrlFromComments", () => {
   it("lifts the deco.cx 'Visit Preview' markdown link", () => {
     expect(extractPreviewUrlFromComments([{ body: decobotBody }])).toBe(
       "https://envs-montecarlo--c8xgrn.decocdn.com",
+    );
+  });
+
+  it("lifts the Vercel bot's Preview link", () => {
+    expect(extractPreviewUrlFromComments([{ body: vercelBody }])).toBe(
+      "https://electrolux-git-fix-pdp-focus-order-mobile-menu-deco13.vercel.app",
     );
   });
 
@@ -289,5 +319,26 @@ describe("extractPreviewUrlFromComments", () => {
     expect(
       extractPreviewUrlFromComments([{ body: "LGTM, nice work!" }]),
     ).toBeNull();
+  });
+
+  it("prefers the newest comment by created_at over array order, so a stale re-deploy comment doesn't win", () => {
+    const staleVercelBody =
+      "[Preview](https://electrolux-git-old-stale-deploy-deco13.vercel.app)";
+    const fresh = extractPreviewUrlFromComments([
+      { body: staleVercelBody, created_at: "2026-08-01T00:00:00Z" },
+      { body: vercelBody, created_at: "2026-08-06T22:32:55Z" },
+    ]);
+    expect(fresh).toBe(
+      "https://electrolux-git-fix-pdp-focus-order-mobile-menu-deco13.vercel.app",
+    );
+  });
+
+  it("falls back to array order when created_at is missing", () => {
+    expect(
+      extractPreviewUrlFromComments([
+        { body: decobotBody },
+        { body: vercelBody },
+      ]),
+    ).toBe("https://envs-montecarlo--c8xgrn.decocdn.com");
   });
 });

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -122,13 +122,13 @@ const NO_LIVE_STATE: PrLiveState = {
   previewUrl: null,
 };
 
-/** Whether `url`'s HOST is a deco.cx preview host — a strict hostname check,
- *  NOT a substring match. The preview is lifted from PR comments, which
- *  external contributors can write, and the result is shown as a trusted
- *  "Open preview" button AND handed to the autonomous QA reviewer to navigate.
- *  So a decoy like `https://evil.example.com/x?y=.decocdn.com` must be rejected.
- *  Exported for the unit test. */
-export function isDecoPreviewHost(url: string): boolean {
+/** Whether `url`'s HOST is a known preview-deploy host — a strict hostname
+ *  check, NOT a substring match. The preview is lifted from PR comments,
+ *  which external contributors can write, and the result is shown as a
+ *  trusted "Open preview" button AND handed to the autonomous QA reviewer to
+ *  navigate. So a decoy like `https://evil.example.com/x?y=.decocdn.com` must
+ *  be rejected. Exported for the unit test. */
+export function isTrustedPreviewHost(url: string): boolean {
   let hostname: string;
   try {
     hostname = new URL(url).hostname.toLowerCase();
@@ -139,14 +139,16 @@ export function isDecoPreviewHost(url: string): boolean {
     hostname === "deco.site" ||
     hostname.endsWith(".decocdn.com") ||
     hostname.endsWith(".deco-cx.workers.dev") ||
-    hostname.endsWith(".deco.site")
+    hostname.endsWith(".deco.site") ||
+    hostname.endsWith(".vercel.app") ||
+    hostname.endsWith(".preview.vtex.app")
   );
 }
 
-/** Pull the deco preview URL out of a combined-status response's `statuses[]`
- *  (a status whose `target_url` is a deco preview host). Kept as a cheap
- *  fallback — deco posts the preview in a comment, not a status, so this
- *  usually finds nothing. `null` when none is posted. */
+/** Pull the preview URL out of a combined-status response's `statuses[]` (a
+ *  status whose `target_url` is a trusted preview host). Kept as a cheap
+ *  fallback — most providers post the preview in a comment, not a status, so
+ *  this usually finds nothing. `null` when none is posted. */
 export function extractPreviewUrl(
   obj: Record<string, unknown> | null,
 ): string | null {
@@ -161,7 +163,7 @@ export function extractPreviewUrl(
       (s): s is { target_url: string; state?: unknown } =>
         !!s &&
         typeof s.target_url === "string" &&
-        isDecoPreviewHost(s.target_url),
+        isTrustedPreviewHost(s.target_url),
     );
   if (previews.length === 0) return null;
   return (
@@ -171,13 +173,16 @@ export function extractPreviewUrl(
 }
 
 /**
- * Pull the deco preview URL out of a PR's comments — where the deploy bot
- * actually posts it. Two shapes: Cloudflare Workers'
+ * Pull the preview URL out of a PR's comments — where the deploy bot
+ * actually posts it. Known shapes: Cloudflare Workers'
  * `cloudflare-workers-and-pages[bot]` (a table with a "Commit Preview URL" AND a
  * "Branch Preview URL" — prefer the branch one, stable across the PR's commits),
- * and deco.cx's `decobot` (a single "Visit Preview" markdown link). Accepts the
- * raw `get_comments` result (an array, or `{ comments }`/`{ items }`) and scans
- * each body. `null` when none is found. Exported for the pure-logic unit test.
+ * deco.cx's `decobot` (a single "Visit Preview" markdown link), and Vercel's
+ * `[Preview](url)` markdown link. Accepts the raw `get_comments` result (an
+ * array, or `{ comments }`/`{ items }`), sorts newest-first by `created_at`
+ * (falling back to array order when the field is absent) so a stale early
+ * comment can't win over a later re-deploy, and scans each body. `null` when
+ * none is found. Exported for the pure-logic unit test.
  */
 export function extractPreviewUrlFromComments(raw: unknown): string | null {
   const list = Array.isArray(raw)
@@ -187,7 +192,20 @@ export function extractPreviewUrlFromComments(raw: unknown): string | null {
       : Array.isArray((raw as { items?: unknown })?.items)
         ? (raw as { items: unknown[] }).items
         : [];
-  for (const c of list) {
+  const sorted = list
+    .map((c, index) => ({ c, index }))
+    .sort((a, b) => {
+      const aTime = Date.parse(
+        (a.c as { created_at?: unknown })?.created_at as string,
+      );
+      const bTime = Date.parse(
+        (b.c as { created_at?: unknown })?.created_at as string,
+      );
+      if (Number.isNaN(aTime) || Number.isNaN(bTime)) return a.index - b.index;
+      return bTime - aTime;
+    })
+    .map(({ c }) => c);
+  for (const c of sorted) {
     const body =
       c && typeof (c as { body?: unknown }).body === "string"
         ? (c as { body: string }).body
@@ -196,9 +214,9 @@ export function extractPreviewUrlFromComments(raw: unknown): string | null {
     // Cloudflare's comment carries both a per-commit and a per-branch preview —
     // prefer the branch URL, which stays valid as the PR gets new commits.
     const branch = body.match(/href=['"]([^'"]+)['"][^>]*>\s*Branch Preview/i);
-    if (branch?.[1] && isDecoPreviewHost(branch[1])) return branch[1];
+    if (branch?.[1] && isTrustedPreviewHost(branch[1])) return branch[1];
     const url = (body.match(/https?:\/\/[^\s"'<>)\]]+/g) ?? []).find((u) =>
-      isDecoPreviewHost(u),
+      isTrustedPreviewHost(u),
     );
     if (url) return url;
   }

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -179,10 +179,15 @@ export function extractPreviewUrl(
  * "Branch Preview URL" — prefer the branch one, stable across the PR's commits),
  * deco.cx's `decobot` (a single "Visit Preview" markdown link), and Vercel's
  * `[Preview](url)` markdown link. Accepts the raw `get_comments` result (an
- * array, or `{ comments }`/`{ items }`), sorts newest-first by `created_at`
- * (falling back to array order when the field is absent) so a stale early
- * comment can't win over a later re-deploy, and scans each body. `null` when
- * none is found. Exported for the pure-logic unit test.
+ * array, or `{ comments }`/`{ items }`), sorts newest-first by `updated_at`
+ * (falling back to `created_at`, then array order, when absent) so a stale
+ * early comment can't win over a later re-deploy. Sorting by `updated_at`
+ * rather than `created_at` matters because Vercel/Cloudflare edit a single
+ * sticky comment in place on each push — `created_at` stays frozen at the
+ * comment's first post, so ranking by it could let an unrelated LATER human
+ * comment (that happens to mention a matching host) outrank the bot's
+ * freshly-edited one. Scans each body; `null` when none is found. Exported
+ * for the pure-logic unit test.
  */
 export function extractPreviewUrlFromComments(raw: unknown): string | null {
   const list = Array.isArray(raw)
@@ -192,15 +197,18 @@ export function extractPreviewUrlFromComments(raw: unknown): string | null {
       : Array.isArray((raw as { items?: unknown })?.items)
         ? (raw as { items: unknown[] }).items
         : [];
+  const recency = (c: unknown): number => {
+    const obj = c as { updated_at?: unknown; created_at?: unknown };
+    return (
+      Date.parse(obj?.updated_at as string) ||
+      Date.parse(obj?.created_at as string)
+    );
+  };
   const sorted = list
     .map((c, index) => ({ c, index }))
     .sort((a, b) => {
-      const aTime = Date.parse(
-        (a.c as { created_at?: unknown })?.created_at as string,
-      );
-      const bTime = Date.parse(
-        (b.c as { created_at?: unknown })?.created_at as string,
-      );
+      const aTime = recency(a.c);
+      const bTime = recency(b.c);
       if (Number.isNaN(aTime) || Number.isNaN(bTime)) return a.index - b.index;
       return bTime - aTime;
     })


### PR DESCRIPTION
## Summary
- `isDecoPreviewHost` only allow-listed deco.cx's own preview hosts (`deco.site`, `*.decocdn.com`, `*.deco-cx.workers.dev`, `*.deco.site`), so PRs deployed via Vercel or VTEX never got a "Preview" button on the task board card — confirmed against `deco-sites/electrolux#10`, which deploys via Vercel.
- Renamed to `isTrustedPreviewHost` and added `*.vercel.app` and `*.preview.vtex.app` (subdomain-only, matching the existing decoy-safe `endsWith` pattern — bare apex and hosts like `vercel.app.evil.com` stay rejected).
- `extractPreviewUrlFromComments` now sorts PR comments newest-first by `created_at` before scanning (falling back to array order if absent), instead of relying on GitHub's default ascending order — fixes a related staleness bug where the first matching deploy-bot comment could permanently shadow a later re-deploy's preview link.

## Testing notes
- Added test coverage: Vercel/VTEX accept/reject cases for `isTrustedPreviewHost`, extraction from a real Vercel bot comment body (`deco-sites/electrolux#10`'s actual shape), and a case proving a newer comment now wins over an older one.
- `bun test apps/api/src/tools/task-board/checks-status.test.ts` — 31/31 pass.
- `bun run check` (typecheck) and `bun run fmt` — clean.

## Follow-up (not in this PR)
Switching to GitHub's Deployments/Environments API as the primary preview source (instead of a hand-maintained per-provider host allow-list) was scoped but deferred to a separate PR, since it relaxes the trust gate on a URL handed to an autonomous QA agent and deserves its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show Preview buttons for PRs deployed via Vercel and VTEX, and keep the link fresh by preferring the newest updated bot comment. Renamed `isDecoPreviewHost` to `isTrustedPreviewHost` with strict hostname checks to prevent decoy URLs.

- **Bug Fixes**
  - Trust `*.vercel.app` and `*.preview.vtex.app` preview hosts (subdomains only); apex and lookalike domains stay blocked.
  - Sort PR comments newest-first by `updated_at` (fallback to `created_at`, then array order) when extracting preview URLs, so sticky bot edits outrank older or unrelated links.
  - Use `isTrustedPreviewHost` in both status and comment extraction to validate bot-posted preview links.
  - Added tests for Vercel/VTEX hosts and the `updated_at` sorting behavior (including sticky comment cases); also fixed Biome formatting drift in `apps/api/src/storage/task-board-advance-review.integration.test.ts` to unblock the format check (no logic change).

<sup>Written for commit c30158b47ece26cbfcfc3fa2f19344598c2dd268. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

