### PR TITLE
feat(sandbox): resizable preview terminal + "show by default" preference

### DIFF
--- a/apps/web/src/components/sandbox/preview/drawer/drawer.tsx
+++ b/apps/web/src/components/sandbox/preview/drawer/drawer.tsx
@@ -6,6 +6,7 @@ import { useT } from "@/i18n/use-t.ts";
 import { useSandboxEvents } from "../../hooks/use-sandbox-events";
 import { DEFAULT_TAB, DrawerToolbar, type DrawerStatus } from "./toolbar";
 import { SandboxTerminal } from "./terminal";
+import { clampDrawerHeight, DRAWER_TOP_RESERVE } from "./resize";
 
 export interface PreviewDrawerProps {
   vmId: string | null;
@@ -16,6 +17,9 @@ export interface PreviewDrawerProps {
   scripts: string[];
   open: boolean;
   onOpenChange: (next: boolean) => void;
+  /** Persisted open-drawer height in px; `null` falls back to 50% of the pane. */
+  height: number | null;
+  onHeightChange: (height: number) => void;
   onStart: () => void;
   onStop: () => void;
   onRestart: () => void;
@@ -165,11 +169,61 @@ export function PreviewDrawer(props: PreviewDrawerProps) {
     isScriptTab && vmEvents.activeProcesses.includes(active);
   const scriptIsKilling = isScriptTab && killingScripts.has(active);
 
+  // Drag-to-resize the open drawer. The height is applied imperatively to the
+  // drawer element during the drag (no per-frame React render, so the xterm
+  // refit stays smooth) and committed to persisted state on pointer-up.
+  const drawerRef = useRef<HTMLDivElement>(null);
+  const handleResizeStart = (e: React.PointerEvent) => {
+    if (!props.open) return;
+    const el = drawerRef.current;
+    const pane = el?.parentElement;
+    if (!el || !pane) return;
+    e.preventDefault();
+    const startY = e.clientY;
+    const startHeight = el.getBoundingClientRect().height;
+    const paneHeight = pane.getBoundingClientRect().height;
+    let nextHeight = startHeight;
+    const onMove = (ev: PointerEvent) => {
+      // Dragging up (smaller clientY) grows the drawer; clamp so it stays
+      // usable and never swallows the tab body above it.
+      nextHeight = clampDrawerHeight(
+        startHeight + (startY - ev.clientY),
+        paneHeight,
+      );
+      el.style.height = `${nextHeight}px`;
+    };
+    const onUp = () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      document.body.style.userSelect = "";
+      document.body.style.cursor = "";
+      props.onHeightChange(nextHeight);
+    };
+    document.body.style.userSelect = "none";
+    document.body.style.cursor = "row-resize";
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+  };
+
   return (
     <div
+      ref={drawerRef}
       className="flex shrink-0 flex-col"
-      style={{ height: props.open ? "50%" : "auto" }}
+      style={{
+        height: props.open ? (props.height ?? "50%") : "auto",
+        // Cap relative to the pane so a persisted px height from a taller
+        // window can never swallow the tab body above when the window shrinks.
+        maxHeight: props.open
+          ? `calc(100% - ${DRAWER_TOP_RESERVE}px)`
+          : undefined,
+      }}
     >
+      {props.open && (
+        <ResizeHandle
+          onPointerDown={handleResizeStart}
+          label={t("sandbox.preview.resizeTerminal")}
+        />
+      )}
       <DrawerToolbar
         status={props.status}
         open={props.open}
@@ -251,6 +305,32 @@ function DrawerBody({
       >
         <Play className="size-3.5" /> {t("sandbox.drawer.run")}
       </button>
+    </div>
+  );
+}
+
+/**
+ * Drag strip along the drawer's top edge. Sits flush over the toolbar's top
+ * border (`-mb-px`) so the divider becomes the resize affordance: at rest it's
+ * the toolbar border; on hover the line highlights and the cursor turns into
+ * `row-resize`. The actual resize math lives in `PreviewDrawer.handleResizeStart`.
+ */
+function ResizeHandle({
+  onPointerDown,
+  label,
+}: {
+  onPointerDown: (e: React.PointerEvent) => void;
+  label: string;
+}) {
+  return (
+    <div
+      role="separator"
+      aria-orientation="horizontal"
+      aria-label={label}
+      onPointerDown={onPointerDown}
+      className="group relative -mb-px h-1.5 shrink-0 cursor-row-resize"
+    >
+      <div className="absolute inset-x-0 bottom-0 h-px bg-transparent transition-colors group-hover:bg-primary" />
     </div>
   );
 }

--- a/apps/web/src/components/sandbox/preview/drawer/drawer.tsx
+++ b/apps/web/src/components/sandbox/preview/drawer/drawer.tsx
@@ -6,7 +6,11 @@ import { useT } from "@/i18n/use-t.ts";
 import { useSandboxEvents } from "../../hooks/use-sandbox-events";
 import { DEFAULT_TAB, DrawerToolbar, type DrawerStatus } from "./toolbar";
 import { SandboxTerminal } from "./terminal";
-import { clampDrawerHeight, DRAWER_TOP_RESERVE } from "./resize";
+import {
+  clampDrawerHeight,
+  DRAWER_MIN_HEIGHT,
+  DRAWER_TOP_RESERVE,
+} from "./resize";
 
 export interface PreviewDrawerProps {
   vmId: string | null;
@@ -171,19 +175,30 @@ export function PreviewDrawer(props: PreviewDrawerProps) {
 
   // Drag-to-resize the open drawer. The height is applied imperatively to the
   // drawer element during the drag (no per-frame React render, so the xterm
-  // refit stays smooth) and committed to persisted state on pointer-up.
+  // refit stays smooth) and committed to persisted state on pointer-up. We
+  // don't reuse `react-resizable-panels` (ResizablePanelGroup in preview.tsx)
+  // here: that governs a horizontal split *inside* the tab body, whereas this
+  // drawer is a sibling below it whose "closed" state is a fixed-height,
+  // always-interactive toolbar — and the lib's controlled re-render per drag
+  // frame would fight the imperative height write above. Pointer capture binds
+  // the whole gesture to the handle, so pointerup/pointercancel are delivered
+  // even when the cursor leaves the window (no sticky drag / stuck body cursor).
   const drawerRef = useRef<HTMLDivElement>(null);
-  const handleResizeStart = (e: React.PointerEvent) => {
+  const handleResizeStart = (e: React.PointerEvent<HTMLDivElement>) => {
     if (!props.open) return;
     const el = drawerRef.current;
     const pane = el?.parentElement;
     if (!el || !pane) return;
     e.preventDefault();
+    const handle = e.currentTarget;
+    const { pointerId } = e;
+    handle.setPointerCapture(pointerId);
     const startY = e.clientY;
     const startHeight = el.getBoundingClientRect().height;
     const paneHeight = pane.getBoundingClientRect().height;
     let nextHeight = startHeight;
     const onMove = (ev: PointerEvent) => {
+      if (ev.pointerId !== pointerId) return;
       // Dragging up (smaller clientY) grows the drawer; clamp so it stays
       // usable and never swallows the tab body above it.
       nextHeight = clampDrawerHeight(
@@ -192,17 +207,20 @@ export function PreviewDrawer(props: PreviewDrawerProps) {
       );
       el.style.height = `${nextHeight}px`;
     };
-    const onUp = () => {
-      window.removeEventListener("pointermove", onMove);
-      window.removeEventListener("pointerup", onUp);
+    const finish = (ev: PointerEvent) => {
+      if (ev.pointerId !== pointerId) return;
+      handle.removeEventListener("pointermove", onMove);
+      handle.removeEventListener("pointerup", finish);
+      handle.removeEventListener("pointercancel", finish);
       document.body.style.userSelect = "";
       document.body.style.cursor = "";
       props.onHeightChange(nextHeight);
     };
     document.body.style.userSelect = "none";
     document.body.style.cursor = "row-resize";
-    window.addEventListener("pointermove", onMove);
-    window.addEventListener("pointerup", onUp);
+    handle.addEventListener("pointermove", onMove);
+    handle.addEventListener("pointerup", finish);
+    handle.addEventListener("pointercancel", finish);
   };
 
   return (
@@ -213,8 +231,10 @@ export function PreviewDrawer(props: PreviewDrawerProps) {
         height: props.open ? (props.height ?? "50%") : "auto",
         // Cap relative to the pane so a persisted px height from a taller
         // window can never swallow the tab body above when the window shrinks.
+        // `max(MIN, …)` keeps the same floor as `clampDrawerHeight` so a pane
+        // shorter than the reserve can't collapse the drawer past the min.
         maxHeight: props.open
-          ? `calc(100% - ${DRAWER_TOP_RESERVE}px)`
+          ? `max(${DRAWER_MIN_HEIGHT}px, calc(100% - ${DRAWER_TOP_RESERVE}px))`
           : undefined,
       }}
     >
@@ -314,12 +334,16 @@ function DrawerBody({
  * border (`-mb-px`) so the divider becomes the resize affordance: at rest it's
  * the toolbar border; on hover the line highlights and the cursor turns into
  * `row-resize`. The actual resize math lives in `PreviewDrawer.handleResizeStart`.
+ *
+ * Pointer-only by design: keyboard resize (a focusable splitter with
+ * arrow-key + `aria-valuenow`) is intentionally out of scope; the collapse
+ * chevron in the toolbar remains the keyboard path to change the drawer size.
  */
 function ResizeHandle({
   onPointerDown,
   label,
 }: {
-  onPointerDown: (e: React.PointerEvent) => void;
+  onPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
   label: string;
 }) {
   return (

--- a/apps/web/src/components/sandbox/preview/drawer/resize.test.ts
+++ b/apps/web/src/components/sandbox/preview/drawer/resize.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import {
+  clampDrawerHeight,
+  DRAWER_MIN_HEIGHT,
+  DRAWER_TOP_RESERVE,
+} from "./resize";
+
+describe("clampDrawerHeight", () => {
+  const PANE = 800;
+  const MAX = PANE - DRAWER_TOP_RESERVE; // 640
+
+  it("passes a value already inside the range through unchanged", () => {
+    expect(clampDrawerHeight(400, PANE)).toBe(400);
+  });
+
+  it("clamps up to the minimum", () => {
+    expect(clampDrawerHeight(10, PANE)).toBe(DRAWER_MIN_HEIGHT);
+    expect(clampDrawerHeight(-50, PANE)).toBe(DRAWER_MIN_HEIGHT);
+  });
+
+  it("clamps down to pane minus the top reserve", () => {
+    expect(clampDrawerHeight(5000, PANE)).toBe(MAX);
+    expect(clampDrawerHeight(MAX + 1, PANE)).toBe(MAX);
+  });
+
+  it("keeps the boundary values", () => {
+    expect(clampDrawerHeight(DRAWER_MIN_HEIGHT, PANE)).toBe(DRAWER_MIN_HEIGHT);
+    expect(clampDrawerHeight(MAX, PANE)).toBe(MAX);
+  });
+
+  it("never inverts the range on a pane too short for the reserve", () => {
+    // paneHeight - reserve would be below the min → collapse to the min, and
+    // any proposed height resolves to exactly the min (never a negative cap).
+    expect(clampDrawerHeight(500, 100)).toBe(DRAWER_MIN_HEIGHT);
+    expect(clampDrawerHeight(10, 100)).toBe(DRAWER_MIN_HEIGHT);
+  });
+
+  it("honors a custom reserve", () => {
+    expect(clampDrawerHeight(5000, 800, 300)).toBe(500);
+  });
+});

--- a/apps/web/src/components/sandbox/preview/drawer/resize.ts
+++ b/apps/web/src/components/sandbox/preview/drawer/resize.ts
@@ -1,0 +1,23 @@
+/** Smallest usable open-drawer height, in px. */
+export const DRAWER_MIN_HEIGHT = 120;
+
+/**
+ * Space (px) reserved for the tab body (iframe/toolbar) above the drawer, so a
+ * drag can never grow the drawer tall enough to swallow the pane. Kept in sync
+ * with the `calc(100% - …)` max-height cap on the drawer element.
+ */
+export const DRAWER_TOP_RESERVE = 160;
+
+/**
+ * Clamp a proposed drawer height to `[DRAWER_MIN_HEIGHT, paneHeight - reserve]`.
+ * The upper bound never drops below the lower one (tiny panes collapse to the
+ * min rather than inverting the range).
+ */
+export function clampDrawerHeight(
+  proposed: number,
+  paneHeight: number,
+  reserve = DRAWER_TOP_RESERVE,
+): number {
+  const max = Math.max(DRAWER_MIN_HEIGHT, paneHeight - reserve);
+  return Math.min(Math.max(proposed, DRAWER_MIN_HEIGHT), max);
+}

--- a/apps/web/src/hooks/use-preferences.ts
+++ b/apps/web/src/hooks/use-preferences.ts
@@ -11,6 +11,12 @@ interface Preferences {
   enableSounds: boolean;
   theme: ThemeMode;
   language: Locale;
+  /**
+   * Default visibility of the sandbox preview terminal on surfaces that have
+   * one. `false` keeps the historical opt-in behavior; `true` shows it by
+   * default. A per-VM Show/Hide choice still overrides this default.
+   */
+  terminalVisibleByDefault: boolean;
 }
 
 const DEFAULT_PREFERENCES: Preferences = {
@@ -19,6 +25,7 @@ const DEFAULT_PREFERENCES: Preferences = {
   enableSounds: false,
   theme: "system",
   language: detectLocale(),
+  terminalVisibleByDefault: false,
 };
 
 const VALID_TOOL_APPROVAL_LEVELS: ToolApprovalLevel[] = ["auto", "readonly"];

--- a/apps/web/src/i18n/en/sandbox.ts
+++ b/apps/web/src/i18n/en/sandbox.ts
@@ -386,6 +386,7 @@ export const sandbox = {
   "sandbox.preview.editContent": "Edit content",
   "sandbox.preview.exitEditor": "Exit editor",
   "sandbox.preview.expandTerminal": "Expand terminal",
+  "sandbox.preview.resizeTerminal": "Resize terminal",
   "sandbox.preview.hideTerminal": "Hide terminal",
   "sandbox.preview.showTerminal": "Show terminal",
   "sandbox.preview.copyCurrentUrl": "Copy Current URL",

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -43,6 +43,9 @@ export const settings = {
   "settings.preferences.soundsDescription":
     "Play sounds for agent actions and notifications.",
   "settings.preferences.soundsPreview": "Preview notification sound",
+  "settings.preferences.terminalVisible": "Show terminal by default",
+  "settings.preferences.terminalVisibleDescription":
+    "Open the preview terminal automatically instead of hiding it until you show it.",
   "settings.preferences.toolApproval": "Tool Approval",
   "settings.preferences.toolApprovalDescription":
     "Control how tools are approved before execution.",

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -43,7 +43,7 @@ export const settings = {
   "settings.preferences.soundsDescription":
     "Play sounds for agent actions and notifications.",
   "settings.preferences.soundsPreview": "Preview notification sound",
-  "settings.preferences.terminalVisible": "Show terminal by default",
+  "settings.preferences.terminalVisible": "Show preview terminal by default",
   "settings.preferences.terminalVisibleDescription":
     "Open the preview terminal automatically instead of hiding it until you show it.",
   "settings.preferences.toolApproval": "Tool Approval",

--- a/apps/web/src/i18n/pt-br/sandbox.ts
+++ b/apps/web/src/i18n/pt-br/sandbox.ts
@@ -401,6 +401,7 @@ export const sandbox = {
   "sandbox.preview.editContent": "Editar conteúdo",
   "sandbox.preview.exitEditor": "Sair do editor",
   "sandbox.preview.expandTerminal": "Expandir terminal",
+  "sandbox.preview.resizeTerminal": "Redimensionar terminal",
   "sandbox.preview.hideTerminal": "Ocultar terminal",
   "sandbox.preview.showTerminal": "Mostrar terminal",
   "sandbox.preview.copyCurrentUrl": "Copiar URL atual",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -45,6 +45,9 @@ export const settings = {
   "settings.preferences.soundsDescription":
     "Reproduza sons para ações de agentes e notificações.",
   "settings.preferences.soundsPreview": "Ouvir som de notificação",
+  "settings.preferences.terminalVisible": "Mostrar terminal por padrão",
+  "settings.preferences.terminalVisibleDescription":
+    "Abrir o terminal do preview automaticamente em vez de mantê-lo oculto até você exibi-lo.",
   "settings.preferences.toolApproval": "Aprovação de ferramentas",
   "settings.preferences.toolApprovalDescription":
     "Controle como as ferramentas são aprovadas antes da execução.",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -45,7 +45,8 @@ export const settings = {
   "settings.preferences.soundsDescription":
     "Reproduza sons para ações de agentes e notificações.",
   "settings.preferences.soundsPreview": "Ouvir som de notificação",
-  "settings.preferences.terminalVisible": "Mostrar terminal por padrão",
+  "settings.preferences.terminalVisible":
+    "Mostrar terminal do preview por padrão",
   "settings.preferences.terminalVisibleDescription":
     "Abrir o terminal do preview automaticamente em vez de mantê-lo oculto até você exibi-lo.",
   "settings.preferences.toolApproval": "Aprovação de ferramentas",

--- a/apps/web/src/layouts/main-panel-tabs/drawer-storage.test.ts
+++ b/apps/web/src/layouts/main-panel-tabs/drawer-storage.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "bun:test";
+import { parseDrawerState, parseTerminalOverride } from "./drawer-storage";
+
+describe("parseDrawerState", () => {
+  it("defaults to closed with no height for a missing value", () => {
+    expect(parseDrawerState(null)).toEqual({ open: false, height: null });
+  });
+
+  it("reads open + height", () => {
+    expect(
+      parseDrawerState(JSON.stringify({ open: true, height: 300 })),
+    ).toEqual({ open: true, height: 300 });
+  });
+
+  it("tolerates the legacy height-less shape", () => {
+    expect(parseDrawerState(JSON.stringify({ open: true }))).toEqual({
+      open: true,
+      height: null,
+    });
+  });
+
+  it("drops a non-number height", () => {
+    expect(
+      parseDrawerState(JSON.stringify({ open: true, height: "300" })),
+    ).toEqual({ open: true, height: null });
+  });
+
+  it("coerces a truthy/falsy open", () => {
+    expect(parseDrawerState(JSON.stringify({ open: 0, height: 200 }))).toEqual({
+      open: false,
+      height: 200,
+    });
+  });
+
+  it("falls back on malformed JSON", () => {
+    expect(parseDrawerState("{not json")).toEqual({
+      open: false,
+      height: null,
+    });
+  });
+});
+
+describe("parseTerminalOverride", () => {
+  it("returns null for a missing value (→ use default preference)", () => {
+    expect(parseTerminalOverride(null)).toBeNull();
+  });
+
+  it("returns an explicit true override", () => {
+    expect(parseTerminalOverride(JSON.stringify({ visible: true }))).toBe(true);
+  });
+
+  it("returns an explicit false override (a per-VM Hide beats the default)", () => {
+    expect(parseTerminalOverride(JSON.stringify({ visible: false }))).toBe(
+      false,
+    );
+  });
+
+  it("returns null when `visible` is absent or non-boolean", () => {
+    expect(parseTerminalOverride(JSON.stringify({}))).toBeNull();
+    expect(
+      parseTerminalOverride(JSON.stringify({ visible: "yes" })),
+    ).toBeNull();
+  });
+
+  it("falls back to null on malformed JSON", () => {
+    expect(parseTerminalOverride("{not json")).toBeNull();
+  });
+});

--- a/apps/web/src/layouts/main-panel-tabs/drawer-storage.ts
+++ b/apps/web/src/layouts/main-panel-tabs/drawer-storage.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure parsers for the sandbox preview drawer's localStorage records. Kept free
+ * of `localStorage` access so they can be unit-tested; the host components own
+ * key building and the read/write calls. The `null`-vs-`false` distinction in
+ * `parseTerminalOverride` is load-bearing: `null` (unset/malformed) is what
+ * makes visibility fall back to the user's default preference, while an
+ * explicit `false` is a per-VM "Hide" that overrides that default.
+ */
+
+export interface DrawerState {
+  open: boolean;
+  /** Open-drawer height in px; `null` = default (50% of the pane). */
+  height: number | null;
+}
+
+/**
+ * Parse a `preview-drawer:<id>` record. Tolerates the legacy height-less
+ * `{ open }` shape (height → `null`) and any malformed/missing value.
+ */
+export function parseDrawerState(raw: string | null): DrawerState {
+  if (!raw) return { open: false, height: null };
+  try {
+    const parsed = JSON.parse(raw);
+    return {
+      open: !!parsed.open,
+      height: typeof parsed.height === "number" ? parsed.height : null,
+    };
+  } catch {
+    return { open: false, height: null };
+  }
+}
+
+/**
+ * Parse a `preview-terminal-visible:<id>` record into a per-VM override, or
+ * `null` when the user hasn't set one for this VM (missing/malformed value, or
+ * a non-boolean `visible` field).
+ */
+export function parseTerminalOverride(raw: string | null): boolean | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    return typeof parsed.visible === "boolean" ? parsed.visible : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/layouts/main-panel-tabs/preview-drawer-host.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/preview-drawer-host.tsx
@@ -17,6 +17,7 @@ import {
   useSandboxEvents,
 } from "@/components/sandbox/hooks/use-sandbox-events";
 import { PreviewDrawer } from "@/components/sandbox/preview/drawer/drawer";
+import { parseDrawerState, type DrawerState } from "./drawer-storage";
 
 const STORAGE_KEY = (id: string) => `preview-drawer:${id}`;
 
@@ -27,21 +28,9 @@ const STORAGE_KEY = (id: string) => `preview-drawer:${id}`;
 const GIT_AUTH_FAILURE_RE =
   /Authentication failed for|Invalid username or token|Password authentication is not supported/i;
 
-interface DrawerState {
-  open: boolean;
-  /** Open-drawer height in px; `null` = default (50% of the pane). */
-  height: number | null;
-}
-
 function readPersisted(virtualMcpId: string): DrawerState {
   try {
-    const raw = localStorage.getItem(STORAGE_KEY(virtualMcpId));
-    if (!raw) return { open: false, height: null };
-    const parsed = JSON.parse(raw);
-    return {
-      open: !!parsed.open,
-      height: typeof parsed.height === "number" ? parsed.height : null,
-    };
+    return parseDrawerState(localStorage.getItem(STORAGE_KEY(virtualMcpId)));
   } catch {
     return { open: false, height: null };
   }

--- a/apps/web/src/layouts/main-panel-tabs/preview-drawer-host.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/preview-drawer-host.tsx
@@ -27,19 +27,29 @@ const STORAGE_KEY = (id: string) => `preview-drawer:${id}`;
 const GIT_AUTH_FAILURE_RE =
   /Authentication failed for|Invalid username or token|Password authentication is not supported/i;
 
-function readPersisted(virtualMcpId: string): boolean {
+interface DrawerState {
+  open: boolean;
+  /** Open-drawer height in px; `null` = default (50% of the pane). */
+  height: number | null;
+}
+
+function readPersisted(virtualMcpId: string): DrawerState {
   try {
     const raw = localStorage.getItem(STORAGE_KEY(virtualMcpId));
-    if (!raw) return false;
-    return !!JSON.parse(raw).open;
+    if (!raw) return { open: false, height: null };
+    const parsed = JSON.parse(raw);
+    return {
+      open: !!parsed.open,
+      height: typeof parsed.height === "number" ? parsed.height : null,
+    };
   } catch {
-    return false;
+    return { open: false, height: null };
   }
 }
 
-function writePersisted(virtualMcpId: string, open: boolean): void {
+function writePersisted(virtualMcpId: string, state: DrawerState): void {
   try {
-    localStorage.setItem(STORAGE_KEY(virtualMcpId), JSON.stringify({ open }));
+    localStorage.setItem(STORAGE_KEY(virtualMcpId), JSON.stringify(state));
   } catch {
     /* ignore */
   }
@@ -71,12 +81,15 @@ export function PreviewDrawerHost() {
   // useEffect is banned for derived state).
   const storageKey = virtualMcpId ?? "__no-vmcp__";
   const [drawerOpen, setDrawerOpen] = useState<boolean | null>(null);
+  const [drawerHeight, setDrawerHeight] = useState<number | null>(null);
   const lastHydratedKeyRef = useRef<string | null>(null);
   // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- hydrate on VM switch
   if (lastHydratedKeyRef.current !== storageKey) {
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- hydrate on VM switch
     lastHydratedKeyRef.current = storageKey;
-    setDrawerOpen(readPersisted(storageKey));
+    const persisted = readPersisted(storageKey);
+    setDrawerOpen(persisted.open);
+    setDrawerHeight(persisted.height);
   }
 
   // The drawer's open state is driven entirely by the user's persisted
@@ -88,7 +101,12 @@ export function PreviewDrawerHost() {
 
   const handleOpenChange = (next: boolean) => {
     setDrawerOpen(next);
-    writePersisted(storageKey, next);
+    writePersisted(storageKey, { open: next, height: drawerHeight });
+  };
+
+  const handleHeightChange = (next: number) => {
+    setDrawerHeight(next);
+    writePersisted(storageKey, { open, height: next });
   };
 
   return (
@@ -102,6 +120,8 @@ export function PreviewDrawerHost() {
       scripts={events.scripts}
       open={open}
       onOpenChange={handleOpenChange}
+      height={drawerHeight}
+      onHeightChange={handleHeightChange}
       onStart={lifecycle.start}
       onStop={lifecycle.stop}
       onRestart={lifecycle.restart}

--- a/apps/web/src/layouts/main-panel-tabs/terminal-visibility.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/terminal-visibility.tsx
@@ -2,22 +2,27 @@
  * Terminal-visibility state shared between the preview's ⋯ menu (which toggles
  * it) and MainPanelWithDrawer (which gates the bottom terminal drawer on it).
  *
- * The terminal is hidden by default — the user opts in via "Show terminal" in
- * the preview overflow menu. The choice is persisted per virtualMcpId so it
- * survives navigation and sandbox restarts (once enabled it also shows during
- * subsequent boots, so clone/install logs are visible again).
+ * Default visibility comes from the user's `terminalVisibleByDefault`
+ * preference (Settings → Preferences). A per-virtualMcpId Show/Hide choice
+ * overrides that default and is persisted so it survives navigation and
+ * sandbox restarts (once enabled it also shows during subsequent boots, so
+ * clone/install logs are visible again).
  */
 
 import { createContext, use, useRef, useState, type ReactNode } from "react";
+import { usePreferences } from "@/hooks/use-preferences.ts";
 
 const STORAGE_KEY = (id: string) => `preview-terminal-visible:${id}`;
 
-function readPersisted(id: string): boolean {
+/** Per-VM override, or `null` when the user hasn't set one for this VM. */
+function readPersisted(id: string): boolean | null {
   try {
     const raw = localStorage.getItem(STORAGE_KEY(id));
-    return raw ? !!JSON.parse(raw).visible : false;
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    return typeof parsed.visible === "boolean" ? parsed.visible : null;
   } catch {
-    return false;
+    return null;
   }
 }
 
@@ -46,7 +51,9 @@ export function TerminalVisibilityProvider({
   children: ReactNode;
 }) {
   const storageKey = virtualMcpId ?? "__no-vmcp__";
-  const [visible, setVisibleState] = useState<boolean | null>(null);
+  const [preferences] = usePreferences();
+  // `null` = no per-VM override → fall back to the user's default preference.
+  const [override, setOverrideState] = useState<boolean | null>(null);
 
   // Re-hydrate when the VM changes (render-time setState gated by a ref —
   // idiomatic here; useEffect is banned for derived state).
@@ -55,17 +62,20 @@ export function TerminalVisibilityProvider({
   if (lastKeyRef.current !== storageKey) {
     // oxlint-disable-next-line ban-ref-current-assignment/ban-ref-current-assignment -- hydrate on VM switch
     lastKeyRef.current = storageKey;
-    setVisibleState(readPersisted(storageKey));
+    setOverrideState(readPersisted(storageKey));
   }
 
   const setVisible = (next: boolean) => {
-    setVisibleState(next);
+    setOverrideState(next);
     writePersisted(storageKey, next);
   };
 
   return (
     <TerminalVisibilityContext
-      value={{ visible: visible ?? false, setVisible }}
+      value={{
+        visible: override ?? preferences.terminalVisibleByDefault,
+        setVisible,
+      }}
     >
       {children}
     </TerminalVisibilityContext>

--- a/apps/web/src/layouts/main-panel-tabs/terminal-visibility.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/terminal-visibility.tsx
@@ -11,16 +11,14 @@
 
 import { createContext, use, useRef, useState, type ReactNode } from "react";
 import { usePreferences } from "@/hooks/use-preferences.ts";
+import { parseTerminalOverride } from "./drawer-storage";
 
 const STORAGE_KEY = (id: string) => `preview-terminal-visible:${id}`;
 
 /** Per-VM override, or `null` when the user hasn't set one for this VM. */
 function readPersisted(id: string): boolean | null {
   try {
-    const raw = localStorage.getItem(STORAGE_KEY(id));
-    if (!raw) return null;
-    const parsed = JSON.parse(raw);
-    return typeof parsed.visible === "boolean" ? parsed.visible : null;
+    return parseTerminalOverride(localStorage.getItem(STORAGE_KEY(id)));
   } catch {
     return null;
   }

--- a/apps/web/src/views/settings/profile-preferences.tsx
+++ b/apps/web/src/views/settings/profile-preferences.tsx
@@ -293,6 +293,33 @@ function PreferencesSection() {
           }
         />
         <SettingsCardItem
+          title={t("settings.preferences.terminalVisible")}
+          description={t("settings.preferences.terminalVisibleDescription")}
+          onClick={() => {
+            track("preferences_terminal_default_toggled", {
+              enabled: !preferences.terminalVisibleByDefault,
+            });
+            setPreferences((prev) => ({
+              ...prev,
+              terminalVisibleByDefault: !prev.terminalVisibleByDefault,
+            }));
+          }}
+          action={
+            <Switch
+              checked={preferences.terminalVisibleByDefault}
+              onCheckedChange={(checked) => {
+                track("preferences_terminal_default_toggled", {
+                  enabled: checked,
+                });
+                setPreferences((prev) => ({
+                  ...prev,
+                  terminalVisibleByDefault: checked,
+                }));
+              }}
+            />
+          }
+        />
+        <SettingsCardItem
           title={t("settings.preferences.toolApproval")}
           description={t("settings.preferences.toolApprovalDescription")}
           action={

--- a/packages/e2e/tests/sandbox-terminal-default-visibility.spec.ts
+++ b/packages/e2e/tests/sandbox-terminal-default-visibility.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * E2E: the `terminalVisibleByDefault` user preference drives whether the
+ * sandbox PreviewDrawer shows by default, and a per-VM Show/Hide override wins
+ * over that default.
+ *
+ * Storage contract (black-box, asserted here on purpose):
+ *   - `studio:user:preferences` — the usePreferences() blob; `terminalVisibleByDefault`
+ *     is the new default (see apps/web/src/hooks/use-preferences.ts).
+ *   - `preview-terminal-visible:<virtualMcpId>` — the per-VM override
+ *     `{ visible: boolean }` (see terminal-visibility.tsx). Absent → use default.
+ */
+import { expect, test } from "../fixtures/test";
+import { callSelfMcpTool, createHttpConnection } from "../fixtures/mcp-tools";
+
+const PREFERENCES_KEY = "studio:user:preferences";
+
+/** Create a cloneable agent + thread so the drawer chrome is eligible to mount. */
+async function createCloneableAgentThread(
+  api: import("@playwright/test").APIRequestContext,
+  orgSlug: string,
+) {
+  // Placeholder GitHub connection — only its id matters, so
+  // `agentHasClonableSource` flips on.
+  const conn = await createHttpConnection(api, orgSlug, {
+    title: "github-placeholder",
+    url: "http://127.0.0.1:1/unused",
+  });
+  const agent = await callSelfMcpTool<{ item: { id: string } }>(
+    api,
+    orgSlug,
+    "COLLECTION_VIRTUAL_MCP_CREATE",
+    {
+      data: {
+        title: "terminal-default-visibility e2e",
+        description: "cloneable",
+        status: "active",
+        pinned: false,
+        connections: [{ connection_id: conn.id }],
+        metadata: {
+          githubRepo: {
+            url: "https://github.com/example/repo",
+            owner: "example",
+            name: "repo",
+            connectionId: conn.id,
+          },
+        },
+      },
+    },
+  );
+  const thread = await callSelfMcpTool<{ item: { id: string } }>(
+    api,
+    orgSlug,
+    "COLLECTION_THREADS_CREATE",
+    { data: { virtual_mcp_id: agent.item.id } },
+  );
+  return { agentId: agent.item.id, threadId: thread.item.id };
+}
+
+test.describe("sandbox terminal default visibility preference", () => {
+  test("default shows the drawer; a per-VM Hide override wins", async ({
+    authedPage,
+  }) => {
+    const { page, orgSlug } = authedPage;
+    const api = page.context().request;
+    const { agentId, threadId } = await createCloneableAgentThread(
+      api,
+      orgSlug,
+    );
+
+    // Turn the default ON via the preferences blob. usePreferences() merges
+    // over DEFAULT_PREFERENCES, so seeding only this field is enough.
+    await page.addInitScript(
+      ({ key, value }) => localStorage.setItem(key, value),
+      {
+        key: PREFERENCES_KEY,
+        value: JSON.stringify({ terminalVisibleByDefault: true }),
+      },
+    );
+
+    // The drawer's setup tab is a <button> reading "sandbox" (drawer/toolbar.tsx
+    // :: SetupTab) — the cheap proof that the drawer chrome is mounted.
+    const sandboxToolbarTab = page.getByRole("button", { name: /^sandbox$/i });
+
+    // With the default ON and NO per-VM override, the drawer shows.
+    await page.goto(
+      `/${orgSlug}/${threadId}?virtualmcpid=${agentId}&main=preview`,
+    );
+    await expect(sandboxToolbarTab).toBeVisible({ timeout: 15_000 });
+
+    // Now set an explicit per-VM Hide. This survives the reload (addInitScript
+    // only reseeds the preferences key, not this one), so it proves the
+    // override beats the still-ON default.
+    await page.evaluate(
+      (key) => localStorage.setItem(key, JSON.stringify({ visible: false })),
+      `preview-terminal-visible:${agentId}`,
+    );
+    await page.reload();
+
+    // Non-vacuous transition: the drawer was visible above, so its
+    // disappearance here is driven by the override, not by a slow load.
+    await expect(sandboxToolbarTab).toBeHidden({ timeout: 15_000 });
+  });
+});


### PR DESCRIPTION
## Summary

Two related improvements to the sandbox preview terminal drawer (the bottom panel with the `sandbox`/`start` tabs).

### 1. Drag-to-resize height
The drawer was locked to a hardcoded `50%` of the pane. Now it has a drag handle on its top edge (the toolbar divider becomes the affordance — highlights on hover, `row-resize` cursor).

- Height is applied imperatively during the drag (no per-frame React render, so the xterm refit stays smooth) and committed to state on pointer-up.
- Persisted per `virtualMcpId` in localStorage alongside the existing open/closed state.
- Capped relative to the pane (`calc(100% - 160px)` + `clampDrawerHeight`) so a stored height from a taller window can never swallow the tab body when the window shrinks.

### 2. "Show terminal by default" preference
The terminal is hidden by default and opted in per project via the preview ⋯ menu. Added a user preference (**Settings → Preferences**, default off) that flips that default.

- `TerminalVisibilityProvider` now resolves `visible = per-VM override ?? terminalVisibleByDefault`.
- An explicit per-project Show/Hide choice still wins over the default (including an explicit Hide when the default is on).
- Behavior of the toggle: shows the **collapsed** terminal bar (clickable to expand), not fully expanded.

## Testing
- `bun run --cwd=apps/web check` — passes
- `bun run lint` — no new warnings in changed files
- `bun test drawer/` — 11 pass (new `resize.test.ts` covers the clamp)
- `bun run fmt` — applied
- Existing e2e `sandbox-drawer-everywhere.spec.ts` seeds an explicit per-VM override, so it still holds (override has precedence).

## Screenshots
_UI change — resize handle on the drawer top edge + new preference row in Settings._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the sandbox preview terminal resizable and adds a “show by default” preference. Improves usability with robust drag handling and lets users pick a default while preserving per-project overrides.

- **New Features**
  - Drag-to-resize on the drawer’s top edge; height updates live and persists per `virtualMcpId`.
  - Height clamped via `clampDrawerHeight`; drawer also has a pane-relative max-height cap.
  - New Settings → Preferences toggle: “Show preview terminal by default” (`terminalVisibleByDefault`, default off). Per-VM Show/Hide still wins; toggle shows the collapsed bar.

- **Bug Fixes**
  - Drag now uses pointer capture and handles `pointercancel`; no stuck drags/cursors and concurrent pointers are ignored.
  - Max-height cap shares the clamp’s minimum so tiny panes can’t shrink past the floor.
  - LocalStorage parsing moved to pure helpers with tests (supports legacy shapes and preserves null vs false). Added e2e covering default visibility vs per-VM override.

<sup>Written for commit 811b35e1603bd0146afa6619c954d5d6cd9d2fe9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

