### PR TITLE
fix(sandbox): name the generic warm pool on the claim, don't say "default"

### DIFF
--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -1282,7 +1282,11 @@ export class AgentSandboxProvider implements SandboxProvider {
           ...(hasAnnotations ? { annotations } : {}),
         },
         env: envEntries,
-        warmpool: claimWarmPoolName(tenantPool, warmPoolMode),
+        warmpool: claimWarmPoolName(
+          tenantPool,
+          warmPoolMode,
+          this.sandboxTemplateName,
+        ),
         lifecycle: {
           shutdownPolicy: "Delete",
           shutdownTime: this.computeShutdownTime(),

--- a/packages/sandbox/server/provider/agent-sandbox/tenant-pools.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/tenant-pools.test.ts
@@ -143,15 +143,22 @@ describe("resolveTenantPool", () => {
 // pool belonging to nobody it should reach.
 describe("claimWarmPoolName", () => {
   it("a resolved pool binds that pool", () => {
-    expect(claimWarmPoolName(POOLS[0] ?? null, true)).toBe("tenant-acme-site");
+    expect(claimWarmPoolName(POOLS[0] ?? null, true, "studio-sandbox")).toBe(
+      "tenant-acme-site",
+    );
   });
 
-  it("no pool in warm-pool mode falls back to the generic pool", () => {
-    expect(claimWarmPoolName(null, true)).toBe("default");
+  // Never the literal "default": that matches no SandboxWarmPool, and the
+  // operator's fallback then binds any warm pod of the template — including
+  // another org's tenant pool, whose repo is already cloned (409 cloneUrl).
+  it("no pool in warm-pool mode names the generic pool explicitly", () => {
+    expect(claimWarmPoolName(null, true, "studio-sandbox")).toBe(
+      "studio-sandbox",
+    );
   });
 
   it("no sentinel → `none`, so the operator still accepts per-claim env", () => {
-    expect(claimWarmPoolName(null, false)).toBe("none");
+    expect(claimWarmPoolName(null, false, "studio-sandbox")).toBe("none");
   });
 });
 

--- a/packages/sandbox/server/provider/agent-sandbox/tenant-pools.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/tenant-pools.ts
@@ -114,15 +114,26 @@ export function resolveTenantPool(
 
 /**
  * The claim's `spec.warmpool`. A resolved tenant pool binds one of that org's
- * already-running pods; otherwise this is exactly today's behavior — the
- * generic (empty) pool in warm-pool mode, `"none"` without a sentinel, because
- * the operator rejects per-claim env outside `"none"`.
+ * already-running pods; otherwise the generic pool, named explicitly, or
+ * `"none"` without a sentinel because the operator rejects per-claim env
+ * outside `"none"`.
+ *
+ * `genericPoolName` must be the SandboxWarmPool object's real name — the
+ * sandbox-env chart names it after the SandboxTemplate. It used to be the
+ * literal `"default"`, which matches no pool: the operator then falls back to
+ * *any* warm pod rendered from the same template. Harmless while one pool
+ * existed; once tenant pools shipped it handed one org's prewarmed pods (repo
+ * already cloned) to another org's claim, and the daemon rejected the
+ * mismatched workload with `409 immutable: cloneUrl`. Observed in prod
+ * 2026-08-07: claims for montecarlo and `ephemeral-*` dispatches bound
+ * `tenant-electrolux-prod-*` pods.
  */
 export function claimWarmPoolName(
   pool: TenantPool | null,
   warmPoolMode: boolean,
+  genericPoolName: string,
 ): string {
-  return pool?.name ?? (warmPoolMode ? "default" : "none");
+  return pool?.name ?? (warmPoolMode ? genericPoolName : "none");
 }
 
 /**


### PR DESCRIPTION
Every new non-tenant sandbox has been failing to start with:

```
sandbox daemon /_sandbox/config returned 409: {"error":"immutable: cloneUrl"}
```

## Cause

A claim that resolves no tenant pool sets `spec.warmpool: "default"`. **No SandboxWarmPool is named that** — the sandbox-env chart names the generic pool after the SandboxTemplate (`studio-sandbox-prod`). The operator falls back to binding *any* warm pod rendered from the same template, which since #5830 includes the tenant pools.

So a montecarlo claim binds a `tenant-electrolux-prod-*` pod that is already prewarmed with electrolux's repo. Studio posts its own workload, the daemon sees a different `cloneUrl` on a config it already holds, and returns 409. Tenant claims are fine: they name their pool and the repo matches by construction.

Confirmed in prod (2026-08-07) from the operator's own bind log — claims bound to pods from both pools over their lifetime:

```
stephanie-moraes-35ew1is-…  studio-sandbox-prod-25scz  tenant-electrolux-prod-dp4ts  tenant-electrolux-prod-kn2pm …
ephemeral-9e94d92d505ae6c5  studio-sandbox-prod-ck427  tenant-electrolux-prod-qcwst
gabriel-6687tism-…          studio-sandbox-prod-thkjr  tenant-electrolux-prod-snt8l
```

This is also a tenant-isolation leak, not only an availability bug: another org's pod (with its repo checked out) was handed to an unrelated claim. The 409 is what stopped it from being used.

## Fix

Pass the real generic pool name — `this.sandboxTemplateName`, the same value the chart derives the pool name from — instead of the literal `"default"`.

## Testing

- `bun test packages/sandbox/server/provider/agent-sandbox/tenant-pools.test.ts` — 20 pass; the "falls back to `default`" case is inverted to assert the explicit name.
- Not verified end-to-end in a cluster; the claim's `spec.warmpool` should read `studio-sandbox-prod` after deploy, and generic claims should stop binding `tenant-*` pods.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes non-tenant sandbox startups by naming the real generic warm pool on claims instead of "default," preventing accidental binding to tenant pods and 409 cloneUrl errors. Restores availability and preserves tenant isolation.

- **Bug Fixes**
  - `claimWarmPoolName` now accepts `genericPoolName` and returns it in warm-pool mode when no tenant pool; `runner.ts` passes `this.sandboxTemplateName`.
  - Updated tests to assert explicit generic pool naming and preserve `"none"` when warm-pool mode is off.

<sup>Written for commit 83d98964af8ebe46acaa9a88afcb31b2745523d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

