### PR TITLE
fix(harness): retry the studio MCP preflight instead of failing the run

### DIFF
--- a/packages/harness-runner/claude-code.test.ts
+++ b/packages/harness-runner/claude-code.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { HarnessStreamInputWire } from "@decocms/sandbox/dispatch/schemas";
 import {
+  brokenStudioMcp,
   buildOptions,
   promptForRun,
   promptFromUserMessage,
@@ -103,6 +104,40 @@ describe("promptForRun", () => {
     expect(prompt).toContain("the studio pod restarted");
     expect(prompt).toContain("<branch>");
     expect(prompt).not.toContain("undefined");
+  });
+});
+
+describe("brokenStudioMcp", () => {
+  const url = "https://studio.example/mcp";
+
+  test("a connected server is usable", () => {
+    expect(
+      brokenStudioMcp([{ name: "studio", status: "connected" }], url),
+    ).toBe(null);
+  });
+
+  test("pending is not broken — http servers connect asynchronously", () => {
+    expect(brokenStudioMcp([{ name: "studio", status: "pending" }], url)).toBe(
+      null,
+    );
+  });
+
+  test("reports every unusable server so the retry log says which", () => {
+    expect(
+      brokenStudioMcp(
+        [
+          { name: "studio", status: "failed" },
+          { name: "other", status: "needs-auth" },
+        ],
+        url,
+      ),
+    ).toBe("studio=failed other=needs-auth");
+  });
+
+  test("no MCP configured means nothing to wait for", () => {
+    expect(brokenStudioMcp([{ name: "studio", status: "failed" }], "")).toBe(
+      null,
+    );
   });
 });
 

--- a/packages/harness-runner/claude-code.ts
+++ b/packages/harness-runner/claude-code.ts
@@ -231,6 +231,41 @@ export function buildOptions(args: {
 }
 
 /**
+ * Studio's MCP servers this session will never get tools from, as
+ * `name=status` — or `null` when the session can act on Studio.
+ *
+ * Keys off the server STATUS, not the tool count: an http MCP server connects
+ * asynchronously, so `pending` with zero `mcp__` tools at init is the normal
+ * case, not a misconfiguration. Exported for the unit test.
+ */
+export function brokenStudioMcp(
+  servers: { name: string; status: string }[],
+  mcpUrl: string,
+): string | null {
+  if (!mcpUrl) return null;
+  const broken = servers.filter((server) =>
+    ["failed", "needs-auth", "disabled"].includes(server.status),
+  );
+  if (broken.length === 0) return null;
+  return broken.map((server) => `${server.name}=${server.status}`).join(" ");
+}
+
+/**
+ * Attempts at reaching Studio's MCP before a run gives up, and the base of the
+ * backoff between them (2s, 4s, 8s, 16s — ~30s in all).
+ *
+ * What this waits out is Studio being momentarily unreachable: a rolling
+ * restart, a saturated pod, a moment with no free DB connection. That is over
+ * in seconds and has nothing to do with the task, so surfacing it as a failed
+ * run — which is what used to happen — put an infrastructure hiccup in front of
+ * the user. A retry costs one SDK session start; the session has produced
+ * nothing at that point (the preflight reads `system/init`, the first message
+ * of all), so restarting it loses nothing.
+ */
+const MCP_ATTEMPTS = 5;
+const MCP_BACKOFF_BASE_MS = 2_000;
+
+/**
  * Run one turn, emitting its chunks as the SDK produces them. An SDK throw
  * becomes a final `error` frame after whatever the turn had already emitted, so
  * a crash mid-turn still shows the work instead of an empty message.
@@ -266,6 +301,34 @@ export async function runClaudeCode(
   };
 
   try {
+    for (let attempt = 1; ; attempt++) {
+      const broken = await attemptTurn();
+      if (!broken) return;
+      if (attempt >= MCP_ATTEMPTS) {
+        fail(
+          `studio MCP is unusable (${input.mcp.url}): ${broken}. The harness ` +
+            `cannot act on Studio; refusing to run rather than return a result ` +
+            `that changed nothing.`,
+        );
+        return;
+      }
+      const waitMs = MCP_BACKOFF_BASE_MS * 2 ** (attempt - 1);
+      console.error(
+        `[claude-code] mcp unusable (${broken}) — retrying in ${waitMs}ms ` +
+          `(attempt ${attempt}/${MCP_ATTEMPTS})`,
+      );
+      await Bun.sleep(waitMs);
+    }
+  } catch (err) {
+    fail(err instanceof Error ? err.message : String(err));
+  }
+
+  /**
+   * One SDK session. Returns the broken-MCP description when the preflight
+   * found Studio unreachable — the one outcome worth starting over for — and
+   * `null` once the turn has been reported, however it ended.
+   */
+  async function attemptTurn(): Promise<string | null> {
     const stream = query({
       prompt: promptForRun(input),
       options: buildOptions({ input, sessionId, resume: stored.length > 0 }),
@@ -306,21 +369,9 @@ export async function runClaudeCode(
         );
         // A run that cannot reach Studio (no board update, no state change)
         // still produces a confident-looking answer — the failure that reads as
-        // success. Fail on it. Key off the server STATUS, not the tool count:
-        // an http MCP server connects asynchronously, so `pending` with zero
-        // mcp__ tools at init is the normal case, not a misconfiguration.
-        const broken = message.mcp_servers.filter((server) =>
-          ["failed", "needs-auth", "disabled"].includes(server.status),
-        );
-        if (input.mcp.url && broken.length > 0) {
-          fail(
-            `studio MCP is unusable (${input.mcp.url}): ${broken
-              .map((server) => `${server.name}=${server.status}`)
-              .join(" ")}. The harness cannot act on Studio; refusing to run ` +
-              `rather than return a result that changed nothing.`,
-          );
-          return;
-        }
+        // success. Never run in that state; the caller retries instead.
+        const broken = brokenStudioMcp(message.mcp_servers, input.mcp.url);
+        if (broken) return broken;
       }
       // First Anthropic message id of the turn becomes Studio's assistant
       // message id: stable if the same turn is delivered twice.
@@ -355,11 +406,10 @@ export async function runClaudeCode(
           ),
         ],
       });
