### PR TITLE
fix(task-board): retry pull_request_read on transient MCP errors, log failures

### DIFF
--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -7,6 +7,7 @@ import { clientFromConnection } from "@/mcp-clients";
 import type { TaskBoardItemPrRef } from "@/storage/types";
 import { getRepoScope } from "@decocms/shared/github-repo-scope";
 import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
+import { retry, RetryError } from "@decocms/shared/std";
 import { TaskBoardItemPrSchema } from "./schema";
 import { recordTaskActivity } from "./activity";
 import { emitTaskBoardUpdated } from "./run-reactions";
@@ -484,22 +485,46 @@ async function fetchPrStatusExtras(
     method: "get_status" | "get_check_runs" | "get_comments",
   ): Promise<Record<string, unknown> | null> => {
     try {
-      return toolResultJson(
-        await client.callTool(
-          {
-            name: "pull_request_read",
-            arguments: {
-              method,
-              owner: pr.repoOwner,
-              repo: pr.repoName,
-              pullNumber: pr.number,
+      const result = await retry(
+        async () => {
+          const raw = await client.callTool(
+            {
+              name: "pull_request_read",
+              arguments: {
+                method,
+                owner: pr.repoOwner,
+                repo: pr.repoName,
+                pullNumber: pr.number,
+              },
             },
-          },
-          undefined,
-          { timeout: PR_FETCH_TIMEOUT_MS },
-        ),
+            undefined,
+            { timeout: PR_FETCH_TIMEOUT_MS },
+          );
+          // callTool resolves (doesn't reject) on an upstream MCP error — throw
+          // so retry() can see it and back off (e.g. GitHub's "too many
+          // requests" on a burst of concurrent pull_request_read calls).
+          if (
+            raw &&
+            typeof raw === "object" &&
+            (raw as { isError?: boolean }).isError
+          ) {
+            throw new Error(
+              (raw as { content?: Array<{ text?: string }> }).content?.[0]
+                ?.text ?? "pull_request_read returned isError",
+            );
+          }
+          return raw;
+        },
+        { maxAttempts: 3, minTimeout: 300, maxTimeout: 3000, jitter: 1 },
       );
-    } catch {
+      return toolResultJson(result);
+    } catch (err) {
+      const cause = err instanceof RetryError ? err.cause : err;
+      console.error(
+        `[task-board] pull_request_read(${method}) failed for ` +
+          `${pr.repoOwner}/${pr.repoName}#${pr.number} after retries:`,
+        cause,
+      );
       return null;
     }
   };


### PR DESCRIPTION
## Summary
- `fetchPrStatusExtras` fires `get_status`/`get_check_runs`/`get_comments` concurrently via `Promise.all`, and any failure was silently swallowed to `null` with **zero logging** — including GitHub's "too many requests" on bursts of concurrent `pull_request_read` calls.
- Confirmed live against a production PR (deco-sites/electrolux#13) whose `previewUrl` kept coming back `null` even though the comment — and a valid Vercel preview link inside it — genuinely existed and was fetchable in isolation (verified 6/6 via manual replay against the real connection).
- Confirmed via prod logs (`kubectl logs`) that this isn't isolated to one repo: the review-sweeper's own best-effort `fetchPrLiveState` call hit the same "no live PR state from GitHub" condition across **15 distinct boards** in under 8 minutes, platform-wide.
- `client.callTool()` resolves (doesn't reject) on an upstream MCP error, so `read()` now throws on `isError` before handing off to `retry()` — the canonical `@decocms/shared/std` retry helper (exponential backoff + full jitter, 3 attempts) — giving a transient rate-limit a couple of chances to clear.
- Behavior stays best-effort by design: on exhaustion, the underlying cause is `console.error`'d (previously invisible in logs) and `null` is returned exactly as before, so a genuine failure still doesn't block the card from rendering.

## Testing notes
- `bun test apps/api/src/tools/task-board/checks-status.test.ts` — 26/26 pass.
- `bun run check` (typecheck) and `bun run fmt` — clean.
- Manually reproduced the failure and fix against live production data via the connection's MCP tool tester and direct API calls (see PR discussion/investigation for detail); did not add a new automated test since this specific path (concurrent MCP burst against a live GitHub connection) isn't reproducible in the pure-logic unit tier and belongs in e2e infra we don't have for this mock-free scenario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries `pull_request_read` on transient MCP errors and logs failures to avoid silently missing PR status (like preview URLs) when GitHub rate limits spike. Keeps behavior best-effort: after retries, we log and still return null so cards render.

- **Bug Fixes**
  - Wraps `pull_request_read` in `retry` from `@decocms/shared/std` (3 attempts, exponential backoff with jitter 300–3000 ms).
  - Treats `client.callTool()` `isError` responses as failures (throw) to trigger retry.
  - On final failure, logs repo/PR and method via `console.error`, then returns null.
  - Covers `get_status`, `get_check_runs`, and `get_comments` in `fetchPrStatusExtras` (run via `Promise.all`).

<sup>Written for commit d4d264aa9e402e16129cab4275bdbad87ceb0e7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

