### PR TITLE
fix(sandbox-env): pin SandboxWarmPool updateStrategy to OnReplenish

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,6 +9,11 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
+# 0.12.1: pin `updateStrategy.type: OnReplenish` on every SandboxWarmPool
+# (generic + tenant). It is already the operator's default as of v0.4.5, so
+# this renders no behaviour change today — it exists so an operator upgrade
+# that moves the default to `Recreate` can't turn a routine SandboxTemplate
+# sync (an image bump) into a pool-wide pod restart.
 # 0.12.0: tenantPools — per-tenant warm pools (SandboxWarmPool per entry
 # against the shared SandboxTemplate). Additive and empty by default; each
 # entry needs a matching object in Studio's STUDIO_SANDBOX_TENANT_POOLS.
@@ -87,7 +92,7 @@ type: application
 # 0.8.0: org-fs sidecar (orgFs.*) — privileged rclone mounter + main-container
 # mounts. NOTE: the publish workflow skips existing versions, so this MUST
 # stay ahead of the latest published chart (0.7.5 at time of writing).
-version: 0.12.0
+version: 0.12.1
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "1.42.0"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/templates/sandbox-tenant-pools.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-tenant-pools.yaml
@@ -25,6 +25,9 @@ metadata:
     studio.decocms.com/tenant-pool: {{ .name }}
 spec:
   replicas: {{ .size }}
+  # Same reasoning as the generic pool — see sandbox-warm-pool.yaml.
+  updateStrategy:
+    type: OnReplenish
   sandboxTemplateRef:
     name: {{ include "sandbox-env.sandboxName" $ }}
 {{- end }}

--- a/deploy/helm/sandbox-env/templates/sandbox-warm-pool.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-warm-pool.yaml
@@ -14,6 +14,15 @@ metadata:
     {{- include "sandbox-env.sandboxLabels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.warmPool.size }}
+  # Pinned, not defaulted: a SandboxTemplate change (an image bump is the
+  # common one) must NOT delete the warm pods already running the old
+  # template — that turns every routine sync into a pool-wide restart.
+  # Stale pods drain by adoption instead, and since a claim's idle TTL is
+  # 15m the whole pool is on the new template within minutes anyway.
+  # `OnReplenish` is also the operator's own default as of v0.4.5; stating
+  # it here is what stops an operator upgrade from silently flipping it.
+  updateStrategy:
+    type: OnReplenish
   sandboxTemplateRef:
     name: {{ include "sandbox-env.sandboxName" . }}
 {{- end }}


### PR DESCRIPTION
## Why

Investigating a reported "the `agent-sandbox-system` sync recreated every pod" incident in prod (2026-08-06 ~23:57 UTC), I traced the actual cause to the `deco-studio` rollout at 23:56:19 (`studio:4.190.1 → 4.191.0`), which produced 16 new SandboxClaims in ~35s. The `studio-sandbox-prod` SandboxTemplate image bump (`1.42.0 → 1.43.0`) that synced ~2min earlier did **not** roll anything — pods created at 23:45 on `1.41.1` were still running well after it.

The reason it didn't roll is that `SandboxWarmPool.spec.updateStrategy` defaults to `OnReplenish` in agent-sandbox v0.4.5 (`extensions/api/v1alpha1/sandboxwarmpool_types.go`), and the delete-stale branch in `extensions/controllers/sandboxwarmpool_controller.go:262` is gated on `Recreate`. We were relying on that default without stating it.

## What

Pin `updateStrategy.type: OnReplenish` on the generic `SandboxWarmPool` and on every `tenantPools` entry.

- **No rendered behaviour change today** — it matches the operator default.
- It exists so an operator upgrade that flips the default to `Recreate` can't silently turn a routine SandboxTemplate sync into a pool-wide pod restart.
- A stale warm pod drains by adoption, and since the claim idle TTL is 15m, the pool is fully on a new template within minutes anyway.

Chart `0.12.0 → 0.12.1`.

## Testing

- `helm template` against prod-shaped values renders `updateStrategy.type: OnReplenish` on both pool kinds; nothing else in the diff changes.
- Verified the live prod CRD accepts the field: `kubectl explain sandboxwarmpool.spec` lists `updateStrategy` on `eks-serverless`.

## Follow-up

The Studio-rollout-recreates-sandboxes behaviour is the real spikiness source and is **not** addressed here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin SandboxWarmPool updateStrategy to OnReplenish on the generic pool and all tenant pools to avoid unintended restarts during SandboxTemplate syncs if operator defaults change. No behavior change today; bumps chart to 0.12.1.

<sup>Written for commit ee8d213203bfbb8be21887968f797e896ae04db9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

