### PR TITLE
fix(sections-editor): keep the edited array item selected when its label changes

### DIFF
--- a/apps/web/src/components/sections-editor/fields/array-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/array-field.tsx
@@ -35,7 +35,6 @@ import {
 } from "../array-item-hidden";
 import { isEmbeddedUnionResolveType } from "../block-type-utils";
 import {
-  arrayItemCrumbIndex,
   buildArrayDrillDownBreadcrumb,
   findBreadcrumbLabelIndex,
   resolveArrayItemSelection,
@@ -327,25 +326,19 @@ export function ArrayField({
 
     // When editing the currently selected item, the display label may change
     // (e.g. editing the "alt" or "name" field that drives getArrayItemLabel).
-    // Rewrite the item's crumb IN PLACE — by its position in the trail, not by
-    // looking up its old text — so resolveArrayItemSelection keeps pointing at
-    // THIS item. A text lookup strands the crumb once the old label is gone
-    // (the edited item then re-resolves to a colliding sibling, e.g. the
-    // "original" a duplicate was copied from), and it rewrites the wrong crumb
-    // when the item's label equals an earlier one (array label == item label).
-    if (index === selectedIndex && selectedIndex !== null && selection) {
+    // Rewrite the item's crumb IN PLACE — at the position resolution matched it
+    // (`selection.crumbIndex`), not by looking up its old text — so
+    // resolveArrayItemSelection keeps pointing at THIS item. A text lookup
+    // strands the crumb once the old label is gone: the edited item then
+    // re-resolves to a colliding sibling, e.g. the "original" a duplicate was
+    // copied from.
+    if (index === selectedIndex && selection) {
       const oldLabel = itemLabel(items[index], index);
       const newLabel = itemLabel(next[index], index, next);
       if (oldLabel !== newLabel) {
-        const crumbIndex = arrayItemCrumbIndex(
-          breadcrumbPath,
-          selection.innerPath,
-        );
-        if (crumbIndex >= 0 && crumbIndex < breadcrumbPath.length) {
-          const updatedBreadcrumb = [...breadcrumbPath];
-          updatedBreadcrumb[crumbIndex] = newLabel;
-          onBreadcrumbChange?.(updatedBreadcrumb);
-        }
+        const updatedBreadcrumb = [...breadcrumbPath];
+        updatedBreadcrumb[selection.crumbIndex] = newLabel;
+        onBreadcrumbChange?.(updatedBreadcrumb);
       }
     }
   };

--- a/apps/web/src/components/sections-editor/fields/array-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/array-field.tsx
@@ -35,6 +35,7 @@ import {
 } from "../array-item-hidden";
 import { isEmbeddedUnionResolveType } from "../block-type-utils";
 import {
+  arrayItemCrumbIndex,
   buildArrayDrillDownBreadcrumb,
   findBreadcrumbLabelIndex,
   resolveArrayItemSelection,
@@ -326,13 +327,21 @@ export function ArrayField({
 
     // When editing the currently selected item, the display label may change
     // (e.g. editing the "alt" or "name" field that drives getArrayItemLabel).
-    // Update the breadcrumb so resolveArrayItemSelection keeps matching.
-    if (index === selectedIndex && selectedIndex !== null) {
+    // Rewrite the item's crumb IN PLACE — by its position in the trail, not by
+    // looking up its old text — so resolveArrayItemSelection keeps pointing at
+    // THIS item. A text lookup strands the crumb once the old label is gone
+    // (the edited item then re-resolves to a colliding sibling, e.g. the
+    // "original" a duplicate was copied from), and it rewrites the wrong crumb
+    // when the item's label equals an earlier one (array label == item label).
+    if (index === selectedIndex && selectedIndex !== null && selection) {
       const oldLabel = itemLabel(items[index], index);
       const newLabel = itemLabel(next[index], index, next);
       if (oldLabel !== newLabel) {
-        const crumbIndex = findBreadcrumbLabelIndex(breadcrumbPath, oldLabel);
-        if (crumbIndex >= 0) {
+        const crumbIndex = arrayItemCrumbIndex(
+          breadcrumbPath,
+          selection.innerPath,
+        );
+        if (crumbIndex >= 0 && crumbIndex < breadcrumbPath.length) {
           const updatedBreadcrumb = [...breadcrumbPath];
           updatedBreadcrumb[crumbIndex] = newLabel;
           onBreadcrumbChange?.(updatedBreadcrumb);

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { SchemaProperty } from "./resolve-schema";
 import {
+  arrayItemCrumbIndex,
   breadcrumbPathForActiveField,
   breadcrumbsForHeaderClick,
   buildArrayDrillDownBreadcrumb,
@@ -846,6 +847,114 @@ describe("resolveArrayItemSelection", () => {
         ),
       ).toEqual({ index: 1, innerPath: [] });
     });
+  });
+});
+
+describe("arrayItemCrumbIndex", () => {
+  test("points at the item crumb (just before its inner trail)", () => {
+    // Trail [Section, Item, Inner]; resolver returned innerPath [Inner] → the
+    // item crumb is at index 1.
+    expect(arrayItemCrumbIndex(["Section", "Item", "Inner"], ["Inner"])).toBe(
+      1,
+    );
+  });
+
+  test("last crumb is the item when innerPath is empty", () => {
+    expect(arrayItemCrumbIndex(["Banners", "Cozinha 2"], [])).toBe(1);
+    expect(arrayItemCrumbIndex(["Cozinha 2"], [])).toBe(0);
+  });
+});
+
+describe("editing an item's label keeps it selected (crumb re-sync)", () => {
+  // Reproduces the reported bug: duplicate a banner (two share a label), open
+  // the copy, edit its text. The editor must stay on the copy — not snap back
+  // to the "original" it was duplicated from. This exercises the exact sequence
+  // ArrayField.updateItem runs: resolve selection → rewrite the item crumb by
+  // POSITION (arrayItemCrumbIndex) → re-resolve against the edited items.
+  const schema = {
+    type: "object",
+    properties: { title: { type: "string", title: "Title" } },
+  } as SchemaProperty;
+
+  const editKeepsSelection = (
+    items: unknown[],
+    openIndex: number,
+    edited: unknown[],
+  ) => {
+    const labels = getArrayItemLabels(items, schema);
+    // The crumb the open row carries, built from the disambiguated label.
+    const trail = [labels[openIndex]!];
+    const selection = resolveArrayItemSelection(
+      "Banners",
+      trail,
+      items,
+      schema,
+      openIndex,
+    );
+    expect(selection).toEqual({ index: openIndex, innerPath: [] });
+
+    // updateItem: rewrite the item crumb in place to the new label.
+    const newLabel = getArrayItemLabels(edited, schema)[openIndex]!;
+    const crumbIndex = arrayItemCrumbIndex(trail, selection!.innerPath);
+    const updatedTrail = [...trail];
+    updatedTrail[crumbIndex] = newLabel;
+
+    // Re-resolving against the edited array must still land on the same item.
+    return resolveArrayItemSelection(
+      "Banners",
+      updatedTrail,
+      edited,
+      schema,
+      openIndex,
+    );
+  };
+
+  test("editing the duplicate's title stays on the duplicate, not the original", () => {
+    const items = [{ title: "Cozinha" }, { title: "Cozinha" }];
+    // Open the copy (index 1), rename it for the new campaign.
+    const edited = [{ title: "Cozinha" }, { title: "Cozinha Nova" }];
+    expect(editKeepsSelection(items, 1, edited)).toEqual({
+      index: 1,
+      innerPath: [],
+    });
+  });
+
+  test("clearing the title mid-edit (label falls back) keeps the same item", () => {
+    // Emptying the label field makes the row fall back to the schema-title
+    // suffix; the crumb still tracks it because it is rewritten by position.
+    const items = [{ title: "Cozinha" }, { title: "Cozinha" }];
+    const edited = [{ title: "Cozinha" }, { title: "" }];
+    expect(editKeepsSelection(items, 1, edited)).toEqual({
+      index: 1,
+      innerPath: [],
+    });
+  });
+
+  test("editing an item that is drilled one level deep keeps the inner trail", () => {
+    // Trail [item, Inner]: the item crumb is at position 0, so rewriting it by
+    // position must leave the inner crumb ("Inner") untouched.
+    const items = [{ title: "Cozinha" }, { title: "Cozinha" }];
+    const labels = getArrayItemLabels(items, schema);
+    const trail = [labels[1]!, "Inner"];
+    const selection = resolveArrayItemSelection(
+      "Banners",
+      trail,
+      items,
+      schema,
+      1,
+    );
+    expect(selection).toEqual({ index: 1, innerPath: ["Inner"] });
+
+    const edited = [{ title: "Cozinha" }, { title: "Cozinha Nova" }];
+    const newLabel = getArrayItemLabels(edited, schema)[1]!;
+    const crumbIndex = arrayItemCrumbIndex(trail, selection!.innerPath);
+    expect(crumbIndex).toBe(0);
+    const updatedTrail = [...trail];
+    updatedTrail[crumbIndex] = newLabel;
+    expect(updatedTrail).toEqual(["Cozinha Nova", "Inner"]);
+    expect(
+      resolveArrayItemSelection("Banners", updatedTrail, edited, schema, 1),
+    ).toEqual({ index: 1, innerPath: ["Inner"] });
   });
 });
 

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import type { SchemaProperty } from "./resolve-schema";
 import {
-  arrayItemCrumbIndex,
   breadcrumbPathForActiveField,
   breadcrumbsForHeaderClick,
   buildArrayDrillDownBreadcrumb,
@@ -15,7 +14,7 @@ import {
   resolveArrayItemSelection,
   isBreadcrumbInsideObject,
 } from "./schema-form-breadcrumb";
-import { getArrayItemLabels } from "./array-item-display";
+import { getArrayItemLabel, getArrayItemLabels } from "./array-item-display";
 import { PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE } from "./section-types";
 
 describe("normalizeBreadcrumbLabel", () => {
@@ -747,13 +746,13 @@ describe("resolveArrayItemSelection", () => {
         items,
         itemSchema,
       ),
-    ).toEqual({ index: 0, innerPath: [] });
+    ).toEqual({ index: 0, innerPath: [], crumbIndex: 2 });
   });
 
   test("returns inner path for nested array drill-down", () => {
     expect(
       resolveArrayItemSelection("Cards", ["Men's", "Sale"], items, itemSchema),
-    ).toEqual({ index: 0, innerPath: ["Sale"] });
+    ).toEqual({ index: 0, innerPath: ["Sale"], crumbIndex: 0 });
   });
 
   test("supports breadcrumb without array label", () => {
@@ -764,7 +763,7 @@ describe("resolveArrayItemSelection", () => {
         items,
         itemSchema,
       ),
-    ).toEqual({ index: 0, innerPath: ["Button"] });
+    ).toEqual({ index: 0, innerPath: ["Button"], crumbIndex: 0 });
   });
 
   test("selects item when its label equals the array label (alt-driven label)", () => {
@@ -784,7 +783,7 @@ describe("resolveArrayItemSelection", () => {
         bannerSchema,
         0,
       ),
-    ).toEqual({ index: 0, innerPath: [] });
+    ).toEqual({ index: 0, innerPath: [], crumbIndex: 0 });
   });
 
   describe("duplicate labels", () => {
@@ -798,10 +797,10 @@ describe("resolveArrayItemSelection", () => {
     test("addresses each duplicate by its positional crumb (no preferredIndex)", () => {
       expect(
         resolveArrayItemSelection("Cards", ["Hello 1"], dupItems, itemSchema),
-      ).toEqual({ index: 0, innerPath: [] });
+      ).toEqual({ index: 0, innerPath: [], crumbIndex: 0 });
       expect(
         resolveArrayItemSelection("Cards", ["Hello 2"], dupItems, itemSchema),
-      ).toEqual({ index: 1, innerPath: [] });
+      ).toEqual({ index: 1, innerPath: [], crumbIndex: 0 });
     });
 
     test("a bare (non-disambiguated) crumb no longer matches a duplicate", () => {
@@ -821,7 +820,7 @@ describe("resolveArrayItemSelection", () => {
           itemSchema,
           1,
         ),
-      ).toEqual({ index: 1, innerPath: [] });
+      ).toEqual({ index: 1, innerPath: [], crumbIndex: 0 });
     });
 
     test("ignores a preferredIndex whose label no longer matches the crumb", () => {
@@ -833,7 +832,7 @@ describe("resolveArrayItemSelection", () => {
           itemSchema,
           0, // preferred item 0 is "Men's" — doesn't match, fall back to search
         ),
-      ).toEqual({ index: 1, innerPath: [] });
+      ).toEqual({ index: 1, innerPath: [], crumbIndex: 0 });
     });
 
     test("falls back to crumb search when preferredIndex is out of range", () => {
@@ -845,45 +844,57 @@ describe("resolveArrayItemSelection", () => {
           itemSchema,
           5,
         ),
-      ).toEqual({ index: 1, innerPath: [] });
+      ).toEqual({ index: 1, innerPath: [], crumbIndex: 0 });
     });
   });
 });
 
