### PR TITLE
fix(auth): backfill display name from email at signup

### DIFF
--- a/apps/api/src/auth/index.ts
+++ b/apps/api/src/auth/index.ts
@@ -47,7 +47,10 @@ import { identifyAuthenticatedUser } from "./posthog-identify";
 import { ADMIN_ROLES } from "@decocms/shared/auth/roles";
 import { getBuiltinRoleStatements } from "./builtin-role-permission";
 import { createSSOConfig } from "./sso";
-import { GENERIC_EMAIL_DOMAINS } from "./org-assurance-policy";
+import {
+  displayNameFromEmail,
+  GENERIC_EMAIL_DOMAINS,
+} from "./org-assurance-policy";
 import { ensureUserOrganization } from "./ensure-user-organization";
 import { isReservedOrganizationSlug } from "@decocms/shared/organization-slugs";
 import { rejectOrganizationSlugChange } from "./reject-slug-change";
@@ -532,6 +535,24 @@ export const auth = betterAuth({
   databaseHooks: {
     user: {
       create: {
+        // Backfill a display name from the email local-part when none is
+        // provided. Email OTP, magic link, and email/password signups never
+        // collect a name, so without this invited members render as
+        // "Unknown" with a "?" avatar. Social/SSO logins already carry a
+        // provider name and are left untouched.
+        before: async (user) => {
+          const name = (user as { name?: unknown }).name;
+          if (typeof name === "string" && name.trim().length > 0) {
+            return;
+          }
+
+          const derived = displayNameFromEmail(user.email);
+          if (!derived) {
+            return;
+          }
+
+          return { data: { ...user, name: derived } };
+        },
         after: async (user, context) => {
           // Tag the PostHog person record with email/name BEFORE the
           // user_signed_up capture so that event lands on a person record

--- a/apps/api/src/auth/org-assurance-policy.test.ts
+++ b/apps/api/src/auth/org-assurance-policy.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   defaultOrgNameForUser,
+  displayNameFromEmail,
   domainDisplayName,
   domainToOrgSlug,
   emailDomainOf,
@@ -54,6 +55,21 @@ describe("org assurance policy", () => {
         emailVerified: false,
       }),
     ).toBe(false);
+  });
+
+  test("derives display names from email local-parts", () => {
+    expect(displayNameFromEmail("ada.lovelace@example.com")).toBe(
+      "Ada Lovelace",
+    );
+    expect(displayNameFromEmail("grace_hopper+studio@example.com")).toBe(
+      "Grace Hopper Studio",
+    );
+    expect(displayNameFromEmail("ALAN@example.com")).toBe("ALAN");
+    expect(displayNameFromEmail("  katherine.johnson@example.com  ")).toBe(
+      "Katherine Johnson",
+    );
+    expect(displayNameFromEmail("@example.com")).toBe("");
+    expect(displayNameFromEmail("")).toBe("");
   });
 
   test("uses name first for generic default org names", () => {

--- a/apps/api/src/auth/org-assurance-policy.ts
+++ b/apps/api/src/auth/org-assurance-policy.ts
@@ -80,6 +80,25 @@ export function domainDisplayName(domain: string): string {
   return name || "Workspace";
 }
 
+/**
+ * Derives a human display name from an email local-part, e.g.
+ * `stephanie.moraes@montecarlo.com.br` -> "Stephanie Moraes".
+ *
+ * Used to backfill `user.name` at signup for flows that never collect one
+ * (email OTP, magic link, email/password), so invited members don't render
+ * as "Unknown". Returns "" when nothing usable can be derived, so callers
+ * can fall back to leaving the name empty.
+ */
+export function displayNameFromEmail(email: string): string {
+  const [localPart = ""] = email.trim().split("@");
+
+  return localPart
+    .split(/[^a-zA-Z0-9]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
 export function defaultOrgNameForUser(user: EmailUserLike): string {
   const firstName = user.name?.trim().split(/\s+/)[0];
 


### PR DESCRIPTION
## Summary

Members invited to an org rendered as **"Desconhecido" / "Unknown"** with a `?` avatar, showing only their email:

- The member list uses `user.name || t("orgs.members.unknown")` and `getInitials(name)` returns `"?"` when the name is empty — so the symptom is a genuinely empty `user.name` in the DB, not a display bug.
- Email OTP, magic link, and email/password signups **never collect a name** (the login form has no name field), and accepting an org invite doesn't backfill one. Only social/SSO logins carry a provider name.

This populates `user.name` from the email local-part at signup:

- **`displayNameFromEmail(email)`** in `org-assurance-policy.ts` — `ada.lovelace@example.com` → `"Ada Lovelace"` (splits on `.`/`_`/`-`/`+`, capitalizes, joins). Returns `""` when nothing usable can be derived.
- **`databaseHooks.user.create.before`** in `auth/index.ts` — fills `name` only when empty; social/SSO users with a provider name are left untouched.

## Scope / follow-up

This fixes **new** signups only. Members who already exist with an empty name stay "Unknown" until a follow-up backfill migration runs the same helper over existing rows (happy to add it if wanted).

## Testing

- `bun test apps/api/src/auth/org-assurance-policy.test.ts` — 8 pass (new cases: compound names, `_`/`+` separators, preserved caps, trim, empty inputs; fictional example emails only)
- `bun run --cwd=apps/api check` — passes
- `bun run fmt` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populate `user.name` at signup by deriving a display name from the email local-part. This stops invited members from appearing as “Unknown” with a “?” avatar.

- **Bug Fixes**
  - Add displayNameFromEmail(email) to build names from the local-part (splits on ".", "_", "-", "+", capitalizes).
  - Use databaseHooks.user.create.before to set name only when empty; SSO/provider names are unchanged.
  - New signups only; existing users with empty names are untouched.
  - Tests added for common cases and edge cases.

<sup>Written for commit d4e06ecf6e0699ce4ada9846d0b0732bb4106bdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

