### PR TITLE
feat(sandbox): node-level uploader that fills the shared golden store

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,6 +9,20 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
+# 0.13.0: opt-in `goldenUploader` (default off) — a DaemonSet that carries L1
+# goldens from a node's hostPath into the shared L2 store, plus its own WRITABLE
+# PV/PVC over that store. Without it the shared store stays empty: a sandbox
+# pod's mount is read-only by design, so nothing a tenant boots can publish
+# there. A DaemonSet rather than a sidecar so the sandbox PodSpec is untouched —
+# no per-pod request, no effect on packing density, nothing new that can degrade
+# the health probe — and so the writable mount lives once per node in
+# infrastructure instead of inside every tenant's pod. Archives are keyed by org,
+# which is what makes fleet-wide publishing acceptable: a repo hash comes from
+# the clone URL, so two orgs cloning one public template would otherwise share a
+# key. Requires depsCache.enabled + depsCache.remote.enabled and a writable
+# volume source (the new PV, or goldenUploader.pvcName — mandatory on the dynamic
+# storageClassName path, which cannot express the read-only/read-write split).
+# Additive; no change unless enabled.
 # 0.12.1: pin `updateStrategy.type: OnReplenish` on every SandboxWarmPool
 # (generic + tenant). It is already the operator's default as of v0.4.5, so
 # this renders no behaviour change today — it exists so an operator upgrade
@@ -92,7 +106,7 @@ type: application
 # 0.8.0: org-fs sidecar (orgFs.*) — privileged rclone mounter + main-container
 # mounts. NOTE: the publish workflow skips existing versions, so this MUST
 # stay ahead of the latest published chart (0.7.5 at time of writing).
