### PR TITLE
fix(task-board): cache linked-PR GitHub reads so polling stops earning 429s

### DIFF
--- a/apps/api/src/tools/task-board/checks-status.test.ts
+++ b/apps/api/src/tools/task-board/checks-status.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "bun:test";
 import {
   conflictFromPrGet,
   extractPreviewUrl,
+  isRateLimitError,
   extractPreviewUrlFromComments,
   isTrustedPreviewHost,
   mergeChecksStatus,
@@ -371,5 +372,28 @@ describe("extractPreviewUrlFromComments", () => {
         { body: vercelBody },
       ]),
     ).toBe("https://envs-montecarlo--c8xgrn.decocdn.com");
+  });
+});
+
+describe("isRateLimitError", () => {
+  // These are the exact strings the GitHub MCP surfaced in prod while the board
+  // hammered it; retrying any of them is what kept the limit shut.
+  it.each([
+    "Streamable HTTP error: Error POSTing to endpoint: too many requests",
+    "API rate limit exceeded for installation",
+    "You have exceeded a secondary rate limit",
+    "request failed with status 429",
+  ])("treats %p as non-retriable", (message) => {
+    expect(isRateLimitError(new Error(message))).toBe(true);
+  });
+
+  it("lets a genuine transient failure through to the retry", () => {
+    expect(isRateLimitError(new Error("socket hang up"))).toBe(false);
+    expect(isRateLimitError(new Error("Not Found"))).toBe(false);
+  });
+
+  it("handles a non-Error rejection", () => {
+    expect(isRateLimitError("too many requests")).toBe(true);
+    expect(isRateLimitError(null)).toBe(false);
   });
 });

--- a/apps/api/src/tools/task-board/merge-pr.ts
+++ b/apps/api/src/tools/task-board/merge-pr.ts
@@ -1,6 +1,10 @@
 import type { StudioContext } from "@/core/studio-context";
 import { clientFromConnection } from "@/mcp-clients";
-import { fetchPrChecksStatus, resolveGithubConnection } from "./prs-get";
+import {
+  fetchPrChecksStatus,
+  invalidatePrReads,
+  resolveGithubConnection,
+} from "./prs-get";
 
 /** Cap the merge round-trip so a slow GitHub can't hang the caller. */
 const MERGE_TIMEOUT_MS = 15000;
@@ -76,6 +80,9 @@ export async function mergeLinkedPr(
       );
       return false;
     }
