### PR TITLE
feat(analytics): instrument task quota, super-agent runs, and subscription lifecycle

### DIFF
--- a/apps/api/src/billing/stripe-webhook.test.ts
+++ b/apps/api/src/billing/stripe-webhook.test.ts
@@ -3,7 +3,10 @@ import { createHmac } from "node:crypto";
 import {
   mapSubscriptionStatus,
   parseStripeEvent,
+  subscriptionFunnelEvent,
   verifyStripeSignature,
+  type HandledStripeEvent,
+  type StripeEvent,
 } from "./stripe-webhook";
 
 const SECRET = "whsec_test_secret";
@@ -113,5 +116,95 @@ describe("mapSubscriptionStatus", () => {
     expect(mapSubscriptionStatus("canceled")).toBe("canceled");
     expect(mapSubscriptionStatus("unpaid")).toBe("canceled");
     expect(mapSubscriptionStatus(undefined)).toBe("canceled");
+  });
+});
+
+describe("subscriptionFunnelEvent", () => {
+  const ORG = "org_1";
+  const handled: HandledStripeEvent = { handled: true, organizationId: ORG };
+  const evt = (
+    type: string,
+    object: Record<string, unknown> = {},
+    livemode?: boolean,
+  ): StripeEvent => ({ type, livemode, data: { object } });
+
+  test("unhandled results and test-mode traffic map to nothing", () => {
+    expect(
+      subscriptionFunnelEvent(evt("invoice.paid"), {
+        handled: false,
+        reason: "unknown org",
+      }),
+    ).toBeNull();
+    expect(
+      subscriptionFunnelEvent(evt("invoice.paid", {}, false), handled),
+    ).toBeNull();
+  });
+
+  test("topUp wins over the type mapping and carries the amount", () => {
+    const r = subscriptionFunnelEvent(evt("checkout.session.completed"), {
+      ...handled,
+      topUp: { creditCents: 5000, referenceId: "stripe-topup:cs_1" },
+    });
+    expect(r).toEqual({
+      name: "credits_topup_succeeded",
+      organizationId: ORG,
+      properties: { credit_cents: 5000 },
+    });
+  });
+
+  test("checkout (both delivery types) → subscription_started", () => {
+    expect(
+      subscriptionFunnelEvent(evt("checkout.session.completed"), handled)?.name,
+    ).toBe("subscription_started");
+    expect(
+      subscriptionFunnelEvent(
+        evt("checkout.session.async_payment_succeeded"),
+        handled,
+      )?.name,
+    ).toBe("subscription_started");
+  });
+
+  test("subscription.updated carries mapped status and churn intent", () => {
+    const r = subscriptionFunnelEvent(
+      evt("customer.subscription.updated", {
+        status: "active",
+        cancel_at_period_end: true,
+      }),
+      handled,
+    );
+    expect(r?.name).toBe("subscription_updated");
+    expect(r?.properties).toEqual({
+      status: "active",
+      cancel_at_period_end: true,
+    });
+  });
+
+  test("subscription.deleted → subscription_canceled", () => {
+    expect(
+      subscriptionFunnelEvent(evt("customer.subscription.deleted"), handled)
+        ?.name,
+    ).toBe("subscription_canceled");
+  });
+
+  test("invoice.paid → subscription_renewed, EXCEPT the first invoice", () => {
+    expect(
+      subscriptionFunnelEvent(
+        evt("invoice.paid", { billing_reason: "subscription_cycle" }),
+        handled,
+      )?.name,
+    ).toBe("subscription_renewed");
+    // The creation invoice is the subscription_started moment, not a renewal.
+    expect(
+      subscriptionFunnelEvent(
+        evt("invoice.paid", { billing_reason: "subscription_create" }),
+        handled,
+      ),
+    ).toBeNull();
+  });
+
+  test("unmapped event types map to nothing", () => {
+    expect(
+      subscriptionFunnelEvent(evt("customer.created"), handled),
+    ).toBeNull();
   });
 });

--- a/apps/api/src/billing/stripe-webhook.ts
+++ b/apps/api/src/billing/stripe-webhook.ts
@@ -20,6 +20,7 @@
 
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { getDb } from "@/database";
+import { captureOrgEvent, deterministicUuid } from "@/posthog";
 import {
   OrganizationBillingStorage,
   type OrganizationBillingRow,
@@ -343,12 +344,100 @@ export async function applyStripeEvent(
   }
 }
 