-      return;
+      return null;
     }
     fail("claude-code ended without a result");
-  } catch (err) {
-    fail(err instanceof Error ? err.message : String(err));
+    return null;
   }
 
   /** Close whatever the turn had emitted, then report what ended it. */


### PR DESCRIPTION
## Problem

A run whose sandbox couldn't reach Studio's MCP at session init died immediately with

> `harness_crashed: studio MCP is unusable (http://.../mcp/task-run/thrd_...): studio=failed. The harness cannot act on Studio; refusing to run rather than return a result that changed nothing.`

The preflight itself is right — a run without Studio's tools produces a confident answer that changed nothing. But what it's usually detecting is Studio being unreachable *for a moment*: a rolling restart, a saturated pod, no free DB connection. That's an infrastructure hiccup shown to the user as a failed task.

## Change

`packages/harness-runner/claude-code.ts` — the preflight now returns the broken servers instead of failing, and `runClaudeCode` restarts the SDK session up to 5 times with exponential backoff (2s/4s/8s/16s, ~30s total) before giving up with the same message as before.

Safe to restart at that point: `system/init` is the first SDK message, so nothing has been emitted, nothing translated, and no session id has been written.

The final error text is unchanged on purpose — the task-board `transient-failure.ts` `/mcp is unusable/i` pattern still matches it, so a genuinely down Studio still gets the card-level retry on top.

## Testing

- Extracted the preflight decision as `brokenStudioMcp()` with unit tests: `connected`/`pending` are usable (an http MCP server connects asynchronously — `pending` at init is normal), multiple broken servers are reported as `name=status`, and no configured MCP means nothing to wait for.
- `bun test` (44 pass), `bun run check`, `bun run fmt` in `packages/harness-runner`.
- Not exercised against a real down Studio; the retry loop needs the SDK, so it isn't unit-testable in this tier.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries the Studio MCP preflight instead of failing the run so transient outages don’t surface as task failures. Adds up to 5 session restarts with exponential backoff (~30s total) before giving up with the same error message.

- **Bug Fixes**
  - In `packages/harness-runner/claude-code.ts`, preflight now returns broken servers; `runClaudeCode` restarts the SDK session until MCP is usable or attempts are exhausted.
  - Backoff per attempt: 2s, 4s, 8s, 16s. Final error text unchanged to keep task-board retry working.
  - Safe to restart: happens before any output (`system/init`), so no work is lost.
  - Added `brokenStudioMcp()` and unit tests; treats `pending` as normal for HTTP MCP and reports broken servers as `name=status`.

<sup>Written for commit 53f544542486639bac873108e19a789bab4f8430. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

