### PR TITLE
fix(sandbox): keep the warm pool's dev server running across a claim

### DIFF
--- a/packages/sandbox/daemon-e2e/daemon.warmpool.e2e.test.ts
+++ b/packages/sandbox/daemon-e2e/daemon.warmpool.e2e.test.ts
@@ -222,4 +222,48 @@ describe("daemon e2e: a second dev server is never spawned", () => {
     },
     SETUP_TIMEOUT_MS,
   );
+
+  it(
+    "a same-commit branch change keeps the running dev server",
+    async () => {
+      // The claim that binds a warm pool pod arrives as branch-change onto a
+      // thread branch cut from the commit the pool warmed: the checkout leaves
+      // the tree byte-identical. Restarting dev there rebuilds a framework that
+      // was already serving — the pod stops being warm at the exact moment
+      // someone asks for it.
+      expect(
+        (
+          await bootstrapRepo(d, repo.url, {
+            application: { packageManager: { name: "npm" } },
+            env: { npm_config_offline: "true" },
+          })
+        ).status,
+      ).toBe(200);
+      await waitForOrchestratorIdle(d, SETUP_TIMEOUT_MS);
+
+      const dev = async () =>
+        (await (
+          await fetch(url(d, "/_sandbox/exec/dev"), {
+            method: "POST",
+            headers: jsonAuthHeaders(),
+            body: "{}",
+          })
+        ).json()) as { taskId: string; alreadyRunning?: boolean };
+      const warm = await dev();
+      expect(warm.alreadyRunning).toBe(true);
+
+      const res = await postConfig(d, {
+        git: { repository: { cloneUrl: repo.url, branch: "thread-x" } },
+      });
+      expect(((await res.json()) as { transition: string }).transition).toBe(
+        "branch-change",
+      );
+      await waitForOrchestratorIdle(d, SETUP_TIMEOUT_MS);
+
+      const afterClaim = await dev();
+      expect(afterClaim.alreadyRunning).toBe(true);
+      expect(afterClaim.taskId).toBe(warm.taskId);
+    },
+    SETUP_TIMEOUT_MS,
+  );
 });

--- a/packages/sandbox/daemon-go/internal/setup/orchestrator.go
+++ b/packages/sandbox/daemon-go/internal/setup/orchestrator.go
@@ -192,10 +192,20 @@ func (o *Orchestrator) drain() {
 	}
 }
 
+// A running dev server is stopped by whoever actually invalidates it — the
+// install (which rewrites node_modules under it) and a start whose command
+// differs — never up front, on the assumption that a step implies a restart.
+// The assumption is what breaks a tenant warm pool: a claim onto a pod that is
+// already serving arrives as branch-change, and the thread branch points at the
+// same commit the pool warmed, so the checkout leaves the tree byte-identical.
+// Killing dev there rebuilds a framework that was already answering requests
+// (~2min for a faststore/Next app) — the whole value of the warm pod, spent on
+// a no-op. Same commit + same fingerprint now keeps the process: install
+// short-circuits on the fingerprint, and stepStart sees its own command already
+// running and skips.
 func (o *Orchestrator) runStep(step Step) {
 	switch step {
 	case StepClone:
-		o.stopDevTask()
 		if !o.stepClone() {
 			return
 		}
@@ -204,7 +214,6 @@ func (o *Orchestrator) runStep(step Step) {
 		}
 		o.stepStart()
 	case StepInstall:
-		o.stopDevTask()
 		if !o.stepInstall() {
 			return
 		}
@@ -381,6 +390,10 @@ func (o *Orchestrator) stepInstallInner() bool {
 		return true
 	}
 
+	// An install rewrites node_modules under whatever is reading it, so the dev
+	// server goes down here — after every early return above, so a claim that
+	// installs nothing keeps its warm process (see runStep).
+	o.stopDevTask()
 	o.deps.Lifecycle.Transition(events.LifecycleState{Phase: events.PhaseInstalling})
 
 	// Timed from here so the reported cost is the whole dependency step: a failed


### PR DESCRIPTION
## The bug

A tenant warm pool pod boots, clones, installs and serves the dev server. A user
claims it and **the dev server is restarted from scratch** — so the pod stops
being warm at the exact moment someone asks for it.

Observed in prod (`tenant-electrolux-prod`), user's own terminal:

```
[DISCOVERY]   HEAD / 200 in 2.3s (next.js: 1431ms, ...)   <- warm, serving
$ cd /app/repo && yarn run dev                            <- claim restarts it
yarn run v1.22.22
[STARTED] Parse Configuration ...                         <- ~2min rebuild
```

Pod `tenant-electrolux-prod-pv828`:

```
01:01:46  bootstrap (pool)   clone -> install (3s, golden hit) -> start
01:02:24  running            [probe] server responded on port 3000 (status 200)
01:02:48  claim              running -> checking-out -> starting     <- restart
```

`runStep` called `stopDevTask()` before every clone/install step, on the
assumption that a step implies a restart. A claim arrives as `branch-change`,
and the thread branch is cut from the same commit the pool warmed — the checkout
leaves the working tree byte-identical, so the restart buys nothing and costs a
full framework boot.

## The fix

The stop belongs to whoever actually invalidates the process, and both already
do it themselves:

- **install** — it rewrites `node_modules` under a live reader (`stopDevTask()`
  moved there, after the clone-only / fingerprint / no-package-manager early
  returns);
- **start with a different command** — `stepStartInner` already stops before
  spawning, and already skips when its own command is running.

So: same commit + same install fingerprint → the process survives (install
short-circuits on the fingerprint, `stepStart` logs `dev already running (dev) —
skipping restart`). Lifecycle lands back on `running` via the prober, which the
`running -> checking-out` transition already reset. A real branch change moves
HEAD, misses the fingerprint, installs and restarts exactly as before.

## Testing

`daemon-e2e` (real binary, black box) — new: *a same-commit branch change keeps
the running dev server*, asserting the dev task id is unchanged across the
claim. Full suite green (the one `ws-proxy` failure under the parallel run is a
daemon-spawn flake — passes in isolation on this branch and on `main`).

## Not in this PR

Two things that also hurt the Electrolux pool, both config/ops:

1. `tenantPools[].size: 2` (deco-apps-cd) vs a measured claim rate of ~1.5/min
   and a ~2.5min warm — the pool is mathematically empty ~100% of the time.
   Needs to be sized ≥ claim rate × warm time.
2. `TENANT_POOL_TICK_MS` is 60s, so a replacement pod idles 12–69s (measured)
   before Studio warms it — a third of the refill time.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents warm pool pods from restarting the dev server on claim when the branch points to the same commit, keeping the server hot and avoiding a full rebuild. Faster handoff and no unnecessary ~2 min reboot for common Next.js apps.

- **Bug Fixes**
  - Move dev stop from upfront `runStep` to the real invalidators: inside install (after fingerprint/early returns) and start when the command changes. Same commit + same install fingerprint keeps the running process.
  - Add `daemon-e2e` test to assert a same-commit branch change keeps the dev server and taskId unchanged.

<sup>Written for commit d1f5acb67e60445c050912baa0d1907190ccca83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