-version: 0.12.11
+version: 0.13.0
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "1.45.0"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/templates/_helpers.tpl
+++ b/deploy/helm/sandbox-env/templates/_helpers.tpl
@@ -363,6 +363,77 @@ agent-sandbox-system with every other release.
 {{- end }}
 
 {{/*
+Node-level uploader: DaemonSet, plus its own writable PV/PVC over the same
+store. A distinct name from goldenRemoteName because the two volumes differ in
+exactly the thing that matters — the tenant's is read-only at the mount, this
+one is not.
+*/}}
+{{- define "sandbox-env.goldenUploaderName" -}}
+{{- printf "studio-sandbox-golden-uploader-%s" (include "sandbox-env.envName" .) -}}
+{{- end }}
+
+{{/*
+Claim the uploader writes through. An explicit goldenUploader.pvcName wins and
+this chart renders no PV/PVC — the escape hatch for a store this chart does not
+manage.
+*/}}
+{{- define "sandbox-env.goldenUploaderClaimName" -}}
+{{- if .Values.goldenUploader.pvcName -}}
+{{- .Values.goldenUploader.pvcName -}}
+{{- else -}}
+{{- include "sandbox-env.goldenUploaderName" . -}}
+{{- end -}}
+{{- end }}
+
+{{- define "sandbox-env.goldenUploaderSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "sandbox-env.goldenUploaderName" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "sandbox-env.goldenUploaderLabels" -}}
+helm.sh/chart: {{ include "sandbox-env.chart" . }}
+{{ include "sandbox-env.goldenUploaderSelectorLabels" . }}
+app.kubernetes.io/component: golden-uploader
+studio.decocms.com/env: {{ include "sandbox-env.envName" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Placement defaults to the sandbox pods': the hostPath this reads only exists on
+nodes that ran one, so following them is the correct default rather than a
+convenience.
+*/}}
+{{- define "sandbox-env.goldenUploaderNodeSelector" -}}
+{{- default .Values.nodeSelector .Values.goldenUploader.nodeSelector | toYaml -}}
+{{- end }}
+
+{{- define "sandbox-env.goldenUploaderTolerations" -}}
+{{- default .Values.tolerations .Values.goldenUploader.tolerations | toYaml -}}
+{{- end }}
+
+{{/*
+Validate the uploader before rendering a DaemonSet that cannot do its job.
+  - it reads the node-local store and writes the shared one, so both tiers must
+    be on.
+  - it needs a writable view of the shared store: either this chart provisions
+    one from depsCache.remote.volume.attributes, or an existing claim is named.
+    Neither means a DaemonSet that crash-loops on a missing volume.
+*/}}
+{{- define "sandbox-env.validateGoldenUploader" -}}
+{{- if .Values.goldenUploader.enabled }}
+{{- if not (and .Values.depsCache.enabled .Values.depsCache.remote.enabled) }}
+{{- fail "sandbox-env: goldenUploader.enabled=true requires depsCache.enabled and depsCache.remote.enabled — it bridges the node-local store to the shared one, so with either off there is nothing to read or nowhere to write." -}}
+{{- end }}
+{{- if and (not .Values.depsCache.remote.volume.attributes) (not .Values.goldenUploader.pvcName) }}
+{{- fail "sandbox-env: goldenUploader.enabled=true needs a writable view of the shared store — either depsCache.remote.volume.attributes (this chart renders a second, writable PV over the same store) or goldenUploader.pvcName (an existing writable claim). With the dynamic storageClassName path you must supply pvcName, because a StorageClass cannot express the read-only/read-write split this relies on." -}}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 Claim the sandbox pod mounts for the L2 store. An explicit
 `depsCache.remote.pvcName` wins and nothing is rendered by
 sandbox-golden-remote.yaml — that is the escape hatch for a volume this chart

--- a/deploy/helm/sandbox-env/templates/sandbox-golden-uploader.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-golden-uploader.yaml
@@ -1,0 +1,159 @@
+{{- if and .Values.depsCache.enabled .Values.depsCache.remote.enabled .Values.goldenUploader.enabled }}
+{{- /*
+Node-level bridge from the L1 hostPath golden store to the shared one.
+
+WHY THIS IS NOT IN THE SANDBOX POD. Writing to a store shared across nodes needs
+write access to it, and a sandbox pod runs untrusted code — a package manager
+installs cached content as-is, so a tenant able to write the shared store could
+poison another node's boot. The tenant's write path stops at its own node's
+hostPath, which is already the accepted trust domain there; this DaemonSet
+carries goldens the rest of the way.
+
+Consequences of that choice, and why it beats a sidecar in the sandbox pod:
+  - the sandbox PodSpec is untouched, so no per-pod request, no effect on how
+    many sandboxes pack onto a node, and nothing new that can degrade the
+    health probe Studio tears the pod down on.
+  - CPU can be capped here without competing with a user's dev server. The
+    compression is the expensive part and nobody is waiting on it.
+  - the writable mount exists once per node, in infrastructure, instead of
+    inside every tenant's pod.
+
+It decides nothing about WHAT to cache. Sandboxes are multi-tenant and run
+third-party code, so the set of (repo, lockfile) pairs cannot be known ahead of
+time — no list, no pre-baked image, no prediction. It only forwards what a real
+boot already produced and the daemon already judged healthy enough to publish.
+*/ -}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "sandbox-env.goldenUploaderName" . }}
+  namespace: agent-sandbox-system
+  labels:
+    {{- include "sandbox-env.goldenUploaderLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "sandbox-env.goldenUploaderSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "sandbox-env.goldenUploaderLabels" . | nindent 8 }}
+    spec:
+      automountServiceAccountToken: false
+      # Placement follows the sandbox pods by default: the hostPath it reads only
+      # exists on nodes that ran one.
+      {{- with (include "sandbox-env.goldenUploaderNodeSelector" . | fromYaml) }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with (include "sandbox-env.goldenUploaderTolerations" . | fromYaml) }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      # Same uid as the sandbox, so it can read goldens the sandbox wrote. It
+      # does not need root: the hostPath is already handed to 1000 by the
+      # sandbox pod's chown init container.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: uploader
+          image: "{{ include "sandbox-env.sandboxImage" . }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # Same binary as the daemon, different role. Keeps the archive format
+          # impossible to drift between writer and reader, and adds no second
+          # image to build or keep in lockstep.
+          args: ["golden-uploader"]
+          env:
+            - name: DEPS_CACHE_ROOT
+              value: {{ .Values.depsCache.hostPath | quote }}
+            - name: GOLDEN_CACHE_REMOTE
+              value: {{ .Values.depsCache.remote.mountPath | quote }}
+            - name: GOLDEN_UPLOAD_INTERVAL_SECONDS
+              value: {{ .Values.goldenUploader.intervalSeconds | quote }}
+          resources:
+            {{- toYaml .Values.goldenUploader.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            readOnlyRootFilesystem: true
+          volumeMounts:
+            # Read-only: this reads what sandboxes published and must never be
+            # able to alter a node's cache.
+            - name: deps-cache
+              mountPath: {{ .Values.depsCache.hostPath | quote }}
+              readOnly: true
+            # The ONLY writable mount of the shared store in this chart. Never
+            # add it to the sandbox PodSpec.
+            - name: golden-remote-rw
+              mountPath: {{ .Values.depsCache.remote.mountPath | quote }}
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: deps-cache
+          hostPath:
+            path: {{ .Values.depsCache.hostPath | quote }}
+            # Never DirectoryOrCreate: a node with no cache has nothing to
+            # upload, and creating the path would only mask a misconfigured
+            # hostPath as an empty store.
+            type: Directory
+        - name: golden-remote-rw
+          persistentVolumeClaim:
+            claimName: {{ include "sandbox-env.goldenUploaderClaimName" . }}
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi
+{{- if not .Values.goldenUploader.pvcName }}
+---
+{{- /*
+Writable view of the same store the sandboxes read. A second PV over one bucket,
+because the mount options are the boundary: the tenant's PV is `read-only` at
+the mount, this one carries allow-delete/allow-overwrite. Splitting by mount
+rather than by convention means a consumer that forgets `readOnly: true` still
+cannot write through the tenant volume.
+*/ -}}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "sandbox-env.goldenUploaderName" . }}
+  labels:
+    {{- include "sandbox-env.goldenUploaderLabels" . | nindent 4 }}
+spec:
+  capacity:
+    storage: {{ .Values.depsCache.remote.capacity }}
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  {{- with .Values.goldenUploader.volume.mountOptions }}
+  mountOptions:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  csi:
+    driver: {{ .Values.depsCache.remote.volume.driver | quote }}
+    volumeHandle: {{ include "sandbox-env.goldenUploaderName" . }}
+    volumeAttributes:
+      {{- toYaml .Values.depsCache.remote.volume.attributes | nindent 6 }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "sandbox-env.goldenUploaderName" . }}
+  namespace: agent-sandbox-system
+  labels:
+    {{- include "sandbox-env.goldenUploaderLabels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  volumeName: {{ include "sandbox-env.goldenUploaderName" . }}
+  resources:
+    requests:
+      storage: {{ .Values.depsCache.remote.capacity }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/sandbox-env/templates/validations.yaml
+++ b/deploy/helm/sandbox-env/templates/validations.yaml
@@ -15,6 +15,7 @@ only really matters for Helm's own bookkeeping.
 {{- include "sandbox-env.validateTenantPools" . -}}
 {{- include "sandbox-env.validateNodePlaceholder" . -}}
 {{- include "sandbox-env.validateGoldenRemote" . -}}
+{{- include "sandbox-env.validateGoldenUploader" . -}}
 {{- /* Force envName validation to run at template time even when no
 resource references it directly (pure-validation render). Discard the
 return value into a local so it doesn't leak into the rendered YAML. */ -}}

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -439,7 +439,8 @@ depsCache:
         - prefix={{ include "sandbox-env.envName" . }}/
 
     # (3) EXISTING CLAIM — mount a PVC this chart neither creates nor
-    # manages. Nothing above is used.
+    # manages. Nothing above is used, including goldenUploader's PV — supply
+    # goldenUploader.pvcName too if you enable the uploader.
     #
     # PROVISION THAT VOLUME'S ROOT YOURSELF — this chart cannot. A freshly
     # provisioned volume comes up root-owned, and nothing here can fix it:
@@ -451,6 +452,74 @@ depsCache:
     # forever. Paths (1) and (2) handle ownership for you: (2) via
     # mountOptions, (1) via your StorageClass / access point.
     pvcName: ""
+
+# ── golden uploader (opt-in, off) ──────────────────────────────────────
+# Node-level bridge from the L1 hostPath store to the shared L2 one. Without
+# it the shared store stays EMPTY: a sandbox pod's mount is read-only, by
+# design, so nothing a tenant boots can publish there.
+#
+# WHY A DaemonSet AND NOT A SIDECAR. Writing a store shared across nodes needs
+# write access, and a sandbox runs untrusted code — a package manager installs
+# cached content as-is, so a tenant able to write it could poison another
+# node's boot. The tenant's write path stops at its own node's hostPath, which
+# is already the accepted trust domain there, and this carries goldens the rest
+# of the way. Consequences that a sidecar in the sandbox pod would not have:
+# the sandbox PodSpec is untouched (no per-pod request, no effect on packing
+# density, nothing new that can degrade the health probe Studio kills the pod
+# on), the writable mount exists once per node in infrastructure rather than
+# inside every tenant's pod, and CPU can be capped without competing with a
+# user's dev server.
+#
+# WHAT IT UPLOADS is not configurable, and cannot be. Sandboxes are
+# multi-tenant and run third-party code, so the set of (repo, lockfile) pairs
+# is not knowable ahead of time — there is no list to curate and no image to
+# pre-bake. It forwards what a real boot already produced and the daemon
+# already judged healthy enough to publish node-locally, and nothing else.
+#
+# KEYED BY ORG. The daemon stamps the owning organization beside each golden
+# (see the orgId note in the daemon protocol); a golden without one is skipped
+# rather than uploaded under an unscoped key. That is what stops two orgs
+# cloning the same public template from sharing an archive — the repo hash
+# comes from the clone URL, so on its own it does not isolate them.
+goldenUploader:
+  enabled: false
+  # How often to sweep. Cheap when there is nothing new: a golden already in
+  # the shared store costs one HEAD and a skip. Compression happens at most
+  # once per (org, repo, lockfile) across the whole fleet.
+  intervalSeconds: 300
+  # Deliberately small. Compression is CPU-bound and shares a node with tenant
+  # sandboxes, whose NodePool has a CPU ceiling — a sweep that takes 60s
+  # instead of 26s costs nobody anything, because no boot waits on it.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+  # Mount options for the writable view. Same store as the tenants read, minus
+  # `read-only` and plus the two that let a publisher replace an object. The
+  # split lives in the MOUNT rather than in convention, so a consumer that
+  # forgets `readOnly: true` on the tenant volume still cannot write.
+  #
+  # No `prefix` here: the uploader writes keys for many orgs, so it needs the
+  # whole store. Isolation comes from the key, which the daemon's meta scopes
+  # per org.
+  volume:
+    mountOptions:
+      - allow-delete
+      - allow-overwrite
+      - uid=1000
+      - gid=1000
+      - allow-other
+  # Existing writable claim, when this chart should not render the PV/PVC.
+  # Required with depsCache.remote.storageClassName, since a StorageClass
+  # cannot express the read-only/read-write split this relies on.
+  pvcName: ""
+  # Defaults to the sandbox pods' placement: the hostPath it reads only exists
+  # on nodes that ran one.
+  nodeSelector: {}
+  tolerations: []
 
 # ── sentinel token ─────────────────────────────────────────────────────
 sentinel:

--- a/packages/sandbox/daemon-go/internal/config/types.go
+++ b/packages/sandbox/daemon-go/internal/config/types.go
@@ -50,6 +50,14 @@ type TenantConfig struct {
 	CloneOnly   *bool             `json:"cloneOnly,omitempty"`
 	Application *Application      `json:"application,omitempty"`
 	Env         map[string]string `json:"env,omitempty"`
+	// Owning organization, stamped by Studio. Nothing in the boot path reads it;
+	// it exists so artifacts that outlive the pod can record whose they are.
+	//
+	// Concretely: the golden dependency cache. A repo hash does not isolate two
+	// organizations cloning the same URL (a public template), so a store shared
+	// across nodes must key by org — otherwise one org's dependency tree can be
+	// restored into another's sandbox. See setup.WriteGoldenMeta.
+	OrgId string `json:"orgId,omitempty"`
 }
 
 // IsCloneOnly reports whether this sandbox should stop after the checkout.

--- a/packages/sandbox/daemon-go/internal/setup/golden.go
+++ b/packages/sandbox/daemon-go/internal/setup/golden.go
@@ -120,7 +120,11 @@ type GoldenParams struct {
 	CloneUrl    string
 	InstallRoot string
 	Pm          string
-	Log         func(msg string)
+	// Owning organization, from Studio's config push. Unused node-locally —
+	// recorded beside the golden so a shared store can key by org. Empty makes
+	// the golden ineligible for that store. See goldenmeta.go.
+	OrgId string
+	Log   func(msg string)
 }
 
 type goldenPaths struct {
@@ -226,6 +230,10 @@ func PublishGolden(p GoldenParams) {
 		os.RemoveAll(tmp)
 		return
 	}
+	// Provenance, after the golden is in place so a meta never describes a tree
+	// that does not exist. Best-effort: without it this golden simply stays
+	// node-local, which is what every golden was before the shared tier.
+	WriteGoldenMeta(paths.golden, GoldenMeta{OrgId: p.OrgId, CloneUrl: p.CloneUrl, Pm: p.Pm})
 	p.log("[golden] published node_modules to cache")
 }
 

--- a/packages/sandbox/daemon-go/internal/setup/goldenmeta.go
+++ b/packages/sandbox/daemon-go/internal/setup/goldenmeta.go
@@ -1,0 +1,87 @@
+package setup
+
+// Provenance for a node-local golden, so a consumer OUTSIDE the pod can tell
+// whose dependency tree it is.
+//
+// The golden's own path carries only a repo hash: `golden/<repoHash>/<pm>-<lockHash>/`.
+// That is enough while the store is node-local, because a node's cache is
+// already one trust domain. It is NOT enough for a store shared across nodes:
+// the hash is derived from the clone URL, so two organizations cloning the same
+// public template land on the same key, and an archive published by one would
+// restore into the other's sandbox.
+//
+// The daemon is the only process that knows both facts at once — it holds the
+// org from Studio's config push and it is what writes the golden. So it records
+// them here at publish time, and the uploader keys the shared archive by org
+// without having to correlate anything after the fact.
+//
+// Best-effort in both directions: a golden with no meta is simply not eligible
+// for upload, which is the safe default (a shared archive with an unknown owner
+// is exactly what must not exist).
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// goldenMetaName sits INSIDE the golden's own directory, next to node_modules,
+// so it is removed by the same prune that drops the golden and can never
+// outlive what it describes.
+const goldenMetaName = ".golden-meta.json"
+
+// GoldenMeta is provenance, not cache content. Fields are additive: an older
+// daemon's meta must stay readable by a newer uploader.
+type GoldenMeta struct {
+	// Owning organization. Empty means unknown, which makes the golden
+	// ineligible for a shared store.
+	OrgId string `json:"orgId"`
+	// Credential-stripped clone URL. Not used for keying — the repo hash in the
+	// path is — but a hash is unreadable in an incident, and this is the only
+	// place the mapping exists outside the pod that wrote it.
+	CloneUrl string `json:"cloneUrl,omitempty"`
+	// Package manager the tree was installed with, mirroring the directory name.
+	// Redundant on purpose: it makes a meta file self-describing when read alone.
+	Pm string `json:"pm,omitempty"`
+}
+
+// goldenMetaPath is the meta path for a golden's node_modules path.
+func goldenMetaPath(goldenNodeModules string) string {
+	return filepath.Join(filepath.Dir(goldenNodeModules), goldenMetaName)
+}
+
+// WriteGoldenMeta records provenance beside a freshly published golden.
+// Best-effort: the golden is already usable node-locally without it, and the
+// only consequence of failure is that this tree is not eligible for the shared
+// tier.
+func WriteGoldenMeta(goldenNodeModules string, meta GoldenMeta) {
+	if meta.OrgId == "" {
+		return // nothing worth recording; absence is the signal
+	}
+	buf, err := json.Marshal(meta)
+	if err != nil {
+		return
+	}
+	// 0o644, not 0o600: the uploader runs as a different identity than the
+	// sandbox uid that wrote it.
+	os.WriteFile(goldenMetaPath(goldenNodeModules), buf, 0o644)
+}
+
+// ReadGoldenMeta returns the provenance for a golden, and false when it is
+// absent or unusable. A golden without a readable org is not eligible for a
+// shared store — an archive whose owner is unknown is the one thing that must
+// not be published.
+func ReadGoldenMeta(goldenNodeModules string) (GoldenMeta, bool) {
+	buf, err := os.ReadFile(goldenMetaPath(goldenNodeModules))
+	if err != nil {
+		return GoldenMeta{}, false
+	}
+	var meta GoldenMeta
+	if err := json.Unmarshal(buf, &meta); err != nil {
+		return GoldenMeta{}, false
+	}
+	if meta.OrgId == "" {
+		return GoldenMeta{}, false
+	}
+	return meta, true
+}

--- a/packages/sandbox/daemon-go/internal/setup/goldenuploader.go
+++ b/packages/sandbox/daemon-go/internal/setup/goldenuploader.go
@@ -1,0 +1,208 @@
+package setup
+
+// The node-local → shared bridge for the golden cache.
+//
+// WHY THIS IS NOT IN THE SANDBOX POD. Publishing to a store shared across nodes
+// needs write access to it, and a sandbox pod runs untrusted code: a package
+// manager installs cached content as-is, so a tenant able to write the shared
+// store could poison another node's boot. The tenant's write path therefore
+// stops at its own node's L1 (a hostPath it already owns, and already the
+// accepted trust domain there), and this walker — running as node-level
+// infrastructure with the writable mount — carries goldens the rest of the way.
+//
+// It decides nothing about WHAT to cache. Sandboxes are multi-tenant and run
+// third-party code, so the set of (repo, lockfile) pairs is not knowable ahead
+// of time: no list to maintain, no image to pre-bake, no prediction. The walker
+// only forwards what a real boot already produced and the daemon already judged
+// healthy enough to publish node-locally.
+//
+// Idempotent and cheap to run often: an object that already exists is a HEAD and
+// a skip. The compression is the expensive part, and it happens at most once per
+// (org, repo, lockfile) across the whole fleet.
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+// UploaderOpts configures one sweep of the node-local store.
+type UploaderOpts struct {
+	// CacheRoot is the node-local golden store (DEPS_CACHE_ROOT).
+	CacheRoot string
+	// RemoteRoot is the shared store's mount point, writable here.
+	RemoteRoot string
+	Log        func(msg string)
+}
+
+// UploaderStats is what one sweep did, for a log line and for tests.
+type UploaderStats struct {
+	Scanned  int
+	Uploaded int
+	// Skipped is goldens already present in the shared store — the steady state.
+	Skipped int
+	// NoMeta is goldens with no readable org. Deliberately not an error: a golden
+	// written before the org was threaded through, or by a boot Studio gave no
+	// org for, simply stays node-local. Counted because a permanently non-zero
+	// value means the org is not arriving and the tier is quietly doing nothing.
+	NoMeta int
+	Failed int
+}
+
+func (o UploaderOpts) log(msg string) {
+	if o.Log != nil {
+		o.Log(msg)
+	}
+}
+
+// UploadNodeGoldens sweeps the node-local store once and publishes every golden
+// that has provenance and is not in the shared store yet.
+//
+// Best-effort per golden: one failure does not stop the sweep. Nothing here
+// deletes from either store — pruning the node-local side belongs to the daemon
+// that owns it, and the shared side is bounded by the object store's own
+// lifecycle policy.
+func UploadNodeGoldens(opts UploaderOpts) UploaderStats {
+	var stats UploaderStats
+	if opts.CacheRoot == "" || opts.RemoteRoot == "" {
+		return stats
+	}
+	root := filepath.Join(opts.CacheRoot, "golden")
+	repos, err := os.ReadDir(root)
+	if err != nil {
+		return stats // nothing published on this node yet
+	}
+	for _, repo := range repos {
+		if !repo.IsDir() {
+			continue
+		}
+		repoDir := filepath.Join(root, repo.Name())
+		lockDirs, err := os.ReadDir(repoDir)
+		if err != nil {
+			continue
+		}
+		for _, lockDir := range lockDirs {
+			if !lockDir.IsDir() {
+				continue
+			}
+			// The node-local layout is golden/<repoHash>/<pm>-<lockHash>/node_modules.
+			goldenNodeModules := filepath.Join(repoDir, lockDir.Name(), "node_modules")
+			if _, err := os.Stat(goldenNodeModules); err != nil {
+				continue // an in-flight publish, or a pruned leftover
+			}
+			stats.Scanned++
+
+			meta, ok := ReadGoldenMeta(goldenNodeModules)
+			if !ok {
+				stats.NoMeta++
+				continue
+			}
+			pm, lockHash, ok := splitGoldenLockDir(lockDir.Name())
+			if !ok {
+				stats.NoMeta++
+				continue
+			}
+			archive := RemoteGoldenArchivePath(opts.RemoteRoot, meta.OrgId, meta.CloneUrl, pm, lockHash)
+			if archive == "" {
+				stats.NoMeta++
+				continue
+			}
+			if fileExists(archive) {
+				stats.Skipped++
+				continue
+			}
+			if uploadGolden(goldenNodeModules, archive, opts) {
+				stats.Uploaded++
+			} else {
+				stats.Failed++
+			}
+		}
+	}
+	return stats
+}
+
+// splitGoldenLockDir splits a `<pm>-<lockHash>` directory name. The lock hash is
+// hex and never contains `-`, so the FIRST separator is the boundary — a package
+// manager name never contains one either, but splitting from the left keeps this
+// correct if one ever does.
+func splitGoldenLockDir(name string) (pm, lockHash string, ok bool) {
+	for i := 0; i < len(name); i++ {
+		if name[i] != '-' {
+			continue
+		}
+		// Both halves or neither: a caller that ignored ok must not be handed a
+		// half-parsed key it would then use to build an archive path.
+		if name[:i] == "" || name[i+1:] == "" {
+			return "", "", false
+		}
+		return name[:i], name[i+1:], true
+	}
+	return "", "", false
+}
+
+// uploadGolden compresses one node-local golden straight into its shared key.
+//
+// Written to the final key rather than a temp name plus rename: the shared store
+// is a blob store, which has no rename and does not need one — an object becomes
+// visible only when its upload completes, so a killed uploader leaves no
+// readable object. Then read back, because a corrupt object would be permanent:
+// every later sweep would skip it as "already present" and every node would keep
+// missing with nothing to repair it.
+func uploadGolden(goldenNodeModules, archive string, opts UploaderOpts) bool {
+	// Best-effort: on a blob store creating the prefix is a no-op, and writing
+	// the key is what creates it.
+	os.MkdirAll(filepath.Dir(archive), 0o755)
+
+	installRoot := filepath.Dir(goldenNodeModules)
+	tarArgs := []string{"-cf", "-", "-C", installRoot}
+	for _, d := range runtimeCacheDirs {
+		tarArgs = append(tarArgs, "--exclude=node_modules/"+d)
+	}
+	tarArgs = append(tarArgs, "node_modules")
+
+	zstdArgs := append(append([]string{}, zstdPublishArgs...), "-q", "-o", archive)
+	if r := runPiped(exec.Command("tar", tarArgs...), exec.Command("zstd", zstdArgs...)); r.code != 0 {
+		opts.log(fmt.Sprintf("[golden-uploader] compress failed for %s (exit %d: %s)", archive, r.code, r.stderr))
+		os.Remove(archive)
+		return false
+	}
+	if check := runPiped(exec.Command("zstd", "-dc", archive), exec.Command("tar", "-tf", "-")); check.code != 0 {
+		opts.log(fmt.Sprintf("[golden-uploader] discarded %s — failed read-back (%s)", archive, check.stderr))
+		os.Remove(archive)
+		return false
+	}
+	opts.log("[golden-uploader] published " + archive)
+	return true
+}
+
+// RunUploader sweeps on an interval until ctx-like cancellation via stop.
+// Sequential by construction: compression is CPU-bound and this shares a node
+// with tenant sandboxes, so overlapping sweeps would compete with the very boots
+// the cache exists to speed up. A sweep that runs long simply delays the next.
+func RunUploader(opts UploaderOpts, interval time.Duration, stop <-chan struct{}) {
+	sweep := func() {
+		started := time.Now()
+		s := UploadNodeGoldens(opts)
+		// Silent when there was nothing to do: this runs on every node, forever,
+		// and a heartbeat per node per interval is noise that buries the lines
+		// that matter.
+		if s.Uploaded > 0 || s.Failed > 0 || s.NoMeta > 0 {
+			opts.log(fmt.Sprintf(
+				"[golden-uploader] swept %d golden(s) in %s: %d uploaded, %d already present, %d without provenance, %d failed",
+				s.Scanned, time.Since(started).Truncate(time.Millisecond), s.Uploaded, s.Skipped, s.NoMeta, s.Failed))
+		}
+	}
+	sweep()
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			sweep()
+		}
+	}
+}

--- a/packages/sandbox/daemon-go/internal/setup/goldenuploader_test.go
+++ b/packages/sandbox/daemon-go/internal/setup/goldenuploader_test.go
@@ -1,0 +1,282 @@
+package setup
+
+// Real files, real tar/zstd. The uploader's whole job is to turn a node-local
+// tree into an archive another node can read, so a mocked pipe proves nothing.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// nodeLocalGolden builds the L1 layout the daemon produces:
+//
+//	<cacheRoot>/golden/<repoHash>/<pm>-<lockHash>/node_modules
+//	                             /.golden-meta.json
+//
+// meta is written only when orgId is non-empty, mirroring WriteGoldenMeta.
+func nodeLocalGolden(t *testing.T, cacheRoot, cloneUrl, pm, lockHash, orgId string) string {
+	t.Helper()
+	dir := filepath.Join(cacheRoot, "golden", repoCacheKey(cloneUrl), pm+"-"+lockHash)
+	nm := filepath.Join(dir, "node_modules", "pkg-a", "dist")
+	if err := os.MkdirAll(nm, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(nm, "index.js"), []byte("module.exports = 1;"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A pod-local cache that must not travel.
+	vite := filepath.Join(dir, "node_modules", ".vite")
+	if err := os.MkdirAll(vite, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(vite, "junk"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	goldenNodeModules := filepath.Join(dir, "node_modules")
+	WriteGoldenMeta(goldenNodeModules, GoldenMeta{OrgId: orgId, CloneUrl: cloneUrl, Pm: pm})
+	return goldenNodeModules
+}
+
+func TestGoldenMetaRoundTrip(t *testing.T) {
+	t.Run("writes and reads back", func(t *testing.T) {
+		nm := filepath.Join(t.TempDir(), "node_modules")
+		if err := os.MkdirAll(nm, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		WriteGoldenMeta(nm, GoldenMeta{OrgId: "org_a", CloneUrl: "https://x/y.git", Pm: "bun"})
+		got, ok := ReadGoldenMeta(nm)
+		if !ok {
+			t.Fatal("meta not readable")
+		}
+		if got.OrgId != "org_a" || got.CloneUrl != "https://x/y.git" || got.Pm != "bun" {
+			t.Fatalf("round trip lost fields: %+v", got)
+		}
+	})
+
+	// Absence is the signal that a golden is not eligible for a shared store.
+	// Writing an org-less meta would make it look eligible with an unknown owner.
+	t.Run("writes nothing without an org", func(t *testing.T) {
+		dir := t.TempDir()
+		nm := filepath.Join(dir, "node_modules")
+		if err := os.MkdirAll(nm, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		WriteGoldenMeta(nm, GoldenMeta{CloneUrl: "https://x/y.git"})
+		if _, ok := ReadGoldenMeta(nm); ok {
+			t.Fatal("reported provenance for a golden with no org")
+		}
+		if _, err := os.Stat(goldenMetaPath(nm)); err == nil {
+			t.Fatal("created a meta file with no org")
+		}
+	})
+
+	t.Run("unreadable meta is absent meta", func(t *testing.T) {
+		dir := t.TempDir()
+		nm := filepath.Join(dir, "node_modules")
+		if err := os.MkdirAll(nm, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(goldenMetaPath(nm), []byte("{not json"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if _, ok := ReadGoldenMeta(nm); ok {
+			t.Fatal("accepted corrupt meta")
+		}
+	})
+
+	// The meta lives inside the golden's own directory so the existing prune
+	// removes it with the tree it describes, and it can never outlive it.
+	t.Run("lives inside the golden directory", func(t *testing.T) {
+		nm := "/cache/golden/abc/bun-def/node_modules"
+		if want := "/cache/golden/abc/bun-def/" + goldenMetaName; goldenMetaPath(nm) != want {
+			t.Fatalf("got %q want %q", goldenMetaPath(nm), want)
+		}
+	})
+}
+
+func TestSplitGoldenLockDir(t *testing.T) {
+	for _, c := range []struct {
+		in, pm, hash string
+		ok           bool
+	}{
+		{"bun-abc123", "bun", "abc123", true},
+		{"pnpm-deadbeef", "pnpm", "deadbeef", true},
+		{"bun", "", "", false},
+		{"-abc", "", "", false},
+		{"bun-", "", "", false},
+		{"", "", "", false},
+	} {
+		pm, hash, ok := splitGoldenLockDir(c.in)
+		if ok != c.ok || pm != c.pm || hash != c.hash {
+			t.Fatalf("%q → (%q, %q, %v), want (%q, %q, %v)", c.in, pm, hash, ok, c.pm, c.hash, c.ok)
+		}
+	}
+}
+
+func TestUploadNodeGoldens(t *testing.T) {
+	t.Run("uploads a golden with provenance, keyed by org", func(t *testing.T) {
+		requireTools(t)
+		cache, remote := t.TempDir(), t.TempDir()
+		nodeLocalGolden(t, cache, "https://github.com/acme/site.git", "bun", "lock1", testOrg)
+
+		s := UploadNodeGoldens(UploaderOpts{CacheRoot: cache, RemoteRoot: remote})
+		if s.Uploaded != 1 || s.Scanned != 1 {
+			t.Fatalf("unexpected stats: %+v", s)
+		}
+		want := RemoteGoldenArchivePath(remote, testOrg, "https://github.com/acme/site.git", "bun", "lock1")
+		if !fileExists(want) {
+			t.Fatalf("archive not at the org-keyed path %q", want)
+		}
+	})
+
+	// The safe default: an archive whose owner is unknown must not exist, because
+	// a repo hash alone does not isolate two orgs cloning the same template.
+	t.Run("skips a golden with no provenance", func(t *testing.T) {
+		requireTools(t)
+		cache, remote := t.TempDir(), t.TempDir()
+		nodeLocalGolden(t, cache, "https://github.com/acme/site.git", "bun", "lock1", "")
+
+		s := UploadNodeGoldens(UploaderOpts{CacheRoot: cache, RemoteRoot: remote})
+		if s.Uploaded != 0 || s.NoMeta != 1 {
+			t.Fatalf("unexpected stats: %+v", s)
+		}
+		if entries, _ := os.ReadDir(remote); len(entries) != 0 {
+			t.Fatal("wrote to the shared store without knowing the owner")
+		}
+	})
+
+	t.Run("second sweep skips what is already there", func(t *testing.T) {
+		requireTools(t)
+		cache, remote := t.TempDir(), t.TempDir()
+		nodeLocalGolden(t, cache, "https://github.com/acme/site.git", "bun", "lock1", testOrg)
+		opts := UploaderOpts{CacheRoot: cache, RemoteRoot: remote}
+
+		UploadNodeGoldens(opts)
+		archive := RemoteGoldenArchivePath(remote, testOrg, "https://github.com/acme/site.git", "bun", "lock1")
+		before, err := os.Stat(archive)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		s := UploadNodeGoldens(opts)
+		if s.Uploaded != 0 || s.Skipped != 1 {
+			t.Fatalf("unexpected stats on the steady-state sweep: %+v", s)
+		}
+		after, err := os.Stat(archive)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !before.ModTime().Equal(after.ModTime()) {
+			t.Fatal("recompressed an archive that was already published")
+		}
+	})
+
+	t.Run("the archive is restorable on a cold root", func(t *testing.T) {
+		requireTools(t)
+		cache, remote := t.TempDir(), t.TempDir()
+		nodeLocalGolden(t, cache, "https://github.com/acme/site.git", "bun", "lock1", testOrg)
+		UploadNodeGoldens(UploaderOpts{CacheRoot: cache, RemoteRoot: remote})
+
+		// A different node: same lockfile content, nothing installed.
+		cold := t.TempDir()
+		if err := os.WriteFile(filepath.Join(cold, "bun.lock"), []byte("whatever"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv(remoteEnabledEnvVar, remote)
+		p := RemoteGoldenParams{
+			RemoteRoot: remote, OrgId: testOrg,
+			CloneUrl: "https://github.com/acme/site.git", InstallRoot: cold, Pm: "bun",
+		}
+		// The lock hash is derived from the file, so point the archive at it.
+		archive := RemoteGoldenArchivePath(remote, testOrg, "https://github.com/acme/site.git", "bun",
+			LockfileHash(cold, "bun"))
+		if err := os.MkdirAll(filepath.Dir(archive), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		published := RemoteGoldenArchivePath(remote, testOrg, "https://github.com/acme/site.git", "bun", "lock1")
+		if err := os.Rename(published, archive); err != nil {
+			t.Fatal(err)
+		}
+
+		if !TryRestoreRemoteGolden(p) {
+			t.Fatal("the uploaded archive did not restore")
+		}
+		if _, err := os.Stat(filepath.Join(cold, "node_modules", "pkg-a", "dist", "index.js")); err != nil {
+			t.Fatalf("restored tree incomplete: %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(cold, "node_modules", ".vite")); err == nil {
+			t.Fatal(".vite travelled — pod-local churn must not be in a shared archive")
+		}
+	})
+
+	t.Run("two orgs on the same repo get separate archives", func(t *testing.T) {
+		requireTools(t)
+		cache, remote := t.TempDir(), t.TempDir()
+		// Same clone URL, same lockfile — the collision the org key exists to stop.
+		// Distinct cache roots because the node-local path has no org in it.
+		cacheA := filepath.Join(cache, "a")
+		cacheB := filepath.Join(cache, "b")
+		nodeLocalGolden(t, cacheA, "https://github.com/deco-cx/template.git", "bun", "lock1", "org_a")
+		nodeLocalGolden(t, cacheB, "https://github.com/deco-cx/template.git", "bun", "lock1", "org_b")
+
+		UploadNodeGoldens(UploaderOpts{CacheRoot: cacheA, RemoteRoot: remote})
+		UploadNodeGoldens(UploaderOpts{CacheRoot: cacheB, RemoteRoot: remote})
+
+		a := RemoteGoldenArchivePath(remote, "org_a", "https://github.com/deco-cx/template.git", "bun", "lock1")
+		b := RemoteGoldenArchivePath(remote, "org_b", "https://github.com/deco-cx/template.git", "bun", "lock1")
+		if a == b {
+			t.Fatal("keys collided")
+		}
+		if !fileExists(a) || !fileExists(b) {
+			t.Fatal("one org's archive is missing — the other overwrote it")
+		}
+	})
+
+	t.Run("no-ops without both roots", func(t *testing.T) {
+		if s := UploadNodeGoldens(UploaderOpts{}); s.Scanned != 0 {
+			t.Fatal("scanned with no roots configured")
+		}
+		if s := UploadNodeGoldens(UploaderOpts{CacheRoot: t.TempDir()}); s.Scanned != 0 {
+			t.Fatal("scanned with no remote root")
+		}
+		if s := UploadNodeGoldens(UploaderOpts{RemoteRoot: t.TempDir()}); s.Scanned != 0 {
+			t.Fatal("scanned with no cache root")
+		}
+	})
+
+	t.Run("an empty node-local store is not an error", func(t *testing.T) {
+		cache, remote := t.TempDir(), t.TempDir()
+		if s := UploadNodeGoldens(UploaderOpts{CacheRoot: cache, RemoteRoot: remote}); s.Scanned != 0 {
+			t.Fatalf("unexpected stats on an empty store: %+v", s)
+		}
+	})
+
+	// A golden directory mid-publish has no node_modules yet. Uploading one would
+	// mean shipping a partial tree fleet-wide.
+	t.Run("skips a directory with no node_modules", func(t *testing.T) {
+		cache, remote := t.TempDir(), t.TempDir()
+		half := filepath.Join(cache, "golden", "abc123", "bun-lock1")
+		if err := os.MkdirAll(half, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if s := UploadNodeGoldens(UploaderOpts{CacheRoot: cache, RemoteRoot: remote}); s.Scanned != 0 {
+			t.Fatalf("scanned an in-flight publish: %+v", s)
+		}
+	})
+
+	t.Run("sweeps every repo and lockfile on the node", func(t *testing.T) {
+		requireTools(t)
+		cache, remote := t.TempDir(), t.TempDir()
+		for i := 0; i < 3; i++ {
+			url := fmt.Sprintf("https://github.com/acme/site-%d.git", i)
+			nodeLocalGolden(t, cache, url, "bun", "lock1", testOrg)
+			nodeLocalGolden(t, cache, url, "bun", "lock2", testOrg)
+		}
+		s := UploadNodeGoldens(UploaderOpts{CacheRoot: cache, RemoteRoot: remote})
+		if s.Scanned != 6 || s.Uploaded != 6 {
+			t.Fatalf("unexpected stats: %+v", s)
+		}
+	})
+}

--- a/packages/sandbox/daemon-go/internal/setup/orchestrator.go
+++ b/packages/sandbox/daemon-go/internal/setup/orchestrator.go
@@ -419,6 +419,7 @@ func (o *Orchestrator) stepInstallInner() bool {
 		CloneUrl:    cloneUrl,
 		InstallRoot: paths.ResolvePmRoot(o.deps.RepoDir, cfg.PmPath()),
 		Pm:          pm,
+		OrgId:       cfg.OrgId,
 		Log:         func(m string) { o.chunk(m + "\r\n") },
 	}
 	if TryRestoreGolden(golden) {

--- a/packages/sandbox/daemon-go/internal/setup/remotegolden.go
+++ b/packages/sandbox/daemon-go/internal/setup/remotegolden.go
@@ -59,7 +59,13 @@ var zstdPublishArgs = []string{"-3", "-T0"}
 // are keyed identically on purpose (same credential-stripped repo hash, same
 // lockfile hash), so they can never disagree about what a key means.
 type RemoteGoldenParams struct {
-	RemoteRoot  string
+	RemoteRoot string
+	// Owning organization. REQUIRED: a repo hash is derived from the clone URL,
+	// so two organizations cloning the same public template collide on one key.
+	// Node-locally that is a single trust domain; here it would let one org's
+	// tree restore into another's sandbox. Empty disables the tier rather than
+	// falling back to an unscoped key.
+	OrgId       string
 	CloneUrl    string
 	InstallRoot string
 	Pm          string
@@ -76,6 +82,7 @@ func (p RemoteGoldenParams) log(msg string) {
 // accidentally key the two tiers differently.
 func RemoteGoldenFrom(g GoldenParams) RemoteGoldenParams {
 	return RemoteGoldenParams{
+		OrgId:       g.OrgId,
 		CloneUrl:    g.CloneUrl,
 		InstallRoot: g.InstallRoot,
 		Pm:          g.Pm,
@@ -90,13 +97,17 @@ func RemoteEnabled() bool {
 	return os.Getenv(remoteEnabledEnvVar) != ""
 }
 
-// RemoteGoldenArchivePath is the archive path for a (repo, pm, lockfile) triple,
-// or empty when L2 cannot apply.
-func RemoteGoldenArchivePath(remoteRoot, cloneUrl, pm, lockHash string) string {
-	if remoteRoot == "" || cloneUrl == "" || lockHash == "" {
+// RemoteGoldenArchivePath is the archive path for an (org, repo, pm, lockfile)
+// tuple, or empty when L2 cannot apply.
+//
+// The org comes FIRST, so a store can be scoped per organization by prefix
+// alone — an object-store policy, a mountpoint `prefix=` mount or a lifecycle
+// rule can all bound one org without knowing anything about repos.
+func RemoteGoldenArchivePath(remoteRoot, orgId, cloneUrl, pm, lockHash string) string {
+	if remoteRoot == "" || orgId == "" || cloneUrl == "" || lockHash == "" {
 		return ""
 	}
-	return filepath.Join(remoteRoot, "golden", repoCacheKey(cloneUrl),
+	return filepath.Join(remoteRoot, "golden", orgId, repoCacheKey(cloneUrl),
 		pm+"-"+lockHash+remoteArchiveSuffix)
 }
 
@@ -108,7 +119,7 @@ func (p RemoteGoldenParams) resolve() (string, bool) {
 	if root == "" {
 		root = os.Getenv(remoteEnabledEnvVar)
 	}
-	archive := RemoteGoldenArchivePath(root, p.CloneUrl, p.Pm,
+	archive := RemoteGoldenArchivePath(root, p.OrgId, p.CloneUrl, p.Pm,
 		LockfileHash(p.InstallRoot, p.Pm))
 	if archive == "" {
 		return "", false
@@ -357,12 +368,25 @@ func pruneRemoteGoldens(remoteRoot string, ttl time.Duration, maxPerRepo int, no
 		return
 	}
 	root := filepath.Join(remoteRoot, "golden")
-	repos, err := os.ReadDir(root)
+	orgs, err := os.ReadDir(root)
 	if err != nil {
 		return // nothing published yet
 	}
-	for _, repo := range repos {
-		repoDir := filepath.Join(root, repo.Name())
+	// Two levels: golden/<org>/<repo>/. The cap is per repo, not per org — one
+	// org with many repos must not evict another's, and one repo's churn must not
+	// evict its sibling.
+	var repoDirs []string
+	for _, org := range orgs {
+		orgDir := filepath.Join(root, org.Name())
+		repos, err := os.ReadDir(orgDir)
+		if err != nil {
+			continue
+		}
+		for _, repo := range repos {
+			repoDirs = append(repoDirs, filepath.Join(orgDir, repo.Name()))
+		}
+	}
+	for _, repoDir := range repoDirs {
 		names, err := os.ReadDir(repoDir)
 		if err != nil {
 			continue

--- a/packages/sandbox/daemon-go/internal/setup/remotegolden_test.go
+++ b/packages/sandbox/daemon-go/internal/setup/remotegolden_test.go
@@ -9,9 +9,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
+
+const testOrg = "org_1rT2srZfM75G"
 
 // requireTools skips rather than fails when the host lacks zstd: the sandbox
 // image ships it, a contributor's machine may not, and a red suite there would
@@ -57,6 +60,7 @@ func installRootWithTree(t *testing.T, pkgs int) string {
 func params(remoteRoot, installRoot string) RemoteGoldenParams {
 	return RemoteGoldenParams{
 		RemoteRoot:  remoteRoot,
+		OrgId:       testOrg,
 		CloneUrl:    "https://github.com/acme/site.git",
 		InstallRoot: installRoot,
 		Pm:          "bun",
@@ -64,38 +68,75 @@ func params(remoteRoot, installRoot string) RemoteGoldenParams {
 }
 
 func TestRemoteGoldenArchivePath(t *testing.T) {
-	t.Run("keyed by repo, pm and lockfile", func(t *testing.T) {
-		got := RemoteGoldenArchivePath("/store", "https://github.com/acme/site.git", "bun", "abc")
-		want := filepath.Join("/store", "golden", repoCacheKey("https://github.com/acme/site.git"), "bun-abc.tar.zst")
+	t.Run("keyed by org, repo, pm and lockfile", func(t *testing.T) {
+		got := RemoteGoldenArchivePath("/store", testOrg, "https://github.com/acme/site.git", "bun", "abc")
+		want := filepath.Join("/store", "golden", testOrg,
+			repoCacheKey("https://github.com/acme/site.git"), "bun-abc.tar.zst")
 		if got != want {
 			t.Fatalf("got %q want %q", got, want)
 		}
 	})
+	t.Run("org comes first, so a prefix scopes one org", func(t *testing.T) {
+		got := RemoteGoldenArchivePath("/store", testOrg, "https://github.com/acme/site.git", "bun", "abc")
+		prefix := filepath.Join("/store", "golden", testOrg) + string(filepath.Separator)
+		if !strings.HasPrefix(got, prefix) {
+			t.Fatalf("%q is not under the org prefix %q — a per-org policy or mount could not bound it", got, prefix)
+		}
+	})
 	t.Run("credentials do not change the key", func(t *testing.T) {
-		bare := RemoteGoldenArchivePath("/store", "https://github.com/acme/site.git", "bun", "abc")
-		creds := RemoteGoldenArchivePath("/store", "https://user:tok@github.com/acme/site.git", "bun", "abc")
+		bare := RemoteGoldenArchivePath("/store", testOrg, "https://github.com/acme/site.git", "bun", "abc")
+		creds := RemoteGoldenArchivePath("/store", testOrg, "https://user:tok@github.com/acme/site.git", "bun", "abc")
 		if bare != creds {
 			t.Fatalf("credential-stripping broken:\n bare  %q\n creds %q", bare, creds)
 		}
 	})
 	t.Run("empty when a component is missing", func(t *testing.T) {
-		for _, c := range [][4]string{
-			{"", "url", "bun", "hash"},
-			{"/store", "", "bun", "hash"},
-			{"/store", "url", "bun", ""},
+		for _, c := range [][5]string{
+			{"", testOrg, "url", "bun", "hash"},
+			{"/store", "", "url", "bun", "hash"}, // no org → no shared archive
+			{"/store", testOrg, "", "bun", "hash"},
+			{"/store", testOrg, "url", "bun", ""},
 		} {
-			if got := RemoteGoldenArchivePath(c[0], c[1], c[2], c[3]); got != "" {
+			if got := RemoteGoldenArchivePath(c[0], c[1], c[2], c[3], c[4]); got != "" {
 				t.Fatalf("expected empty for %v, got %q", c, got)
 			}
 		}
 	})
 	t.Run("two repos never share an archive", func(t *testing.T) {
-		a := RemoteGoldenArchivePath("/store", "https://github.com/acme/a.git", "bun", "same")
-		b := RemoteGoldenArchivePath("/store", "https://github.com/acme/b.git", "bun", "same")
+		a := RemoteGoldenArchivePath("/store", testOrg, "https://github.com/acme/a.git", "bun", "same")
+		b := RemoteGoldenArchivePath("/store", testOrg, "https://github.com/acme/b.git", "bun", "same")
 		if a == b {
 			t.Fatal("distinct repos collided on one archive — bun does not re-verify cache content")
 		}
 	})
+	// The reason the org is in the key at all: a repo hash comes from the clone
+	// URL, so two orgs cloning the same public template would otherwise collide
+	// and one could publish an archive the other restores.
+	t.Run("two orgs on the SAME repo never share an archive", func(t *testing.T) {
+		a := RemoteGoldenArchivePath("/store", "org_a", "https://github.com/deco-cx/template.git", "bun", "same")
+		b := RemoteGoldenArchivePath("/store", "org_b", "https://github.com/deco-cx/template.git", "bun", "same")
+		if a == b {
+			t.Fatal("orgs collided on one archive for a shared template — cross-org poisoning path")
+		}
+	})
+}
+
+func TestRemoteGoldenRequiresOrg(t *testing.T) {
+	requireTools(t)
+	store := t.TempDir()
+	t.Setenv(remoteEnabledEnvVar, store)
+
+	root := installRootWithTree(t, 4)
+	p := params(store, root)
+	p.OrgId = "" // Studio did not supply one, or an older daemon wrote the golden
+
+	PublishRemoteGolden(p)
+	if entries, _ := os.ReadDir(store); len(entries) != 0 {
+		t.Fatal("published without an org — an archive with an unknown owner must not exist")
+	}
+	if TryRestoreRemoteGolden(p) {
+		t.Fatal("restored without an org")
+	}
 }
 
 func TestRemoteEnabled(t *testing.T) {
@@ -224,7 +265,7 @@ func TestRemoteGoldenTruncatedArchiveFailsClosed(t *testing.T) {
 	nodeA := installRootWithTree(t, 20)
 	PublishRemoteGolden(params(store, nodeA))
 
-	archive := RemoteGoldenArchivePath(store, "https://github.com/acme/site.git", "bun",
+	archive := RemoteGoldenArchivePath(store, testOrg, "https://github.com/acme/site.git", "bun",
 		LockfileHash(nodeA, "bun"))
 	full, err := os.ReadFile(archive)
 	if err != nil {
@@ -262,7 +303,7 @@ func TestRemoteGoldenPublishIsIdempotent(t *testing.T) {
 
 	nodeA := installRootWithTree(t, 6)
 	PublishRemoteGolden(params(store, nodeA))
-	archive := RemoteGoldenArchivePath(store, "https://github.com/acme/site.git", "bun",
+	archive := RemoteGoldenArchivePath(store, testOrg, "https://github.com/acme/site.git", "bun",
 		LockfileHash(nodeA, "bun"))
 	first, err := os.Stat(archive)
 	if err != nil {
@@ -302,7 +343,7 @@ func TestRemoteGoldenRestoreRejectsCorruptArchive(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(nodeB, "bun.lock"), []byte("lockfile-v1"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	archive := RemoteGoldenArchivePath(store, "https://github.com/acme/site.git", "bun",
+	archive := RemoteGoldenArchivePath(store, testOrg, "https://github.com/acme/site.git", "bun",
 		LockfileHash(nodeB, "bun"))
 	if err := os.MkdirAll(filepath.Dir(archive), 0o755); err != nil {
 		t.Fatal(err)
@@ -344,7 +385,7 @@ func TestPruneRemoteGoldens(t *testing.T) {
 
 	t.Run("drops archives past the TTL", func(t *testing.T) {
 		store := t.TempDir()
-		repo := filepath.Join(store, "golden", "repo-a")
+		repo := filepath.Join(store, "golden", testOrg, "repo-a")
 		fresh := write(t, repo, "bun-fresh.tar.zst", time.Hour)
 		stale := write(t, repo, "bun-stale.tar.zst", 8*24*time.Hour)
 		pruneRemoteGoldens(store, GoldenTTL, GoldenMaxPerRepo, now, nil)
@@ -358,7 +399,7 @@ func TestPruneRemoteGoldens(t *testing.T) {
 
 	t.Run("keeps only the newest per repo", func(t *testing.T) {
 		store := t.TempDir()
-		repo := filepath.Join(store, "golden", "repo-a")
+		repo := filepath.Join(store, "golden", testOrg, "repo-a")
 		var paths []string
 		for i := 0; i < GoldenMaxPerRepo+3; i++ {
 			paths = append(paths, write(t, repo, fmt.Sprintf("bun-%d.tar.zst", i), time.Duration(i)*time.Minute))
@@ -377,7 +418,7 @@ func TestPruneRemoteGoldens(t *testing.T) {
 
 	t.Run("leaves non-archive entries alone", func(t *testing.T) {
 		store := t.TempDir()
-		repo := filepath.Join(store, "golden", "repo-a")
+		repo := filepath.Join(store, "golden", testOrg, "repo-a")
 		other := write(t, repo, "README", 8*24*time.Hour)
 		pruneRemoteGoldens(store, GoldenTTL, GoldenMaxPerRepo, now, nil)
 		if _, err := os.Stat(other); err != nil {
@@ -387,8 +428,8 @@ func TestPruneRemoteGoldens(t *testing.T) {
 
 	t.Run("one repo's cap does not affect another", func(t *testing.T) {
 		store := t.TempDir()
-		a := filepath.Join(store, "golden", "repo-a")
-		b := filepath.Join(store, "golden", "repo-b")
+		a := filepath.Join(store, "golden", testOrg, "repo-a")
+		b := filepath.Join(store, "golden", testOrg, "repo-b")
 		for i := 0; i < GoldenMaxPerRepo+2; i++ {
 			write(t, a, fmt.Sprintf("bun-%d.tar.zst", i), time.Duration(i)*time.Minute)
 		}
@@ -408,7 +449,7 @@ func TestRemoteGoldenPublishPrunes(t *testing.T) {
 	t.Setenv(remoteEnabledEnvVar, store)
 
 	nodeA := installRootWithTree(t, 4)
-	repoDir := filepath.Dir(RemoteGoldenArchivePath(store, "https://github.com/acme/site.git", "bun",
+	repoDir := filepath.Dir(RemoteGoldenArchivePath(store, testOrg, "https://github.com/acme/site.git", "bun",
 		LockfileHash(nodeA, "bun")))
 	if err := os.MkdirAll(repoDir, 0o755); err != nil {
 		t.Fatal(err)

--- a/packages/sandbox/daemon-go/main.go
+++ b/packages/sandbox/daemon-go/main.go
@@ -508,8 +508,57 @@ func (d *daemon) operatorIdentity() *gitx.CoAuthorIdentity {
 	return id
 }
 
+// runGoldenUploader is the node-level bridge from the L1 hostPath store to the
+// shared one. Same binary as the daemon on purpose: the logic and the archive
+// format live in internal/setup, which Go's `internal/` rule keeps unimportable
+// from outside this module — and reusing the sandbox image means there is no
+// second artifact to build, publish or keep in lockstep.
+//
+// It is NOT the daemon: no HTTP server, no lifecycle, no tenant. It runs as node
+// infrastructure precisely because a sandbox pod must never hold write access to
+// a store shared across nodes.
+func runGoldenUploader() {
+	opts := setup.UploaderOpts{
+		CacheRoot:  os.Getenv("DEPS_CACHE_ROOT"),
+		RemoteRoot: os.Getenv("GOLDEN_CACHE_REMOTE"),
+		Log:        func(m string) { slog.Info(m) },
+	}
+	if opts.CacheRoot == "" || opts.RemoteRoot == "" {
+		slog.Error("golden-uploader needs DEPS_CACHE_ROOT (node-local store) and " +
+			"GOLDEN_CACHE_REMOTE (shared store, writable here)")
+		os.Exit(2)
+	}
+	interval := 5 * time.Minute
+	if v := os.Getenv("GOLDEN_UPLOAD_INTERVAL_SECONDS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			interval = time.Duration(n) * time.Second
+		}
+	}
+	slog.Info("golden-uploader start", "cache_root", opts.CacheRoot,
+		"remote_root", opts.RemoteRoot, "interval", interval.String())
+
+	stop := make(chan struct{})
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		<-sig
+		// A sweep in flight keeps running: it writes to a final key and verifies
+		// before reporting, so being cut short leaves no readable half-object.
+		slog.Info("golden-uploader stopping")
+		close(stop)
+	}()
+	setup.RunUploader(opts, interval, stop)
+}
+
 func main() {
 	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, nil)))
+
+	// One binary, two roles. Subcommand rather than a separate image so the
+	// uploader cannot drift from the archive format the daemon reads.
+	if len(os.Args) > 1 && os.Args[1] == "golden-uploader" {
+		runGoldenUploader()
+		return
+	}
 
 	bootId := os.Getenv("DAEMON_BOOT_ID")
 	if bootId == "" {

--- a/packages/sandbox/daemon-protocol.ts
+++ b/packages/sandbox/daemon-protocol.ts
@@ -83,6 +83,18 @@ export interface TenantConfig {
   readonly cloneOnly?: boolean;
   readonly application?: Application;
   readonly env?: Readonly<Record<string, string>>;
+  /**
+   * Owning organization. Informational to the boot itself — the daemon uses it
+   * only to stamp provenance on artifacts that outlive the pod, so a consumer
+   * outside it can tell whose they are.
+   *
+   * Concretely: the shared golden cache keys archives by org, because the repo
+   * hash alone does not isolate two organizations that clone the same URL (a
+   * public template). Without this the daemon cannot record which org produced
+   * a cached dependency tree, and a shared cache would let one org's tree be
+   * restored into another's sandbox.
+   */
+  readonly orgId?: string;
 }
 
 /** A `/config` PATCH body. `null` env values delete the variable. */

--- a/packages/sandbox/server/provider/shared/build-config-payload.test.ts
+++ b/packages/sandbox/server/provider/shared/build-config-payload.test.ts
@@ -59,7 +59,13 @@ describe("buildConfigPayload", () => {
     const payload = buildConfigPayload({
       runtime: "node",
       packageManager: null,
-      repo: { cloneUrl: "https://github.com/acme/site.git" } as never,
+      // A tenant warm pool bootstraps with a repo and no author, which is also
+      // the only way to reach this function with no tenant at all.
+      repo: {
+        cloneUrl: "https://github.com/acme/site.git",
+        userName: "",
+        userEmail: "",
+      },
     });
 
     expect(payload).not.toHaveProperty("orgId");

--- a/packages/sandbox/server/provider/shared/build-config-payload.test.ts
+++ b/packages/sandbox/server/provider/shared/build-config-payload.test.ts
@@ -21,7 +21,7 @@ describe("buildConfigPayload", () => {
     });
   });
 
-  it("returns operator-only payload when repo and application are absent", () => {
+  it("returns identity and org only, when repo and application are absent", () => {
     const payload = buildConfigPayload({
       runtime: "node",
       packageManager: null,
@@ -35,7 +35,34 @@ describe("buildConfigPayload", () => {
 
     expect(payload).toEqual({
       operator: { userName: "Jane Doe" },
+      orgId: "org",
     });
+  });
+
+  it("forwards orgId, which the golden cache keys shared archives by", () => {
+    const payload = buildConfigPayload({
+      runtime: "node",
+      packageManager: null,
+      repo: null,
+      tenant: { orgId: "org_abc123", userId: "user" },
+    });
+
+    // Previously this case produced null: with no repo, no application and no
+    // co-author identity there was nothing worth sending. The org alone is now
+    // worth sending, because without it the daemon cannot stamp which org
+    // produced a cached dependency tree and a cross-node cache cannot isolate
+    // two orgs cloning the same public template.
+    expect(payload).toEqual({ orgId: "org_abc123" });
+  });
+
+  it("omits orgId when there is no tenant", () => {
+    const payload = buildConfigPayload({
+      runtime: "node",
+      packageManager: null,
+      repo: { cloneUrl: "https://github.com/acme/site.git" } as never,
+    });
+
+    expect(payload).not.toHaveProperty("orgId");
   });
 
   it("builds git.repository from a repo and derives repoName from the clone URL", () => {

--- a/packages/sandbox/server/provider/shared/build-config-payload.ts
+++ b/packages/sandbox/server/provider/shared/build-config-payload.ts
@@ -66,10 +66,20 @@ export function buildConfigPayload(args: {
       }
     : undefined;
 
-  if (!git && !application && !operator && !args.cloneOnly) return null;
+  const orgId = tenant?.orgId;
+
+  if (!git && !application && !operator && !args.cloneOnly && !orgId) {
+    return null;
+  }
   return {
     ...(git ? { git } : {}),
     ...(operator ? { operator } : {}),
+    // Provenance for artifacts that outlive the pod. The daemon does not use it
+    // to boot; it stamps it on the golden dependency cache so the shared tier
+    // can key by org. Repo hash alone does not isolate two orgs cloning the
+    // same public template, and a shared cache without this would let one org's
+    // tree restore into another's sandbox.
+    ...(orgId ? { orgId } : {}),
     // Always sent when true, never as an absent-means-false: a sandbox reused
     // from a warm pool carries the previous claim's config, so the flag has to
     // be able to turn itself back off on a normal (dev-server) provision.


### PR DESCRIPTION
**Stacked on #5824** — that PR adds the L2 *restore*; this one adds the *publish*. Base is its branch, so the diff here is only this change and GitHub will retarget to `main` when #5824 merges.

Neither is useful alone: #5824 restores from a store nothing fills, and this fills a store nothing reads. **Merge both or neither.**

## The gap this closes

A sandbox pod's L2 mount is read-only by design, so nothing a tenant boots can publish. The store is therefore permanently empty, and #5824's restore always misses. This is the missing half.

## Why a DaemonSet and not a sidecar

Writing a store shared across nodes needs write access, and a sandbox runs untrusted code — a package manager installs cached content as-is, so a tenant able to write it could poison another node's boot. The tenant's write path stops at its own node's hostPath, which is *already* the accepted trust domain there (`depsCache`'s own comment: *"Do NOT widen to a shared cache without making it read-only to tenant pods"*). This carries goldens the rest of the way.

| | sidecar | DaemonSet |
|---|---|---|
| sandbox PodSpec | +1 container in **every** pod | untouched |
| packing density (just tuned in terraform#91) | reduced | unaffected |
| can degrade the health probe | yes | no |
| writable mount lives | in the tenant's pod | once per node, in infrastructure |
| compression CPU | competes with the user's dev server | capped (50m/500m), nobody waits on it |

Asserted against the rendered output, not just intended: the SandboxTemplate never references the writable claim, and the DaemonSet mounts the hostPath `readOnly: true`.

## Keyed by org — this is what makes fleet-wide publishing acceptable

A repo hash is derived from the clone URL, so two orgs cloning the same public template land on **one key**. Node-locally that is a single trust domain; fleet-wide it would let one org's tree restore into another's sandbox.

The daemon is the only process holding both facts at once — the org from Studio's config push, and the golden it writes — so it records them together beside the tree. A golden **without** a readable org is skipped rather than uploaded under an unscoped key: an archive whose owner is unknown must not exist.

`orgId` already reached `buildConfigPayload` via `EnsureOptions.tenant`; it was simply never put on the wire. Getting the key right *now* matters because adding the org later would change every key and invalidate the whole store.

## What it uploads is not configurable, and cannot be

Sandboxes are multi-tenant and run third-party code, so the set of `(repo, lockfile)` pairs is not knowable ahead of time. There is no list to curate and no image to pre-bake — measured: 18 distinct repos in a 41-event sample over 30 days, long tail, no concentration to exploit. It forwards what a real boot produced and the daemon already judged healthy enough to publish node-locally, and nothing else.

## Cost

One PUT per `(org, repo, lockfile)` across the whole fleet — an existing key is a HEAD and a skip. At ~300 MB/archive and ~200 lockfiles that is single-digit dollars a month in S3, and $0 transfer via the VPC Gateway Endpoint. The real cost is compression CPU on the sandbox NodePool, which is why the limit is low and sweeps are sequential.

## Shape

Same binary as the daemon, via a `golden-uploader` subcommand — the archive format lives in `internal/setup`, which Go's `internal/` rule keeps unimportable from outside the module, and reusing the sandbox image means no second artifact to build or keep in lockstep. It is **not** the daemon: no HTTP server, no lifecycle, no tenant.

Chart `0.12.0`, `goldenUploader.enabled` default **off**.

## Testing

Real files, real `tar`/`zstd`, no mocks. 26 tests pass in `internal/setup`; `go build`, `go vet`, `gofmt` clean; `helm lint` clean; `bun run fmt` clean.

| test | why |
|---|---|
| uploads keyed by org | the archive lands under the org prefix, not a bare repo hash |
| skips without provenance | an archive with an unknown owner must not exist |
| steady-state sweep | recompresses nothing; mtime unchanged |
| restores on a cold root | the uploaded archive is actually readable by #5824's restore |
| two orgs, one repo | separate archives; neither overwrites the other |
| in-flight publish | a golden dir with no `node_modules` is skipped, so no partial tree ships |
| `.vite` excluded | pod-local churn does not travel |
| both no-op paths | missing cache root, missing remote root |

Inverted the `build-config-payload` test that asserted an operator-only payload, since the org is now sent too. Fixed `splitGoldenLockDir` to return empty strings alongside `ok=false` — a test caught it handing back a half-parsed key.

Chart render verified across: uploader off (nothing), on (DaemonSet + writable PV/PVC, distinct from the tenant's), dynamic path without `pvcName` (fails with the reason), dynamic path with it (renders, no PV).

**Not validated on a real pod.** Per the repo norm, "done" is a tailed pod showing an L2 hit; that needs both PRs deployed and `goldenUploader.enabled` on, which is a `deco-apps-cd` change after these land.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a node-level `golden-uploader` DaemonSet that moves dependency goldens from each node’s L1 cache to a shared L2 store. Keys are per‑org to prevent cross‑org restores; `orgId` now reaches the daemon and is written beside each golden. Helm chart bumped to 0.13.0 (uploader off by default).

- **New Features**
  - Node-scoped uploader (same image, `golden-uploader` subcommand) reads a read‑only hostPath and writes to a writable shared store; sequential sweeps with low CPU limits.
  - Shared archive paths: org → repo → `<pm>-<lock>.tar.zst`; existing archives are skipped; remote restore/publish require `orgId`.
  - Daemon writes `.golden-meta.json` (`orgId`/`cloneUrl`/`pm`); uploader skips goldens without a readable org.
  - Helm 0.13.0: DaemonSet plus a writable PV/PVC and validations; placement matches sandbox pods; default disabled.

- **Migration**
  - Enable with `goldenUploader.enabled: true` and ensure `depsCache.enabled` and `depsCache.remote.enabled` are true.
  - Provide a writable L2 view via `depsCache.remote.volume.attributes` (chart‑provisioned PV/PVC) or set `goldenUploader.pvcName` to an existing claim.
  - If using a dynamic `depsCache.remote.storageClassName`, you must set `goldenUploader.pvcName` (the StorageClass cannot express the read‑only/read‑write split).

<sup>Written for commit ce884146ddb60bdd018412190323a2378eebf839. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

