### PR TITLE
fix(sandbox): don't report `starting` for a dev server that never stopped

### DIFF
--- a/packages/sandbox/daemon-e2e/daemon.warmpool.e2e.test.ts
+++ b/packages/sandbox/daemon-e2e/daemon.warmpool.e2e.test.ts
@@ -15,7 +15,9 @@ import {
   bootstrapRepo,
   type Daemon,
   HOOK_TIMEOUT_MS,
+  freePort,
   postConfig,
+  readSseUntil,
   setupBareRepo,
   startDaemon,
   stopDaemon,
@@ -263,6 +265,84 @@ describe("daemon e2e: a second dev server is never spawned", () => {
       const afterClaim = await dev();
       expect(afterClaim.alreadyRunning).toBe(true);
       expect(afterClaim.taskId).toBe(warm.taskId);
+    },
+    SETUP_TIMEOUT_MS,
+  );
+});
+
+describe("daemon e2e: a claim onto a serving pod keeps reporting running", () => {
+  let d: Daemon;
+  let repo: BareRepo;
+  let devPort: number;
+  beforeEach(async () => {
+    devPort = await freePort();
+    // A dev script that actually serves, so the daemon reaches `running` —
+    // that is the state a warm pool pod is in when a claim arrives.
+    repo = setupBareRepo({
+      withPackageJson: true,
+      scripts: {
+        dev: `node -e "require('http').createServer((_q,s)=>{s.setHeader('content-type','text/html');s.end('<html>ok</html>')}).listen(process.env.PORT||3000)"`,
+      },
+    });
+    d = await startDaemon();
+  }, HOOK_TIMEOUT_MS);
+  afterEach(async () => {
+    await stopDaemon(d);
+    repo.cleanup();
+  }, HOOK_TIMEOUT_MS);
+
+  const lifecyclePhase = async (): Promise<string> => {
+    // /_sandbox/events replays the current lifecycle state as its first frame.
+    const { text } = await readSseUntil(url(d, "/_sandbox/events"), {
+      headers: authHeaders(),
+      predicate: (acc) => acc.includes("event: lifecycle"),
+    });
+    return (
+      (
+        JSON.parse(
+          /event: lifecycle\ndata: (.*)\n/.exec(text)?.[1] ?? "{}",
+        ) as { state?: { phase?: string } }
+      ).state?.phase ?? ""
+    );
+  };
+
+  /** Poll until the prober has confirmed the server (bounded). */
+  const waitForRunning = async (): Promise<void> => {
+    const deadline = Date.now() + 20_000;
+    while (Date.now() < deadline) {
+      if ((await lifecyclePhase()) === "running") return;
+    }
+    throw new Error("lifecycle never reached running");
+  };
+
+  it(
+    "reports running immediately, not starting, when the checkout spared the dev server",
+    async () => {
+      // `starting` is a lie when the process behind the port never stopped, and
+      // Studio holds a full-canvas booting overlay over a live preview until the
+      // prober re-confirms the server — 13-26s measured on a warm pool pod.
+      expect(
+        (
+          await bootstrapRepo(d, repo.url, {
+            application: { packageManager: { name: "npm" }, port: devPort },
+            env: { npm_config_offline: "true" },
+          })
+        ).status,
+      ).toBe(200);
+      await waitForOrchestratorIdle(d, SETUP_TIMEOUT_MS);
+      await waitForRunning();
+
+      const res = await postConfig(d, {
+        git: { repository: { cloneUrl: repo.url, branch: "thread-x" } },
+      });
+      expect(((await res.json()) as { transition: string }).transition).toBe(
+        "branch-change",
+      );
+      await waitForOrchestratorIdle(d, SETUP_TIMEOUT_MS);
+
+      // No sleep: the point is that this is true the moment the checkout ends,
+      // without waiting on the prober.
+      expect(await lifecyclePhase()).toBe("running");
     },
     SETUP_TIMEOUT_MS,
   );

--- a/packages/sandbox/daemon-go/internal/setup/orchestrator.go
+++ b/packages/sandbox/daemon-go/internal/setup/orchestrator.go
@@ -62,6 +62,9 @@ type Orchestrator struct {
 	// PublishPendingGolden() once the dev server is confirmed healthy. Nil when
 	// the boot restored an existing golden (nothing new to publish).
 	pendingGolden *GoldenParams
+	// The `running` state a checkout interrupted, restored by stepStartInner
+	// when the dev server turns out never to have stopped. Zero otherwise.
+	interruptedRunning events.LifecycleState
 }
 
 func NewOrchestrator(deps OrchestratorDeps) *Orchestrator {
@@ -329,6 +332,7 @@ func (o *Orchestrator) stepCloneInner() bool {
 	} else if cloneUrl != "" {
 		branch := cfg.Branch()
 		if branch != "" && !config.IsSyntheticBranch(branch) {
+			o.noteInterruptedRunning()
 			o.deps.Lifecycle.Transition(events.LifecycleState{Phase: events.PhaseCheckingOut, To: branch})
 			if err := o.checkoutBranch(branch); err != nil {
 				o.chunk(fmt.Sprintf("\r\n[orchestrator] checkout failed: %s\r\n", err.Error()))
@@ -505,7 +509,7 @@ func (o *Orchestrator) stepStartInner() startOutcome {
 		o.chunk(fmt.Sprintf("[orchestrator] dev already running (%s) — skipping restart\r\n", command.Source))
 		cur := o.deps.Lifecycle.Current().Phase
 		if cur != events.PhaseRunning && cur != events.PhaseStarting {
-			o.deps.Lifecycle.Transition(events.LifecycleState{Phase: events.PhaseStarting})
+			o.deps.Lifecycle.Transition(o.resumeAfterCheckout(cfg))
 		}
 		return startSkipped
 	}
@@ -589,6 +593,41 @@ func (o *Orchestrator) diagnoseNoStartCommand(cfg *config.Enriched) string {
 		return fmt.Sprintf("\r\n[orchestrator] skipping start: no scripts defined in %s/package.json — update the VM config if a dev server should run\r\n", cwd)
 	}
 	return fmt.Sprintf("\r\n[orchestrator] skipping start: no 'dev' or 'start' script found (available: %s) — update the VM config to set the correct start script\r\n", strings.Join(scripts, ", "))
+}
+
+// noteInterruptedRunning remembers a serving state about to be interrupted by a
+// checkout, so resumeAfterCheckout can put it back.
+func (o *Orchestrator) noteInterruptedRunning() {
+	prev := o.deps.Lifecycle.Current()
+	if prev.Phase != events.PhaseRunning {
+		return
+	}
+	o.mu.Lock()
+	o.interruptedRunning = prev
+	o.mu.Unlock()
+}
+
+// resumeAfterCheckout is the state to report once a checkout finishes without
+// restarting the dev server. `starting` would be a lie: the process behind that
+// port never stopped, and it costs a user the whole probe re-confirmation —
+// 13–26s measured on a warm tenant-pool pod, during which Studio holds the
+// booting overlay over a preview that is already answering requests. Falls back
+// to `starting` when there is nothing to resume or the port moved under it (the
+// saved port would then name something that is no longer there).
+func (o *Orchestrator) resumeAfterCheckout(cfg *config.Enriched) events.LifecycleState {
+	o.mu.Lock()
+	prev := o.interruptedRunning
+	o.interruptedRunning = events.LifecycleState{}
+	o.mu.Unlock()
+
+	starting := events.LifecycleState{Phase: events.PhaseStarting}
+	if prev.Phase != events.PhaseRunning || prev.Port == 0 {
+		return starting
+	}
+	if port, ok := cfg.Port(); ok && port != prev.Port {
+		return starting
+	}
+	return prev
 }
 
 func (o *Orchestrator) stopDevTask() {


### PR DESCRIPTION
## Why the preview still isn't instant

#5840 stopped the claim from restarting the dev server. But the daemon still
reports the pod as *booting* afterwards, and Studio's preview believes it.

Prod, five tenant-pool pods, all warm-claimed after that fix shipped:

```
11:25:12  claim → running → checking-out              overlay appears
11:25:14  "dev already running (dev) — skipping restart" → starting
11:25:38  [probe] 200 → running                       overlay clears
```

gap between checkout done and `running`: **24s, 19s, 13s, 26s, 26s**

Two things compound:

1. `stepStartInner`'s skip branch reports `starting` — about a process that
   never stopped.
2. Leaving `running` resets the prober (`lifecycle.OnTransition` in `main.go`),
   so getting back to `running` costs a full re-confirmation. The dev server is
   answering the whole time.

And `resolvePreviewDisplay` gates the sandbox iframe on `progressStatus !==
"doing"`, so the canvas holds the booting skeleton for that entire window —
directly above a terminal streaming the running app's logs. That's the
screenshot users keep sending.

## The change

`checking-out` stays as-is (the tree really is mid-write — `IsWorkingTreeReadyPhase`
excludes it deliberately). What changes is where it lands: the orchestrator
remembers the `running` state the checkout interrupted, and the start step
restores it instead of announcing `starting` when it finds its own command
already running.

Falls back to `starting` when there is nothing to resume, or when the
configured port moved under it (the saved port would name something that is no
longer there).

Known edge: if the process is alive but has *stopped serving*, the phase now
reads `running` until the prober notices. The user gets the daemon's own
auto-reloading status page in the iframe instead of a spinner — and a dead
process is caught separately by `OnTaskExit` → `start-failed`.

## Testing

`daemon-e2e`, new case: a repo whose `dev` script actually serves, so the
daemon reaches `running`; after a same-commit branch change the lifecycle reads
`running` immediately, with no wait on the prober. Fails on `main` (reads
`starting`). Suite green (the `ws-proxy` failure under the parallel run is the
same daemon-spawn flake as #5840 — passes in isolation on both branches; the
one `error` is this worktree missing `@decocms/shared/std`, not the daemon).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop reporting `starting` when a warm-claim doesn’t restart the dev server. We now restore `running` right after checkout so the preview appears instantly (removes a 13–26s wait).

- **Bug Fixes**
  - Orchestrator now remembers a `running` state before branch checkout and restores it in `stepStartInner` when the dev command is still running (`packages/sandbox/daemon-go/internal/setup/orchestrator.go`).
  - Falls back to `starting` if there’s nothing to resume or if the configured port changed. `checking-out` remains unchanged during writes.
  - Added an e2e test that verifies the lifecycle reads `running` immediately after a same-commit branch change (`packages/sandbox/daemon-e2e/daemon.warmpool.e2e.test.ts`).

<sup>Written for commit 7a39ddbf3d73f3e2c4960dad0719b677833ed018. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

