### PR TITLE
fix(sections-editor): stop array item delete/duplicate from drilling in

### DIFF
--- a/apps/web/src/components/sections-editor/fields/array-row.tsx
+++ b/apps/web/src/components/sections-editor/fields/array-row.tsx
@@ -209,13 +209,24 @@ export function SortableArrayRow({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
-          <DropdownMenuItem onClick={onDuplicate}>
+          <DropdownMenuItem
+            onClick={(e) => {
+              // Stop the click from bubbling up the React tree (portaled
+              // content still propagates to the row's onClick) and drilling
+              // into the item right after this action runs.
+              e.stopPropagation();
+              onDuplicate();
+            }}
+          >
             <Copy01 size={14} />
             {t("sectionsEditor.arrayField.duplicate")}
           </DropdownMenuItem>
           <DropdownMenuItem
             className="text-destructive focus:text-destructive"
-            onClick={onRemove}
+            onClick={(e) => {
+              e.stopPropagation();
+              onRemove();
+            }}
           >
             <Trash01 size={14} />
             {t("sectionsEditor.arrayField.delete")}


### PR DESCRIPTION
## Summary

Clicking **Delete** (or **Duplicate**) in a CMS array item's dropdown menu drilled *into* an item right after the action ran, instead of staying on the list.

**Root cause:** React synthetic events propagate along the React component tree even when the source is rendered in a portal. So a click on the `DropdownMenuItem` bubbled up to the row's `onClick={onOpen}`, firing `openItem()` immediately after `removeItem()` had already shifted the array indices — opening the wrong item.

The dropdown trigger button and the hide/show toggle already call `e.stopPropagation()` for exactly this reason; the two `DropdownMenuItem`s (Duplicate and Delete) were the only interactive controls that didn't.

## Change

`apps/web/src/components/sections-editor/fields/array-row.tsx` — stop propagation on both `DropdownMenuItem` `onClick` handlers before invoking the action.

## Testing notes

- Manually: in the sections editor, open an array field with multiple items, delete an item from the middle of the list — it now stays on the list view with no drill-in. Same for Duplicate.
- Affected area: CMS / sections-editor array field editing only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents drill-in after clicking Delete or Duplicate in sections-editor array rows by stopping click propagation from the dropdown. Users stay on the list after the action, avoiding opening the wrong item.

- **Bug Fixes**
  - Stop event propagation in dropdown `onClick` for Duplicate and Delete before running actions.
  - Scope: CMS sections editor array field (`apps/web/src/components/sections-editor/fields/array-row.tsx`).

<sup>Written for commit 82d8400ad4a16fb51a04d639db59e93c19a74cee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

