### PR TITLE
fix(sandbox): corepack's download prompt hangs the dev server forever

### DIFF
--- a/packages/sandbox/daemon-go/internal/proc/proc_test.go
+++ b/packages/sandbox/daemon-go/internal/proc/proc_test.go
@@ -134,3 +134,33 @@ func TestPortSnifferPerSourceCarryIsolation(t *testing.T) {
 		t.Fatalf("dev carry corrupted by start chunk, got %d", s.Current())
 	}
 }
+
+// A dev server spawned on a PTY inherits a tty, and corepack blocks on
+// "Do you want to continue? [Y/n]" forever the first time it fetches a
+// yarn/pnpm shim. Nothing times that out — the sandbox just never boots.
+func TestBuildEnvSilencesCorepackPrompt(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		env  []string
+	}{
+		{"pty", buildEnv(true, map[string]string{"PORT": "3000"}, map[string]string{"TERM": "xterm-256color"})},
+		{"pipe", buildEnv(false, map[string]string{"PORT": "3000"}, nil)},
+	} {
+		got := map[string]string{}
+		for _, kv := range tc.env {
+			if i := strings.IndexByte(kv, '='); i >= 0 {
+				got[kv[:i]] = kv[i+1:]
+			}
+		}
+		if got["COREPACK_ENABLE_DOWNLOAD_PROMPT"] != "0" {
+			t.Fatalf("%s: download prompt not disabled: %q", tc.name, got["COREPACK_ENABLE_DOWNLOAD_PROMPT"])
+		}
+		if got["COREPACK_ENABLE_STRICT"] != "0" {
+			t.Fatalf("%s: strict not disabled: %q", tc.name, got["COREPACK_ENABLE_STRICT"])
+		}
+		// Caller-supplied env still wins.
+		if got["PORT"] != "3000" {
+			t.Fatalf("%s: overrides lost: %q", tc.name, got["PORT"])
+		}
+	}
+}

--- a/packages/sandbox/daemon-go/internal/proc/taskmanager.go
+++ b/packages/sandbox/daemon-go/internal/proc/taskmanager.go
@@ -227,6 +227,12 @@ func buildEnv(inherit bool, overrides map[string]string, extra map[string]string
 			}
 		}
 	}
+	// Tasks run on a PTY, so corepack sees a tty and blocks forever on "Do you
+	// want to continue? [Y/n]" the first time it has to fetch a yarn/pnpm shim:
+	// the dev server never starts and nothing times out. SpawnStep and the
+	// install step already pin these — the task path is the third spawner.
+	env["COREPACK_ENABLE_STRICT"] = "0"
+	env["COREPACK_ENABLE_DOWNLOAD_PROMPT"] = "0"
 	for k, v := range extra {
 		env[k] = v
 	}


### PR DESCRIPTION
## The bug

Every pod in the `tenant-electrolux-prod` warm pool has a cloned repo and a full `node_modules`, and a `dev` task that has never produced a byte of output:

```
sandbox  79  0.0  sh -c cd /app/repo && yarn run dev
sandbox  80  0.0  node /usr/local/bin/yarn run dev
```

`/usr/local/bin/yarn` is the corepack shim. Its first line is `process.env.COREPACK_ENABLE_DOWNLOAD_PROMPT ??= '1'`, so when it has to fetch a yarn version it asks:

```
! Corepack is about to download https://registry.yarnpkg.com/yarn/-/yarn-1.22.22.tgz
? Do you want to continue? [Y/n]
```

Tasks spawn on a **PTY**, so corepack sees a tty, prints the prompt, and blocks on stdin. Nothing times it out. The dev port never opens, so the preview sits on "Starting your preview…" until the sandbox is reaped — and a warm pool of these is a pool of pods that are warm in every respect except the one that matters.

Verified on the live pod: with `COREPACK_ENABLE_DOWNLOAD_PROMPT=0`, `yarn --version` returns instantly.

## The fix

`install.go` and `SpawnStep` already pin `COREPACK_ENABLE_STRICT=0` / `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` — that's why `install` succeeded while `dev` hung. `buildEnv` in the task manager is the third spawner and was missed; it's the one that runs the dev server, `/exec`, and `/bash`.

Two lines in `buildEnv`, seeded before `extra`/`overrides` so caller env still wins.

## Testing

- `TestBuildEnvSilencesCorepackPrompt` — asserts both vars on the pty and pipe paths, and that caller overrides survive.
- `go build ./... && go test ./internal/proc/ ./internal/setup/ ./internal/routes/` pass.

Only affects repos whose package manager is a corepack shim (yarn, pnpm). npm/bun were never blocked, which is why this hid until a yarn tenant showed up.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent dev server hangs caused by `corepack`’s interactive download prompt by disabling it in task-run envs. Repos using `yarn`/`pnpm` now start previews reliably.

- **Bug Fixes**
  - Set `COREPACK_ENABLE_STRICT=0` and `COREPACK_ENABLE_DOWNLOAD_PROMPT=0` in `buildEnv` before applying overrides.
  - Covers PTY and pipe spawns; caller env still wins.
  - Added `TestBuildEnvSilencesCorepackPrompt`.

<sup>Written for commit 688d31ea4a8ce8cf7fcd39a27fa0abdadf3e4afc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

