### PR TITLE
fix(sandbox): a displaced dispatch reports superseded, not cancelled

### DIFF
--- a/apps/api/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/api/src/dbos/workflow-source-guard.snapshot.json
@@ -1,7 +1,7 @@
 {
   "auth/install-studio-pack-workflow.ts": "e284b2fd9950d5cc803d66a3b79e86258968b7d9a124cf2746363f8a4f7513a3",
   "automations/dbos-workflow.ts": "dd8535f7577bbd3c0270c60f14f480d4fb42e366666245c3efa77f0ce73a9da2",
-  "dispatch-queue/hosted-harness-workflow.ts": "f5d4a8168c366575bbf7218b87fab17ea7aa749195e7a19d47abca2673a28eca",
+  "dispatch-queue/hosted-harness-workflow.ts": "3f125c877fb4dfbca0cfce9c4f9a59a329b6fae586532f1b78fcf706f9ccb6cf",
   "dispatch-queue/thread-gate-workflow.ts": "28823d1de22256bda37c50da051e9e9b32d9e48365410a6fd752def8530345f1",
   "file-storage/dbos-public-sets-sync.ts": "efd9c4bfd9ae29b13970e6b1072e067f43f151b3530d552efc1b4daf038bea7e",
   "harnesses/decopilot/background-tool-workflow.ts": "9febb699f45b63b418481ed998aee0ec8251c97cb5c409d54d714eb365a08fd0",

--- a/apps/api/src/dispatch-queue/hosted-harness-workflow.test.ts
+++ b/apps/api/src/dispatch-queue/hosted-harness-workflow.test.ts
@@ -7,6 +7,10 @@ import type { WithLastAckSeq } from "@/api/routes/decopilot/ingest-run";
 import { buildRunStatusChunk } from "@/api/routes/decopilot/run-status-stage";
 import type { StudioContext } from "@/core/studio-context";
 import {
+  isRunSuperseded,
+  RunSupersededError,
+} from "@/harnesses/sandbox-dispatch-client";
+import {
   acquireHostedRunSlot,
   HOSTED_RUN_CAPS,
 } from "./hosted-run-concurrency";
@@ -208,6 +212,44 @@ describe("hostedHarnessWorkflowFn's try/catch contract (Finding 1)", () => {
     expect(dispatchRunFn).toHaveBeenCalledTimes(1);
     expect(streamBuffer.publishRawChunk).toHaveBeenCalledTimes(1);
     expect(streamBuffer.publishDone).toHaveBeenCalledTimes(1);
+  });
+
+  // The prod failure of 2026-08-07: KEDA scaled in the worker holding a run,
+  // DBOS recovered the workflow onto another pod, and its re-dispatch took the
+  // sandbox over. The displaced attempt then published a fenced error terminal
+  // under the SAME fence the live successor was streaming on, settling the
+  // thread as `Error: cancelled: run cancelled` mid-run.
+  test("a superseded attempt publishes NO terminal — the successor owns it", async () => {
+    const takeover = new RunSupersededError("a newer dispatch took over");
+    const dispatchRunFn = mock(() => Promise.reject(takeover));
+    const { streamBuffer } = runtimeWithDispatchFn(dispatchRunFn);
+
+    // Mirrors hostedHarnessWorkflowFn's catch: the superseded branch returns
+    // before the publish step.
+    try {
+      await runHostedHarness(input, {} as StudioContext);
+    } catch (err) {
+      if (!isRunSuperseded(err)) await publishHostedHarnessFailure(input, err);
+    }
+
+    expect(dispatchRunFn).toHaveBeenCalledTimes(1);
+    expect(streamBuffer.publishRawChunk).not.toHaveBeenCalled();
+    expect(streamBuffer.publishDone).not.toHaveBeenCalled();
+  });
+
+  test("the workflow's catch checks for a takeover before publishing", () => {
+    // Source-text assertion, same technique as the retriesAllowed check below:
+    // the real catch can't run without a launched DBOS instance, so this proves
+    // the guard sits BEFORE the publish step rather than after it (where it
+    // would be useless).
+    const src = readFileSync(
+      join(import.meta.dir, "hosted-harness-workflow.ts"),
+      "utf8",
+    );
+    const guard = src.indexOf("isRunSuperseded(err)");
+    const publish = src.indexOf('name: "publishHostedHarnessFailure"');
+    expect(guard).toBeGreaterThan(-1);
+    expect(publish).toBeGreaterThan(guard);
   });
 
   test("registers the runHostedHarness step with retriesAllowed: false", () => {

--- a/apps/api/src/dispatch-queue/hosted-harness-workflow.ts
+++ b/apps/api/src/dispatch-queue/hosted-harness-workflow.ts
@@ -80,6 +80,7 @@ import type {
   DurableDispatchRunInput,
 } from "@/api/routes/decopilot/dispatch-run";
 import { synthesizedErrorMessageId } from "@/api/routes/decopilot/message-ids";
+import { isRunSuperseded } from "@/harnesses/sandbox-dispatch-client";
 import type { WithLastAckSeq } from "@/api/routes/decopilot/ingest-run";
 import type { StudioContext } from "@/core/studio-context";
 
@@ -465,6 +466,26 @@ async function hostedHarnessWorkflowFn(
       retriesAllowed: false,
     });
   } catch (err) {
+    // A takeover is not a failure. `RunSupersededError` means a newer dispatch
+    // of this same run displaced our attempt — the successor is the run's writer
+    // and publishes its terminal under the same fence, so publishing one here
+    // would race it and settle a live run as failed (the prod failure of
+    // 2026-08-07). Return normally: the outcome lives on the stream, and the
+    // successor owns it. Deliberately narrow — every other error still
+    // publishes the terminal below, per this workflow's guarantee.
+    //
+    // Recovery-compatible, so no DBOS_WORKFLOW_VERSION bump (snapshot
+    // re-baseline only): this branch SKIPS a step the old code recorded, which
+    // would normally be a replay divergence — but it is only reachable for a
+    // `superseded` terminal, a code the daemon did not emit before this change.
+    // No pre-existing journal can carry it, so every in-flight workflow replays
+    // down the publish path exactly as it recorded.
+    if (isRunSuperseded(err)) {
+      console.log(
+        `[hostedHarness] attempt superseded by a newer dispatch; leaving the terminal to it run=${input.runId} fence=${input.fenceToken}`,
+      );
+      return;
+    }
     // Second step, only reached on failure: publish the fence-scoped error +
     // {done} terminal, then RETURN NORMALLY — do not rethrow. The child's
     // DBOS status becoming SUCCESS here is intentional: run OUTCOME lives on

--- a/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
@@ -4,8 +4,10 @@ import { harnessRunResultSchema } from "@decocms/sandbox/dispatch/schemas";
 import {
   dispatchWithContinuation,
   harnessRunsInSandbox,
+  isRunSuperseded,
   isUnreachableStatus,
   ndjsonLines,
+  RunSupersededError,
   SandboxUnreachableError,
 } from "./sandbox-dispatch-client";
 
@@ -285,5 +287,54 @@ describe("dispatchWithContinuation", () => {
     });
     await expect(collect(run)).rejects.toThrow("pod gone again");
     expect(attempts).toBe(2);
+  });
+
+  // A displaced attempt must NOT continue: continuing re-dispatches the same
+  // runId, which takes the run back off the successor that displaced us — the
+  // two attempts would trade it back and forth until maxAttempts.
+  test("a superseded attempt stops instead of taking the run back", async () => {
+    let attempts = 0;
+    const run = dispatchWithContinuation({
+      runId: "run_1",
+      resume: null,
+      aborted: () => false,
+      dispatchOnce: () => {
+        attempts++;
+        return dispatch(
+          [chunk("start"), chunk("text-delta")],
+          new RunSupersededError("a newer dispatch took over this run"),
+        )();
+      },
+    });
+    await expect(collect(run)).rejects.toThrow("a newer dispatch took over");
+    expect(attempts).toBe(1);
+  });
+});
+
+describe("isRunSuperseded", () => {
+  test("recognizes a superseded attempt", () => {
+    expect(isRunSuperseded(new RunSupersededError("taken over"))).toBe(true);
+  });
+
+  test("does not mistake other failures for a takeover", () => {
+    expect(isRunSuperseded(new SandboxUnreachableError("pod gone"))).toBe(
+      false,
+    );
+    expect(isRunSuperseded(new Error("cancelled: run cancelled"))).toBe(false);
+    expect(isRunSuperseded(undefined)).toBe(false);
+  });
+
+  // The error is thrown from inside a DBOS step, which serializes it into the
+  // durable journal and rebuilds a PLAIN Error on replay — the subclass is gone,
+  // so `instanceof` silently reports false and the run gets failed after all.
+  // Only an own-enumerable property survives that round trip.
+  test("survives the DBOS step boundary, where the subclass does not", () => {
+    const thrown = new RunSupersededError("taken over");
+    const replayed = Object.assign(
+      new Error(thrown.message),
+      JSON.parse(JSON.stringify({ ...thrown })),
+    );
+    expect(replayed instanceof RunSupersededError).toBe(false);
+    expect(isRunSuperseded(replayed)).toBe(true);
   });
 });

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -99,6 +99,50 @@ export class SandboxUnreachableError extends Error {
 }
 
 /**
+ * A newer dispatch of this run took the sandbox over, so THIS attempt is no
+ * longer the run's writer — the successor is, and it will publish the run's
+ * terminal. Distinct from every other failure because the run has not failed
+ * at all; only this attempt has stopped, and it must stop QUIETLY:
+ *
+ * - not a `SandboxUnreachableError`: continuing would re-dispatch the same
+ *   runId and take the run back off the successor, trading it back and forth;
+ * - not a plain `Error`: that becomes the run's fence-scoped error terminal
+ *   (see `hostedHarnessWorkflowFn`), which is what settled a live thread as
+ *   `Error: cancelled: run cancelled` in prod on 2026-08-07.
+ *
+ * Two attempts exist for one turn whenever the pod running it goes away and DBOS
+ * recovers the workflow elsewhere — a rolling deploy, an eviction, or KEDA
+ * scaling in a worker that was mid-run.
+ */
+export class RunSupersededError extends Error {
+  /**
+   * Own-enumerable marker, NOT an `instanceof` check, because this error is
+   * thrown from inside a DBOS step: DBOS serializes a step's error through
+   * `serialize-error` for its durable journal and reconstructs a plain `Error`
+   * on replay, losing the subclass — but own-enumerable properties survive that
+   * round trip. Same idiom as `WithLastAckSeq` / `PermanentRunError.permanent`.
+   * Read it via `isRunSuperseded`, never with `instanceof`.
+   */
+  readonly superseded = true;
+
+  constructor(reason: string) {
+    super(reason);
+    this.name = "RunSupersededError";
+  }
+}
+
+/** See `RunSupersededError.superseded` for why this is not an `instanceof`. */
+export function isRunSuperseded(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    (err as Error & { superseded?: boolean }).superseded === true
+  );
+}
+
+/** The daemon's terminal code for an attempt displaced by a takeover. */
+const SUPERSEDED_TERMINAL_CODE = "superseded";
+
+/**
  * Is a non-2xx dispatch response the sandbox being gone, or the daemon rejecting
  * the envelope? 404/410 is the proxy finding no pod (or a reprovisioned one that
  * never adopted the claim) and 5xx is the pod failing to answer at all — both
@@ -520,6 +564,11 @@ async function* dispatchToDaemon(args: {
     throw new SandboxUnreachableError(
       `the sandbox stopped streaming after ${total} chunks without finishing the run`,
     );
+  }
+  if (error?.code === SUPERSEDED_TERMINAL_CODE) {
+    // Another dispatch owns this run now. Whatever this attempt streamed above
+    // is already yielded; the successor publishes the terminal.
+    throw new RunSupersededError(error.message);
   }
   if (error) throw new Error(`${error.code}: ${error.message}`);
 }

--- a/packages/sandbox/daemon-e2e/daemon.dispatch.e2e.test.ts
+++ b/packages/sandbox/daemon-e2e/daemon.dispatch.e2e.test.ts
@@ -378,9 +378,16 @@ describe("daemon e2e: dispatch runs a harness", () => {
 
       const { frames, endedAt } = await displaced;
       // The displaced run ended, and said why — it did not outlive the takeover.
+      // `superseded`, NOT `cancelled`: this attempt no longer owns the run, so
+      // its ending is not the run's verdict. Asserting `cancelled` here is what
+      // let the prod regression of 2026-08-07 through — a scaled-in worker's
+      // displaced attempt settled a live thread as
+      // `Error: cancelled: run cancelled`. It is still a terminal, because an
+      // unterminated body would make the loser continue the turn and take the
+      // run back off its successor.
       const terminal = frames.at(-1);
       expect(terminal?.done).toBe(true);
-      expect(terminal?.error?.code).toBe("cancelled");
+      expect(terminal?.error?.code).toBe("superseded");
       // And it ended BEFORE the replacement produced anything: the daemon waits
       // for the old process group to die before exec'ing the new harness.
       expect(secondFirstFrameAt).toBeGreaterThanOrEqual(endedAt);

--- a/packages/sandbox/daemon-go/internal/dispatch/dispatch.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/dispatch.go
@@ -155,6 +155,16 @@ func (reg *Registry) CancelAll() {
 	}
 }
 
+// displaced reports whether `entry` has lost the claim on `runId` to a newer
+// dispatch. The same ownership test `release` makes, exposed because a cancelled
+// run has to know WHICH cancel it got: its own client leaving, or a successor
+// taking the run over. Only the former is the run's outcome.
+func (reg *Registry) displaced(runId string, entry *activeRun) bool {
+	reg.mu.Lock()
+	defer reg.mu.Unlock()
+	return reg.activeRuns[runId] != entry
+}
+
 // release retires this run's claim. Only clears the map when the entry is still
 // the current one — a run that was taken over must not delete its successor's
 // claim on the way out.
@@ -420,9 +430,31 @@ func (reg *Registry) runHarness(
 	elapsed := int(time.Since(startedAt).Seconds())
 
 	if ctx.Err() != nil {
-		// Cancelled: either the client hung up (its half of the terminal is
-		// moot) or a DELETE/takeover stopped the run while it was still being
-		// read. Terminal either way, so the reader is never left guessing.
+		// A displaced run reports `superseded`, not `cancelled`: it no longer
+		// owns this runId, so its cancellation is not the RUN's outcome — the
+		// successor's will be. Studio reads `cancelled` as the verdict for the
+		// whole turn, which is how the prod failure of 2026-08-07 happened:
+		// KEDA scaled in the worker holding a run, DBOS recovered the workflow
+		// onto another pod, its re-dispatch took over here, and the displaced
+		// handler's `cancelled` frame settled the thread as
+		// `Error: cancelled: run cancelled` while the new attempt was still
+		// streaming.
+		//
+		// It must still be a TERMINAL (not a truncated body): an unterminated
+		// body is Studio's signal to continue the turn on a replacement, and a
+		// displaced attempt continuing would re-dispatch this same runId and
+		// take over the successor — the two attempts would trade the run back
+		// and forth. `superseded` says "stop, someone else has this."
+		if reg.displaced(runId, entry) {
+			slog.Info("dispatch superseded by takeover",
+				"harness", harnessId, "run_id", runId, "elapsed_s", elapsed)
+			body.write(terminalFrame("superseded",
+				"a newer dispatch took over this run"))
+			return
+		}
+		// Genuinely cancelled: the client hung up, or a DELETE stopped the run
+		// and nothing replaced it. Terminal, so the reader is never left
+		// guessing.
 		slog.Info("dispatch cancelled", "harness", harnessId, "run_id", runId, "elapsed_s", elapsed)
 		body.write(terminalFrame("cancelled", "run cancelled"))
 		return

--- a/packages/sandbox/daemon-go/internal/dispatch/dispatch_test.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/dispatch_test.go
@@ -199,6 +199,35 @@ func TestClaimTakesOverAnInFlightRun(t *testing.T) {
 	}
 }
 
+// Who owns the run decides whose cancel counts. A displaced attempt's
+// cancellation is not the RUN's outcome — the successor's is — so the displaced
+// handler must be able to tell the two apart and stay silent. Writing a
+// "cancelled" terminal from the loser is what settled a live thread as
+// `Error: cancelled: run cancelled` in prod on 2026-08-07.
+func TestDisplacedReportsOnlyTheLoserOfATakeover(t *testing.T) {
+	reg := NewRegistry()
+	first, _ := reg.claim("run-1", func() {})
+	if reg.displaced("run-1", first) {
+		t.Fatal("the only claimant must not report as displaced")
+	}
+
+	second, _ := reg.claim("run-1", func() {})
+	if !reg.displaced("run-1", first) {
+		t.Fatal("the run that lost the claim must report as displaced")
+	}
+	if reg.displaced("run-1", second) {
+		t.Fatal("the run that HOLDS the claim must not report as displaced")
+	}
+
+	// A cancel with nothing replacing the run (client hangup, DELETE) is the
+	// run's real outcome, so it must still write its terminal.
+	reg.release("run-1", second)
+	solo, _ := reg.claim("run-2", func() {})
+	if reg.displaced("run-2", solo) {
+		t.Fatal("an uncontested run must not report as displaced")
+	}
+}
+
 // The takeover wait is bounded: a displaced run whose process refuses to die
 // must not wedge the thread forever.
 func TestClaimTakeoverGivesUpAfterTheTimeout(t *testing.T) {

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -1282,7 +1282,11 @@ export class AgentSandboxProvider implements SandboxProvider {
           ...(hasAnnotations ? { annotations } : {}),
         },
         env: envEntries,
-        warmpool: claimWarmPoolName(tenantPool, warmPoolMode),
+        warmpool: claimWarmPoolName(
+          tenantPool,
+          warmPoolMode,
+          this.sandboxTemplateName,
+        ),
         lifecycle: {
           shutdownPolicy: "Delete",
           shutdownTime: this.computeShutdownTime(),

--- a/packages/sandbox/server/provider/agent-sandbox/tenant-pools.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/tenant-pools.test.ts
@@ -143,15 +143,22 @@ describe("resolveTenantPool", () => {
 // pool belonging to nobody it should reach.
 describe("claimWarmPoolName", () => {
   it("a resolved pool binds that pool", () => {
-    expect(claimWarmPoolName(POOLS[0] ?? null, true)).toBe("tenant-acme-site");
+    expect(claimWarmPoolName(POOLS[0] ?? null, true, "studio-sandbox")).toBe(
+      "tenant-acme-site",
+    );
   });
 
-  it("no pool in warm-pool mode falls back to the generic pool", () => {
-    expect(claimWarmPoolName(null, true)).toBe("default");
+  // Never the literal "default": that matches no SandboxWarmPool, and the
+  // operator's fallback then binds any warm pod of the template — including
+  // another org's tenant pool, whose repo is already cloned (409 cloneUrl).
+  it("no pool in warm-pool mode names the generic pool explicitly", () => {
+    expect(claimWarmPoolName(null, true, "studio-sandbox")).toBe(
+      "studio-sandbox",
+    );
   });
 
   it("no sentinel → `none`, so the operator still accepts per-claim env", () => {
-    expect(claimWarmPoolName(null, false)).toBe("none");
+    expect(claimWarmPoolName(null, false, "studio-sandbox")).toBe("none");
   });
 });
 

--- a/packages/sandbox/server/provider/agent-sandbox/tenant-pools.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/tenant-pools.ts
@@ -114,15 +114,26 @@ export function resolveTenantPool(
 
 /**
  * The claim's `spec.warmpool`. A resolved tenant pool binds one of that org's
- * already-running pods; otherwise this is exactly today's behavior — the
- * generic (empty) pool in warm-pool mode, `"none"` without a sentinel, because
- * the operator rejects per-claim env outside `"none"`.
+ * already-running pods; otherwise the generic pool, named explicitly, or
+ * `"none"` without a sentinel because the operator rejects per-claim env
+ * outside `"none"`.
+ *
+ * `genericPoolName` must be the SandboxWarmPool object's real name — the
+ * sandbox-env chart names it after the SandboxTemplate. It used to be the
+ * literal `"default"`, which matches no pool: the operator then falls back to
+ * *any* warm pod rendered from the same template. Harmless while one pool
+ * existed; once tenant pools shipped it handed one org's prewarmed pods (repo
+ * already cloned) to another org's claim, and the daemon rejected the
+ * mismatched workload with `409 immutable: cloneUrl`. Observed in prod
+ * 2026-08-07: claims for montecarlo and `ephemeral-*` dispatches bound
+ * `tenant-electrolux-prod-*` pods.
  */
 export function claimWarmPoolName(
   pool: TenantPool | null,
   warmPoolMode: boolean,
+  genericPoolName: string,
 ): string {
-  return pool?.name ?? (warmPoolMode ? "default" : "none");
+  return pool?.name ?? (warmPoolMode ? genericPoolName : "none");
 }
 
 /**


### PR DESCRIPTION
A run whose pod goes away gets recovered by DBOS onto another pod, which re-dispatches the same `runId` and takes the sandbox over. The displaced attempt then wrote a `cancelled` terminal — and Studio reads a terminal as the verdict for the **whole turn**, so the loser settled the winners live run as failed.

## The incident

Thread `thrd_f4rZeAwQz1CHy-c1biG2F` (electrolux-poc), 2026-08-07:

| time (UTC) | event |
|---|---|
| 13:47:18 | run starts, DBOS `decopilot-hosted:thrd_f4rZ…:902616c2` on worker `nmc8n` |
| 13:47:21 | dispatched to `studio-sandbox-prod-jd5s9`, claude-code streaming (seq 42 at 68s) |
| ~13:49:0x | KEDA `SuccessfulRescale … New size: 2; reason: All metrics below target` → deletes `nmc8n` **mid-run** |
| 13:49:22 | DBOS recovers the workflow, re-dispatches, daemon takes over — displaced attempt writes `cancelled` |
| 13:51:26 | thread settles `failed` / `failure_kind: error`, error part `Error: cancelled: run cancelled` |

`dbos.workflow_status` for that id: `recovery_attempts = 2`, `status = SUCCESS` — while the thread said failed. The sandbox pod was never the problem (alive, 0 restarts, re-adopted its claim cleanly at 13:53).

KEDA scaling in a busy worker is what triggered it, but a rolling deploy or an eviction produces the same two-attempt race. This PR fixes the race, not the trigger.

## The fix

The displaced attempt reports `superseded`, and Studio treats that as "stop quietly, the successor owns this run":

- **Still a terminal, not a truncated body.** An unterminated body is Studios signal to *continue* the turn — and continuing would re-dispatch the same `runId` and take the run back off the successor, trading it back and forth until `MAX_DISPATCH_ATTEMPTS`. I wrote that version first; the test for it is in this PR.
- **`RunSupersededError`, not a plain `Error`.** A plain error becomes the runs fence-scoped error terminal in `hostedHarnessWorkflowFn`, racing the terminal the successor publishes under the same fence. Both attempts of one turn share a fence token, so nothing downstream can tell them apart — the losing writer has to stay silent.
- **Own-enumerable marker, not `instanceof`.** The error is thrown from inside a DBOS step, which serializes it into the journal and rebuilds a plain `Error` on replay. `instanceof` reports false there and the run gets failed anyway. Same idiom as `WithLastAckSeq` / `PermanentRunError.permanent`; theres a test that fails on the `instanceof` version.

## Recovery compatibility

No `DBOS_WORKFLOW_VERSION` bump — snapshot re-baseline only. The new branch *skips* a step the old code recorded, which would normally be a replay divergence, but it is only reachable for a `superseded` terminal, a code the daemon did not emit before this change. No in-flight journal can carry it, so every recovering workflow replays down the publish path exactly as it recorded.

## Testing

- `internal/dispatch`: `displaced` reports only the loser of a takeover; an uncontested cancel still writes its terminal.
- **Inverted** the daemon e2e case that asserted `cancelled` on takeover — that assertion is what let this through. Now asserts `superseded`. Verified against the real built binary (16 pass): logs show `dispatch superseded by takeover` then the successor reaching `dispatch done`.
- `dispatchWithContinuation`: a superseded attempt stops after 1 attempt instead of taking the run back.
- `hostedHarnessWorkflowFn`: a superseded attempt publishes no chunk and no `{done}`; source-text assertion that the guard sits *before* the publish step.
- `bun run fmt` / `bun run check` / `bun run lint` clean. `bun test apps/api/src`: 2977 pass, 101 fail — identical 101 on a stashed baseline (pre-existing, all real-Postgres integration tests).

## Not covered

The thread that hit this in prod was cleaned up by hand (status → `completed`, failure columns nulled, error part deleted). Two follow-ups this PR deliberately does not take on:

1. **The trigger.** KEDAs `ScaledObject` for `deco-studio-worker` lives in `deco-apps-cd`; neither of its triggers sees a run thats already executing, so a drained queue can still scale in a busy pod. Worth a `scaleDown` stabilization window there.
2. **The wasted work.** A recovered attempt restarts the harness from scratch even though the sandbox survived with the work in its checkout. Reattaching to the in-flight run instead needs the fence to be per-attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016MPqAd5Srr9VfEEGe8nub8

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents live runs from being marked failed when a worker is rescheduled by reporting displaced attempts as “superseded” instead of “cancelled”. Also fixes warm-pool selection by naming the generic pool explicitly to avoid binding another org’s tenant pool.

- **Bug Fixes**
  - Daemon emits `superseded` terminal when a dispatch is displaced; `sandbox-dispatch-client` maps it to `RunSupersededError`.
  - `hosted-harness-workflow` detects `isRunSuperseded(err)` and returns without publishing an error terminal, avoiding races with the successor.
  - Superseded detection uses an own-enumerable marker (survives DBOS replay), not `instanceof`.
  - E2E inverted to assert `superseded` on takeover; added unit tests for propagation and guard placement.
  - Warm-pool claims now use the real generic pool name (SandboxTemplate name) instead of `"default"`, preventing cross-tenant pod binding and `409 immutable: cloneUrl`.

<sup>Written for commit c064533abadbe1ff185abf3fd81643ca8c8708e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

