### PR TITLE
docs(quickstart): recommend the desktop app for local use, not running the server

### DIFF
--- a/apps/docs/client/src/content/deco-studio/en/studio/overview.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/overview.mdx
@@ -10,7 +10,7 @@ import Callout from "../../../../components/ui/Callout.astro";
 
 ## The control plane for your AI agents
 
-deco Studio is the open-source control plane for your AI agents — **one MCP endpoint for all your agents, tools, and models**. Build and hire agents, connect them to your tools, run them on schedules or events, and **track every token and dollar in real time**. It runs locally but you control it from any browser. Self-host or use the cloud — built on the [Model Context Protocol](https://modelcontextprotocol.io).
+deco Studio is the open-source control plane for your AI agents — **one MCP endpoint for all your agents, tools, and models**. Build and hire agents, connect them to your tools, run them on schedules or events, and **track every token and dollar in real time**. Use the cloud or self-host on your own infrastructure — built on the [Model Context Protocol](https://modelcontextprotocol.io).
 
 ### Agents
 
@@ -71,8 +71,8 @@ Most teams use all three at once: the pilot for quick work, hand-built systems f
 
 | | |
 |---|---|
-| **Local** | `bunx decocms` — runs entirely on your machine, fully private |
 | **Cloud** | [studio.decocms.com](https://studio.decocms.com) — manage everything from your browser |
+| **Desktop** | `brew install --cask deco-studio` — run agents on your machine with your Claude Code or Codex subscription |
 | **Team** | Shared connections, roles, and cost tracking across your organization |
 | **Self-hosted** | Deploy to your own infrastructure with Docker or Kubernetes |
 
@@ -80,7 +80,7 @@ Most teams use all three at once: the pilot for quick work, hand-built systems f
 
 ## Get started
 
-**[Quickstart](./quickstart)** — Get running in 5 minutes (cloud or local)
+**[Quickstart](./quickstart)** — Get running in 5 minutes
 
 **[Key concepts](./concepts)** — Anatomy of the Studio UI, plus how the pieces fit together
 

--- a/apps/docs/client/src/content/deco-studio/en/studio/quickstart.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/quickstart.mdx
@@ -8,30 +8,26 @@ import Callout from "../../../../components/ui/Callout.astro";
 
 ## Get Studio running
 
-There are two ways to start.
-
-### Option A — Managed cloud
-
 Sign up at [studio.decocms.com](https://studio.decocms.com) and you're ready to go.
 
 1. Create your account (email, GitHub, or Google)
 2. Create an organization — your top-level workspace
 3. You're in.
 
-### Option B — Run locally
+### Desktop app (recommended for local agents)
+
+The native desktop app lets agents run **on your machine** — with your files, your tooling, and your existing **Claude Code or Codex subscription** as the harness. Studio still handles chat, connections, and logging.
 
 ```bash
-bunx decocms
+brew tap decocms/studio https://github.com/decocms/studio
+brew install --cask deco-studio
 ```
 
-This spins up a local instance with embedded PostgreSQL. Fully private — everything stays on your machine. Or clone and run from source:
+macOS (Apple Silicon) for now. See [where an agent runs](./agents#where-an-agent-runs) for how local runtimes work.
 
-```bash
-git clone https://github.com/decocms/studio.git
-cd studio
-bun install
-bun run dev
-```
+<Callout type="info">
+  Want to run the Studio server itself on your own infrastructure? See [Self-hosting](./self-hosting/quickstart).
+</Callout>
 
 ---
 

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/overview.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/overview.mdx
@@ -10,7 +10,7 @@ import Callout from "../../../../components/ui/Callout.astro";
 
 ## O control plane para seus agentes de IA
 
-O deco Studio é o control plane open-source para seus agentes de IA — **um único endpoint MCP para todos os seus agents, tools e models**. Construa e contrate agents, conecte-os às suas tools, execute-os em schedules ou eventos e **acompanhe cada token e cada dólar em tempo real**. Ele roda localmente, mas você controla tudo a partir de qualquer navegador. Self-host ou use a cloud — construído sobre o [Model Context Protocol](https://modelcontextprotocol.io).
+O deco Studio é o control plane open-source para seus agentes de IA — **um único endpoint MCP para todos os seus agents, tools e models**. Construa e contrate agents, conecte-os às suas tools, execute-os em schedules ou eventos e **acompanhe cada token e cada dólar em tempo real**. Use a cloud ou faça self-host na sua própria infraestrutura — construído sobre o [Model Context Protocol](https://modelcontextprotocol.io).
 
 ### Agents
 
@@ -71,8 +71,8 @@ A maioria dos times usa as três ao mesmo tempo: o pilot para tarefas rápidas, 
 
 | | |
 |---|---|
-| **Local** | `bunx decocms` — roda inteiramente na sua máquina, totalmente privado |
 | **Cloud** | [studio.decocms.com](https://studio.decocms.com) — gerencie tudo pelo navegador |
+| **Desktop** | `brew install --cask deco-studio` — rode agents na sua máquina com sua assinatura do Claude Code ou Codex |
 | **Team** | Connections, roles e tracking de custos compartilhados em toda a organização |
 | **Self-hosted** | Faça deploy na sua própria infraestrutura com Docker ou Kubernetes |
 
@@ -80,7 +80,7 @@ A maioria dos times usa as três ao mesmo tempo: o pilot para tarefas rápidas, 
 
 ## Comece por aqui
 
-**[Quickstart](./quickstart)** — Rode em 5 minutos (cloud ou local)
+**[Quickstart](./quickstart)** — Rode em 5 minutos
 
 **[Conceitos-chave](./concepts)** — Anatomia da UI do Studio, e como as peças se encaixam
 

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/quickstart.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/quickstart.mdx
@@ -8,30 +8,26 @@ import Callout from "../../../../components/ui/Callout.astro";
 
 ## Coloque o Studio para rodar
 
-Existem duas formas de começar.
-
-### Opção A — Cloud gerenciada
-
 Cadastre-se em [studio.decocms.com](https://studio.decocms.com) e está tudo pronto.
 
 1. Crie sua conta (email, GitHub ou Google)
 2. Crie uma organização — seu workspace de nível mais alto
 3. Pronto, você está dentro.
 
-### Opção B — Rodar localmente
+### App desktop (recomendado para agents locais)
+
+O app desktop nativo permite que agents rodem **na sua máquina** — com seus arquivos, suas ferramentas e sua assinatura existente do **Claude Code ou Codex** como harness. O Studio continua cuidando do chat, das connections e dos logs.
 
 ```bash
-bunx decocms
+brew tap decocms/studio https://github.com/decocms/studio
+brew install --cask deco-studio
 ```
 
-Isso sobe uma instância local com PostgreSQL embutido. Totalmente privado — tudo fica na sua máquina. Ou clone e rode a partir do código-fonte:
+Por enquanto, macOS (Apple Silicon). Veja [onde um agent roda](./agents#where-an-agent-runs) para entender como runtimes locais funcionam.
 
-```bash
-git clone https://github.com/decocms/studio.git
-cd studio
-bun install
-bun run dev
-```
+<Callout type="info">
+  Quer rodar o servidor do Studio na sua própria infraestrutura? Veja [Self-hosting](./self-hosting/quickstart).
+</Callout>
 
 ---
 


### PR DESCRIPTION
## Summary

The quickstart and overview recommended running Studio locally (`bunx decocms` or clone + `bun run dev`) as a normal way to get started. That path is really for trying out self-hosting, so it now lives only in the [self-hosting docs](apps/docs/client/src/content/deco-studio/en/studio/self-hosting/quickstart.mdx), which already cover it.

The local option we *do* recommend is the **native desktop app**: it runs agents on your machine — your files, your tooling — using your existing **Claude Code or Codex subscription** as the harness, while Studio keeps handling chat, connections, and logging.

## Changes

- **Quickstart** (en + pt-BR): removed "Option B — Run locally"; added a "Desktop app (recommended for local agents)" section with `brew install --cask deco-studio` and a link to *Where an agent runs*. The self-hosting callout now says "run the Studio *server* on your own infrastructure" to keep the two apart.
- **Overview** (en + pt-BR): intro no longer says "it runs locally but you control it from any browser"; the deployment table swaps the **Local** (`bunx decocms`) row for a **Desktop** row; quickstart link drops "(cloud or local)".

Left untouched: the self-hosting quickstart (the right home for local runs) and the ai-providers note about local-only providers (describes behavior, not a recommendation).

## Testing

Docs-only (`.mdx` content). Verified the `#where-an-agent-runs` anchor exists in both en and pt-BR agents pages, and that the brew tap/cask commands match `Casks/deco-studio.rb`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recommend the native desktop app for running agents locally, instead of running the Studio server. Quickstart and Overview (en + pt-BR) now show `brew tap decocms/studio https://github.com/decocms/studio` and `brew install --cask deco-studio`, update the deployment table to “Desktop,” clarify cloud vs self-hosting, and link server-only local runs to the self-hosting docs; removed `bunx decocms`/source steps from quickstart.

<sup>Written for commit fa674533b344f5e085e8ce51cb317a30afc92fe3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