-describe("arrayItemCrumbIndex", () => {
-  test("points at the item crumb (just before its inner trail)", () => {
-    // Trail [Section, Item, Inner]; resolver returned innerPath [Inner] → the
-    // item crumb is at index 1.
-    expect(arrayItemCrumbIndex(["Section", "Item", "Inner"], ["Inner"])).toBe(
-      1,
-    );
+describe("resolveArrayItemSelection crumbIndex", () => {
+  const schema = {
+    type: "object",
+    properties: { title: { type: "string", title: "Title" } },
+  } as SchemaProperty;
+  const items = [{ title: "Men's" }, { title: "Women's" }];
+
+  test("points at the item crumb, before its inner trail", () => {
+    // Trail [Section, Cards, Men's, Inner]: the item crumb is at index 2.
+    expect(
+      resolveArrayItemSelection(
+        "Cards",
+        ["Section", "Cards", "Men's", "Inner"],
+        items,
+        schema,
+      ),
+    ).toEqual({ index: 0, innerPath: ["Inner"], crumbIndex: 2 });
   });
 
-  test("last crumb is the item when innerPath is empty", () => {
-    expect(arrayItemCrumbIndex(["Banners", "Cozinha 2"], [])).toBe(1);
-    expect(arrayItemCrumbIndex(["Cozinha 2"], [])).toBe(0);
+  test("is the last crumb when innerPath is empty", () => {
+    expect(
+      resolveArrayItemSelection("Cards", ["Women's"], items, schema),
+    ).toEqual({ index: 1, innerPath: [], crumbIndex: 0 });
   });
 });
 
 describe("editing an item's label keeps it selected (crumb re-sync)", () => {
   // Reproduces the reported bug: duplicate a banner (two share a label), open
   // the copy, edit its text. The editor must stay on the copy — not snap back
-  // to the "original" it was duplicated from. This exercises the exact sequence
-  // ArrayField.updateItem runs: resolve selection → rewrite the item crumb by
-  // POSITION (arrayItemCrumbIndex) → re-resolve against the edited items.
+  // to the "original" it was duplicated from. Runs the exact sequence
+  // ArrayField.updateItem runs against the real functions: resolve selection →
+  // rewrite the crumb at `selection.crumbIndex` → re-resolve against the edits.
   const schema = {
     type: "object",
     properties: { title: { type: "string", title: "Title" } },
   } as SchemaProperty;
 
-  const editKeepsSelection = (
+  // Mirror ArrayField.updateItem's crumb re-sync exactly (same label helper it
+  // uses, `getArrayItemLabel` with siblings), so this test tracks the component
+  // rather than re-deriving the label a different way.
+  const rewriteAndReresolve = (
     items: unknown[],
+    trail: string[],
     openIndex: number,
     edited: unknown[],
   ) => {
-    const labels = getArrayItemLabels(items, schema);
-    // The crumb the open row carries, built from the disambiguated label.
-    const trail = [labels[openIndex]!];
     const selection = resolveArrayItemSelection(
       "Banners",
       trail,
@@ -891,31 +902,44 @@ describe("editing an item's label keeps it selected (crumb re-sync)", () => {
       schema,
       openIndex,
     );
-    expect(selection).toEqual({ index: openIndex, innerPath: [] });
-
-    // updateItem: rewrite the item crumb in place to the new label.
-    const newLabel = getArrayItemLabels(edited, schema)[openIndex]!;
-    const crumbIndex = arrayItemCrumbIndex(trail, selection!.innerPath);
-    const updatedTrail = [...trail];
-    updatedTrail[crumbIndex] = newLabel;
-
-    // Re-resolving against the edited array must still land on the same item.
-    return resolveArrayItemSelection(
-      "Banners",
-      updatedTrail,
-      edited,
-      schema,
+    if (!selection) throw new Error("expected a selection");
+    const oldLabel = getArrayItemLabel(
+      items[openIndex],
       openIndex,
+      schema,
+      items,
     );
+    const newLabel = getArrayItemLabel(
+      edited[openIndex],
+      openIndex,
+      schema,
+      edited,
+    );
+    let nextTrail = trail;
+    if (oldLabel !== newLabel) {
+      nextTrail = [...trail];
+      nextTrail[selection.crumbIndex] = newLabel;
+    }
+    return {
+      nextTrail,
+      selection: resolveArrayItemSelection(
+        "Banners",
+        nextTrail,
+        edited,
+        schema,
+        openIndex,
+      ),
+    };
   };
 
   test("editing the duplicate's title stays on the duplicate, not the original", () => {
     const items = [{ title: "Cozinha" }, { title: "Cozinha" }];
-    // Open the copy (index 1), rename it for the new campaign.
+    const trail = [getArrayItemLabels(items, schema)[1]!]; // open the copy
     const edited = [{ title: "Cozinha" }, { title: "Cozinha Nova" }];
-    expect(editKeepsSelection(items, 1, edited)).toEqual({
+    expect(rewriteAndReresolve(items, trail, 1, edited).selection).toEqual({
       index: 1,
       innerPath: [],
+      crumbIndex: 0,
     });
   });
 
@@ -923,38 +947,59 @@ describe("editing an item's label keeps it selected (crumb re-sync)", () => {
     // Emptying the label field makes the row fall back to the schema-title
     // suffix; the crumb still tracks it because it is rewritten by position.
     const items = [{ title: "Cozinha" }, { title: "Cozinha" }];
+    const trail = [getArrayItemLabels(items, schema)[1]!];
     const edited = [{ title: "Cozinha" }, { title: "" }];
-    expect(editKeepsSelection(items, 1, edited)).toEqual({
+    expect(rewriteAndReresolve(items, trail, 1, edited).selection).toEqual({
       index: 1,
       innerPath: [],
+      crumbIndex: 0,
     });
   });
 
-  test("editing an item that is drilled one level deep keeps the inner trail", () => {
-    // Trail [item, Inner]: the item crumb is at position 0, so rewriting it by
-    // position must leave the inner crumb ("Inner") untouched.
-    const items = [{ title: "Cozinha" }, { title: "Cozinha" }];
-    const labels = getArrayItemLabels(items, schema);
-    const trail = [labels[1]!, "Inner"];
+  test("editing a non-label field leaves the crumb untouched (no-op)", () => {
+    // oldLabel === newLabel → updateItem must not rewrite the breadcrumb.
+    const withExtra = {
+      type: "object",
+      properties: {
+        title: { type: "string", title: "Title" },
+        href: { type: "string", title: "Href" },
+      },
+    } as SchemaProperty;
+    const items = [{ title: "Cozinha", href: "/a" }];
+    const trail = ["Cozinha"];
     const selection = resolveArrayItemSelection(
       "Banners",
       trail,
       items,
-      schema,
-      1,
+      withExtra,
+      0,
     );
-    expect(selection).toEqual({ index: 1, innerPath: ["Inner"] });
+    const edited = [{ title: "Cozinha", href: "/b" }]; // label field unchanged
+    const oldLabel = getArrayItemLabel(items[0], 0, withExtra, items);
+    const newLabel = getArrayItemLabel(edited[0], 0, withExtra, edited);
+    expect(oldLabel).toBe(newLabel); // title drives the label; href doesn't
+    // Trail stays as-is; re-resolving still lands on the item.
+    expect(selection).toEqual({ index: 0, innerPath: [], crumbIndex: 0 });
+  });
 
+  test("editing an item drilled one level deep keeps the inner trail", () => {
+    // Trail [item, Inner]: the item crumb is at position 0, so rewriting it
+    // must leave the inner crumb ("Inner") untouched.
+    const items = [{ title: "Cozinha" }, { title: "Cozinha" }];
+    const trail = [getArrayItemLabels(items, schema)[1]!, "Inner"];
     const edited = [{ title: "Cozinha" }, { title: "Cozinha Nova" }];
-    const newLabel = getArrayItemLabels(edited, schema)[1]!;
-    const crumbIndex = arrayItemCrumbIndex(trail, selection!.innerPath);
-    expect(crumbIndex).toBe(0);
-    const updatedTrail = [...trail];
-    updatedTrail[crumbIndex] = newLabel;
-    expect(updatedTrail).toEqual(["Cozinha Nova", "Inner"]);
-    expect(
-      resolveArrayItemSelection("Banners", updatedTrail, edited, schema, 1),
-    ).toEqual({ index: 1, innerPath: ["Inner"] });
+    const { nextTrail, selection } = rewriteAndReresolve(
+      items,
+      trail,
+      1,
+      edited,
+    );
+    expect(nextTrail).toEqual(["Cozinha Nova", "Inner"]);
+    expect(selection).toEqual({
+      index: 1,
+      innerPath: ["Inner"],
+      crumbIndex: 0,
+    });
   });
 });
 
@@ -967,7 +1012,7 @@ describe("array item label build↔resolve round-trip", () => {
     labels.forEach((label, i) => {
       expect(
         resolveArrayItemSelection("Items", [label], items, schema),
-      ).toEqual({ index: i, innerPath: [] });
+      ).toEqual({ index: i, innerPath: [], crumbIndex: 0 });
     });
   };
 

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -184,6 +184,27 @@ export function findBreadcrumbLabelIndex(
   );
 }
 
+/**
+ * Position of the open array item's own crumb inside `breadcrumbPath`, derived
+ * from the `innerPath` that {@link resolveArrayItemSelection} returned for it.
+ * The item crumb always sits immediately before its inner trail, so this is
+ * `length - innerPath.length - 1`.
+ *
+ * Use this — not `findBreadcrumbLabelIndex(oldLabel)` — to rewrite the crumb
+ * when the item's label changes while it is open. A label lookup breaks the
+ * moment the label churns: once the old text is gone it finds nothing and the
+ * crumb is left stale (which then re-resolves to a colliding sibling — the
+ * "editing a duplicate's title snaps back to the original" bug); and when the
+ * item's label equals an earlier crumb (array label == item label), it rewrites
+ * the wrong (earlier) crumb. The position is stable regardless of the text.
+ */
+export function arrayItemCrumbIndex(
+  breadcrumbPath: string[],
+  innerPath: string[],
+): number {
+  return breadcrumbPath.length - innerPath.length - 1;
+}
+
 /** Breadcrumb drill-down applies to array fields only (not nested objects). */
 export function isArrayDrillDownField(
   schema: SchemaProperty,

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -184,27 +184,6 @@ export function findBreadcrumbLabelIndex(
   );
 }
 
-/**
- * Position of the open array item's own crumb inside `breadcrumbPath`, derived
- * from the `innerPath` that {@link resolveArrayItemSelection} returned for it.
- * The item crumb always sits immediately before its inner trail, so this is
- * `length - innerPath.length - 1`.
- *
- * Use this — not `findBreadcrumbLabelIndex(oldLabel)` — to rewrite the crumb
- * when the item's label changes while it is open. A label lookup breaks the
- * moment the label churns: once the old text is gone it finds nothing and the
- * crumb is left stale (which then re-resolves to a colliding sibling — the
- * "editing a duplicate's title snaps back to the original" bug); and when the
- * item's label equals an earlier crumb (array label == item label), it rewrites
- * the wrong (earlier) crumb. The position is stable regardless of the text.
- */
-export function arrayItemCrumbIndex(
-  breadcrumbPath: string[],
-  innerPath: string[],
-): number {
-  return breadcrumbPath.length - innerPath.length - 1;
-}
-
 /** Breadcrumb drill-down applies to array fields only (not nested objects). */
 export function isArrayDrillDownField(
   schema: SchemaProperty,
@@ -541,13 +520,31 @@ function findItemIndexForCrumb(
   return labels.findIndex((label) => labelsMatch(label, crumb));
 }
 
+/**
+ * Resolve which array item the breadcrumb trail points at.
+ *
+ * Returns `crumbIndex` — the position of the matched item's own crumb in
+ * `breadcrumbPath` — alongside `index` (the item's position in `items`) and
+ * `innerPath` (the trail *inside* the item). `crumbIndex` is the single source
+ * of truth for "where the open item's label lives in the trail": callers that
+ * rewrite that crumb when the label changes (see `ArrayField.updateItem`) MUST
+ * use it rather than re-deriving the position by looking up the old label text
+ * — a text lookup strands the crumb the moment the label churns (the edited
+ * item then re-resolves to a colliding sibling — the "editing a duplicate's
+ * title snaps back to the original" bug). Because it comes straight from the
+ * crumb this function actually matched, it can never point at a non-item crumb.
+ *
+ * `innerPath` is always a trailing suffix of `breadcrumbPath` (both return sites
+ * slice from `crumbIndex + 1`), so `crumbIndex === length - innerPath.length - 1`
+ * — keep it that way if you touch the slicing.
+ */
 export function resolveArrayItemSelection(
   label: string,
   breadcrumbPath: string[],
   items: unknown[],
   itemSchema: SchemaProperty | undefined,
   preferredIndex?: number | null,
-): { index: number; innerPath: string[] } | null {
+): { index: number; innerPath: string[]; crumbIndex: number } | null {
   if (breadcrumbPath.length === 0) return null;
 
   for (let pi = 0; pi < breadcrumbPath.length; pi++) {
@@ -559,7 +556,7 @@ export function resolveArrayItemSelection(
       preferredIndex,
     );
     if (index >= 0) {
-      return { index, innerPath: breadcrumbPath.slice(pi + 1) };
+      return { index, innerPath: breadcrumbPath.slice(pi + 1), crumbIndex: pi };
     }
   }
 
@@ -575,7 +572,11 @@ export function resolveArrayItemSelection(
       preferredIndex,
     );
     if (index >= 0) {
-      return { index, innerPath: breadcrumbPath.slice(labelIndex + 2) };
+      return {
+        index,
+        innerPath: breadcrumbPath.slice(labelIndex + 2),
+        crumbIndex: labelIndex + 1,
+      };
     }
   }
 


### PR DESCRIPTION
## Summary

When editing the text of an array item in the CMS sections editor — e.g. duplicating a banner and renaming the copy for a new campaign — the editor could snap back to the **original** item the copy was made from.

**Root cause:** the open array item is addressed by its (mutable, non-unique) display **label** via the breadcrumb, not by a stable id. `ArrayField.updateItem` kept the breadcrumb in sync by looking up the item's **old label text** (`findBreadcrumbLabelIndex(oldLabel)`). That lookup breaks the moment the label churns:

- Once you type over the old text, the lookup finds nothing → the crumb is left **stale**, and the next `resolveArrayItemSelection` falls back to `findIndex` → the **first** sibling still matching the old text (the original a duplicate was copied from).
- When the item's label equals an earlier crumb (array label == item label), it rewrote the **wrong** (earlier) crumb.

**Fix:** rewrite the item's crumb **by its position** in the trail — derived from the `innerPath` the resolver already returns (`length - innerPath.length - 1`) — instead of by text lookup. Selection stays pinned to the edited item regardless of how the label changes.

## Changes
- `schema-form-breadcrumb.ts` — new pure helper `arrayItemCrumbIndex()` with the rationale documented.
- `fields/array-field.tsx` — `updateItem` uses the position-based crumb index.
- `schema-form-breadcrumb.test.ts` — 3 new tests encoding the reported flow: editing/clearing a duplicate's title keeps it selected (doesn't jump to the original), including a drilled-one-level-deep case that must leave the inner trail intact.

## Testing
- `bun test` sections-editor: **586 pass, 0 fail**
- `bun run --cwd=apps/web check` (type-check): clean
- `bun run lint`: 0 errors (14 pre-existing warnings, untouched files)
- `bun run fmt`: applied

## Notes
Reproduced via unit tests at the pure-logic seam (resolver + label disambiguation), where the failure lives. The full app was not driven to re-enact the video; happy to run `bun run dev` and validate the campaign-swap flow on screen if wanted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the edited array item selected when its label changes in the sections editor. Prevents snapping back to the original item after renaming a duplicate.

- **Bug Fixes**
  - `resolveArrayItemSelection` now returns `crumbIndex`; `ArrayField.updateItem` uses it to rewrite the correct breadcrumb item.
  - Stop looking up the old label text; use `selection.crumbIndex` so selection stays on the edited item when labels collide or are cleared.
  - Tests updated to assert `crumbIndex` and cover: renaming a duplicate, clearing the label mid-edit, preserving inner trails, and no-op edits to non-label fields.

<sup>Written for commit 268281b49707ac5d91246fd0b6f8c15c456c514b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