+    // The PR just changed under the polled read cache — drop it so the next
+    // poll sees `merged` and moves the card to Done immediately.
+    invalidatePrReads(conn.id);
     return true;
   } catch (err) {
     console.error("[task-board] merge PR failed", err);

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -8,6 +8,7 @@ import type { TaskBoardItemPrRef } from "@/storage/types";
 import { getRepoScope } from "@decocms/shared/github-repo-scope";
 import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
 import { retry, RetryError } from "@decocms/shared/std";
+import { InMemoryMcpReadCache } from "@/mcp-clients/mcp-read-cache";
 import { TaskBoardItemPrSchema } from "./schema";
 import { recordTaskActivity } from "./activity";
 import { emitTaskBoardUpdated } from "./run-reactions";
@@ -16,6 +17,137 @@ import { reactToApprovedPrConflict } from "./conflict-reaction";
 
 /** Cap a single live PR fetch — the modal shouldn't hang on a slow GitHub. */
 const PR_FETCH_TIMEOUT_MS = 8000;
+
+/**
+ * GitHub answers "too many requests" — the primary or (more often here) the
+ * SECONDARY rate limit, which punishes bursts of concurrent calls rather than a
+ * raw hourly count. Retrying that is not a retry, it's the burst: it triples the
+ * very thing being limited, and the retried calls are what keep the limit shut.
+ * So a rate-limit answer ends the attempt immediately and the cache below serves
+ * the last good value instead.
+ *
+ * Matched on the message because the answer arrives as an MCP tool result
+ * (`isError` + text), not an HTTP status we can read. Exported for the unit test.
+ */
+export function isRateLimitError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return /too many requests|rate limit|\b429\b/i.test(message);
+}
+
+/**
+ * Stale-while-revalidate cache for the PR reads on the POLLED paths — the task
+ * dialog's 60s refresh and the review sweeper — which is where the GitHub 429s
+ * came from. Each poll costs four `pull_request_read` calls per PR plus one
+ * `GET_CHECK_RUN` per failing check, uncached: `clientFromConnection` (what this
+ * file uses) bypasses the proxy's read cache entirely, so every viewer, every
+ * poll, every replica hit GitHub live.
+ *
+ * SWR is what keeps the UI alive: past `revalidateAfterMs` a poll is served from
+ * the entry it already has while ONE background call refreshes it (single-flight
+ * — concurrent viewers of the same PR collapse into one), and a failed refresh
+ * keeps serving the previous value until `maxStaleMs`. So a rate-limit window
+ * shows the last known PR state instead of blanking the card to all-nulls.
+ *
+ * `maxStaleMs` is deliberately much longer than the poll: it only matters while
+ * GitHub is refusing us, and half an hour of "the state as of when GitHub last
+ * answered" beats an empty card that loses its checks, preview and ship button.
+ *
+ * Its own instance, not the shared `getMcpReadCache()`: that one is tuned for
+ * proxied tool calls (30s/5min) and is settings-gated off in development, and
+ * this path wants a longer stale window and to work the same everywhere.
+ *
+ * ponytail: per-pod, so N replicas still cost N fetches per window. Move it to
+ * NATS KV if that's still too many.
+ */
+const PR_READ_CACHE_ENTRY = {
+  /** Just under the dialog's 60s poll, so a poll refreshes rather than blocks. */
+  revalidateAfterMs: 55_000,
+  /** How long a rate-limit window may be papered over with the last good read. */
+  maxStaleMs: 30 * 60_000,
+  maxValueBytes: 512 * 1024,
+} as const;
+const prReadCache = new InMemoryMcpReadCache({
+  "tools/call": PR_READ_CACHE_ENTRY,
+  "resources/read": PR_READ_CACHE_ENTRY,
+  "prompts/get": PR_READ_CACHE_ENTRY,
+});
+
+/**
+ * Drop this connection's cached PR reads. Call it after WRITING to GitHub
+ * through the connection (a merge), so the next poll sees the new state instead
+ * of serving the pre-merge one for the rest of the revalidate window — the card
+ * only moves to Done once a poll observes `merged`, and a minute of "did my ship
+ * button work?" is exactly the confusion this cache must not introduce.
+ */
+export function invalidatePrReads(connectionId: string): void {
+  prReadCache.invalidate(connectionId);
+}
+
+/** `owner/repo#number`, for log lines. */
+const prLabel = (pr: TaskBoardItemPrRef) =>
+  `${pr.repoOwner}/${pr.repoName}#${pr.number}`;
+
+/**
+ * One cached, best-effort GitHub read for a PR. Best-effort in the same sense as
+ * the rest of this file: `null` on any failure, so the card still renders.
+ *
+ * `callTool` RESOLVES (doesn't reject) on an upstream MCP error, so an `isError`
+ * result is rethrown here — otherwise the cache would happily store GitHub's
+ * "too many requests" as the PR's state and serve it for half an hour.
+ */
+async function cachedPrRead(
+  client: Awaited<ReturnType<typeof clientFromConnection>>,
+  connectionId: string,
+  name: string,
+  args: Record<string, unknown>,
+  describe: string,
+): Promise<Record<string, unknown> | null> {
+  try {
+    const raw = await prReadCache.fetch({
+      type: "tools/call",
+      connectionId,
+      // The GitHub installation is the connection's, not the caller's, so every
+      // org member reading the same PR shares one entry.
+      scope: { kind: "org" },
+      params: { name, arguments: args },
+      fetchLive: () =>
+        retry(
+          async () => {
+            const result = await client.callTool(
+              { name, arguments: args },
+              undefined,
+              {
+                timeout: PR_FETCH_TIMEOUT_MS,
+              },
+            );
+            if (
+              result &&
+              typeof result === "object" &&
+              (result as { isError?: boolean }).isError
+            ) {
+              throw new Error(
+                (result as { content?: Array<{ text?: string }> }).content?.[0]
+                  ?.text ?? `${name} returned isError`,
+              );
+            }
+            return result;
+          },
+          {
+            maxAttempts: 3,
+            minTimeout: 300,
+            maxTimeout: 3000,
+            jitter: 1,
+            isRetriable: (err) => !isRateLimitError(err),
+          },
+        ),
+    });
+    return toolResultJson(raw);
+  } catch (err) {
+    const cause = err instanceof RetryError ? err.cause : err;
+    console.error(`[task-board] ${name} failed for ${describe}:`, cause);
+    return null;
+  }
+}
 
 /**
  * The GitHub MCP connection to fetch/merge a PR through: the one that opened it
@@ -360,33 +492,23 @@ function isFailingRun(r: RawCheckRun): boolean {
  *  (the list tool omits `output`). Best-effort: null on any failure. */
 async function fetchCheckRunSummary(
   client: Awaited<ReturnType<typeof clientFromConnection>>,
+  connectionId: string,
   pr: TaskBoardItemPrRef,
   checkRunId: number,
 ): Promise<string | null> {
-  try {
-    const obj = toolResultJson(
-      await client.callTool(
-        {
-          name: "GET_CHECK_RUN",
-          arguments: {
-            owner: pr.repoOwner,
-            repo: pr.repoName,
-            checkRunId,
-          },
-        },
-        undefined,
-        { timeout: PR_FETCH_TIMEOUT_MS },
-      ),
-    );
-    const output = obj?.output as
-      | { summary?: unknown; text?: unknown }
-      | undefined;
-    const summary = typeof output?.summary === "string" ? output.summary : null;
-    const text = typeof output?.text === "string" ? output.text : null;
-    return summary ?? text ?? null;
-  } catch {
-    return null;
-  }
+  const obj = await cachedPrRead(
+    client,
+    connectionId,
+    "GET_CHECK_RUN",
+    { owner: pr.repoOwner, repo: pr.repoName, checkRunId },
+    `${prLabel(pr)} check-run ${checkRunId}`,
+  );
+  const output = obj?.output as
+    | { summary?: unknown; text?: unknown }
+    | undefined;
+  const summary = typeof output?.summary === "string" ? output.summary : null;
+  const text = typeof output?.text === "string" ? output.text : null;
+  return summary ?? text ?? null;
 }
 
 /** Just the PR's checks summary (combined status ∪ check-runs) — used to gate
@@ -501,59 +623,26 @@ export async function fetchPrConflict(
  *  deploy preview URL. Best-effort: any failure yields nulls. */
 async function fetchPrStatusExtras(
   client: Awaited<ReturnType<typeof clientFromConnection>>,
+  connectionId: string,
   pr: TaskBoardItemPrRef,
 ): Promise<{
   checksStatus: ChecksStatus;
   checks: PrCheck[];
   previewUrl: string | null;
 }> {
-  const read = async (
-    method: "get_status" | "get_check_runs" | "get_comments",
-  ): Promise<Record<string, unknown> | null> => {
-    try {
-      const result = await retry(
-        async () => {
-          const raw = await client.callTool(
-            {
-              name: "pull_request_read",
-              arguments: {
-                method,
-                owner: pr.repoOwner,
-                repo: pr.repoName,
-                pullNumber: pr.number,
-              },
-            },
-            undefined,
-            { timeout: PR_FETCH_TIMEOUT_MS },
-          );
-          // callTool resolves (doesn't reject) on an upstream MCP error — throw
-          // so retry() can see it and back off (e.g. GitHub's "too many
-          // requests" on a burst of concurrent pull_request_read calls).
-          if (
-            raw &&
-            typeof raw === "object" &&
-            (raw as { isError?: boolean }).isError
-          ) {
-            throw new Error(
-              (raw as { content?: Array<{ text?: string }> }).content?.[0]
-                ?.text ?? "pull_request_read returned isError",
-            );
-          }
-          return raw;
-        },
-        { maxAttempts: 3, minTimeout: 300, maxTimeout: 3000, jitter: 1 },
-      );
-      return toolResultJson(result);
-    } catch (err) {
-      const cause = err instanceof RetryError ? err.cause : err;
-      console.error(
-        `[task-board] pull_request_read(${method}) failed for ` +
-          `${pr.repoOwner}/${pr.repoName}#${pr.number} after retries:`,
-        cause,
-      );
-      return null;
-    }
-  };
+  const read = (method: "get_status" | "get_check_runs" | "get_comments") =>
+    cachedPrRead(
+      client,
+      connectionId,
+      "pull_request_read",
+      {
+        method,
+        owner: pr.repoOwner,
+        repo: pr.repoName,
+        pullNumber: pr.number,
+      },
+      `${prLabel(pr)} (${method})`,
+    );
   // The three reads are independent — run them CONCURRENTLY. Serial was the
   // slowness (each is a remote MCP → GitHub round-trip, ~1.5-2s; the card made
   // 4-5 of them in a row).
@@ -581,7 +670,7 @@ async function fetchPrStatusExtras(
         detailsUrl: r.detailsUrl,
         summary:
           isFailingRun(r) && r.id != null
-            ? await fetchCheckRunSummary(client, pr, r.id)
+            ? await fetchCheckRunSummary(client, connectionId, pr, r.id)
             : null,
       }),
     ),
