### PR TITLE
fix(sandbox): a sandbox someone is watching must not die at the claim TTL

### DIFF
--- a/apps/api/src/api/routes/sandbox-events-handler.ts
+++ b/apps/api/src/api/routes/sandbox-events-handler.ts
@@ -50,6 +50,20 @@ const NO_CLAIM_MAX_MS = 90_000;
 const HEARTBEAT_MS = 15_000;
 
 /**
+ * How often an open event stream pushes the claim's shutdown back out.
+ *
+ * An open stream is what "somebody is watching this sandbox" looks like from
+ * Studio: preview traffic goes gateway → pod and never reaches us, so without
+ * this the 15-min claim TTL expires under a user who is actively reading the
+ * preview, and they get a cold reprovision instead of the pod they were on.
+ *
+ * Well inside the TTL so a single failed renewal is harmless, and far coarser
+ * than HEARTBEAT_MS because each one is two API-server calls per watcher —
+ * there is no reason to spend them at keepalive rate.
+ */
+const TTL_RENEW_MS = 5 * 60_000;
+
+/**
  * Budget for the "lifecycle says ready but studio hasn't finished its
  * post-Ready bookkeeping" race.
  */
@@ -105,9 +119,15 @@ export function handleVmEvents(c: Context<Env>, args: VmEventsHandlerArgs) {
         clearInterval(heartbeat);
       });
     }, HEARTBEAT_MS);
+    // Renew immediately as well as on the interval: a stream that reconnects
+    // onto a long-lived sandbox is adopting a TTL that is already part-spent.
+    const renew = () => void runner.renewTtl?.(claimName);
+    renew();
+    const ttlRenew = setInterval(renew, TTL_RENEW_MS);
     stream.onAbort(() => {
       abortCtl.abort();
       clearInterval(heartbeat);
+      clearInterval(ttlRenew);
     });
 
     try {
@@ -184,6 +204,7 @@ export function handleVmEvents(c: Context<Env>, args: VmEventsHandlerArgs) {
       });
     } finally {
       clearInterval(heartbeat);
+      clearInterval(ttlRenew);
     }
   });
 }

