### PR TITLE
fix(org-fs): stamp x-thread-id on fs hooks so org/output actually reaches org-fs

### DIFF
--- a/apps/api/src/harnesses/decopilot/built-in-tools/cluster-sandbox-fs.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/cluster-sandbox-fs.ts
@@ -92,6 +92,9 @@ export async function buildClusterSandboxFs(
     /** When true, tools/sync fires after each (re)provisioning — see
      *  `syncToolsCatalog`. */
     syncTools?: boolean;
+    /** Stamped as `x-thread-id` on every daemon call so the daemon repoints
+     *  `org/output`/`org/upload` at this thread's org-fs subtree. */
+    threadId?: string;
   },
 ): Promise<SandboxFsHooks> {
   // `dispatch-run` already populated `ctx.sandboxPreference` from the resolved
@@ -188,6 +191,7 @@ export async function buildClusterSandboxFs(
     ensureHandle,
     invalidateHandle,
     canAutoRestart,
+    threadId: vm.threadId,
   });
 }
 

--- a/apps/api/src/harnesses/decopilot/built-in-tools/index.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/index.ts
@@ -241,6 +241,7 @@ async function buildAllTools(
       branch: vmContext.branch,
       userId: vmContext.userId,
       syncTools: vmContext.syncTools,
+      threadId: vmContext.threadId,
     });
     // The VM tools are built once and close over the fs. `load_repo` switches
     // the thread's repo mid-run onto a new sandbox branch — so the tools call
@@ -279,6 +280,7 @@ async function buildAllTools(
             branch,
             userId: vmContext.userId,
             syncTools: vmContext.syncTools,
+            threadId: vmContext.threadId,
           }),
         );
       },

--- a/apps/api/src/harnesses/decopilot/built-in-tools/load-repo.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/load-repo.ts
@@ -257,6 +257,7 @@ export async function createLoadRepoTool(opts: {
         virtualMcpId,
         branch,
         userId,
+        threadId,
       });
       const deadline = Date.now() + CLONE_TIMEOUT_MS;
       let listing = "";

