### PR TITLE
fix(sections-editor): show clean array-item labels in the list, not the positional suffix

### DIFF
--- a/apps/web/ct/tests/array-object-drilldown.ct.tsx
+++ b/apps/web/ct/tests/array-object-drilldown.ct.tsx
@@ -278,11 +278,12 @@ test("colliding fallback-title rows are position-disambiguated and each drills i
   mount,
 }) => {
   // The osklen bug: object-array items with no name/title field all fall back
-  // to the item schema `title` ("Spec"), so every row's label collided and
-  // navigation collapsed every item back to the first ("all items show the
-  // same content"). Rows must now render as "Spec 1/2/3", and drilling a
-  // NON-first row must uniquely address that row (no reliance on a transient
-  // open-index), showing its own value.
+  // to the item schema `title` ("Spec"), so every row's label collides and
+  // navigation used to collapse every item back to the first ("all items show
+  // the same content"). The list rows now render the clean, identical label
+  // "Spec" (the positional suffix is a display-only implementation detail of the
+  // breadcrumb), and drilling a NON-first row must uniquely address that row —
+  // showing its own value.
   const meta = sectionWithProps({
     specs: {
       type: "array",
@@ -302,13 +303,13 @@ test("colliding fallback-title rows are position-disambiguated and each drills i
     />,
   );
 
-  await expect(itemRow(component, "Spec 1")).toBeVisible();
-  await expect(itemRow(component, "Spec 2")).toBeVisible();
-  await expect(itemRow(component, "Spec 3")).toBeVisible();
+  // All three rows render the same clean label "Spec" (no positional suffix).
+  await expect(itemRow(component, "Spec")).toHaveCount(3);
 
-  await itemRow(component, "Spec 3").click();
+  // Drill into the THIRD row (index 2). It must uniquely address that row —
+  // the editor shows its own value "c", not the first row's.
+  await itemRow(component, "Spec").nth(2).click();
 
-  await expect.poll(() => readBreadcrumb(component)).toContain("Spec 3");
   const body = component.getByLabel("Body");
   await expect(body).toHaveAttribute("id", "specs.2.body");
   await expect(body).toHaveValue("c");

--- a/apps/web/src/components/sections-editor/array-item-display.test.ts
+++ b/apps/web/src/components/sections-editor/array-item-display.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  getArrayItemDisplayLabels,
   getArrayItemImageSrc,
   getArrayItemLabel,
   getArrayItemLabels,
@@ -195,6 +196,30 @@ describe("getArrayItemLabels (batch disambiguation)", () => {
     };
     const items = [{ title: "Alpha" }, { title: "Beta" }];
     expect(getArrayItemLabels(items, schema)).toEqual(["Alpha", "Beta"]);
+  });
+});
+
+describe("getArrayItemDisplayLabels (no positional suffix)", () => {
+  const schema: SchemaProperty = {
+    type: "object",
+    properties: { name: { type: "string" } },
+  };
+
+  test("keeps colliding base labels un-suffixed (display only)", () => {
+    const items = [
+      { name: "Cozinha – Festival da CASA" },
+      { name: "Cozinha – Festival da CASA" },
+    ];
+    // getArrayItemLabels would return "... 1"/"... 2"; the display variant must not.
+    expect(getArrayItemDisplayLabels(items, schema)).toEqual([
+      "Cozinha – Festival da CASA",
+      "Cozinha – Festival da CASA",
+    ]);
+  });
+
+  test("still resolves distinct base labels", () => {
+    const items = [{ name: "Alpha" }, { name: "Beta" }];
+    expect(getArrayItemDisplayLabels(items, schema)).toEqual(["Alpha", "Beta"]);
   });
 });
 

--- a/apps/web/src/components/sections-editor/array-item-display.ts
+++ b/apps/web/src/components/sections-editor/array-item-display.ts
@@ -229,6 +229,26 @@ export function getArrayItemLabels(
 }
 
 /**
+ * Plain per-item base labels for a whole array, WITHOUT the positional
+ * disambiguation suffix that {@link getArrayItemLabels} adds.
+ *
+ * Use this for pure display surfaces that address the item some other way — the
+ * list rows and the drag overlay open an item by its `entry.index`, never by its
+ * label, so two rows sharing a base label ("Cozinha – Festival da CASA") is
+ * harmless there and the synthetic " N" suffix is just visual noise.
+ *
+ * Do NOT use it anywhere a breadcrumb crumb is built or resolved: the crumb
+ * addresses an item by label, so it MUST stay unique — see
+ * {@link getArrayItemLabels}.
+ */
+export function getArrayItemDisplayLabels(
+  items: unknown[],
+  itemSchema?: SchemaProperty,
+): string[] {
+  return items.map((item, i) => baseArrayItemLabel(item, i, itemSchema));
+}
+
+/**
  * Display label for a single array item. Pass `siblings` (the whole array) to
  * get a label disambiguated against the others — see {@link getArrayItemLabels}.
  * Callers that build or resolve a breadcrumb crumb MUST pass `siblings` so the

--- a/apps/web/src/components/sections-editor/fields/array-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/array-field.tsx
@@ -23,9 +23,9 @@ import { useT } from "@/i18n/use-t.ts";
 import { SORTABLE_DROP_ANIMATION } from "@/lib/dnd-drop-animation.ts";
 import { cn } from "@deco/ui/lib/utils.ts";
 import {
+  getArrayItemDisplayLabels,
   getArrayItemImageSrc,
   getArrayItemLabel,
-  getArrayItemLabels,
 } from "../array-item-display";
 import {
   arrayItemDisplayValue,
@@ -383,9 +383,11 @@ export function ArrayField({
     ? entries.find((entry) => entry.id === activeEntryId)
     : null;
   const activeItem = activeEntry != null ? items[activeEntry.index] : undefined;
+  // Match the list row: the drag overlay is display only, so it shows the
+  // un-disambiguated base label (no positional " N" suffix).
   const activeLabel =
     activeEntry != null && activeItem !== undefined
-      ? itemLabel(activeItem, activeEntry.index)
+      ? getArrayItemDisplayLabels(items, itemSchema)[activeEntry.index]
       : null;
   const activeImage =
     activeEntry != null && activeItem !== undefined
@@ -503,9 +505,16 @@ export function ArrayField({
             >
               <div className="min-w-0 overflow-hidden rounded-xl border border-border/50 p-1.5">
                 {(() => {
-                  // Compute disambiguated labels once for the whole list rather
-                  // than per row (each derivation scans all siblings).
-                  const itemLabels = getArrayItemLabels(items, itemSchema);
+                  // Compute base labels once for the whole list rather than per
+                  // row (each derivation scans all siblings). These are display
+                  // only — the row opens its item by `entry.index`, not by label
+                  // — so they stay un-disambiguated (no positional " N" suffix);
+                  // the breadcrumb still addresses items by the unique label from
+                  // getArrayItemLabels.
+                  const itemLabels = getArrayItemDisplayLabels(
+                    items,
+                    itemSchema,
+                  );
                   return entries.map((entry) => {
                     const item = items[entry.index];
                     if (item === undefined) return null;


### PR DESCRIPTION
## Summary

Array items whose base label collides — e.g. two `Cozinha – Festival da CASA` — were rendered in the **list** and the **drag overlay** with the breadcrumb's positional disambiguation suffix (`… 7` / `… 8`). That number reads as an arbitrary value glued onto the title (see the reported screenshot).

The suffix comes from `getArrayItemLabels`, which exists to keep an item **addressable** in the breadcrumb after a form remount wipes the transient open-index. But the list rows and the drag overlay never address an item by its label — they open it by `entry.index` — so they don't need the suffix at all.

This PR separates **display** from **addressing**:

- New `getArrayItemDisplayLabels()` returns the plain per-item base labels (no positional suffix).
- The array-field **list rows** and the **drag overlay** now use it, so colliding items show the clean title.
- The breadcrumb keeps using `getArrayItemLabels()` (still unique), so item resolution after a remount is unchanged.

## Follow-up (separate PR)

The positional number can still surface in one place: the breadcrumb crumb when you drill into two identically-titled items. Removing it there without either a visible number or a hidden marker requires making the breadcrumb trail carry the item index as structured data (`string[]` → structured crumb) across the resolver. Tracked as a follow-up.

## Testing

- `bun test apps/web/src/components/sections-editor/` → 600 pass, 0 fail
- `tsc --noEmit` (apps/web) clean
- Added unit tests for `getArrayItemDisplayLabels` (colliding bases stay un-suffixed; distinct bases resolve).

## Affected areas

`apps/web` sections-editor array field only. No API/storage/wire changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes array item labels in the sections editor list and drag overlay to show clean titles without the positional suffix. Colliding titles display as-is; the breadcrumb still uses unique labels, so addressing after remounts is unchanged.

- **Bug Fixes**
  - Added `getArrayItemDisplayLabels` to return plain labels for display (no suffix).
  - Updated list rows and drag overlay to use display labels; breadcrumb stays on `getArrayItemLabels`.
  - Added unit tests and updated the CT drilldown test to assert identical row labels and drill by index; no API or storage changes.

<sup>Written for commit 0fe3267678e68cbe9d0d48be04ea46ecf4922acd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

