### PR TITLE
fix(task-board): don't close the GitHub client out from under a cache revalidation

### DIFF
--- a/apps/api/src/mcp-clients/mcp-read-cache.test.ts
+++ b/apps/api/src/mcp-clients/mcp-read-cache.test.ts
@@ -506,3 +506,63 @@ describe("InMemoryMcpReadCache", () => {
     expect(afterSecond.bytes).toBe(JSON.stringify({ value: "second" }).length);
   });
 });
+
+/**
+ * A revalidation runs on whatever connection the caller's `fetchLive` closes
+ * over, and it starts AFTER the stale value is returned. So a caller that tears
+ * that connection down as soon as `fetch` resolves kills every refresh it ever
+ * triggers, and the entry then sits unchanged until `maxStaleMs` — which is how
+ * a task-board PR card got stuck showing no deploy preview and no checks for
+ * half an hour. `onRevalidation` is the contract that prevents it: hold the
+ * connection open until the promises it hands out settle.
+ */
+describe("onRevalidation guards the caller's connection lifetime", () => {
+  const staleThenRefresh = async (holdOpen: boolean) => {
+    const { cache, advance } = newCache({
+      revalidateAfterMs: 10_000,
+      maxStaleMs: 60_000,
+    });
+    let closed = false;
+    let version = 1;
+    // A real call is in flight for a while; closing the transport under it is
+    // what fails it, so the check belongs at resolution time, not at entry.
+    const fetchLive = async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      if (closed) throw new Error("connection closed");
+      return { version };
+    };
+    const read = async () => {
+      const pending: Promise<void>[] = [];
+      const value = await cache.fetch({
+        type: TOOL,
+        connectionId: CONN,
+        scope: ORG,
+        params: {},
+        fetchLive,
+        onRevalidation: (p) => pending.push(p),
+      });
+      // The eager close is the bug; awaiting `pending` first is the fix.
+      if (holdOpen) await Promise.allSettled(pending);
+      closed = true;
+      return value;
+    };
+
+    expect(await read()).toEqual({ version: 1 });
+    version = 2;
+    closed = false;
+    advance(11_000);
+    // Stale: serves the old value either way, and kicks off the refresh.
+    expect(await read()).toEqual({ version: 1 });
+    closed = false;
+    advance(1_000);
+    return read();
+  };
+
+  test("closing eagerly loses the refresh — the entry stays stale", async () => {
+    expect(await staleThenRefresh(false)).toEqual({ version: 1 });
+  });
+
+  test("holding open until it settles refreshes the entry", async () => {
+    expect(await staleThenRefresh(true)).toEqual({ version: 2 });
+  });
+});

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -101,6 +101,7 @@ async function cachedPrRead(
   name: string,
   args: Record<string, unknown>,
   describe: string,
+  pending: Promise<void>[],
 ): Promise<Record<string, unknown> | null> {
   try {
     const raw = await prReadCache.fetch({
@@ -140,6 +141,9 @@ async function cachedPrRead(
             isRetriable: (err) => !isRateLimitError(err),
           },
         ),
+      // A background revalidation runs on `client` AFTER this call returns the
+      // stale value — so the caller must keep the client open until it settles.
+      onRevalidation: (promise) => pending.push(promise),
     });
     return toolResultJson(raw);
   } catch (err) {
@@ -495,6 +499,7 @@ async function fetchCheckRunSummary(
   connectionId: string,
   pr: TaskBoardItemPrRef,
   checkRunId: number,
+  pending: Promise<void>[],
 ): Promise<string | null> {
   const obj = await cachedPrRead(
     client,
@@ -502,6 +507,7 @@ async function fetchCheckRunSummary(
     "GET_CHECK_RUN",
     { owner: pr.repoOwner, repo: pr.repoName, checkRunId },
     `${prLabel(pr)} check-run ${checkRunId}`,
+    pending,
   );
   const output = obj?.output as
     | { summary?: unknown; text?: unknown }
@@ -625,6 +631,7 @@ async function fetchPrStatusExtras(
   client: Awaited<ReturnType<typeof clientFromConnection>>,
   connectionId: string,
   pr: TaskBoardItemPrRef,
+  pending: Promise<void>[],
 ): Promise<{
   checksStatus: ChecksStatus;
   checks: PrCheck[];
@@ -642,6 +649,7 @@ async function fetchPrStatusExtras(
         pullNumber: pr.number,
       },
       `${prLabel(pr)} (${method})`,
+      pending,
     );
   // The three reads are independent — run them CONCURRENTLY. Serial was the
   // slowness (each is a remote MCP → GitHub round-trip, ~1.5-2s; the card made
@@ -670,7 +678,13 @@ async function fetchPrStatusExtras(
         detailsUrl: r.detailsUrl,
         summary:
           isFailingRun(r) && r.id != null
-            ? await fetchCheckRunSummary(client, connectionId, pr, r.id)
+            ? await fetchCheckRunSummary(
+                client,
+                connectionId,
+                pr,
+                r.id,
+                pending,
+              )
             : null,
       }),
     ),
@@ -728,6 +742,9 @@ export async function fetchPrLiveState(
   });
   if (!conn) return NO_LIVE_STATE;
   const client = await clientFromConnection(conn, ctx, true);
