### PR TITLE
fix(sections-editor): address array-item breadcrumbs by index, not a numbered label

### DIFF
--- a/apps/web/ct/harness/ct-utils.ts
+++ b/apps/web/ct/harness/ct-utils.ts
@@ -37,10 +37,18 @@ export async function readFormValue(component: Locator): Promise<unknown> {
   return JSON.parse(txt ?? "null");
 }
 
-/** Parse the harness's `breadcrumb` <pre> back into a string[]. */
+/**
+ * Parse the harness's `breadcrumb` <pre> into the visible crumb labels. Item
+ * crumbs serialize as `{ label, itemIndex }`; this returns the `label` part (the
+ * text the UI renders), so assertions read the trail the way a user sees it.
+ */
 export async function readBreadcrumb(component: Locator): Promise<string[]> {
   const txt = await component.getByTestId("breadcrumb").textContent();
-  return JSON.parse(txt ?? "[]");
+  const crumbs = JSON.parse(txt ?? "[]") as (
+    | string
+    | { label: string; itemIndex: number }
+  )[];
+  return crumbs.map((c) => (typeof c === "string" ? c : c.label));
 }
 
 /**

--- a/apps/web/ct/harness/field-harness.tsx
+++ b/apps/web/ct/harness/field-harness.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { renderField } from "@/components/sections-editor/schema-form";
+import type { Crumb } from "@/components/sections-editor/schema-form-breadcrumb";
 import type {
   LiveMeta,
   SchemaProperty,
@@ -28,7 +29,7 @@ export function FieldHarness({
   decofile?: Record<string, unknown>;
 }) {
   const [value, setValue] = useState<unknown>(initialValue);
-  const [breadcrumb, setBreadcrumb] = useState<string[]>([]);
+  const [breadcrumb, setBreadcrumb] = useState<Crumb[]>([]);
 
   return (
     <div data-testid="harness">

--- a/apps/web/ct/harness/schema-form-harness.tsx
+++ b/apps/web/ct/harness/schema-form-harness.tsx
@@ -4,6 +4,7 @@ import {
   type LiveMeta,
 } from "@/components/sections-editor/resolve-schema";
 import { SchemaForm } from "@/components/sections-editor/schema-form";
+import type { Crumb } from "@/components/sections-editor/schema-form-breadcrumb";
 
 /**
  * Canonical CT surface: raw CMS JSON Schema (LiveMeta) in → resolveSchema →
@@ -28,7 +29,7 @@ export function SchemaFormHarness({
 }) {
   const resolved = resolveSchema(resolveType, meta);
   const [value, setValue] = useState<unknown>(initialValue);
-  const [breadcrumb, setBreadcrumb] = useState<string[]>([]);
+  const [breadcrumb, setBreadcrumb] = useState<Crumb[]>([]);
 
   return (
     <div data-testid="harness">

--- a/apps/web/ct/harness/schema-form-panel-harness.tsx
+++ b/apps/web/ct/harness/schema-form-panel-harness.tsx
@@ -4,6 +4,7 @@ import {
   type LiveMeta,
 } from "@/components/sections-editor/resolve-schema";
 import { SchemaFormPanel } from "@/components/sections-editor/sections-editor-panels";
+import type { Crumb } from "@/components/sections-editor/schema-form-breadcrumb";
 
 /**
  * CT surface for the `SchemaFormPanel` boundary specifically — the panel the
@@ -30,7 +31,7 @@ export function SchemaFormPanelHarness({
 }) {
   const resolved = resolveSchema(resolveType, meta);
   const [value, setValue] = useState<unknown>(initialValue);
-  const [breadcrumb, setBreadcrumb] = useState<string[]>([]);
+  const [breadcrumb, setBreadcrumb] = useState<Crumb[]>([]);
   const [events, setEvents] = useState<string[]>([]);
 
   return (

--- a/apps/web/ct/tests/array-object-drilldown.ct.tsx
+++ b/apps/web/ct/tests/array-object-drilldown.ct.tsx
@@ -280,10 +280,10 @@ test("colliding fallback-title rows are position-disambiguated and each drills i
   // The osklen bug: object-array items with no name/title field all fall back
   // to the item schema `title` ("Spec"), so every row's label collides and
   // navigation used to collapse every item back to the first ("all items show
-  // the same content"). The list rows now render the clean, identical label
-  // "Spec" (the positional suffix is a display-only implementation detail of the
-  // breadcrumb), and drilling a NON-first row must uniquely address that row —
-  // showing its own value.
+  // the same content"). Rows now render with the clean, identical label "Spec"
+  // (the crumb carries the item's index, not a positional suffix), and drilling
+  // a NON-first row must still uniquely address that row — showing its own
+  // value — with no reliance on a transient open-index.
   const meta = sectionWithProps({
     specs: {
       type: "array",
@@ -306,10 +306,11 @@ test("colliding fallback-title rows are position-disambiguated and each drills i
   // All three rows render the same clean label "Spec" (no positional suffix).
   await expect(itemRow(component, "Spec")).toHaveCount(3);
 
-  // Drill into the THIRD row (index 2). It must uniquely address that row —
-  // the editor shows its own value "c", not the first row's.
+  // Drill into the THIRD row (index 2). Its crumb carries itemIndex 2, so it
+  // addresses that exact row — the editor shows its own value "c".
   await itemRow(component, "Spec").nth(2).click();
 
+  await expect.poll(() => readBreadcrumb(component)).toContain("Spec");
   const body = component.getByLabel("Body");
   await expect(body).toHaveAttribute("id", "specs.2.body");
   await expect(body).toHaveValue("c");

--- a/apps/web/src/components/sandbox/content/app-editor.tsx
+++ b/apps/web/src/components/sandbox/content/app-editor.tsx
@@ -16,7 +16,11 @@ import {
 import { resolveAppEditorSchema } from "./app-editor-schema";
 import { buildSectionBlockFromCatalogEntry } from "./section-create";
 import { SchemaForm } from "@/components/sections-editor/schema-form";
-import { breadcrumbsForHeaderClick } from "@/components/sections-editor/schema-form-breadcrumb";
+import {
+  breadcrumbsForHeaderClick,
+  type Crumb,
+  crumbLabel,
+} from "@/components/sections-editor/schema-form-breadcrumb";
 import { SaveStatus } from "./blog/save-status";
 import { useT } from "@/i18n/use-t.ts";
 
@@ -76,7 +80,7 @@ export function AppEditor({
     null,
   );
   const [formResetKey, setFormResetKey] = useState(0);
-  const [breadcrumbs, setBreadcrumbs] = useState<string[]>([]);
+  const [breadcrumbs, setBreadcrumbs] = useState<Crumb[]>([]);
   const [addSectionOpen, setAddSectionOpen] = useState(false);
   const pendingAppendRef = useRef<((item: unknown) => void) | null>(null);
 
@@ -102,7 +106,7 @@ export function AppEditor({
     });
   };
 
-  const handleBreadcrumbChange = (next: string[]) => {
+  const handleBreadcrumbChange = (next: Crumb[]) => {
     setBreadcrumbs(next);
   };
 
@@ -162,9 +166,10 @@ export function AppEditor({
           >
             {headerCrumbs.map((crumb, index) => {
               const isLast = index === headerCrumbs.length - 1;
+              const crumbText = crumbLabel(crumb);
               return (
                 <span
-                  key={`${crumb}-${index}`}
+                  key={`${crumbText}-${index}`}
                   className="flex min-w-0 items-center gap-1 overflow-hidden"
                 >
                   {index > 0 && (
@@ -182,7 +187,7 @@ export function AppEditor({
                       }
                       setFormResetKey((key) => key + 1);
                     }}
-                    title={crumb}
+                    title={crumbText}
                     className={cn(
                       "min-w-0 truncate rounded-md px-1 py-0.5 text-left transition-colors",
                       isLast
@@ -190,7 +195,7 @@ export function AppEditor({
                         : "text-muted-foreground hover:bg-accent hover:text-accent-foreground",
                     )}
                   >
-                    {crumb}
+                    {crumbText}
                   </button>
                 </span>
               );

--- a/apps/web/src/components/sandbox/content/available-section-editor.tsx
+++ b/apps/web/src/components/sandbox/content/available-section-editor.tsx
@@ -13,6 +13,10 @@ import { useT } from "@/i18n/use-t.ts";
 import { useInsetContext } from "@/layouts/agent-shell-layout";
 import { SchemaForm } from "@/components/sections-editor/schema-form";
 import {
+  type Crumb,
+  crumbLabel,
+} from "@/components/sections-editor/schema-form-breadcrumb";
+import {
   resolveSchema,
   type LiveMeta,
 } from "@/components/sections-editor/resolve-schema";
@@ -62,7 +66,7 @@ export function AvailableSectionEditor({
       : null;
 
   const [formValue, setFormValue] = useState<Record<string, unknown>>({});
-  const [fieldBreadcrumbs, setFieldBreadcrumbs] = useState<string[]>([]);
+  const [fieldBreadcrumbs, setFieldBreadcrumbs] = useState<Crumb[]>([]);
   const [formResetKey, setFormResetKey] = useState(0);
   const [saveOpen, setSaveOpen] = useState(false);
 
@@ -109,9 +113,10 @@ export function AvailableSectionEditor({
             >
               {headerCrumbs.map((crumb, index) => {
                 const isLast = index === headerCrumbs.length - 1;
+                const crumbText = crumbLabel(crumb);
                 return (
                   <span
-                    key={`${crumb}-${index}`}
+                    key={`${crumbText}-${index}`}
                     className="flex min-w-0 items-center gap-1 overflow-hidden"
                   >
                     {index > 0 && (
@@ -120,7 +125,7 @@ export function AvailableSectionEditor({
                     <button
                       type="button"
                       onClick={() => handleBreadcrumbClick(index)}
-                      title={crumb}
+                      title={crumbText}
                       className={cn(
                         "min-w-0 truncate rounded-md px-1 py-0.5 text-left transition-colors hover:bg-accent hover:text-accent-foreground",
                         isLast
@@ -128,7 +133,7 @@ export function AvailableSectionEditor({
                           : "text-muted-foreground",
                       )}
                     >
-                      {crumb}
+                      {crumbText}
                     </button>
                   </span>
                 );

--- a/apps/web/src/components/sandbox/content/runnable-block-editor.tsx
+++ b/apps/web/src/components/sandbox/content/runnable-block-editor.tsx
@@ -25,6 +25,10 @@ import { useInsetContext } from "@/layouts/agent-shell-layout";
 import { MonacoCodeEditor } from "@/components/monaco-editor";
 import { SchemaForm } from "@/components/sections-editor/schema-form";
 import {
+  type Crumb,
+  crumbLabel,
+} from "@/components/sections-editor/schema-form-breadcrumb";
+import {
   inferSchemaFromValue,
   isFreeformPropsSchema,
   resolveSchema,
@@ -107,7 +111,7 @@ export function RunnableBlockEditor({
 
   const [formValue, setFormValue] =
     useState<Record<string, unknown>>(initialValue);
-  const [fieldBreadcrumbs, setFieldBreadcrumbs] = useState<string[]>([]);
+  const [fieldBreadcrumbs, setFieldBreadcrumbs] = useState<Crumb[]>([]);
   const [formResetKey, setFormResetKey] = useState(0);
   const [jsonError, setJsonError] = useState(false);
   const [jsonCode, setJsonCode] = useState<string | null>(null);
@@ -248,9 +252,10 @@ export function RunnableBlockEditor({
           >
             {headerCrumbs.map((crumb, index) => {
               const isLast = index === headerCrumbs.length - 1;
+              const crumbText = crumbLabel(crumb);
               return (
                 <span
-                  key={`${crumb}-${index}`}
+                  key={`${crumbText}-${index}`}
                   className="flex min-w-0 items-center gap-1 overflow-hidden"
                 >
                   {index > 0 && (
@@ -259,7 +264,7 @@ export function RunnableBlockEditor({
                   <button
                     type="button"
                     onClick={() => handleBreadcrumbClick(index)}
-                    title={crumb}
+                    title={crumbText}
                     className={cn(
                       "min-w-0 truncate rounded-md px-1 py-0.5 text-left transition-colors hover:bg-accent hover:text-accent-foreground",
                       isLast
@@ -267,7 +272,7 @@ export function RunnableBlockEditor({
                         : "text-muted-foreground",
                     )}
                   >
-                    {crumb}
+                    {crumbText}
                   </button>
                 </span>
               );

--- a/apps/web/src/components/sandbox/content/saved-section-editor.tsx
+++ b/apps/web/src/components/sandbox/content/saved-section-editor.tsx
@@ -11,6 +11,10 @@ import { cn } from "@deco/ui/lib/utils.js";
 import { useInsetContext } from "@/layouts/agent-shell-layout";
 import { SchemaForm } from "@/components/sections-editor/schema-form";
 import {
+  type Crumb,
+  crumbLabel,
+} from "@/components/sections-editor/schema-form-breadcrumb";
+import {
   resolveSchema,
   type LiveMeta,
 } from "@/components/sections-editor/resolve-schema";
@@ -79,7 +83,7 @@ export function SavedSectionEditor({
   const [formValue, setFormValue] = useState<Record<string, unknown>>(
     seed?.data ?? {},
   );
-  const [fieldBreadcrumbs, setFieldBreadcrumbs] = useState<string[]>([]);
+  const [fieldBreadcrumbs, setFieldBreadcrumbs] = useState<Crumb[]>([]);
   const [formResetKey, setFormResetKey] = useState(0);
   const [jsonError, setJsonError] = useState(false);
   // The text Monaco renders. `null` means the JSON view is closed. Seeded from
@@ -167,9 +171,10 @@ export function SavedSectionEditor({
             >
               {headerCrumbs.map((crumb, index) => {
                 const isLast = index === headerCrumbs.length - 1;
+                const crumbText = crumbLabel(crumb);
                 return (
                   <span
-                    key={`${crumb}-${index}`}
+                    key={`${crumbText}-${index}`}
                     className="flex min-w-0 items-center gap-1 overflow-hidden"
                   >
                     {index > 0 && (
@@ -178,7 +183,7 @@ export function SavedSectionEditor({
                     <button
                       type="button"
                       onClick={() => handleBreadcrumbClick(index)}
-                      title={crumb}
+                      title={crumbText}
                       className={cn(
                         "min-w-0 truncate rounded-md px-1 py-0.5 text-left transition-colors hover:bg-accent hover:text-accent-foreground",
                         isLast
@@ -186,7 +191,7 @@ export function SavedSectionEditor({
                           : "text-muted-foreground",
                       )}
                     >
-                      {crumb}
+                      {crumbText}
                     </button>
                   </span>
                 );

--- a/apps/web/src/components/sections-editor/array-item-display.test.ts
+++ b/apps/web/src/components/sections-editor/array-item-display.test.ts
@@ -3,7 +3,6 @@ import {
   getArrayItemDisplayLabels,
   getArrayItemImageSrc,
   getArrayItemLabel,
-  getArrayItemLabels,
   renderMustacheTemplate,
 } from "./array-item-display";
 import type { SchemaProperty } from "./resolve-schema";
@@ -96,106 +95,22 @@ describe("getArrayItemLabel", () => {
     );
   });
 
-  describe("collision disambiguation (siblings)", () => {
-    // An object array with no distinguishing field: every item's label falls
-    // back to the item schema title, so all rows collapse to one string. The
-    // breadcrumb addresses an item by its label and the transient open-index is
-    // wiped whenever the form subtree remounts (formResetKey), so a non-unique
-    // label makes every item resolve back to the first one — the "all items
-    // show the same content" bug. Positional suffixes keep them addressable.
+  test("colliding items keep an identical base label (no positional suffix)", () => {
+    // Items with no distinguishing field share a label — intentional: the
+    // breadcrumb addresses an item by index (Crumb.itemIndex), never by a unique
+    // label, so no positional " N" suffix is added.
     const itemSchema: SchemaProperty = {
       type: "object",
       title: "ProductSpecifications",
       properties: { body: { type: "string" } },
     };
-    const specs = [{ body: "a" }, { body: "b" }, { body: "c" }];
-
-    test("suffixes the position when the base label collides", () => {
-      expect(getArrayItemLabel(specs[0], 0, itemSchema, specs)).toBe(
-        "ProductSpecifications 1",
-      );
-      expect(getArrayItemLabel(specs[2], 2, itemSchema, specs)).toBe(
-        "ProductSpecifications 3",
-      );
-    });
-
-    test("leaves a unique label untouched", () => {
-      const mixed = [{ title: "Alpha" }, { title: "Beta" }];
-      const schema: SchemaProperty = {
-        type: "object",
-        properties: { title: { type: "string" } },
-      };
-      expect(getArrayItemLabel(mixed[0], 0, schema, mixed)).toBe("Alpha");
-      expect(getArrayItemLabel(mixed[1], 1, schema, mixed)).toBe("Beta");
-    });
-
-    test("only the colliding items get a suffix", () => {
-      const mixed = [{ title: "Dup" }, { title: "Unique" }, { title: "Dup" }];
-      const schema: SchemaProperty = {
-        type: "object",
-        properties: { title: { type: "string" } },
-      };
-      expect(getArrayItemLabel(mixed[0], 0, schema, mixed)).toBe("Dup 1");
-      expect(getArrayItemLabel(mixed[1], 1, schema, mixed)).toBe("Unique");
-      expect(getArrayItemLabel(mixed[2], 2, schema, mixed)).toBe("Dup 3");
-    });
-
-    test("no siblings argument keeps the legacy bare label", () => {
-      expect(getArrayItemLabel(specs[1], 1, itemSchema)).toBe(
-        "ProductSpecifications",
-      );
-    });
-  });
-});
-
-describe("getArrayItemLabels (batch disambiguation)", () => {
-  const titleSchema = (title: string): SchemaProperty => ({
-    type: "object",
-    title,
-    properties: { body: { type: "string" } },
-  });
-
-  test("suffixes every item when they all share the fallback title", () => {
-    const items = [{ body: "a" }, { body: "b" }, { body: "c" }];
-    expect(getArrayItemLabels(items, titleSchema("Spec"))).toEqual([
-      "Spec 1",
-      "Spec 2",
-      "Spec 3",
-    ]);
-  });
-
-  test("disambiguates NFC/NFD near-duplicates the resolver would treat as equal", () => {
-    // "café" composed (U+00E9) vs decomposed (e + U+0301). labelsMatch
-    // NFC-normalizes both, so a bare label would collapse them to index 0.
-    const schema: SchemaProperty = {
-      type: "object",
-      properties: { name: { type: "string" } },
-    };
-    const items = [{ name: "café" }, { name: "café" }];
-    const labels = getArrayItemLabels(items, schema);
-    expect(labels[0]).not.toBe(labels[1]);
-    expect(labels[0]!.normalize("NFC")).not.toBe(labels[1]!.normalize("NFC"));
-  });
-
-  test("keeps the final set unique when a suffix collides with a literal label", () => {
-    // ["X","X","X 2"]: naive per-item suffixing yields "X 1","X 2","X 2".
-    const schema: SchemaProperty = {
-      type: "object",
-      properties: { title: { type: "string" } },
-    };
-    const items = [{ title: "X" }, { title: "X" }, { title: "X 2" }];
-    const labels = getArrayItemLabels(items, schema);
-    expect(new Set(labels).size).toBe(labels.length);
-    expect(labels[0]).toBe("X 1");
-  });
-
-  test("leaves unique labels untouched", () => {
-    const schema: SchemaProperty = {
-      type: "object",
-      properties: { title: { type: "string" } },
-    };
-    const items = [{ title: "Alpha" }, { title: "Beta" }];
-    expect(getArrayItemLabels(items, schema)).toEqual(["Alpha", "Beta"]);
+    const specs = [{ body: "a" }, { body: "b" }];
+    expect(getArrayItemLabel(specs[0], 0, itemSchema)).toBe(
+      "ProductSpecifications",
+    );
+    expect(getArrayItemLabel(specs[1], 1, itemSchema)).toBe(
+      "ProductSpecifications",
+    );
   });
 });
 

--- a/apps/web/src/components/sections-editor/array-item-display.ts
+++ b/apps/web/src/components/sections-editor/array-item-display.ts
@@ -175,71 +175,14 @@ function baseArrayItemLabel(
 }
 
 /**
- * Normalize a label the same way breadcrumb matching does (`labelsMatch` in
- * schema-form-breadcrumb.ts) so collision detection here agrees with crumb
- * resolution there. Duplicated locally rather than imported to avoid a cyclic
- * dependency (that module already imports from this one).
- */
-function normalizeLabel(label: string): string {
-  return label.normalize("NFC").trim();
-}
-
-/**
- * Display labels for a whole array, disambiguated so every label is unique.
+ * Base display labels for a whole array.
  *
- * When an item's base label is shared by another item (e.g. an object array
- * with no name/title field, so every row falls back to the item schema's static
- * `title`), the label is suffixed with the item's position. Uniqueness is not
- * cosmetic: the breadcrumb addresses an array item by its label, and the only
- * other handle — the transiently-opened index in `ArrayField` — is reset
- * whenever the form subtree remounts (a `formResetKey` bump on back/breadcrumb
- * navigation). A non-unique label would then collapse every item back to the
- * first one on the next remount, so the editor appears to show the same content
- * for every item.
- *
- * Computed as a set (not per item) so the result is globally unique and
- * deterministic in `(items, itemSchema)` — the crumb built from this list
- * re-resolves to the same index even when a positional suffix happens to equal
- * another row's literal label. Comparison uses `normalizeLabel` to match the
- * resolver, so NFC/NFD and whitespace near-duplicates disambiguate too.
- */
-export function getArrayItemLabels(
-  items: unknown[],
-  itemSchema?: SchemaProperty,
-): string[] {
-  const bases = items.map((item, i) => baseArrayItemLabel(item, i, itemSchema));
-  const baseCounts = new Map<string, number>();
-  for (const base of bases) {
-    const key = normalizeLabel(base);
-    baseCounts.set(key, (baseCounts.get(key) ?? 0) + 1);
-  }
-  const seen = new Set<string>();
-  return bases.map((base, i) => {
-    let label =
-      (baseCounts.get(normalizeLabel(base)) ?? 0) > 1
-        ? `${base} ${i + 1}`
-        : base;
-    // A suffixed label can still coincide with another row's literal label;
-    // keep extending (positions are unique, so this terminates quickly) until
-    // the final set has no duplicates.
-    while (seen.has(normalizeLabel(label))) label = `${label} ${i + 1}`;
-    seen.add(normalizeLabel(label));
-    return label;
-  });
-}
-
-/**
- * Plain per-item base labels for a whole array, WITHOUT the positional
- * disambiguation suffix that {@link getArrayItemLabels} adds.
- *
- * Use this for pure display surfaces that address the item some other way — the
- * list rows and the drag overlay open an item by its `entry.index`, never by its
- * label, so two rows sharing a base label ("Cozinha – Festival da CASA") is
- * harmless there and the synthetic " N" suffix is just visual noise.
- *
- * Do NOT use it anywhere a breadcrumb crumb is built or resolved: the crumb
- * addresses an item by label, so it MUST stay unique — see
- * {@link getArrayItemLabels}.
+ * Two items with no distinguishing field share a label — which is fine, and
+ * deliberately so: array items are addressed by their index (the breadcrumb
+ * crumb carries `itemIndex` — see `Crumb` in schema-form-breadcrumb.ts), never
+ * by a unique label, and the list rows / drag overlay open an item by its
+ * `entry.index`. So the displayed label stays clean — no positional " N" suffix
+ * ever reaches the UI, even when items collide.
  */
 export function getArrayItemDisplayLabels(
   items: unknown[],
@@ -248,25 +191,13 @@ export function getArrayItemDisplayLabels(
   return items.map((item, i) => baseArrayItemLabel(item, i, itemSchema));
 }
 
-/**
- * Display label for a single array item. Pass `siblings` (the whole array) to
- * get a label disambiguated against the others — see {@link getArrayItemLabels}.
- * Callers that build or resolve a breadcrumb crumb MUST pass `siblings` so the
- * built and resolved labels agree; only genuinely single-item callers omit it.
- */
+/** Base display label for a single array item. */
 export function getArrayItemLabel(
   item: unknown,
   index: number,
   itemSchema?: SchemaProperty,
-  siblings?: unknown[],
 ): string {
-  if (!siblings || siblings.length < 2) {
-    return baseArrayItemLabel(item, index, itemSchema);
-  }
-  return (
-    getArrayItemLabels(siblings, itemSchema)[index] ??
-    baseArrayItemLabel(item, index, itemSchema)
-  );
+  return baseArrayItemLabel(item, index, itemSchema);
 }
 
 function getArrayItemImageTemplate(

--- a/apps/web/src/components/sections-editor/fields/any-of-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/any-of-field.tsx
@@ -39,6 +39,7 @@ import {
   isEmbeddedUnionResolveType,
 } from "../block-type-utils";
 import { labelFromResolveType } from "../section-types";
+import { crumbLabel, type Crumb } from "../schema-form-breadcrumb";
 import { suggestBlockId, validateBlockId } from "../page-sections";
 import type { SchemaProperty } from "../resolve-schema";
 import { FieldLabel } from "./field-label";
@@ -241,11 +242,13 @@ export function AnyOfField({
   // the parent's re-prepend would double it (["Página de Listagem", "Página de
   // Listagem", …]) when this loader union is the active narrowed field.
   const strippedOwnCrumb =
-    isModuleLoaderUnion && safeBreadcrumbPath[0] === outerCrumb;
+    isModuleLoaderUnion &&
+    safeBreadcrumbPath.length > 0 &&
+    crumbLabel(safeBreadcrumbPath[0]!) === outerCrumb;
   const nestedBreadcrumbPath = strippedOwnCrumb
     ? safeBreadcrumbPath.slice(1)
     : safeBreadcrumbPath;
-  const nestedOnBreadcrumbChange: ((p: string[]) => void) | undefined =
+  const nestedOnBreadcrumbChange: ((p: Crumb[]) => void) | undefined =
     strippedOwnCrumb
       ? (newPath) => {
           onBreadcrumbChange?.([outerCrumb, ...newPath]);

--- a/apps/web/src/components/sections-editor/fields/array-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/array-field.tsx
@@ -141,12 +141,10 @@ export function ArrayField({
   // Only plain object arrays (banners, links, …) get the hide toggle. Section
   // pickers have their own hide flow, and primitive arrays can't be wrapped.
   const canHideItems = !usesSectionPicker && itemSchema?.type === "object";
-  // Index of the item the user has explicitly opened. Array items are addressed
-  // in the breadcrumb by their (mutable) display label; `getArrayItemLabels`
-  // keeps those labels unique, but this preferred index still pins selection to
-  // the opened row through the brief window where an edit makes labels churn
-  // (e.g. typing a name/alt that momentarily matches a sibling before the
-  // positional suffix settles).
+  // Index of the item the user has explicitly opened. The breadcrumb crumb
+  // carries the item's index (see `Crumb`), so selection survives a remount on
+  // its own; this preferred index is only a churn-window fallback that pins the
+  // open row while an edit briefly changes its label.
   const [openIndex, setOpenIndex] = useState<number | null>(null);
 
   const selection = resolveArrayItemSelection(
@@ -194,12 +192,10 @@ export function ArrayField({
     setEntries((current) => resizeArrayEntries(current, items.length));
   }
 
-  const itemLabel = (
-    item: unknown,
-    index: number,
-    siblings: unknown[] = items,
-  ) =>
-    getArrayItemLabel(arrayItemDisplayValue(item), index, itemSchema, siblings);
+  // The item's base (un-suffixed) label — the crumb carries the index for
+  // addressing, so the label is display-only and must stay clean.
+  const itemLabel = (item: unknown, index: number) =>
+    getArrayItemLabel(arrayItemDisplayValue(item), index, itemSchema);
 
   const openItem = (index: number) => {
     if (suppressClickRef.current) return;
@@ -210,6 +206,7 @@ export function ArrayField({
         breadcrumbPath,
         label,
         labelText,
+        index,
         drillDownOpts,
       ),
     );
@@ -220,12 +217,13 @@ export function ArrayField({
     onChange(next);
     const nextIndex = next.length - 1;
     setOpenIndex(nextIndex);
-    const labelText = getArrayItemLabel(item, nextIndex, itemSchema, next);
+    const labelText = itemLabel(item, nextIndex);
     onBreadcrumbChange?.(
       buildArrayDrillDownBreadcrumb(
         breadcrumbPath,
         label,
         labelText,
+        nextIndex,
         drillDownOpts,
       ),
     );
@@ -257,17 +255,13 @@ export function ArrayField({
     onChange(next);
     const nextIndex = next.length - 1;
     setOpenIndex(nextIndex);
-    const labelText = getArrayItemLabel(
-      defaultVal,
-      nextIndex,
-      itemSchema,
-      next,
-    );
+    const labelText = itemLabel(defaultVal, nextIndex);
     onBreadcrumbChange?.(
       buildArrayDrillDownBreadcrumb(
         breadcrumbPath,
         label,
         labelText,
+        nextIndex,
         drillDownOpts,
       ),
     );
@@ -324,20 +318,23 @@ export function ArrayField({
     next[index] = isArrayItemHidden(items[index]) ? hideArrayItem(val) : val;
     onChange(next);
 
-    // When editing the currently selected item, the display label may change
+    // When editing the currently selected item, its display label may change
     // (e.g. editing the "alt" or "name" field that drives getArrayItemLabel).
     // Rewrite the item's crumb IN PLACE — at the position resolution matched it
-    // (`selection.crumbIndex`), not by looking up its old text — so
-    // resolveArrayItemSelection keeps pointing at THIS item. A text lookup
-    // strands the crumb once the old label is gone: the edited item then
-    // re-resolves to a colliding sibling, e.g. the "original" a duplicate was
-    // copied from.
+    // (`selection.crumbIndex`) — keeping the same `itemIndex`. Syncing the label
+    // part still matters: ownership resolution matches the crumb's label against
+    // this array's current base labels, so a stale label would let the item
+    // re-resolve to a colliding sibling (the "editing a duplicate snaps to the
+    // original" bug).
     if (index === selectedIndex && selection) {
       const oldLabel = itemLabel(items[index], index);
-      const newLabel = itemLabel(next[index], index, next);
+      const newLabel = itemLabel(next[index], index);
       if (oldLabel !== newLabel) {
         const updatedBreadcrumb = [...breadcrumbPath];
-        updatedBreadcrumb[selection.crumbIndex] = newLabel;
+        updatedBreadcrumb[selection.crumbIndex] = {
+          label: newLabel,
+          itemIndex: index,
+        };
         onBreadcrumbChange?.(updatedBreadcrumb);
       }
     }
@@ -409,6 +406,7 @@ export function ArrayField({
         breadcrumbPath,
         label,
         itemName,
+        selectedIndex,
         drillDownOpts,
       );
       const itemIndex = findBreadcrumbLabelIndex(trail, itemName);
@@ -506,11 +504,10 @@ export function ArrayField({
               <div className="min-w-0 overflow-hidden rounded-xl border border-border/50 p-1.5">
                 {(() => {
                   // Compute base labels once for the whole list rather than per
-                  // row (each derivation scans all siblings). These are display
-                  // only — the row opens its item by `entry.index`, not by label
-                  // — so they stay un-disambiguated (no positional " N" suffix);
-                  // the breadcrumb still addresses items by the unique label from
-                  // getArrayItemLabels.
+                  // row. Display only — the row opens its item by `entry.index`,
+                  // not by label — so colliding rows share a clean label (no
+                  // positional " N" suffix); the breadcrumb addresses items by
+                  // the index its crumb carries.
                   const itemLabels = getArrayItemDisplayLabels(
                     items,
                     itemSchema,

--- a/apps/web/src/components/sections-editor/fields/field-props.ts
+++ b/apps/web/src/components/sections-editor/fields/field-props.ts
@@ -1,4 +1,5 @@
 import type { LiveMeta, SchemaProperty } from "../resolve-schema";
+import type { Crumb } from "../schema-form-breadcrumb";
 import type { SectionCatalogEntry } from "../section-catalog";
 
 export interface SandboxConfig {
@@ -15,8 +16,8 @@ export interface FieldProps {
   onChange: (value: unknown) => void;
   path: string;
   label: string;
-  breadcrumbPath?: string[];
-  onBreadcrumbChange?: (path: string[]) => void;
+  breadcrumbPath?: Crumb[];
+  onBreadcrumbChange?: (path: Crumb[]) => void;
   /**
    * True when this field shares its object scope with another array/drill-down
    * field. Array fields use it to decide whether their own label must stay in

--- a/apps/web/src/components/sections-editor/page-seo-form.tsx
+++ b/apps/web/src/components/sections-editor/page-seo-form.tsx
@@ -3,6 +3,7 @@ import { SeoFormChrome } from "./seo-form-chrome";
 import { SeoFormFields } from "./seo-form-fields";
 import { SeoTypeSelect } from "./seo-type-select";
 import type { SchemaProperty } from "./resolve-schema";
+import type { Crumb } from "./schema-form-breadcrumb";
 import type { SeoTypeOption } from "./seo-schema";
 import {
   defaultEnabledSeo,
@@ -19,7 +20,7 @@ interface PageSeoFormProps {
   seoTypeOptions?: SeoTypeOption[];
   formResetKey: number;
   siteDefaultSeo?: Record<string, unknown>;
-  onBreadcrumbChange?: (path: string[]) => void;
+  onBreadcrumbChange?: (path: Crumb[]) => void;
   onPersistRaw: (raw: Record<string, unknown> | null) => void;
   onInnerChange: (inner: Record<string, unknown>) => void;
   /** Clears inner form state (enable/disable). */

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -5,6 +5,7 @@ import {
   breadcrumbsForHeaderClick,
   buildArrayDrillDownBreadcrumb,
   consumedBreadcrumbPrefix,
+  type Crumb,
   headerBackTargetIndex,
   fieldDisplayLabel,
   findBreadcrumbLabelIndex,
@@ -16,7 +17,10 @@ import {
   siblingFieldLabel,
   isBreadcrumbInsideObject,
 } from "./schema-form-breadcrumb";
-import { getArrayItemLabel, getArrayItemLabels } from "./array-item-display";
+import {
+  getArrayItemDisplayLabels,
+  getArrayItemLabel,
+} from "./array-item-display";
 import { PAGE_MULTIVARIATE_FLAG_RESOLVE_TYPE } from "./section-types";
 
 describe("normalizeBreadcrumbLabel", () => {
@@ -704,16 +708,16 @@ describe("buildArrayDrillDownBreadcrumb", () => {
     // parent); the breadcrumb jumps straight to the item so there's no
     // redundant "list only" crumb to click back through.
     expect(
-      buildArrayDrillDownBreadcrumb([], "Flag Desconto", "Partiu ferias"),
-    ).toEqual(["Partiu ferias"]);
+      buildArrayDrillDownBreadcrumb([], "Flag Desconto", "Partiu ferias", 0),
+    ).toEqual([{ label: "Partiu ferias", itemIndex: 0 }]);
   });
 
   test("keeps the array label to disambiguate an item labelled like the array", () => {
     // Item label == array label (e.g. label driven by `alt`): keep the array
     // crumb so breadcrumbPathForActiveField can tell the two levels apart.
-    expect(buildArrayDrillDownBreadcrumb([], "Banner", "Banner")).toEqual([
+    expect(buildArrayDrillDownBreadcrumb([], "Banner", "Banner", 0)).toEqual([
       "Banner",
-      "Banner",
+      { label: "Banner", itemIndex: 0 },
     ]);
   });
 
@@ -721,10 +725,10 @@ describe("buildArrayDrillDownBreadcrumb", () => {
     // Item label == array's property key: breadcrumbPathForActiveField strips a
     // head crumb matching the key too, so the array crumb must be kept.
     expect(
-      buildArrayDrillDownBreadcrumb([], "Products", "items", {
+      buildArrayDrillDownBreadcrumb([], "Products", "items", 0, {
         arrayKey: "items",
       }),
-    ).toEqual(["Products", "items"]);
+    ).toEqual(["Products", { label: "items", itemIndex: 0 }]);
   });
 
   test("keeps the array label when a sibling array/drill-down field exists", () => {
@@ -732,37 +736,46 @@ describe("buildArrayDrillDownBreadcrumb", () => {
     // (two label-less arrays both fall back to "Item N"), so keep the array
     // label as a disambiguator when siblings are present.
     expect(
-      buildArrayDrillDownBreadcrumb([], "Logos", "Item 1", {
+      buildArrayDrillDownBreadcrumb([], "Logos", "Item 1", 0, {
         hasSiblingDrillDownFields: true,
       }),
-    ).toEqual(["Logos", "Item 1"]);
+    ).toEqual(["Logos", { label: "Item 1", itemIndex: 0 }]);
   });
 
   test("omits the array label when it is the sole drill-down field in scope", () => {
     expect(
-      buildArrayDrillDownBreadcrumb([], "Images", "Item 1", {
+      buildArrayDrillDownBreadcrumb([], "Images", "Item 1", 0, {
         arrayKey: "images",
         hasSiblingDrillDownFields: false,
       }),
-    ).toEqual(["Item 1"]);
+    ).toEqual([{ label: "Item 1", itemIndex: 0 }]);
   });
 
   test("does not duplicate crumbs already in trail", () => {
     expect(
       buildArrayDrillDownBreadcrumb(
-        ["Flag Desconto", "Partiu ferias"],
+        ["Flag Desconto", { label: "Partiu ferias", itemIndex: 0 }],
         "Flag Desconto",
         "Partiu ferias",
+        0,
       ),
-    ).toEqual(["Flag Desconto", "Partiu ferias"]);
+    ).toEqual(["Flag Desconto", { label: "Partiu ferias", itemIndex: 0 }]);
   });
 
   test("nested drill-down stays free of array labels (no doubled crumb)", () => {
     // Opening an item inside an already-open item appends only the new item
     // label — the intermediate array levels never enter the trail.
     expect(
-      buildArrayDrillDownBreadcrumb(["Leve 3 pague 2"], "Images", "Detroit"),
-    ).toEqual(["Leve 3 pague 2", "Detroit"]);
+      buildArrayDrillDownBreadcrumb(
+        [{ label: "Leve 3 pague 2", itemIndex: 0 }],
+        "Images",
+        "Detroit",
+        0,
+      ),
+    ).toEqual([
+      { label: "Leve 3 pague 2", itemIndex: 0 },
+      { label: "Detroit", itemIndex: 0 },
+    ]);
   });
 });
 
@@ -782,11 +795,11 @@ describe("sibling array disambiguation (regression)", () => {
   const objValue = { images: [{ src: "a" }], logos: [{ src: "b" }] };
 
   test("keeps array label and resolves to the clicked array, not the first sibling", () => {
-    const trail = buildArrayDrillDownBreadcrumb([], "Logos", "Item 1", {
+    const trail = buildArrayDrillDownBreadcrumb([], "Logos", "Item 1", 0, {
       arrayKey: "logos",
       hasSiblingDrillDownFields: true,
     });
-    expect(trail).toEqual(["Logos", "Item 1"]);
+    expect(trail).toEqual(["Logos", { label: "Item 1", itemIndex: 0 }]);
     expect(
       resolveActiveFieldKey(
         Object.keys(properties),
@@ -801,11 +814,11 @@ describe("sibling array disambiguation (regression)", () => {
     const soleProps = {
       cards: { title: "Cards", type: "array", items: { type: "object" } },
     } as Record<string, SchemaProperty>;
-    const trail = buildArrayDrillDownBreadcrumb([], "Cards", "Men's", {
+    const trail = buildArrayDrillDownBreadcrumb([], "Cards", "Men's", 0, {
       arrayKey: "cards",
       hasSiblingDrillDownFields: false,
     });
-    expect(trail).toEqual(["Men's"]);
+    expect(trail).toEqual([{ label: "Men's", itemIndex: 0 }]);
     expect(
       resolveActiveFieldKey(
         ["cards"],
@@ -885,7 +898,7 @@ describe("resolveArrayItemSelection", () => {
     expect(
       resolveArrayItemSelection(
         "Cards",
-        ["Options", "Cards", "Men's"],
+        ["Options", "Cards", { label: "Men's", itemIndex: 0 }],
         items,
         itemSchema,
       ),
@@ -894,7 +907,12 @@ describe("resolveArrayItemSelection", () => {
 
   test("returns inner path for nested array drill-down", () => {
     expect(
-      resolveArrayItemSelection("Cards", ["Men's", "Sale"], items, itemSchema),
+      resolveArrayItemSelection(
+        "Cards",
+        [{ label: "Men's", itemIndex: 0 }, "Sale"],
+        items,
+        itemSchema,
+      ),
     ).toEqual({ index: 0, innerPath: ["Sale"], crumbIndex: 0 });
   });
 
@@ -902,7 +920,7 @@ describe("resolveArrayItemSelection", () => {
     expect(
       resolveArrayItemSelection(
         "Cards",
-        ["Men's", "Button"],
+        [{ label: "Men's", itemIndex: 0 }, "Button"],
         items,
         itemSchema,
       ),
@@ -921,7 +939,7 @@ describe("resolveArrayItemSelection", () => {
     expect(
       resolveArrayItemSelection(
         "Banner",
-        ["Banner Sale"],
+        [{ label: "Banner Sale", itemIndex: 0 }],
         bannerItems,
         bannerSchema,
         0,
@@ -932,57 +950,66 @@ describe("resolveArrayItemSelection", () => {
   describe("duplicate labels", () => {
     // Two items share a base label ("Hello") — e.g. after Duplicate, or when an
     // object array has no distinguishing field so every row falls back to the
-    // item schema title. getArrayItemLabel disambiguates them positionally
-    // ("Hello 1" / "Hello 2"), so each item stays uniquely addressable by its
-    // crumb even after a form remount clears the transiently-opened index.
+    // item schema title. The crumb carries the exact `itemIndex`, so each item
+    // stays uniquely addressable even after a form remount clears the transient
+    // open index — while the displayed label stays clean ("Hello", no number).
     const dupItems = [{ title: "Hello" }, { title: "Hello" }];
 
-    test("addresses each duplicate by its positional crumb (no preferredIndex)", () => {
+    test("addresses each duplicate by its item index (no preferredIndex)", () => {
       expect(
-        resolveArrayItemSelection("Cards", ["Hello 1"], dupItems, itemSchema),
+        resolveArrayItemSelection(
+          "Cards",
+          [{ label: "Hello", itemIndex: 0 }],
+          dupItems,
+          itemSchema,
+        ),
       ).toEqual({ index: 0, innerPath: [], crumbIndex: 0 });
       expect(
-        resolveArrayItemSelection("Cards", ["Hello 2"], dupItems, itemSchema),
+        resolveArrayItemSelection(
+          "Cards",
+          [{ label: "Hello", itemIndex: 1 }],
+          dupItems,
+          itemSchema,
+        ),
       ).toEqual({ index: 1, innerPath: [], crumbIndex: 0 });
     });
 
-    test("a bare (non-disambiguated) crumb no longer matches a duplicate", () => {
-      // The old behaviour silently resolved a shared label to the first item;
-      // now the crumb must carry the position, so a bare label finds nothing.
+    test("a plain string crumb never resolves to an item", () => {
+      // Item crumbs are objects carrying an index; a bare string is a
+      // field/array label, so it must not silently resolve to the first item.
       expect(
         resolveArrayItemSelection("Cards", ["Hello"], dupItems, itemSchema),
       ).toBeNull();
     });
 
-    test("keeps the opened item when a preferredIndex is supplied", () => {
+    test("the index pins the item even without a preferredIndex", () => {
       expect(
         resolveArrayItemSelection(
           "Cards",
-          ["Hello 2"],
+          [{ label: "Hello", itemIndex: 1 }],
           dupItems,
           itemSchema,
-          1,
         ),
       ).toEqual({ index: 1, innerPath: [], crumbIndex: 0 });
     });
 
-    test("ignores a preferredIndex whose label no longer matches the crumb", () => {
+    test("the index wins over a stale preferredIndex", () => {
       expect(
         resolveArrayItemSelection(
           "Cards",
-          ["Women's"],
+          [{ label: "Women's", itemIndex: 1 }],
           items,
           itemSchema,
-          0, // preferred item 0 is "Men's" — doesn't match, fall back to search
+          0, // preferred item 0 is "Men's" — the crumb's index pins item 1
         ),
       ).toEqual({ index: 1, innerPath: [], crumbIndex: 0 });
     });
 
-    test("falls back to crumb search when preferredIndex is out of range", () => {
+    test("resolves by index even when preferredIndex is out of range", () => {
       expect(
         resolveArrayItemSelection(
           "Cards",
-          ["Hello 2"],
+          [{ label: "Hello", itemIndex: 1 }],
           dupItems,
           itemSchema,
           5,
@@ -1004,7 +1031,7 @@ describe("resolveArrayItemSelection crumbIndex", () => {
     expect(
       resolveArrayItemSelection(
         "Cards",
-        ["Section", "Cards", "Men's", "Inner"],
+        ["Section", "Cards", { label: "Men's", itemIndex: 0 }, "Inner"],
         items,
         schema,
       ),
@@ -1013,7 +1040,12 @@ describe("resolveArrayItemSelection crumbIndex", () => {
 
   test("is the last crumb when innerPath is empty", () => {
     expect(
-      resolveArrayItemSelection("Cards", ["Women's"], items, schema),
+      resolveArrayItemSelection(
+        "Cards",
+        [{ label: "Women's", itemIndex: 1 }],
+        items,
+        schema,
+      ),
     ).toEqual({ index: 1, innerPath: [], crumbIndex: 0 });
   });
 });
@@ -1029,12 +1061,12 @@ describe("editing an item's label keeps it selected (crumb re-sync)", () => {
     properties: { title: { type: "string", title: "Title" } },
   } as SchemaProperty;
 
-  // Mirror ArrayField.updateItem's crumb re-sync exactly (same label helper it
-  // uses, `getArrayItemLabel` with siblings), so this test tracks the component
-  // rather than re-deriving the label a different way.
+  // Mirror ArrayField.updateItem's crumb re-sync exactly: the item's base label
+  // (no siblings → no positional suffix) plus the stable `itemIndex`, rewritten
+  // in place at `selection.crumbIndex`.
   const rewriteAndReresolve = (
     items: unknown[],
-    trail: string[],
+    trail: Crumb[],
     openIndex: number,
     edited: unknown[],
   ) => {
@@ -1046,22 +1078,15 @@ describe("editing an item's label keeps it selected (crumb re-sync)", () => {
       openIndex,
     );
     if (!selection) throw new Error("expected a selection");
-    const oldLabel = getArrayItemLabel(
-      items[openIndex],
-      openIndex,
-      schema,
-      items,
-    );
-    const newLabel = getArrayItemLabel(
-      edited[openIndex],
-      openIndex,
-      schema,
-      edited,
-    );
+    const oldLabel = getArrayItemLabel(items[openIndex], openIndex, schema);
+    const newLabel = getArrayItemLabel(edited[openIndex], openIndex, schema);
     let nextTrail = trail;
     if (oldLabel !== newLabel) {
       nextTrail = [...trail];
-      nextTrail[selection.crumbIndex] = newLabel;
+      nextTrail[selection.crumbIndex] = {
+        label: newLabel,
+        itemIndex: openIndex,
+      };
     }
     return {
       nextTrail,
@@ -1075,9 +1100,15 @@ describe("editing an item's label keeps it selected (crumb re-sync)", () => {
     };
   };
 
+  // Open the copy (index 1) by its crumb — carries the exact index.
+  const openCrumb = (items: unknown[], index: number): Crumb => ({
+    label: getArrayItemDisplayLabels(items, schema)[index]!,
+    itemIndex: index,
+  });
+
   test("editing the duplicate's title stays on the duplicate, not the original", () => {
     const items = [{ title: "Cozinha" }, { title: "Cozinha" }];
-    const trail = [getArrayItemLabels(items, schema)[1]!]; // open the copy
+    const trail = [openCrumb(items, 1)];
     const edited = [{ title: "Cozinha" }, { title: "Cozinha Nova" }];
     expect(rewriteAndReresolve(items, trail, 1, edited).selection).toEqual({
       index: 1,
@@ -1087,10 +1118,10 @@ describe("editing an item's label keeps it selected (crumb re-sync)", () => {
   });
 
   test("clearing the title mid-edit (label falls back) keeps the same item", () => {
-    // Emptying the label field makes the row fall back to the schema-title
-    // suffix; the crumb still tracks it because it is rewritten by position.
+    // Emptying the label field makes the row fall back to the "Item N" label;
+    // the crumb still tracks it because the rewritten crumb keeps the index.
     const items = [{ title: "Cozinha" }, { title: "Cozinha" }];
-    const trail = [getArrayItemLabels(items, schema)[1]!];
+    const trail = [openCrumb(items, 1)];
     const edited = [{ title: "Cozinha" }, { title: "" }];
     expect(rewriteAndReresolve(items, trail, 1, edited).selection).toEqual({
       index: 1,
@@ -1109,7 +1140,7 @@ describe("editing an item's label keeps it selected (crumb re-sync)", () => {
       },
     } as SchemaProperty;
     const items = [{ title: "Cozinha", href: "/a" }];
-    const trail = ["Cozinha"];
+    const trail: Crumb[] = [{ label: "Cozinha", itemIndex: 0 }];
     const selection = resolveArrayItemSelection(
       "Banners",
       trail,
@@ -1118,8 +1149,8 @@ describe("editing an item's label keeps it selected (crumb re-sync)", () => {
       0,
     );
     const edited = [{ title: "Cozinha", href: "/b" }]; // label field unchanged
-    const oldLabel = getArrayItemLabel(items[0], 0, withExtra, items);
-    const newLabel = getArrayItemLabel(edited[0], 0, withExtra, edited);
+    const oldLabel = getArrayItemLabel(items[0], 0, withExtra);
+    const newLabel = getArrayItemLabel(edited[0], 0, withExtra);
     expect(oldLabel).toBe(newLabel); // title drives the label; href doesn't
     // Trail stays as-is; re-resolving still lands on the item.
     expect(selection).toEqual({ index: 0, innerPath: [], crumbIndex: 0 });
@@ -1129,7 +1160,7 @@ describe("editing an item's label keeps it selected (crumb re-sync)", () => {
     // Trail [item, Inner]: the item crumb is at position 0, so rewriting it
     // must leave the inner crumb ("Inner") untouched.
     const items = [{ title: "Cozinha" }, { title: "Cozinha" }];
-    const trail = [getArrayItemLabels(items, schema)[1]!, "Inner"];
+    const trail: Crumb[] = [openCrumb(items, 1), "Inner"];
     const edited = [{ title: "Cozinha" }, { title: "Cozinha Nova" }];
     const { nextTrail, selection } = rewriteAndReresolve(
       items,
@@ -1137,7 +1168,10 @@ describe("editing an item's label keeps it selected (crumb re-sync)", () => {
       1,
       edited,
     );
-    expect(nextTrail).toEqual(["Cozinha Nova", "Inner"]);
+    expect(nextTrail).toEqual([
+      { label: "Cozinha Nova", itemIndex: 1 },
+      "Inner",
+    ]);
     expect(selection).toEqual({
       index: 1,
       innerPath: ["Inner"],
@@ -1147,14 +1181,19 @@ describe("editing an item's label keeps it selected (crumb re-sync)", () => {
 });
 
 describe("array item label build↔resolve round-trip", () => {
-  // The fix's core promise: a crumb built from getArrayItemLabels must resolve
-  // back to the same item with no transient state — this is what survives a
-  // form remount. Exercises both seams together, not hand-copied literals.
+  // The fix's core promise: an item crumb (clean base label + itemIndex) must
+  // resolve back to the same item with no transient state — this is what
+  // survives a form remount. Exercises both seams together.
   const roundTrips = (items: unknown[], schema: SchemaProperty) => {
-    const labels = getArrayItemLabels(items, schema);
+    const labels = getArrayItemDisplayLabels(items, schema);
     labels.forEach((label, i) => {
       expect(
-        resolveArrayItemSelection("Items", [label], items, schema),
+        resolveArrayItemSelection(
+          "Items",
+          [{ label, itemIndex: i }],
+          items,
+          schema,
+        ),
       ).toEqual({ index: i, innerPath: [], crumbIndex: 0 });
     });
   };

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -1,7 +1,28 @@
-import { getArrayItemLabels } from "./array-item-display";
+import { getArrayItemDisplayLabels } from "./array-item-display";
 import { isPageMultivariateSectionArrayField } from "./page-variants";
 import type { SchemaProperty } from "./resolve-schema";
 import { unwrapBlockReference } from "./unwrap-section";
+
+/**
+ * A breadcrumb crumb. Field/context crumbs (page name, section label, an
+ * ancestor field's disambiguated label) are plain strings. An array-item crumb
+ * additionally carries the item's exact array index, so it re-resolves to that
+ * item after a form remount without leaking a positional number into the label
+ * the UI renders — the crumb is addressed by `itemIndex`, displayed by `label`.
+ */
+export type Crumb = string | { label: string; itemIndex: number };
+
+/** The human-visible text of a crumb (the label part of an item crumb). */
+export function crumbLabel(crumb: Crumb): string {
+  return typeof crumb === "string" ? crumb : crumb.label;
+}
+
+/** Whether a crumb addresses an array item (carries an `itemIndex`). */
+function isItemCrumb(
+  crumb: Crumb,
+): crumb is { label: string; itemIndex: number } {
+  return typeof crumb === "object";
+}
 
 function humanize(key: string): string {
   return key
@@ -20,10 +41,11 @@ export function normalizeBreadcrumbLabel(label: string): string {
  * (NFC-insensitive). Used to stamp the disambiguated ancestor label onto a drill
  * trail so the resolver can tell same-titled sibling props apart.
  */
-export function prependCrumbIfAbsent(label: string, trail: string[]): string[] {
+export function prependCrumbIfAbsent(label: string, trail: Crumb[]): Crumb[] {
   if (
     trail.length > 0 &&
-    normalizeBreadcrumbLabel(trail[0]!) === normalizeBreadcrumbLabel(label)
+    normalizeBreadcrumbLabel(crumbLabel(trail[0]!)) ===
+      normalizeBreadcrumbLabel(label)
   ) {
     return trail;
   }
@@ -87,16 +109,18 @@ function arrayCrumbNeededForDisambiguation(
  * right array (and item) still resolves.
  */
 export function buildArrayDrillDownBreadcrumb(
-  breadcrumbPath: string[],
+  breadcrumbPath: Crumb[],
   arrayLabel: string,
   itemLabel: string,
+  itemIndex: number,
   opts?: { arrayKey?: string; hasSiblingDrillDownFields?: boolean },
-): string[] {
+): Crumb[] {
   const normalizedItem = normalizeBreadcrumbLabel(itemLabel);
   if (
     breadcrumbPath.some(
       (crumb) =>
-        labelsMatch(crumb, normalizedItem) || labelsMatch(crumb, itemLabel),
+        labelsMatch(crumbLabel(crumb), normalizedItem) ||
+        labelsMatch(crumbLabel(crumb), itemLabel),
     )
   ) {
     return breadcrumbPath;
@@ -104,11 +128,11 @@ export function buildArrayDrillDownBreadcrumb(
   const trail = [...breadcrumbPath];
   if (
     arrayCrumbNeededForDisambiguation(arrayLabel, itemLabel, opts) &&
-    !trail.some((crumb) => labelsMatch(crumb, arrayLabel))
+    !trail.some((crumb) => labelsMatch(crumbLabel(crumb), arrayLabel))
   ) {
     trail.push(arrayLabel);
   }
-  trail.push(itemLabel);
+  trail.push({ label: itemLabel, itemIndex });
   return trail;
 }
 
@@ -124,9 +148,9 @@ export function buildArrayDrillDownBreadcrumb(
  * child's own crumb (array labelled "Banner" + lone item labelled "Banner").
  */
 export function consumedBreadcrumbPrefix(
-  breadcrumbPath: string[],
-  fieldBreadcrumbPath: string[],
-): string[] {
+  breadcrumbPath: Crumb[],
+  fieldBreadcrumbPath: Crumb[],
+): Crumb[] {
   return breadcrumbPath.slice(
     0,
     breadcrumbPath.length - fieldBreadcrumbPath.length,
@@ -145,12 +169,12 @@ export function consumedBreadcrumbPrefix(
 export function breadcrumbPathForActiveField(
   activeKey: string,
   schema: SchemaProperty,
-  breadcrumbPath: string[],
+  breadcrumbPath: Crumb[],
   overrideLabel?: string,
-): string[] {
+): Crumb[] {
   if (breadcrumbPath.length === 0) return breadcrumbPath;
   const label = overrideLabel ?? fieldDisplayLabel(activeKey, schema);
-  const head = breadcrumbPath[0]!;
+  const head = crumbLabel(breadcrumbPath[0]!);
   if (labelsMatch(head, label) || labelsMatch(head, activeKey)) {
     return breadcrumbPath.slice(1);
   }
@@ -207,20 +231,20 @@ export function headerBackTargetIndex(
 
 /** Map a header crumb index to the breadcrumb trail (`headerCrumbs = [title, ...breadcrumbs]`). */
 export function breadcrumbsForHeaderClick(
-  breadcrumbs: string[],
+  breadcrumbs: Crumb[],
   headerIndex: number,
-): string[] {
+): Crumb[] {
   if (headerIndex <= 0) return [];
   return breadcrumbs.slice(0, headerIndex);
 }
 
 export function findBreadcrumbLabelIndex(
-  path: string[],
+  path: Crumb[],
   targetLabel: string,
 ): number {
   const normalized = normalizeBreadcrumbLabel(targetLabel);
   return path.findIndex(
-    (crumb) => normalizeBreadcrumbLabel(crumb) === normalized,
+    (crumb) => normalizeBreadcrumbLabel(crumbLabel(crumb)) === normalized,
   );
 }
 
@@ -291,20 +315,15 @@ function valueOwnsItemCrumb(
   ) {
     return false;
   }
-  // A colliding item's crumb carries a positional suffix ("Dup 1"), but the
-  // ownership labels scanned here are bare (no item schema is available at this
-  // nesting level), so also try the crumb with a trailing " N" stripped. This
-  // only widens matching, and the actual item is still pinned downstream by the
-  // suffix-aware resolveArrayItemSelection.
-  const crumbBase = crumb.replace(/\s+\d+$/, "");
+  // The crumb passed here is already the item's base label (callers unwrap the
+  // crumb via crumbLabel), and the ownership labels scanned here are bare too, so
+  // a direct match suffices. The actual item is still pinned downstream by the
+  // index-carrying resolveArrayItemSelection.
   if (Array.isArray(value)) {
     for (const item of value) {
       if (--budget.n <= 0) return false;
       const label = itemOwnershipLabel(item);
-      if (
-        label &&
-        (labelsMatch(label, crumb) || labelsMatch(label, crumbBase))
-      ) {
+      if (label && labelsMatch(label, crumb)) {
         return true;
       }
       if (valueOwnsItemCrumb(item, crumb, budget, depth + 1)) return true;
@@ -324,11 +343,11 @@ function resolveActiveFieldKeyInScope(
   keys: string[],
   properties: Record<string, SchemaProperty>,
   objValue: Record<string, unknown>,
-  breadcrumbPath: string[],
+  breadcrumbPath: Crumb[],
   decofile?: Record<string, unknown>,
 ): string | null {
   if (breadcrumbPath.length === 0) return null;
-  const head = breadcrumbPath[0]!;
+  const head = crumbLabel(breadcrumbPath[0]!);
 
   for (const key of keys) {
     const schema = properties[key];
@@ -337,7 +356,9 @@ function resolveActiveFieldKeyInScope(
     if (labelsMatch(head, label) || labelsMatch(head, key)) return key;
     if (
       breadcrumbPath.some(
-        (crumb) => labelsMatch(crumb, label) || labelsMatch(crumb, key),
+        (crumb) =>
+          labelsMatch(crumbLabel(crumb), label) ||
+          labelsMatch(crumbLabel(crumb), key),
       )
     ) {
       return key;
@@ -349,7 +370,7 @@ function resolveActiveFieldKeyInScope(
     if (!schema || !isArrayDrillDownField(schema, objValue[key])) continue;
     const val = objValue[key];
     if (!Array.isArray(val)) continue;
-    const labels = getArrayItemLabels(val, schema.items);
+    const labels = getArrayItemDisplayLabels(val, schema.items);
     if (labels.some((label) => labelsMatch(label, head))) return key;
   }
 
@@ -476,7 +497,7 @@ function resolveActiveFieldKeyInScope(
     if (breadcrumbPath.length > 1) {
       const val = objValue[key];
       if (val && typeof val === "object" && !Array.isArray(val)) {
-        const nextCrumb = breadcrumbPath[1]!;
+        const nextCrumb = crumbLabel(breadcrumbPath[1]!);
         const hasInnerMatch = Object.keys(val as Record<string, unknown>).some(
           (k) =>
             !k.startsWith("__") &&
@@ -499,7 +520,7 @@ export function resolveActiveFieldKey(
   keys: string[],
   properties: Record<string, SchemaProperty>,
   objValue: Record<string, unknown>,
-  breadcrumbPath: string[],
+  breadcrumbPath: Crumb[],
   decofile?: Record<string, unknown>,
 ): string | null {
   return resolveActiveFieldKeyInScope(
@@ -517,7 +538,7 @@ export function isBreadcrumbInsideObject(
   label: string,
   schema: SchemaProperty,
   objValue: Record<string, unknown>,
-  breadcrumbPath: string[],
+  breadcrumbPath: Crumb[],
   decofile?: Record<string, unknown>,
 ): boolean {
   if (breadcrumbPath.length === 0 || !schema.properties) return false;
@@ -535,7 +556,7 @@ export function isBreadcrumbInsideObject(
     return true;
   }
 
-  const head = breadcrumbPath[0]!;
+  const head = crumbLabel(breadcrumbPath[0]!);
   if (!labelsMatch(head, label) && !labelsMatch(head, fieldKey)) return false;
 
   return (
@@ -551,31 +572,43 @@ export function isBreadcrumbInsideObject(
 }
 
 /**
- * Find the array item whose label matches `crumb`.
+ * Find the array item a crumb points at.
  *
- * Array items are addressed in the breadcrumb by their (mutable, non-unique)
- * display label, so two items can resolve to the same crumb — e.g. after
- * duplicating an item, or when the label field (name/title/alt/…) is edited to
- * a value another item already uses. A plain `findIndex` always returns the
- * FIRST such item, which yanks the editor away from a later item the moment its
- * label collides with an earlier sibling (dropping focus mid-typing).
+ * An item crumb carries the item's exact `itemIndex`, so it re-resolves to that
+ * item directly — no reliance on a unique display label or on the transient open
+ * index (which is wiped on a form remount). The `label` part still does
+ * *ownership*: a bare index is valid for any array with ≥2 items, so we confirm
+ * this array is the crumb's owner by matching the item's base label before
+ * trusting the index. Plain string crumbs (field/array labels) never identify an
+ * item, so they return -1.
  *
- * `preferredIndex` is the item the caller currently has open. When it still
- * matches the crumb we keep it, so editing a colliding label never snaps
- * selection to a different row.
+ * `preferredIndex` (the item the caller currently has open) is only a churn-window
+ * fallback: while a label edit is mid-flight it keeps selection pinned to the
+ * open row. The exact-index path makes it non-load-bearing.
  */
 function findItemIndexForCrumb(
   items: unknown[],
   itemSchema: SchemaProperty | undefined,
-  crumb: string,
+  crumb: Crumb,
   preferredIndex?: number | null,
 ): number {
-  const labels = getArrayItemLabels(items, itemSchema);
+  if (!isItemCrumb(crumb)) return -1;
+  const labels = getArrayItemDisplayLabels(items, itemSchema);
+  // Exact pin: the index addresses the item; the label confirms this array owns it.
+  if (
+    crumb.itemIndex >= 0 &&
+    crumb.itemIndex < items.length &&
+    labelsMatch(labels[crumb.itemIndex]!, crumb.label)
+  ) {
+    return crumb.itemIndex;
+  }
+  // Churn-window fallback: keep the open row while its label is mid-edit.
   const preferred = preferredIndex != null ? labels[preferredIndex] : undefined;
-  if (preferred !== undefined && labelsMatch(preferred, crumb)) {
+  if (preferred !== undefined && labelsMatch(preferred, crumb.label)) {
     return preferredIndex!;
   }
-  return labels.findIndex((label) => labelsMatch(label, crumb));
+  // Last resort: the item shifted; match by label (−1 if this array isn't the owner).
+  return labels.findIndex((label) => labelsMatch(label, crumb.label));
 }
 
 /**
@@ -598,11 +631,11 @@ function findItemIndexForCrumb(
  */
 export function resolveArrayItemSelection(
   label: string,
-  breadcrumbPath: string[],
+  breadcrumbPath: Crumb[],
   items: unknown[],
   itemSchema: SchemaProperty | undefined,
   preferredIndex?: number | null,
-): { index: number; innerPath: string[]; crumbIndex: number } | null {
+): { index: number; innerPath: Crumb[]; crumbIndex: number } | null {
   if (breadcrumbPath.length === 0) return null;
 
   for (let pi = 0; pi < breadcrumbPath.length; pi++) {
@@ -619,7 +652,7 @@ export function resolveArrayItemSelection(
   }
 
   const labelIndex = breadcrumbPath.findIndex((crumb) =>
-    labelsMatch(crumb, label),
+    labelsMatch(crumbLabel(crumb), label),
   );
   if (labelIndex >= 0 && breadcrumbPath.length > labelIndex + 1) {
     const itemCrumb = breadcrumbPath[labelIndex + 1]!;

--- a/apps/web/src/components/sections-editor/schema-form.tsx
+++ b/apps/web/src/components/sections-editor/schema-form.tsx
@@ -28,6 +28,7 @@ import {
 import {
   breadcrumbPathForActiveField,
   consumedBreadcrumbPrefix,
+  type Crumb,
   fieldDisplayLabel,
   isArrayDrillDownField,
   prependCrumbIfAbsent,
@@ -421,8 +422,8 @@ export function SchemaForm({
   value: unknown;
   onChange: (value: unknown) => void;
   basePath: string;
-  breadcrumbPath?: string[];
-  onBreadcrumbChange?: (path: string[]) => void;
+  breadcrumbPath?: Crumb[];
+  onBreadcrumbChange?: (path: Crumb[]) => void;
   meta?: LiveMeta;
   decofile?: Record<string, unknown>;
   onSaveReferencedBlock?: (
@@ -566,7 +567,7 @@ export function SchemaForm({
   );
   const fieldOnBreadcrumbChange =
     consumedPrefix.length > 0 && onBreadcrumbChange
-      ? (next: string[]) => onBreadcrumbChange([...consumedPrefix, ...next])
+      ? (next: Crumb[]) => onBreadcrumbChange([...consumedPrefix, ...next])
       : onBreadcrumbChange;
   return (
     <div className="min-w-0 space-y-6">
@@ -596,7 +597,7 @@ export function SchemaForm({
           });
         const fieldOnBreadcrumbChangeForKey =
           collidesWithSibling && fieldOnBreadcrumbChange
-            ? (next: string[]) =>
+            ? (next: Crumb[]) =>
                 fieldOnBreadcrumbChange(prependCrumbIfAbsent(label, next))
             : fieldOnBreadcrumbChange;
 

--- a/apps/web/src/components/sections-editor/sections-editor-panels.tsx
+++ b/apps/web/src/components/sections-editor/sections-editor-panels.tsx
@@ -8,6 +8,7 @@ import {
 } from "@deco/ui/components/tooltip.tsx";
 import { cn } from "@deco/ui/lib/utils.js";
 import { SchemaForm } from "./schema-form";
+import { type Crumb, crumbLabel } from "./schema-form-breadcrumb";
 import { type LiveMeta, type SchemaProperty } from "./resolve-schema";
 import type { FieldProps, SandboxConfig } from "./fields/field-props";
 import { SeoFormFields } from "./seo-form-fields";
@@ -42,7 +43,7 @@ export function VariantRuleForm({
   sandbox?: SandboxConfig | null;
 }) {
   const t = useT();
-  const [breadcrumbPath, setBreadcrumbPath] = useState<string[]>([]);
+  const [breadcrumbPath, setBreadcrumbPath] = useState<Crumb[]>([]);
 
   return (
     <div className="space-y-2">
@@ -63,9 +64,10 @@ export function VariantRuleForm({
           </button>
           {breadcrumbPath.map((crumb, index) => {
             const isLast = index === breadcrumbPath.length - 1;
+            const crumbText = crumbLabel(crumb);
             return (
               <span
-                key={`${crumb}-${index}`}
+                key={`${crumbText}-${index}`}
                 className="flex min-w-0 items-center gap-1 overflow-hidden"
               >
                 {index > 0 && (
@@ -76,7 +78,7 @@ export function VariantRuleForm({
                   onClick={() =>
                     setBreadcrumbPath(breadcrumbPath.slice(0, index + 1))
                   }
-                  title={crumb}
+                  title={crumbText}
                   className={cn(
                     "min-w-0 truncate rounded-md px-1 py-0.5 text-left transition-colors hover:bg-accent hover:text-accent-foreground",
                     isLast
@@ -84,7 +86,7 @@ export function VariantRuleForm({
                       : "text-muted-foreground",
                   )}
                 >
-                  {crumb}
+                  {crumbText}
                 </button>
               </span>
             );
@@ -129,8 +131,8 @@ export function SchemaFormPanel({
   formValue: unknown;
   formResetKey: number;
   onFormChange: (v: unknown) => void;
-  onBreadcrumbChange: (path: string[]) => void;
-  breadcrumbPath?: string[];
+  onBreadcrumbChange: (path: Crumb[]) => void;
+  breadcrumbPath?: Crumb[];
   emptyMessage: string;
   beforeForm?: ReactNode;
   seoResolveType?: string;

--- a/apps/web/src/components/sections-editor/sections-editor.tsx
+++ b/apps/web/src/components/sections-editor/sections-editor.tsx
@@ -50,7 +50,11 @@ import { AddSectionModal } from "./add-section-modal";
 import { useSectionPreviewBase } from "./use-section-preview-base";
 import type { SectionCatalogEntry } from "./section-catalog";
 import { SectionVariantList } from "./section-variant-list";
-import { headerBackTargetIndex } from "./schema-form-breadcrumb";
+import {
+  type Crumb,
+  crumbLabel,
+  headerBackTargetIndex,
+} from "./schema-form-breadcrumb";
 import { ALWAYS_MATCHER_RESOLVE_TYPE, type RawSection } from "./section-types";
 import {
   buildMatcherBlockData,
@@ -208,7 +212,7 @@ export function SectionsEditor({
     unknown
   > | null>(null);
   const [ruleResolveType, setRuleResolveType] = useState<string | null>(null);
-  const [fieldBreadcrumbs, setFieldBreadcrumbs] = useState<string[]>([]);
+  const [fieldBreadcrumbs, setFieldBreadcrumbs] = useState<Crumb[]>([]);
   // Reset the form panel's scroll to the top whenever the drill-down DEPTH
   // changes (entering/leaving an item), so a drilled-in item form always starts
   // at the top instead of inheriting the previous view's scroll offset. Keyed on
@@ -261,7 +265,7 @@ export function SectionsEditor({
   const [seoRawOverride, setSeoRawOverride] = useState<
     Record<string, unknown> | null | undefined
   >(undefined);
-  const [seoFieldBreadcrumbs, setSeoFieldBreadcrumbs] = useState<string[]>([]);
+  const [seoFieldBreadcrumbs, setSeoFieldBreadcrumbs] = useState<Crumb[]>([]);
   const [seoFormResetKey, setSeoFormResetKey] = useState(0);
   const [activeSectionVariantIndex, setActiveSectionVariantIndex] = useState(0);
   const [sectionRuleFormValue, setSectionRuleFormValue] = useState<Record<
@@ -2553,10 +2557,11 @@ export function SectionsEditor({
               >
                 {headerCrumbs.map((crumb, index) => {
                   const isLast = index === headerCrumbs.length - 1;
+                  const crumbText = crumbLabel(crumb);
 
                   return (
                     <span
-                      key={`${crumb}-${index}`}
+                      key={`${crumbText}-${index}`}
                       className="flex min-w-0 items-center gap-1 overflow-hidden"
                     >
                       {index > 0 && (
@@ -2565,7 +2570,7 @@ export function SectionsEditor({
                       <button
                         type="button"
                         onClick={() => handleBreadcrumbClick(index)}
-                        title={crumb}
+                        title={crumbText}
                         className={cn(
                           "min-w-0 truncate rounded-md px-1 py-0.5 text-left transition-colors",
                           isLast
@@ -2580,7 +2585,7 @@ export function SectionsEditor({
                             : "hover:bg-accent hover:text-accent-foreground",
                         )}
                       >
-                        {crumb}
+                        {crumbText}
                       </button>
                     </span>
                   );

--- a/apps/web/src/components/sections-editor/seo-form-fields.tsx
+++ b/apps/web/src/components/sections-editor/seo-form-fields.tsx
@@ -1,5 +1,6 @@
 import type { SchemaProperty } from "./resolve-schema";
 import { SchemaForm } from "./schema-form";
+import type { Crumb } from "./schema-form-breadcrumb";
 import { GeneralSeoForm } from "./general-seo-form";
 import { filterSeoSchema, getSeoFormMode } from "./seo-form-mode";
 
@@ -9,7 +10,7 @@ interface SeoFormFieldsProps {
   value: Record<string, unknown>;
   formResetKey: number;
   onChange: (value: unknown) => void;
-  onBreadcrumbChange?: (path: string[]) => void;
+  onBreadcrumbChange?: (path: Crumb[]) => void;
   /** Page SEO only — enables General "Use default" toggles. */
   siteDefaultSeo?: Record<string, unknown>;
 }


### PR DESCRIPTION
> Stacked on #5861 (base is that branch). Retarget to `main` once #5861 merges.

## Summary

Follow-up to #5861. That PR cleaned the **list**; this one removes the positional number from the **breadcrumb** too — without a visible number and without any hidden/sentinel character.

The breadcrumb crumb was addressed by a display **label**, so two identically-titled items needed the `" N"` suffix to stay uniquely addressable after a form remount (the transient open-index is wiped on remount). That suffix showed up in the crumb bar when you drilled into a colliding item.

### Approach: decouple display from addressing, structurally

The breadcrumb trail changes from `string[]` to `Crumb[]`:

```ts
type Crumb = string | { label: string; itemIndex: number };
```

- **Field/context crumbs** (page name, section label, ancestor field labels) stay plain **strings** — so every producer, every `breadcrumbPath={[]}`, and most tests are untouched.
- **Array-item crumbs** become objects carrying the item's exact `itemIndex`.
- The UI renders `crumbLabel(crumb)` (always the clean label, **no number, anywhere**); resolution uses `itemIndex` (exact), with the label still confirming which array owns the crumb.

An item now re-resolves to itself after a remount purely from the trail — the transient open-index is a churn-window fallback, not load-bearing.

### Changes

- `Crumb` type + `crumbLabel()` helper in `schema-form-breadcrumb.ts`; every matcher unwraps via `crumbLabel`; `findItemIndexForCrumb` pins by `itemIndex`.
- `buildArrayDrillDownBreadcrumb` takes the item index; `ArrayField.updateItem` rewrites the crumb in place, keeping the index and syncing the label.
- Threaded `Crumb[]` through `SchemaForm`, both breadcrumb bars, the four `sandbox/content` editors, and the CT harnesses; each bar renders `crumbLabel`.
- **Removed dead code**: the positional-suffix labeler `getArrayItemLabels` and the `getArrayItemLabel` `siblings` branch now have no callers (knip-clean).

## Testing

- `bun test apps/web/src/components/sections-editor/` → 593 pass, 0 fail (updated the resolver tests to object crumbs; inverted the ones that asserted the old `" N"` suffix).
- `tsc --noEmit` (apps/web) clean · `knip` clean · `lint` 0 errors.
- Updated the Playwright CT specs + harnesses (`Crumb[]`, `crumbLabel`-based reads, the "osklen" collision test now asserts index-addressing). Not run locally (needs a browser env) — will rely on CI.

## Affected areas

`apps/web` sections-editor + sandbox content editors. No API/storage/wire changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes numbered array-item breadcrumbs and addresses items by index instead. Breadcrumbs now use structured item crumbs with the index, so duplicates show clean labels and selections survive remounts.

- **Bug Fixes**
  - Duplicate item labels no longer collapse navigation; items resolve by exact `itemIndex`.
  - Breadcrumb UIs render clean labels (no positional suffix) across sections, variants, sandbox, and SEO editors.
  - Sibling-array disambiguation preserved; nested drill-downs avoid doubled array crumbs.

- **Refactors**
  - Introduced `Crumb` (`string | { label; itemIndex }`) and `crumbLabel()`; migrated breadcrumb APIs/props to `Crumb[]` in `SchemaForm`, panels, SEO forms, sandbox editors, and CT harnesses.
  - `buildArrayDrillDownBreadcrumb` now takes `itemIndex` and appends an item crumb; `ArrayField.updateItem` rewrites the item crumb in place, keeping the index and syncing the label; `findItemIndexForCrumb` resolves by `itemIndex` with label ownership.
  - Removed numbered-label logic: deleted `getArrayItemLabels` and the `siblings` branch of `getArrayItemLabel`; `getArrayItemLabel` now returns the base label only; tests updated.

<sup>Written for commit c2ab76263ecfcbf1ea68b6f677c6b51c3b446fa8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