--- a/packages/sandbox/server/provider/agent-sandbox/runner.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import type { EnsureOptions } from "../types";
-import { earlierShutdown, stripEnsureOpts } from "./runner";
+import { earlierShutdown, laterShutdown, stripEnsureOpts } from "./runner";
 
 describe("stripEnsureOpts", () => {
   it("retains orgFsConfigJson so resurrection replays org-fs mounts", () => {
@@ -65,5 +65,39 @@ describe("earlierShutdown", () => {
 
   it("treats an unparseable shutdownTime as no commitment", () => {
     expect(earlierShutdown("not-a-date", target)).toBe(target.toISOString());
+  });
+});
+
+describe("laterShutdown", () => {
+  const target = new Date("2026-08-04T18:00:00.000Z");
+
+  it("pushes an earlier shutdown out to the target", () => {
+    expect(laterShutdown("2026-08-04T17:50:00.000Z", target)).toBe(
+      target.toISOString(),
+    );
+  });
+
+  it("leaves an already-later shutdown alone", () => {
+    expect(laterShutdown("2026-08-04T18:10:00.000Z", target)).toBeNull();
+  });
+
+  it("leaves an equal shutdown alone (no pointless write)", () => {
+    expect(laterShutdown(target.toISOString(), target)).toBeNull();
+  });
+
+  // The mirror of earlierShutdown's safety property: a renewal fires from every
+  // open event stream, and must never undercut a longer commitment — otherwise
+  // watching a sandbox could *shorten* its life.
+  it("never shortens a shutdown something else pushed further out", () => {
+    const extended = new Date(target.getTime() + 15 * 60_000).toISOString();
+    expect(laterShutdown(extended, target)).toBeNull();
+  });
+
+  it("treats an absent shutdownTime as no commitment", () => {
+    expect(laterShutdown(undefined, target)).toBe(target.toISOString());
+  });
+
+  it("treats an unparseable shutdownTime as no commitment", () => {
+    expect(laterShutdown("not-a-date", target)).toBe(target.toISOString());
   });
 });

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -2417,6 +2417,36 @@ export class AgentSandboxProvider implements SandboxProvider {
     );
   }
 
+  /** See `SandboxProvider.renewTtl`. */
+  async renewTtl(handle: string): Promise<void> {
+    const claim = await getSandboxClaim(
+      this.kubeConfig,
+      this.namespace,
+      handle,
+    );
+    // Already gone. Do NOT recreate it — the watcher's own self-heal owns
+    // reprovisioning, and a claim resurrected from here would carry none of
+    // the env a working sandbox needs.
+    if (!claim) return;
+    const next = laterShutdown(
+      claim.spec?.lifecycle?.shutdownTime,
+      new Date(Date.now() + this.idleTtlMs),
+    );
+    if (!next) return;
+    await patchSandboxClaimShutdown(
+      this.kubeConfig,
+      this.namespace,
+      handle,
+      next,
+    ).catch((err) =>
+      // Best-effort: a missed renewal costs one reprovision, and the next
+      // heartbeat retries well inside the TTL. Never fail an SSE stream over it.
+      console.warn(
+        `[${LOG_LABEL}] TTL renew failed for ${handle}: ${err instanceof Error ? err.message : String(err)}`,
+      ),
+    );
+  }
+
   // ---- Port-forwarding ------------------------------------------------------
 
   /**
@@ -2900,6 +2930,24 @@ export function earlierShutdown(
   if (current) {
     const currentMs = new Date(current).getTime();
     if (Number.isFinite(currentMs) && currentMs <= target.getTime())
+      return null;
+  }
+  return target.toISOString();
+}
+
+/**
+ * The shutdownTime to patch so a watched claim survives to `target`, or null to
+ * leave it alone. Only ever moves shutdown LATER — the mirror of
+ * `earlierShutdown`, and monotonic for the same reason: a renewal must never
+ * undercut a longer commitment something else just made.
+ */
+export function laterShutdown(
+  current: string | undefined,
+  target: Date,
+): string | null {
+  if (current) {
+    const currentMs = new Date(current).getTime();
+    if (Number.isFinite(currentMs) && currentMs >= target.getTime())
       return null;
   }
   return target.toISOString();

--- a/packages/sandbox/server/provider/types.ts
+++ b/packages/sandbox/server/provider/types.ts
@@ -205,6 +205,24 @@ export interface SandboxProvider {
   releaseAfter?(handle: string, graceMs: number): Promise<void>;
 
   /**
+   * Push this sandbox's shutdown back out to a full idle window, because
+   * someone is still watching it.
+   *
+   * The claim TTL is a wall clock that only `ensure()` renews, and nothing on
+   * the preview path calls `ensure()`: preview traffic goes gateway → pod
+   * without passing through Studio, and the housekeeper only ever moves
+   * shutdown earlier. So a sandbox a user was reading — but whose agent was
+   * idle — died mid-session at the TTL and self-healed into a cold reprovision.
+   *
+   * The counterpart to `releaseAfter`, and its mirror image: never brings
+   * shutdown EARLIER than it already is. Truly idle pods are still reaped —
+   * the housekeeper sweeps on daemon idle, which an open tab does not reset.
+   *
+   * Optional: callers must `?.()`.
+   */
+  renewTtl?(handle: string): Promise<void>;
+
+  /**
    * Drop this provider's in-process cache + persistent state for `handle`
    * WITHOUT contacting the daemon. Used by the auto-restart path when the
    * daemon is known-dead — `delete()` would try to reach the link and


### PR DESCRIPTION
## The bug

A `SandboxClaim` carries `lifecycle.shutdownTime` = `now + 15min`, and the operator deletes claim + pod when the wall clock passes it. Exactly one thing renews it — `runner.ts:1168`, reached only from the two `.ensure()` call sites (`SANDBOX_START` and the internal resurrection).

Nothing on the preview path calls `ensure()`:

- **Preview traffic** goes gateway → pod directly. `sandbox-proxy.ts` never touches the provider.
- **The events SSE** (`sandbox-events-handler.ts`) never touches the provider.
- **The housekeeper** only ever moves shutdown *earlier* — `housekeeper-sweep.sh:157` is the reap path; a healthy claim logs `keep …` and patches nothing.
- **Daemon activity** feeds only the housekeeper's reap decision. Nothing extends the claim.

So: sit on a preview for 16 minutes while the agent is idle, and the pod is deleted under you. The UI's self-heal (`sandbox-lifecycle-context.tsx:4`, on `events.notFound`) re-fires `SANDBOX_START` and you get a **cold clone + install + dev boot** — the loading screen, replacing a pod that was perfectly warm.

## The fix

Renew from the open event stream. An open SSE is precisely what "somebody is watching this sandbox" looks like from Studio's side — it's the one preview-path signal that does reach us.

`renewTtl` is the mirror of the existing `releaseAfter`: same `patchSandboxClaimShutdown`, same best-effort failure handling, opposite direction. `laterShutdown` mirrors `earlierShutdown` and keeps it monotonic, so a renewal can never *shorten* a claim something else extended further.

Renews on connect (a reconnecting stream adopts a part-spent TTL) and every 5 min after — well inside the 15-min TTL so one failed renewal is harmless, and deliberately much coarser than the 15s keepalive since each renewal is two API-server calls per watcher.

## What this does not do

Idle pods are still reaped: the housekeeper sweeps on **daemon idle**, which an open browser tab does not reset. This extends sandboxes being *used*, not sandboxes merely left open in a background tab.

A missing claim is a no-op — `renewTtl` returns rather than recreating one. Reprovisioning stays the self-heal's job; a claim resurrected from here would carry none of the env a working sandbox needs.

## Testing

- 6 new cases for `laterShutdown` incl. the monotonicity property. `runner.test.ts` 15 pass.
- `bun run check` clean for `packages/sandbox` and `apps/api`.

The interval is cleared on both exit paths (`stream.onAbort` and the `finally`), alongside the existing heartbeat.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents watched sandboxes from being deleted at the 15‑minute claim TTL by renewing the shutdown time from the open events stream. Keeps warm pods alive while viewed, without changing idle reaping.

- **Bug Fixes**
  - Added `renewTtl(handle)` to `SandboxProvider` and implemented it in the agent provider.
  - Renew on SSE connect and every 5 minutes; best-effort and intervals cleared on abort/finish.
  - Introduced `laterShutdown` to only push shutdown later; includes tests for monotonic behavior.
  - No-op when the claim is missing; reprovisioning stays with the existing self-heal path.

<sup>Written for commit 1f71096de0ad1d2d0a1ceb61576cbb4203b703e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