+/** Pure mapping: which subscription-lifecycle funnel event (if any) a webhook
+ *  delivery represents. Null for unhandled results, test-mode traffic
+ *  (livemode:false must not land in the PLG dashboards), and a subscription's
+ *  FIRST invoice — that moment is subscription_started (the checkout event),
+ *  counting it as a renewal would overcount renewals by one per subscriber.
+ *  Exported for unit tests. */
+export function subscriptionFunnelEvent(
+  event: StripeEvent,
+  result: HandledStripeEvent,
+): {
+  name: string;
+  organizationId: string;
+  properties: Record<string, unknown>;
+} | null {
+  if (!result.handled || event.livemode === false) return null;
+  const obj = event.data.object;
+  if (result.topUp) {
+    return {
+      name: "credits_topup_succeeded",
+      organizationId: result.organizationId,
+      properties: { credit_cents: result.topUp.creditCents },
+    };
+  }
+  switch (event.type) {
+    case "checkout.session.completed":
+    case "checkout.session.async_payment_succeeded":
+      return {
+        name: "subscription_started",
+        organizationId: result.organizationId,
+        properties: {},
+      };
+    case "customer.subscription.deleted":
+      return {
+        name: "subscription_canceled",
+        organizationId: result.organizationId,
+        properties: {},
+      };
+    case "customer.subscription.updated":
+      return {
+        name: "subscription_updated",
+        organizationId: result.organizationId,
+        properties: {
+          status: mapSubscriptionStatus(obj.status),
+          // Churn intent: a scheduled cancel keeps status "active" — this is
+          // the only place it's visible.
+          ...(typeof obj.cancel_at_period_end === "boolean"
+            ? { cancel_at_period_end: obj.cancel_at_period_end }
+            : {}),
+        },
+      };
+    case "invoice.paid":
+      if (obj.billing_reason === "subscription_create") return null;
+      return {
+        name: "subscription_renewed",
+        organizationId: result.organizationId,
+        properties: {},
+      };
+    default:
+      return null;
+  }
+}
+
+/** Emit the mapped funnel event. Stripe is at-least-once even on success, so
+ *  the uuid + timestamp pair is deterministic per (event id, event name) —
+ *  PostHog collapses redeliveries server-side. Fire-and-forget. */
+function captureSubscriptionEvent(
+  event: StripeEvent,
+  result: HandledStripeEvent,
+): void {
+  const mapped = subscriptionFunnelEvent(event, result);
+  if (!mapped) return;
+  captureOrgEvent({
+    event: mapped.name,
+    organizationId: mapped.organizationId,
+    ...(event.id
+      ? { uuid: deterministicUuid(`stripe:${event.id}:${mapped.name}`) }
+      : {}),
+    ...(event.created ? { timestamp: new Date(event.created * 1000) } : {}),
+    properties: mapped.properties,
+  });
+}
+
 /** Route-facing wrapper: apply, then clean up refused-but-paid orphans. */
 export async function processStripeEvent(
   event: StripeEvent,
 ): Promise<HandledStripeEvent> {
   const storage = new OrganizationBillingStorage(getDb().db);
   const result = await applyStripeEvent(storage, event);
+  // The top-up's event is emitted only AFTER the gateway credit lands below —
+  // "succeeded" must not fire for money that hasn't been applied (and a
+  // gateway outage means Stripe redelivers this event for days).
+  if (!(result.handled && result.topUp)) {
+    captureSubscriptionEvent(event, result);
+  }
   // Top-up: forward the paid credits to the gateway. NOT fail-soft — a throw
   // 500s the route so Stripe redelivers, and the gateway referenceId dedupe
   // makes every replay a no-op. Stripe is the retry queue here.
@@ -358,6 +447,8 @@ export async function processStripeEvent(
       amountCents: result.topUp.creditCents,
       referenceId: result.topUp.referenceId,
     });
+    // Only now did the top-up actually succeed.
+    captureSubscriptionEvent(event, result);
   }
   // Cancel a refused-but-paid subscription so it stops charging. NOT
   // fail-soft: a transient failure must 500 the route so Stripe redelivers

