### PR TITLE
fix(task-board): make Auto Fix button primary in task modal

### DIFF
--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -762,7 +762,7 @@ export function TaskBoardItemDialog({
               </Button>
             )}
             {showAutoFix && (
-              <Button variant="outline" size="sm" onClick={onAutoFix}>
+              <Button size="sm" onClick={onAutoFix}>
                 <Lightning01 size={16} />
                 {t("taskBoard.taskBoard.autoFix")}
               </Button>


### PR DESCRIPTION
## What is this contribution about?
Changes the Auto Fix button in the task board item modal from `variant="outline"` to the default (primary) button style, since it's the primary action a reviewer takes on a failed task.

## How did you verify your code works?
Visual change only; verified by inspecting the `Button` component's default variant mapping to `"default"` (primary) in `packages/ui`.

## Screenshots/Demonstration
N/A (see attached reference screenshot in the original request).

## How to Test
1. Open a task board item that has failed (showing the Auto Fix action).
2. Open the task modal.
3. Expected outcome: the Auto Fix button renders with the primary button style instead of an outline style.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the Auto Fix button in the task modal to the primary style so the main action stands out on failed tasks. Replaces the outline variant with the default primary button.

<sup>Written for commit 2164e62037de6bfff0e984a7a148cf163f065124. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5844?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