--- a/packages/sandbox/daemon-go/internal/orgfs/links.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/links.go
@@ -483,10 +483,16 @@ func (l *Links) repointThreadLink(threadId, mountDir, linkName string) bool {
 	target := filepath.Join(mountDir, threadId)
 	if st, err := os.Lstat(link); err == nil {
 		if st.Mode()&os.ModeSymlink == 0 {
-			slog.Warn("org-fs link skipped: exists and is not a symlink", "link", link)
-			return false
-		}
-		if cur, err := os.Readlink(link); err == nil && cur == target {
+			// A write that lands before the first repoint materializes a REAL
+			// `org/output` on ephemeral disk (the fs write route MkdirAlls its
+			// parent), which would shadow the mount for the pod's whole life.
+			// Empty: safe to replace with the link. Populated: those are agent
+			// bytes with nowhere else to live — leave them visible and loud.
+			if entries, err := os.ReadDir(link); err != nil || len(entries) > 0 {
+				slog.Warn("org-fs link skipped: exists and is not a symlink", "link", link)
+				return false
+			}
+		} else if cur, err := os.Readlink(link); err == nil && cur == target {
 			return true
 		}
 		if err := os.Remove(link); err != nil {

--- a/packages/sandbox/daemon-go/internal/orgfs/links_test.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/links_test.go
@@ -56,6 +56,53 @@ func TestRepointDoesNotCacheAFailedLink(t *testing.T) {
 	}
 }
 
+// A write that lands before the first repoint materializes a REAL `org/output`
+// on ephemeral disk (the fs write route MkdirAlls its parent). An empty one
+// must be healed — replaced by the link — or the mount stays shadowed for the
+// pod's whole life. A populated one holds agent bytes and must be left alone.
+func TestRepointHealsAnEmptyRealOutputDir(t *testing.T) {
+	appRoot := t.TempDir()
+	statusPath := filepath.Join(t.TempDir(), "status.json")
+	mountPath := filepath.Join(appRoot, "org", ".outputs")
+	if err := os.MkdirAll(mountPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := json.Marshal(sidecarStatus{Mounts: []Mount{{Volume: ".outputs", MountPath: mountPath}}})
+	if err := os.WriteFile(statusPath, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	l := &Links{AppRoot: appRoot, StatusPath: statusPath, ConfigPath: "unused"}
+
+	// Empty real dir in the link's place: healed.
+	link := filepath.Join(appRoot, "org", "output")
+	if err := os.MkdirAll(link, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !l.RepointForRun("t1") {
+		t.Fatal("did not heal an empty real org/output dir")
+	}
+	if target, err := os.Readlink(link); err != nil || target != filepath.Join(".outputs", "t1") {
+		t.Fatalf("output link = %q (err %v), want .outputs/t1", target, err)
+	}
+
+	// Populated real dir: agent bytes, never discarded.
+	if err := os.Remove(link); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(link, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(link, "plan.md"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if l.RepointForRun("t2") {
+		t.Fatal("reported a repoint over a populated real org/output dir")
+	}
+	if _, err := os.Stat(filepath.Join(link, "plan.md")); err != nil {
+		t.Fatalf("populated dir was discarded: %v", err)
+	}
+}
+
 func TestExpectedRequiresSidecarEnv(t *testing.T) {
 	if (&Links{}).Expected() {
 		t.Error("org-fs expected with no sidecar env — every call would pay the mount wait")

--- a/packages/sandbox/server/provider/sandbox-fs-hooks.test.ts
+++ b/packages/sandbox/server/provider/sandbox-fs-hooks.test.ts
@@ -132,6 +132,40 @@ describe("createSandboxFsHooks", () => {
     ]);
   });
 
+  test("stamps x-thread-id on every daemon call when the lifecycle carries a threadId", async () => {
+    // The daemon's `linked()` middleware repoints `org/output` at the thread's
+    // org-fs subtree keyed on this header. Without it, the fs write's MkdirAll
+    // materializes `org/output` as a real dir on ephemeral disk and every
+    // deliverable written there dies with the pod (silently: the write reports
+    // success, the Library shows "no longer available").
+    let sawThreadHeader: string | null = null;
+    const provider = {
+      kind: "agent-sandbox",
+      proxyDaemonRequest: async (
+        _handle: string,
+        _path: string,
+        init: { headers: Headers },
+      ) => {
+        sawThreadHeader = init.headers.get("x-thread-id");
+        return new Response(JSON.stringify({ ok: true, bytesWritten: 2 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    } as unknown as SandboxProvider;
+    const hooks = createSandboxFsHooks(provider, {
+      ...lifecycle,
+      threadId: "thread-42",
+    });
+    await hooks.onWrite("org/output/plan.md", "hi");
+    expect(sawThreadHeader).toBe("thread-42" as never);
+
+    // Without a threadId (e.g. a threadless probe) the header is absent.
+    const bare = createSandboxFsHooks(provider, lifecycle);
+    await bare.onWrite("org/output/plan.md", "hi");
+    expect(sawThreadHeader).toBe(null);
+  });
+
   test("a daemon op that never responds fails at the op deadline — without reaping the sandbox", async () => {
     // The silent-hang regression: a wedged daemon (stalled org-fs mount) left
     // the harness awaiting forever with no chunks, so the 10-min liveness

--- a/packages/sandbox/server/provider/sandbox-fs-hooks.ts
+++ b/packages/sandbox/server/provider/sandbox-fs-hooks.ts
@@ -117,6 +117,15 @@ export interface SandboxFsHooksLifecycle {
    * should not need to.
    */
   opTimeoutMs?: number;
+  /**
+   * Thread driving this run. Stamped as `x-thread-id` on every daemon call so
+   * the daemon's `linked()` middleware repoints `org/output` (and `org/upload`)
+   * at this thread's org-fs subtree before the handler runs. Without it the
+   * daemon never repoints for hosted-harness runs, the fs write's MkdirAll
+   * materializes `org/output` as a REAL dir on the pod's ephemeral disk, and
+   * every deliverable written there dies with the pod.
+   */
+  threadId?: string;
 }
 
 /**
@@ -198,7 +207,7 @@ async function daemonRequest(
   path: string,
   body: Record<string, unknown> | null,
   method: "GET" | "POST" | "PUT" = "POST",
-  opts?: { signal?: AbortSignal; timeoutMs?: number },
+  opts?: { signal?: AbortSignal; timeoutMs?: number; threadId?: string },
 ): Promise<unknown> {
   const timeoutMs = opts?.timeoutMs ?? opDeadlineMs(body ?? {});
   const timeout = AbortSignal.timeout(timeoutMs);
@@ -208,6 +217,10 @@ async function daemonRequest(
   let res: Response;
   let rawText: string;
   try {
+    const headers = new Headers({ "content-type": "application/json" });
+    // The daemon's `linked()` middleware keys org-fs link repointing on this
+    // header — see `SandboxFsHooksLifecycle.threadId`.
+    if (opts?.threadId) headers.set("x-thread-id", opts.threadId);
     const init: {
       method: string;
       headers: Headers;
@@ -215,7 +228,7 @@ async function daemonRequest(
       signal: AbortSignal;
     } = {
       method,
-      headers: new Headers({ "content-type": "application/json" }),
+      headers,
       body: null,
       signal: reqSignal,
     };
@@ -343,6 +356,7 @@ export function createSandboxFsHooks(
       daemonRequest(provider, handle, daemonPath, input, method, {
         signal,
         timeoutMs: lifecycle.opTimeoutMs,
+        threadId: lifecycle.threadId,
       });
     const firstHandle = await ensureHandle();
     try {


### PR DESCRIPTION
## Summary

Deliverables written to `org/output/` from chat runs were silently lost: the write tool reported success, but the file never reached the org-fs `outputs` volume, so the thread-outputs UI showed **"This file is no longer available"** — and the bytes died with the pod.

**Root cause:** the daemon's `linked()` middleware repoints the per-run `org/output` symlink at `.outputs/<threadId>` keyed on an `x-thread-id` header (`daemon-go/main.go`), but the Studio side never sent it — `createSandboxFsHooks` stamped only `content-type`. (The daemon comment "vm-tools stamp the thread on each call" described a sender that didn't exist; the only real sender in the codebase was task-board's `TASK_ADD_REPO`.) With no repoint, the daemon fs write route's `MkdirAll` materializes `org/output` as a **real dir on the pod's ephemeral disk**, which additionally blocks any later repoint forever (`repointThreadLink` refuses to replace a non-symlink).

Fleet-wide effect: since the Aug 4 harness migration, **zero** files have landed in any org's `outputs` volume and no chat thread has had its outputs dir created — only dispatch-envelope runs (task board), whose `BeforeRun` hook passes the threadId directly, kept working. Observed in prod as an agent writing a plan to `org/output/`, the file surviving only because the agent also copied it into `org/home/` (which needs no repoint), and the first copy being wiped entirely by a mid-thread `load_repo` pod swap.

## Changes

- **`packages/sandbox/server/provider/sandbox-fs-hooks.ts`** — `SandboxFsHooksLifecycle` gains `threadId?`; every daemon call now stamps `x-thread-id` when present.
- **`apps/api/.../cluster-sandbox-fs.ts` + call sites** — `buildClusterSandboxFs` accepts `threadId` and the decopilot glue threads it through from `vmContext` (initial build, `load_repo` rebind, and `load_repo`'s clone-poll probe).
- **`packages/sandbox/daemon-go/internal/orgfs/links.go`** — `repointThreadLink` heals the poisoned state: an **empty** real dir squatting on the link path is replaced by the symlink. A **populated** one still wins (agent bytes with nowhere else to live are never discarded).

## Testing

- `sandbox-fs-hooks.test.ts`: header stamped when the lifecycle carries a threadId, absent otherwise (13 pass).
- `links_test.go`: empty-real-dir heal + populated-dir refusal (`go test ./internal/orgfs/` ok).
- `bun run fmt`, `bun run lint`, `bun run check` pass. The one failing test under the touched paths (`web_search async-research e2e`, connection refused) fails identically on main — pre-existing, needs a local service.

## Notes

- The daemon side of the header contract was already covered by `daemon-e2e/daemon.orgfs.e2e.test.ts`; this PR fixes the sender.
- Follow-up worth considering: salvage (copy onto the mount) for a *populated* squatting `org/output` dir, and a reconcile pass for manifest/object size drift (#5827's residual gap).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lost files written to `org/output` during chat runs by sending the `x-thread-id` header on all sandbox FS daemon calls and healing empty real dirs that blocked org-fs link repoints. Restores thread outputs in the UI and prevents future data loss.

- **Bug Fixes**
  - `packages/sandbox/server/provider/sandbox-fs-hooks.ts`: add `threadId?` to `SandboxFsHooksLifecycle`; send `x-thread-id` on every daemon request.
  - `apps/api/src/harnesses/decopilot/built-in-tools/*`: thread `vmContext.threadId` through `buildClusterSandboxFs` (initial build, `load_repo` rebind, and clone probe).
  - `packages/sandbox/daemon-go/internal/orgfs/links.go`: `repointThreadLink` now replaces an empty real `org/output` with the symlink to `.outputs/<threadId>`; preserves populated dirs.
  - Tests: `sandbox-fs-hooks.test.ts` covers header stamping; `links_test.go` covers empty-dir heal and populated-dir refusal.

<sup>Written for commit 221576fdb1bada2cca6c62487bb2e1d7fa0acc69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