+  // Background revalidations started by the read cache below run on `client`,
+  // so it may not be closed until they settle — see the `finally`.
+  const pending: Promise<void>[] = [];
   try {
     // Fetch the PR's basic state AND its checks/preview extras CONCURRENTLY.
     // An open PR (the common case in the review dialog) is fully populated in a
@@ -745,8 +762,9 @@ export async function fetchPrLiveState(
           pullNumber: pr.number,
         },
         `${prLabel(pr)} (get)`,
+        pending,
       ),
-      fetchPrStatusExtras(client, conn.id, pr),
+      fetchPrStatusExtras(client, conn.id, pr, pending),
     ]);
     if (!obj) return NO_LIVE_STATE;
     const rawState = obj.state;
@@ -769,7 +787,13 @@ export async function fetchPrLiveState(
   } catch {
     return NO_LIVE_STATE;
   } finally {
-    await client.close().catch(() => {});
+    // Close only once the background revalidations are done, and do NOT await
+    // that here — the whole point of serving a stale value is to return without
+    // waiting on GitHub. Closing eagerly (which this did) killed every
+    // revalidation the moment it started, so a cached entry could never
+    // refresh: a PR read before its deploy comment existed showed no preview
+    // and no checks until the entry aged out half an hour later.
+    void Promise.allSettled(pending).then(() => client.close().catch(() => {}));
   }
 }
 


### PR DESCRIPTION
Follow-up to #5849. Reported from prod: a card with a linked PR showed **Open #19 and nothing else** — no deploy preview, no checks — and stayed that way.

<img width="600" alt="card with no preview or checks" src="https://github.com/user-attachments/assets/placeholder" />

## What I got wrong

#5849 put the polled PR reads behind a stale-while-revalidate cache, but never passed `onRevalidation`. So:

1. A poll finds a stale entry → cache returns the old value immediately and kicks off a background refresh **on the same MCP client**.
2. `fetchPrLiveState` returns → its `finally` runs `client.close()`.
3. The refresh, now mid-flight on a closed client, dies.

The entry therefore **never refreshed**. A PR first read before its Vercel/Cloudflare deploy comment existed cached "no preview, no checks" and served that for the full 30-minute `maxStaleMs`, then hard-missed and cached whatever it saw next. Every other read-cache call site (`lazy-client.ts`, `connection/get.ts`, `connection/list.ts`, `transports/auth.ts`) already threads the promise into `ctx.pendingRevalidations` for exactly this reason — I missed it.

Confirmed against prod: `deco-sites/electrolux#19`'s Vercel comment does contain a `.vercel.app` preview link, and `extractPreviewUrlFromComments` extracts it correctly from the real payload — the read was fine, the refresh was dead.

## Fix

Collect the revalidation promises locally and close the client once they settle. Deliberately **not** awaited on the request path — returning without waiting on GitHub is the point of serving stale:

```ts
} finally {
  void Promise.allSettled(pending).then(() => client.close().catch(() => {}));
}
```

## Testing

- New regression test in `mcp-read-cache.test.ts` against the real cache (no mocks, injected clock): a caller that closes eagerly keeps serving the stale value; one that holds open until the handed-out promises settle gets the refreshed one.
- `bun run --cwd=apps/api check` clean, `bun run lint` 0 errors, `bun test apps/api/src/mcp-clients apps/api/src/tools/task-board/checks-status.test.ts` 53 pass.

## Note on the 429s

The cache itself is doing its job — GitHub rate-limit errors dropped from ~458 per 3h on a single api pod to ~35 since 4.192.9 shipped. This PR is about the refresh never landing, not the call volume.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes task-board PR cards getting stuck with stale data by keeping the GitHub MCP client alive until cache revalidations finish. PR cards now refresh deploy previews and checks promptly after a stale read.

- **Bug Fixes**
  - Collect revalidation promises via `onRevalidation` and defer `client.close()` until they settle, without blocking the request; thread this through `cachedPrRead`, `fetchPrStatusExtras`, and `fetchCheckRunSummary`.
  - Added a regression test in `mcp-read-cache.test.ts` that shows eager closing keeps serving stale data, while holding open until revalidations settle updates the cache.

<sup>Written for commit fa9ddd8e64be8bc5463be0d94208311fc0229206. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

