### PR TITLE
fix(web): mobile Chat taps no longer land on the preview

### DIFF
--- a/apps/web/src/hooks/use-layout-state.test.ts
+++ b/apps/web/src/hooks/use-layout-state.test.ts
@@ -4,6 +4,7 @@ import {
   computeWorkspacePanelSizes,
   mobileSurfaceSearch,
   resolveDefaultPanelState,
+  resolveMobileSurface,
   resolveWorkspacePanelAction,
 } from "./use-layout-state";
 
@@ -233,5 +234,40 @@ describe("mobileSurfaceSearch", () => {
       sidepanel: 0,
       main: "preview",
     });
+  });
+});
+
+describe("resolveMobileSurface", () => {
+  test("an explicit ?sidepanel=chat wins over an open main panel", () => {
+    expect(
+      resolveMobileSurface({
+        visibility: { sidePanel: "chat", mainOpen: true },
+        sidePanelParamPresent: true,
+      }),
+    ).toBe("chat");
+  });
+
+  test("the default main view still wins when ?sidepanel is absent", () => {
+    expect(
+      resolveMobileSurface({
+        visibility: { sidePanel: "chat", mainOpen: true },
+        sidePanelParamPresent: false,
+      }),
+    ).toBe("main");
+  });
+
+  test("falls back to main / chat when only one panel is open", () => {
+    expect(
+      resolveMobileSurface({
+        visibility: { sidePanel: null, mainOpen: true },
+        sidePanelParamPresent: true,
+      }),
+    ).toBe("main");
+    expect(
+      resolveMobileSurface({
+        visibility: { sidePanel: "chat", mainOpen: false },
+        sidePanelParamPresent: false,
+      }),
+    ).toBe("chat");
   });
 });

--- a/apps/web/src/hooks/use-layout-state.ts
+++ b/apps/web/src/hooks/use-layout-state.ts
@@ -40,6 +40,8 @@ export interface WorkspaceLayoutState {
   mainOpen: boolean;
   /** Current ?main value (undefined when param absent). "0" = closed. */
   mainParam: string | undefined;
+  /** Whether ?sidepanel was in the URL (vs. the agent-configured default). */
+  sidePanelParamPresent: boolean;
 }
 
 export interface WorkspaceLayoutActions {
@@ -157,6 +159,26 @@ export function computeWorkspacePanelSizes(
 }
 
 export type MobileWorkspaceSurface = SidePanelKind | "main";
+
+/**
+ * Mobile shows ONE surface at a time, so `?sidepanel` and `?main` can't both
+ * win. An explicit `?sidepanel=chat` does: it only ever gets written by an
+ * intentional "open the chat" action (openSidePanel, the mobile view select),
+ * and before this it was a silent no-op whenever the main panel happened to be
+ * open — tapping Chat left you on ?main=preview, booting a sandbox.
+ * With no `?sidepanel` in the URL the panel state is the agent-configured
+ * default, and there the main view keeps precedence.
+ */
+export function resolveMobileSurface(ctx: {
+  visibility: WorkspaceVisibility;
+  sidePanelParamPresent: boolean;
+}): MobileWorkspaceSurface {
+  const { sidePanel, mainOpen } = ctx.visibility;
+  if (sidePanel !== null && (ctx.sidePanelParamPresent || !mainOpen)) {
+    return sidePanel;
+  }
+  return mainOpen ? "main" : "chat";
+}
 
 export function mobileSurfaceSearch(
   surface: MobileWorkspaceSurface,
@@ -314,6 +336,7 @@ export function useWorkspaceLayoutState(
     sidePanel,
     mainOpen,
     mainParam,
+    sidePanelParamPresent: search.sidepanel !== undefined,
     setTaskId,
     toggleMain,
     toggleSidePanel,

--- a/apps/web/src/layouts/agent-shell-layout/index.tsx
+++ b/apps/web/src/layouts/agent-shell-layout/index.tsx
@@ -51,7 +51,10 @@ import { useStatusSounds } from "../../hooks/use-status-sounds";
 import { authClient } from "@/lib/auth-client";
 import { Button } from "@deco/ui/components/button.tsx";
 import { EmptyState } from "@/components/empty-state";
-import { useWorkspaceLayoutState } from "@/hooks/use-layout-state";
+import {
+  resolveMobileSurface,
+  useWorkspaceLayoutState,
+} from "@/hooks/use-layout-state";
 import { useRefreshViewedThreadMetadata } from "@/hooks/use-refresh-viewed-thread-metadata";
 import { getActiveGithubRepo } from "@/lib/github-repo";
 import { useT } from "@/i18n/use-t.ts";
@@ -386,7 +389,10 @@ function MobileTaskWorkspace({
   onNewTaskRef: React.MutableRefObject<(() => void) | null>;
 }) {
   const t = useT();
-  const mobileSurface = layout.mainOpen ? "main" : (layout.sidePanel ?? "chat");
+  const mobileSurface = resolveMobileSurface({
+    visibility: { sidePanel: layout.sidePanel, mainOpen: layout.mainOpen },
+    sidePanelParamPresent: layout.sidePanelParamPresent,
+  });
 
   return (
     <>


### PR DESCRIPTION
## Summary

On mobile the workspace renders a single surface, chosen by `mainOpen ? "main" : sidePanel` — the main panel won unconditionally. Every in-app "open the chat" affordance (`openSidePanel("chat")` from tool-call cards, the file explorer, the visual-editor prompt, the GitHub header actions) only writes `?sidepanel=chat` and leaves `?main` alone, so on mobile it was a **silent no-op**: the URL said chat was open, the screen kept showing `?main=preview` — which boots a sandbox ("Installing packages…").

Reported state matches exactly: `?main=preview&sidepanel=chat` while staring at the preview.

Fix: extract `resolveMobileSurface` — an explicit `?sidepanel` wins over an open main panel; when the param is absent (agent-configured default) the default main view keeps precedence, so first-load defaults are unchanged.

## Testing

`bun test apps/web/src/hooks/use-layout-state.test.ts` — 23 pass, including three new cases for the precedence rule. Not reproduced on a device; the change is a pure function plus its one call site.

## Not covered

The mobile view dropdown's own Chat entry already wrote `main: 0` and worked; only the programmatic openers were broken.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes mobile chat navigation so taps and open-chat actions actually show Chat instead of staying on the Preview. On mobile, an explicit `?sidepanel` now takes precedence over an open main panel; defaults remain unchanged when `?sidepanel` is absent.

- **Bug Fixes**
  - Added `resolveMobileSurface` to pick the single mobile surface: explicit `?sidepanel` wins; otherwise fall back to main or chat.
  - Switched mobile workspace to use the resolver instead of `mainOpen ? "main" : sidePanel`.
  - Added tests for the new precedence logic (3 new cases; all tests pass).

<sup>Written for commit 7737d981bb56a7ac5830f4a04d41b59c775df10a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