--- a/apps/api/src/billing/task-quota.integration.test.ts
+++ b/apps/api/src/billing/task-quota.integration.test.ts
@@ -254,8 +254,12 @@ describe("task quota (integration)", () => {
       /^\[SUBSCRIPTION_REQUIRED\]/,
     );
 
-    await releaseTaskExecution(billing, org, a!.id);
-    await releaseTaskExecution(billing, org, a!.id); // idempotent
+    // The storage release reports whether a held claim actually transitioned
+    // — true once, false on the repeat — which is what gates the
+    // task_quota_refunded telemetry to refunds that happened.
+    expect(await billing.releaseTaskClaim(org, a!.id)).toBe(true);
+    expect(await billing.releaseTaskClaim(org, a!.id)).toBe(false); // idempotent
+    await releaseTaskExecution(billing, org, a!.id); // wrapper stays a no-op too
     expect(await stateOf(a!.id)).toBe("released");
     expect(await billing.countTaskClaims(org, "trial")).toBe(1);
     await claimTaskExecution(ctxR, c!, CONFIG);

--- a/apps/api/src/billing/task-quota.ts
+++ b/apps/api/src/billing/task-quota.ts
@@ -33,6 +33,7 @@
 
 import type { StudioContext } from "@/core/studio-context";
 import { isReportsTask } from "@decocms/shared/task-board";
+import { captureOrgEvent } from "@/posthog";
 import { getSettings } from "../settings";
 import type {
   OrganizationBillingRow,
@@ -68,6 +69,29 @@ export class TaskQuotaError extends Error {
     super(`${SUBSCRIPTION_REQUIRED_PREFIX} ${QUOTA_MESSAGES[reason]}`);
     this.name = "TaskQuotaError";
   }
+}
+
+/** "trial" vs "subscription" — the free-or-paid axis of the PLG funnel. */
+function billingMode(periodKey: string): "trial" | "subscription" {
+  return periodKey === "trial" ? "trial" : "subscription";
+}
+
+/** The paywall/consumption funnel events. The acting user (when the gate ran
+ *  under an interactive context, e.g. the TASK_BOARD_ITEM_UPDATE paywall
+ *  pre-check) owns the event; a system dispatch falls back to the org
+ *  identity. Fire-and-forget; no-op without POSTHOG_KEY. */
+function captureQuotaEvent(
+  ctx: StudioContext,
+  event: "task_quota_claimed" | "task_quota_blocked",
+  task: { id: string; organizationId: string },
+  properties: Record<string, unknown> = {},
+): void {
+  captureOrgEvent({
+    event,
+    organizationId: task.organizationId,
+    ...(ctx.auth?.user?.id ? { userId: ctx.auth.user.id } : {}),
+    properties: { task_id: task.id, ...properties },
+  });
 }
 
 /** `past_due` counts — Stripe dunning grace. */
@@ -172,6 +196,10 @@ export async function ensureTaskExecutionAllowed(
   if (!config.enforced || !isReportsTask(task)) return;
   const claim = await ctx.storage.organizationBilling.taskClaim(task.id);
   if (claim && claim.runCount >= config.maxRunsPerTask) {
+    captureQuotaEvent(ctx, "task_quota_blocked", task, {
+      phase: "precheck",
+      reason: "runs_exhausted",
+    });
     throw new TaskQuotaError("runs_exhausted");
   }
   // A live (held or committed) claim already owns its slot — re-runs are free
@@ -185,7 +213,15 @@ export async function ensureTaskExecutionAllowed(
     task.organizationId,
     quota.periodKey,
   );
-  if (used >= quota.limit) throw new TaskQuotaError(quota.exhaustedReason);
+  if (used >= quota.limit) {
+    captureQuotaEvent(ctx, "task_quota_blocked", task, {
+      phase: "precheck",
+      reason: quota.exhaustedReason,
+      billing_mode: billingMode(quota.periodKey),
+      limit: quota.limit,
+    });
+    throw new TaskQuotaError(quota.exhaustedReason);
+  }
 }
 
 /**
@@ -217,8 +253,29 @@ export async function claimTaskExecution(
     quota.limit,
     config.maxRunsPerTask,
   );
-  if (result === "exhausted") throw new TaskQuotaError(quota.exhaustedReason);
-  if (result === "runs_exhausted") throw new TaskQuotaError("runs_exhausted");
+  if (result === "exhausted") {
+    captureQuotaEvent(ctx, "task_quota_blocked", task, {
+      phase: "claim",
+      reason: quota.exhaustedReason,
+      billing_mode: billingMode(quota.periodKey),
+      limit: quota.limit,
+    });
+    throw new TaskQuotaError(quota.exhaustedReason);
+  }
+  if (result === "runs_exhausted") {
+    captureQuotaEvent(ctx, "task_quota_blocked", task, {
+      phase: "claim",
+      reason: "runs_exhausted",
+    });
+    throw new TaskQuotaError("runs_exhausted");
+  }
+  if (result === "claimed") {
+    captureQuotaEvent(ctx, "task_quota_claimed", task, {
+      billing_mode: billingMode(quota.periodKey),
+      period_key: quota.periodKey,
+      limit: quota.limit,
+    });
+  }
   return result;
 }
 
@@ -267,9 +324,20 @@ export async function releaseTaskExecution(
   organizationId: string,
   taskBoardItemId: string,
 ): Promise<void> {
-  await billing
+  const released = await billing
     .releaseTaskClaim(organizationId, taskBoardItemId)
-    .catch((err) =>
-      console.error("[task-quota] refund failed (stays charged)", err),
-    );
+    .catch((err) => {
+      console.error("[task-quota] refund failed (stays charged)", err);
+      return false;
+    });
+  // Only a refund that HAPPENED is an event: a repeat release (second
+  // thread-finish pass), a task with no claim, or a failed write all return
+  // false and emit nothing.
+  if (released) {
+    captureOrgEvent({
+      event: "task_quota_refunded",
+      organizationId,
+      properties: { task_id: taskBoardItemId },
+    });
+  }
 }

--- a/apps/api/src/posthog.ts
+++ b/apps/api/src/posthog.ts
@@ -11,9 +11,13 @@
  * /api/config handler and exposed to the browser at runtime.
  */
 
+import { createHash } from "node:crypto";
 import { PostHog } from "posthog-node";
 
-const apiKey = process.env.POSTHOG_KEY;
+// `bun test` sets NODE_ENV=test — a developer machine with POSTHOG_KEY
+// exported must not emit fixture events into the production project.
+const apiKey =
+  process.env.NODE_ENV === "test" ? undefined : process.env.POSTHOG_KEY;
 const host = process.env.POSTHOG_HOST;
 
 type PostHogLike = Pick<
@@ -48,4 +52,48 @@ if (apiKey) {
   };
   process.on("SIGTERM", shutdown);
   process.on("SIGINT", shutdown);
+}
+
+/** Deterministic v4-shaped uuid from a seed — same seed ⇒ same uuid, and
+ *  PostHog collapses rows sharing (event, distinct_id, uuid, timestamp), so
+ *  redundant emissions of one logical event (e.g. a redelivered Stripe
+ *  webhook) dedupe server-side instead of "dedupe in analysis". */
+export function deterministicUuid(seed: string): string {
+  const b = createHash("sha256").update(seed).digest();
+  b[6] = ((b[6] ?? 0) & 0x0f) | 0x40;
+  b[8] = ((b[8] ?? 0) & 0x3f) | 0x80;
+  const hex = b.subarray(0, 16).toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
+
+/**
+ * Org-scoped funnel event. When no acting user exists (webhooks, system
+ * reactions), identity is `org:<id>` with person processing off — an org must
+ * not become a person in the persons table. Pass `userId` when one is known
+ * (e.g. the interactive paywall); their person then owns the event.
+ * Fire-and-forget; no-op without POSTHOG_KEY.
+ */
+export function captureOrgEvent(input: {
+  event: string;
+  organizationId: string;
+  userId?: string;
+  properties?: Record<string, unknown>;
+  /** deterministicUuid(...) for events that can be emitted more than once
+   *  per logical occurrence. PostHog's dedupe contract needs uuid + event +
+   *  distinct_id + timestamp to ALL match — pass a stable `timestamp` too. */
+  uuid?: string;
+  timestamp?: Date;
+}): void {
+  posthog.capture({
+    distinctId: input.userId ?? `org:${input.organizationId}`,
+    event: input.event,
+    groups: { organization: input.organizationId },
+    ...(input.uuid ? { uuid: input.uuid } : {}),
+    ...(input.timestamp ? { timestamp: input.timestamp } : {}),
+    properties: {
+      organization_id: input.organizationId,
+      ...(input.userId ? {} : { $process_person_profile: false }),
+      ...input.properties,
+    },
+  });
 }

--- a/apps/api/src/storage/organization-billing.ts
+++ b/apps/api/src/storage/organization-billing.ts
@@ -241,18 +241,21 @@ export class OrganizationBillingStorage {
    *  decision site in tools/task-board/run-reactions.ts). Org-scoped so the
    *  invariant doesn't rest on every future caller passing a scoped id.
    *  Idempotent; `run_count` is left intact on purpose, so a refund can't be
-   *  looped into free dispatches. */
+   *  looped into free dispatches. Returns whether a held claim actually
+   *  transitioned — false for a repeat release or a claim that never existed,
+   *  so telemetry can report only refunds that happened. */
   async releaseTaskClaim(
     organizationId: string,
     taskBoardItemId: string,
-  ): Promise<void> {
-    await this.db
+  ): Promise<boolean> {
+    const result = await this.db
       .updateTable("task_quota_claims")
       .set({ state: "released" })
       .where("organization_id", "=", organizationId)
       .where("task_board_item_id", "=", taskBoardItemId)
       .where("state", "=", "held")
-      .execute();
+      .executeTakeFirst();
+    return (result.numUpdatedRows ?? 0n) > 0n;
   }
 
   /**

--- a/apps/api/src/tools/task-board/enqueue-super-agent.ts
+++ b/apps/api/src/tools/task-board/enqueue-super-agent.ts
@@ -6,6 +6,8 @@ import {
   rollbackTaskExecution,
   TaskQuotaError,
 } from "../../billing/task-quota";
+import { isReportsTask } from "@decocms/shared/task-board";
+import { captureOrgEvent } from "@/posthog";
 import { getSettings } from "@/settings";
 import { enqueueAgentRunForTask } from "./enqueue-task-run";
 import type { RunClass } from "@/dispatch-queue/run-priority";
@@ -169,6 +171,7 @@ export async function enqueueSuperAgentForTask(
   // BEFORE the write; here the claim is the enforcement.
   const claim = await claimTaskExecution(ctx, task);
 
+  let harness: "claude-code" | "decopilot" = "decopilot";
   try {
     // A re-run told to update an existing PR must land on that PR's BRANCH.
     // Asking the model to `gh pr checkout` (which the prompt does, and has
@@ -194,6 +197,7 @@ export async function enqueueSuperAgentForTask(
     const choice = await resolveTaskRepoChoice(ctx, task.organizationId);
 
     if (choice) {
+      harness = "claude-code";
       const repo = "repo" in choice ? choice.repo : null;
       await enqueueAgentRunForTask(ctx, task, {
         title: `Super Agent: ${task.title}`,
@@ -209,16 +213,15 @@ export async function enqueueSuperAgentForTask(
         harnessId: "claude-code",
         ...(repo ? { repo } : {}),
       });
-      return;
+    } else {
+      await enqueueAgentRunForTask(ctx, task, {
+        title: `Super Agent: ${task.title}`,
+        ...(opts?.runClass ? { runClass: opts.runClass } : {}),
+        prompt: buildSuperAgentTaskPrompt(task, opts),
+        temperature: 0.5,
+        ...(pinnedRef ? { pinnedRef } : {}),
+      });
     }
-
-    await enqueueAgentRunForTask(ctx, task, {
-      title: `Super Agent: ${task.title}`,
-      ...(opts?.runClass ? { runClass: opts.runClass } : {}),
-      prompt: buildSuperAgentTaskPrompt(task, opts),
-      temperature: 0.5,
-      ...(pinnedRef ? { pinnedRef } : {}),
-    });
   } catch (err) {
     // Nothing was dispatched — no thread exists to ever trigger the
     // thread-finish refund pass (run-reactions.ts). Without this, a failure
@@ -242,4 +245,21 @@ export async function enqueueSuperAgentForTask(
     }
     throw err;
   }
+
+  // The dispatch really happened — the auto-fix leg of the PLG funnel.
+  // OUTSIDE the try/catch above: telemetry must never couple into the
+  // billing rollback (a throw here after a successful dispatch would refund
+  // a run that exists). Whether this dispatch is a re-run is `claim ===
+  // "rerun"` — no separate flag.
+  captureOrgEvent({
+    event: "task_run_enqueued",
+    organizationId: task.organizationId,
+    properties: {
+      task_id: task.id,
+      reports_task: isReportsTask(task),
+      claim,
+      harness,
+      ...(opts?.runClass ? { run_class: opts.runClass } : {}),
+    },
+  });
 }

--- a/apps/api/src/tools/task-board/run-reactions.ts
+++ b/apps/api/src/tools/task-board/run-reactions.ts
@@ -20,6 +20,7 @@
  */
 
 import { releaseTaskExecution } from "@/billing/task-quota";
+import { captureOrgEvent } from "@/posthog";
 import type { OrganizationBillingStorage } from "@/storage/organization-billing";
 import { TERMINAL_THREAD_STATUSES } from "@/storage/task-board";
 import type { StudioContext } from "@/core/studio-context";
@@ -28,6 +29,7 @@ import { retryBudgetFor } from "./transient-failure";
 import { exponentialBackoffWithJitter } from "@decocms/shared/std";
 import { sseHub } from "@/event-bus/sse-hub";
 import {
+  isReportsTask,
   TASK_BOARD_ITEM_DELETED_EVENT,
   TASK_BOARD_ITEM_UPDATED_EVENT,
 } from "@decocms/shared/task-board";
@@ -42,6 +44,26 @@ const RANK: Record<TaskBoardItemStatus, number> = {
   in_review: 3,
   done: 4,
 };
+
+/** Run-lifecycle funnel events (auto-fix leg of the PLG funnel). System
+ *  actions with no acting user — org identity, person processing off.
+ *  Fire-and-forget; posthog no-ops without POSTHOG_KEY. */
+function captureTaskRunEvent(
+  event: "task_run_started" | "task_run_completed" | "task_run_failed",
+  orgId: string,
+  item: Pick<TaskBoardItem, "id" | "createdBy">,
+  properties?: Record<string, unknown>,
+): void {
+  captureOrgEvent({
+    event,
+    organizationId: orgId,
+    properties: {
+      task_id: item.id,
+      reports_task: isReportsTask(item),
+      ...properties,
+    },
+  });
+}
 
 /** Push a task board item change to every SSE listener on its org. */
 export function emitTaskBoardUpdated(orgId: string, item: TaskBoardItem): void {
@@ -147,6 +169,15 @@ export async function advanceTaskBoardForRun(
           console.error("[task-board] activity log write failed", err),
         );
       emitTaskBoardUpdated(orgId, item);
+      if (status === "in_progress" || status === "in_review") {
+        captureTaskRunEvent(
+          status === "in_progress" ? "task_run_started" : "task_run_completed",
+          orgId,
+          item,
+          // in_review lands here only from the PR-open hook (see module doc).
+          { from: current.status, via: "pr_open" },
+        );
+      }
     }
   } catch (err) {
     console.error("[task-board] run transition failed", err);
@@ -209,7 +240,13 @@ export async function advanceTasksToReviewOnThreadFinish(
       threadId,
       orgId,
     );
-    for (const item of moved) emitTaskBoardUpdated(orgId, item);
+    for (const item of moved) {
+      emitTaskBoardUpdated(orgId, item);
+      captureTaskRunEvent("task_run_completed", orgId, item, {
+        from: "in_progress",
+        via: "thread_finish",
+      });
+    }
     for (const item of moved) {
       // The card produced something, so the next unrelated failure gets a full
       // retry budget rather than inheriting this card's history.
@@ -326,6 +363,10 @@ export async function reactToFailedTaskRun(
         })
         .catch(() => {});
       emitTaskBoardUpdated(orgId, returned);
+      captureTaskRunEvent("task_run_failed", orgId, item, {
+        reason: failure.kind ?? "error",
+        retries_spent: attempts,
+      });
     }
   } catch (err) {
     console.error("[task-board] failed-run reaction failed", err);
@@ -368,6 +409,8 @@ async function refundUnproductiveTaskClaims(
       );
       if (stillRunning) continue;
       if ((await taskBoard.listPrs(taskId, orgId)).length > 0) continue;
+      // task_quota_refunded is emitted inside releaseTaskExecution, gated on
+      // the release actually transitioning a held claim.
       await releaseTaskExecution(billing, orgId, taskId);
     }
   } catch (err) {


### PR DESCRIPTION
## Summary

The PLG onboarding funnel (report → data sources → tasks → auto-fix → subscription) was blind after task generation: no server-side events for auto-fix delegation, quota consumption, run lifecycle, or the org subscription lifecycle. This PR instruments all of it with PostHog events. Sibling PR on the reports engine covers the task-generation/push half.

## New events

| Event | Site | Key properties |
|---|---|---|
| `task_quota_claimed` / `task_quota_blocked` | `billing/task-quota.ts` | `billing_mode: trial\|subscription`, `limit`, `reason`, `phase: precheck\|claim` |
| `task_quota_refunded` | `releaseTaskExecution` | gated on a new boolean from `releaseTaskClaim` — only refunds that happened |
| `task_run_enqueued` | `enqueueSuperAgentForTask` | `harness`, `claim`, `run_class`, `reports_task` |
| `task_run_started/completed/failed` | `run-reactions.ts` | `via: pr_open\|thread_finish`, `reason`, `retries_spent` |
| `subscription_started/updated/canceled/renewed`, `credits_topup_succeeded` | Stripe webhook | `status`, `cancel_at_period_end`, `credit_cents` |

## Correctness properties (review-driven)

- **Redelivery-safe revenue counters**: subscription events carry a deterministic uuid + `event.created` timestamp so Stripe redeliveries dedupe server-side; the top-up event fires only **after** `creditGatewayTopUp` succeeds.
- **No renewal overcount**: `invoice.paid` with `billing_reason=subscription_create` is not a renewal.
- **Test-mode Stripe traffic dropped** (`livemode:false`).
- **Persons table protected**: system events identify as `org:<id>` with `$process_person_profile: false`; the interactive paywall pre-check attributes to the acting user.
- **Telemetry decoupled from billing**: the enqueue capture sits outside the rollback try/catch; `task_quota_refunded` cannot fire for a release that didn't transition.
- **Tests can't pollute prod analytics**: `posthog.ts` no-ops under `NODE_ENV=test`.

## Testing

- `subscriptionFunnelEvent` extracted as a pure function + 7 unit tests (topUp precedence, all event types, livemode drop, first-invoice gate).
- `releaseTaskClaim` boolean asserted in the existing quota integration idempotency test.
- `bun run check` clean across workspaces, `bun run lint` 0 errors, knip clean, all touched unit suites green, and the 4 `*.integration.test.ts` files green against a real Postgres 16 with migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds server-side PostHog telemetry for task quota, Super Agent run lifecycle, and Stripe subscription lifecycle to give full visibility across the PLG funnel. Includes safe dedupe, test-mode drops, and decoupled telemetry so billing logic is never affected.

- **New Features**
  - Task quota: `task_quota_claimed`, `task_quota_blocked` (with `billing_mode`, `limit`, `phase`), and `task_quota_refunded` only when a held claim actually releases. Interactive pre-checks attribute to the acting user.
  - Super Agent runs: `task_run_enqueued` (with `harness`, `claim`, `run_class`) and `task_run_started` / `task_run_completed` / `task_run_failed` (with `via`, `reason`, `retries_spent`).
  - Stripe lifecycle: `subscription_started` / `subscription_updated` (with `status`, `cancel_at_period_end`) / `subscription_canceled` / `subscription_renewed`, plus `credits_topup_succeeded`. Drops `livemode:false`, ignores the first `invoice.paid` (no renewal overcount), and only fires top-up after gateway credit lands. Redeliveries dedupe via deterministic `uuid` and Stripe `event.created` timestamp.
  - Plumbing: `captureOrgEvent` uses `org:<id>` identity with `$process_person_profile: false` for system events; `NODE_ENV=test` no-ops analytics.

- **Refactors**
  - Extracted pure `subscriptionFunnelEvent(...)` with unit tests.
  - `releaseTaskClaim(...)` now returns a boolean to indicate a real transition; callers gate `task_quota_refunded` on it.

<sup>Written for commit 369b14e9c1c8d182610348746c75351112207221. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