@@ -644,23 +733,21 @@ export async function fetchPrLiveState(
     // An open PR (the common case in the review dialog) is fully populated in a
     // single round-trip window instead of ~5 serial hops; a merged/closed PR
     // wastes the extras, but that's rare here and best-effort.
-    const [liveResult, extras] = await Promise.all([
-      client.callTool(
+    const [obj, extras] = await Promise.all([
+      cachedPrRead(
+        client,
+        conn.id,
+        "pull_request_read",
         {
-          name: "pull_request_read",
-          arguments: {
-            method: "get",
-            owner: pr.repoOwner,
-            repo: pr.repoName,
-            pullNumber: pr.number,
-          },
+          method: "get",
+          owner: pr.repoOwner,
+          repo: pr.repoName,
+          pullNumber: pr.number,
         },
-        undefined,
-        { timeout: PR_FETCH_TIMEOUT_MS },
+        `${prLabel(pr)} (get)`,
       ),
-      fetchPrStatusExtras(client, pr),
+      fetchPrStatusExtras(client, conn.id, pr),
     ]);
-    const obj = toolResultJson(liveResult);
     if (!obj) return NO_LIVE_STATE;
     const rawState = obj.state;
     const isOpen = rawState === "open";


### PR DESCRIPTION
## Problem

The task dialog polls `TASK_BOARD_ITEM_PRS_GET` every 60s, and the review sweeper reconciles parked cards. Both bottom out in `fetchPrLiveState`, which costs **four `pull_request_read` calls per PR plus one `GET_CHECK_RUN` per failing check** — all live.

They're live because `prs-get.ts` builds its client with `clientFromConnection`, which **bypasses the proxy's read cache** (`getMcpReadCache()` only sits behind `createLazyClient`, used by the MCP proxy paths). So every viewer, every poll, every replica went straight to GitHub.

Prod, last 3h:

```
deco-studio-579fc9b978-4khdt (api):    458 x "too many requests"
deco-studio-worker-ccb46d96b-g9thc:    200 x "too many requests"

[task-board] pull_request_read(get_status) failed for deco-sites/demo-storefront#72 after retries: ...
[task-board-review-sweeper] board_jLnILamXKUqsT6y-QZWfq: no live PR state from GitHub (4 PR(s)) — proceeding on unknown
```

Two consequences: the card blanks to all-nulls (loses checks, preview, ship button), and the sweeper falls through to "proceeding on unknown". The `retry({ maxAttempts: 3 })` around the read made it worse — retrying a rate-limit answer *is* the burst GitHub's secondary limit punishes.

## Fix

- **Route the polled PR reads through their own `InMemoryMcpReadCache`** (the primitive already in `mcp-clients/`), tuned for this path: 55s revalidate / 30min max stale. Stale-while-revalidate means concurrent readers of the same PR collapse into **one** background refresh (single-flight), and a refresh that fails **keeps serving the last good value** — so a rate-limit window shows the last known PR state instead of an empty card.
- **A rate-limit answer is non-retriable** (`isRateLimitError`), so we stop tripling the calls that keep the limit shut. Genuine transient failures still retry.
- **A merge invalidates the connection's cached reads**, so the card still moves to Done on the next poll rather than a revalidate window later.
- The **write gates stay live and uncached** on purpose: `fetchPrChecksStatus` (the don't-ship-on-red gate in `merge-pr.ts`) and `fetchPrConflict` (`review-decision.ts`) are low-frequency and must not decide on stale state.

Own cache instance rather than the shared `getMcpReadCache()`: that one is tuned for proxied tool calls (30s/5min) and is settings-gated off in development; this path wants a longer stale window and the same behavior everywhere.

## Testing

- `bun run --cwd=apps/api check` — clean
- `bun run lint` — 0 errors
- `bun test apps/api/src/tools/task-board/` — 192 pass; the 11 failures are the pre-existing `*.integration.test.ts` files that need a live Postgres
- Unit test added for `isRateLimitError`, using the exact strings prod surfaced

## Follow-up

The cache is per-pod, so 3 replicas still cost 3 fetches per window. Marked with a `ponytail:` comment — move it to NATS KV if that's still too many.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache GitHub PR reads for the task board to stop 429s during polling and keep cards stable. Adds SWR caching, skips retrying rate-limit errors, and invalidates cache on merge so status updates immediately.

- **Bug Fixes**
  - Route polled `pull_request_read` and `GET_CHECK_RUN` through `InMemoryMcpReadCache` (55s revalidate, 30m max stale) with single-flight; serve last good value on failures instead of blanking the card.
  - Treat rate-limit responses as non-retriable via `isRateLimitError`; unit test added with prod strings.
  - Invalidate cached reads on merge (`invalidatePrReads`) so the next poll sees `merged` and moves the card to Done.
  - Keep write gates live and uncached (`fetchPrChecksStatus`, `fetchPrConflict`) to avoid decisions on stale data.

<sup>Written for commit eb4ed61cc3a66c03a8d52928e2430fcf441794ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

