### PR TITLE
fix(sandbox): heal dangling githubRepo.connectionId on sandbox start

### DIFF
--- a/apps/api/src/tools/sandbox/start.test.ts
+++ b/apps/api/src/tools/sandbox/start.test.ts
@@ -208,6 +208,11 @@ function makeCtx(overrides: {
   /** Row returned by `storage.threads.get` — set `created_by` to exercise the
    *  thread-owner keying (see resolveSandboxUserId). */
   thread?: { created_by: string; metadata: Record<string, unknown> } | null;
+  /** Override `storage.connections` to exercise the dangling-connection heal. */
+  connections?: {
+    findById: ReturnType<typeof mock>;
+    list?: ReturnType<typeof mock>;
+  };
 }): StudioContext {
   const {
     orgId = ORG_ID,
@@ -215,6 +220,7 @@ function makeCtx(overrides: {
     virtualMcp,
     updateSpy = mock(async () => {}),
     thread = null,
+    connections,
   } = overrides;
 
   const findById = mock(async (_id: string) => virtualMcp ?? null);
@@ -240,9 +246,11 @@ function makeCtx(overrides: {
       // Non-repo-scoped org connection: getRepoScope() returns null, so the
       // repo-scoped mint path in provisionSandbox is skipped and these tests
       // exercise the clone/token path unchanged. (Minting is covered by the
-      // e2e suite, github-import-repo-scope.spec.ts.)
-      connections: {
+      // e2e suite, github-import-repo-scope.spec.ts.) The connection existing
+      // (truthy findById) also makes the dangling-connection heal a no-op.
+      connections: connections ?? {
         findById: mock(async (_id: string) => ({ metadata: null })),
+        list: mock(async () => ({ items: [], totalCount: 0 })),
       },
       // A `thread:` branch resolves the thread's creator + bound repo. Default
       // is no thread, so provisioning falls back to the VM's own githubRepo and
@@ -611,6 +619,78 @@ describe("SANDBOX_START", () => {
     const virtualMcp = makeVirtualMcp(ORG_ID, BASE_METADATA);
     const ctx = makeCtx({ virtualMcp });
 
+    await expect(
+      SANDBOX_START.handler({ virtualMcpId: VMCP_ID, branch: BRANCH }, ctx),
+    ).rejects.toThrow("No GitHub token found");
+  });
+
+  it("heals a dangling repo connectionId via a live connection for the same repo", async () => {
+    // The recorded connection was deleted (e.g. force-delete left the metadata
+    // pointer dangling); another live connection covers the same repo. Its id
+    // is conn_github_1 so buildCloneInfo resolves through the token mock above.
+    const liveConnection = {
+      id: "conn_github_1",
+      status: "active",
+      metadata: {
+        repoScope: { installationId: 42, owner: "acme", repo: "app" },
+      },
+    };
+    const updateSpy = mock(async () => {});
+    const virtualMcp = makeVirtualMcp(ORG_ID, {
+      ...BASE_METADATA,
+      githubRepo: { owner: "acme", name: "app", connectionId: "conn_gone" },
+    });
+    const ctx = makeCtx({
+      virtualMcp,
+      updateSpy,
+      connections: {
+        findById: mock(async (id: string) =>
+          id === "conn_github_1" ? liveConnection : null,
+        ),
+        list: mock(async () => ({ items: [liveConnection], totalCount: 1 })),
+      },
+    });
+
+    await SANDBOX_START.handler({ virtualMcpId: VMCP_ID, branch: BRANCH }, ctx);
+
+    // The runner clones through the live connection, not the dangling one.
+    const [, opts] = mockEnsure.mock.calls[0]! as [SandboxId, EnsureOptions];
+    expect(opts.repo?.connectionId).toBe("conn_github_1");
+
+    // The heal is persisted so publish/credential-sync read the live id too.
+    const persisted = (updateSpy.mock.calls as unknown[][]).find(
+      (call) =>
+        (call[2] as { metadata?: { githubRepo?: { connectionId?: string } } })
+          ?.metadata?.githubRepo?.connectionId === "conn_github_1",
+    );
+    expect(persisted).toBeDefined();
+    const meta = (
+      persisted![2] as {
+        metadata: {
+          githubRepo: { connectionId: string; installationId: number };
+        };
+      }
+    ).metadata;
+    expect(meta.githubRepo.installationId).toBe(42);
+  });
+
+  it("keeps failing loudly when the dangling repo connection has no live replacement", async () => {
+    (
+      mockTokenGet as unknown as {
+        mockImplementation: (fn: () => Promise<null>) => void;
+      }
+    ).mockImplementation(async () => null);
+    const virtualMcp = makeVirtualMcp(ORG_ID, BASE_METADATA);
+    const ctx = makeCtx({
+      virtualMcp,
+      connections: {
+        findById: mock(async (_id: string) => null),
+        list: mock(async () => ({ items: [], totalCount: 0 })),
+      },
+    });
+
+    // Never a silent anonymous-clone downgrade: no replacement → the existing
+    // loud GITHUB_NOT_AUTHENTICATED failure (client shows the reconnect card).
     await expect(
       SANDBOX_START.handler({ virtualMcpId: VMCP_ID, branch: BRANCH }, ctx),
     ).rejects.toThrow("No GitHub token found");

--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -43,6 +43,10 @@ import {
   resolveVm,
 } from "./sandbox-map";
 import {
+  findReusableRepoConnection,
+  getRepoScope,
+} from "@decocms/shared/github-repo-scope";
+import {
   buildAnonymousCloneInfo,
   buildCloneInfo,
   ensureGithubCloneToken,
@@ -361,11 +365,26 @@ async function provisionSandbox(
     virtualMcpId,
     branch,
     metadata,
-    githubRepo,
     existing,
     runner,
     cloneOnly,
   } = params;
+
+  // A recorded connectionId can dangle — deleting a connection (force-delete,
+  // or another agent's delete tearing down its repo-scoped child) removes
+  // aggregation rows but never rewrites `metadata.githubRepo` on other agents
+  // that recorded it — and the clone path below fails loudly on a connectionId
+  // with no connection behind it. Re-point at a live connection covering the
+  // same repo when one exists.
+  const githubRepo = params.githubRepo
+    ? await healDanglingRepoConnection({
+        ctx,
+        orgId,
+        virtualMcpId,
+        userId,
+        githubRepo: params.githubRepo,
+      })
+    : null;
 
   let { runtime, packageManager, port, packageManagerPath } =
     resolveRuntimeConfig(metadata);
@@ -686,6 +705,84 @@ async function provisionSandbox(
   // Different handle = new sandbox (stale entry / orphan recovery / state miss).
   const isNewVm = !existing || existing.sandboxHandle !== sandbox.handle;
   return { entry, isNewVm };
+}
+
+/**
+ * Falls back to a live connection covering the same repo when the recorded
+ * `githubRepo.connectionId` no longer resolves (see the call site for how it
+ * dangles). Org-shared connections win — findReusableRepoConnection. The heal
+ * is persisted back onto the agent's metadata (best-effort) so every other
+ * consumer of the recorded id — git publish, credential sync, the companion
+ * repo-reuse plan — reads the live connection too, instead of re-healing here
+ * on every start. With no replacement the repo is returned unchanged and
+ * buildCloneInfo keeps failing loudly (GITHUB_NOT_AUTHENTICATED → the client's
+ * reconnect affordance); stripping the id would silently downgrade a private
+ * repo to an anonymous clone that can't push.
+ */
+async function healDanglingRepoConnection(params: {
+  ctx: StudioContext;
+  orgId: string;
+  virtualMcpId: string;
+  userId: string;
+  githubRepo: GithubRepo;
+}): Promise<GithubRepo> {
+  const { ctx, orgId, virtualMcpId, userId, githubRepo } = params;
+  if (!githubRepo.connectionId) return githubRepo;
+  const recorded = await ctx.storage.connections.findById(
+    githubRepo.connectionId,
+    orgId,
+  );
+  if (recorded) return githubRepo;
+
+  const { items } = await ctx.storage.connections.list(orgId);
+  const replacement = findReusableRepoConnection(
+    items,
+    githubRepo.owner,
+    githubRepo.name,
+  );
+  if (!replacement) {
+    console.warn(
+      "[provisionSandbox] recorded repo connection no longer exists and no live connection covers the repo",
+      { virtualMcpId, connectionId: githubRepo.connectionId },
+    );
+    return githubRepo;
+  }
+  console.warn("[provisionSandbox] healed dangling repo connection", {
+    virtualMcpId,
+    staleConnectionId: githubRepo.connectionId,
+    connectionId: replacement.id,
+  });
+
+  // Persist only while the agent's own metadata still records the stale id —
+  // a thread-scoped repo or a concurrent update must not be overwritten.
+  try {
+    const virtualMcp = await ctx.storage.virtualMcps.findById(virtualMcpId);
+    const meta = (virtualMcp?.metadata ?? {}) as Record<string, unknown>;
+    const current = (meta as GithubRepoMeta).githubRepo;
+    if (current?.connectionId === githubRepo.connectionId) {
+      const scope = getRepoScope(replacement);
+      await ctx.storage.virtualMcps.update(virtualMcpId, userId, {
+        metadata: {
+          ...meta,
+          githubRepo: {
+            ...current,
+            connectionId: replacement.id,
+            ...(scope ? { installationId: scope.installationId } : {}),
+          },
+        } as VirtualMCPUpdateData["metadata"],
+      });
+    }
+  } catch (err) {
+    console.warn(
+      "[provisionSandbox] failed to persist healed repo connection",
+      {
+        virtualMcpId,
+        error: (err as Error).message,
+      },
+    );
+  }
+
+  return { ...githubRepo, connectionId: replacement.id };
 }
 
 /**


### PR DESCRIPTION
## Summary

An agent's `metadata.githubRepo.connectionId` can dangle: deleting a connection (`CONNECTION_DELETE` with `force`, or an agent delete tearing down its repo-scoped child) removes `connection_aggregations` rows and pinned views, but never rewrites `metadata.githubRepo` on **other** agents that recorded that connection. `SANDBOX_START` clones through the recorded id with no fallback, so the affected agent's Preview tab fails loudly with `GITHUB_NOT_AUTHENTICATED` forever — even when another live connection covering the same repo exists in the org (e.g. the one a coding agent for the same repo uses).

Hit in production on one tenant: the well-known Report Agent's recorded repo connection had been deleted, its aggregation already pointed at the live repo connection, but the metadata pointer still named the dead one — so its Preview tab could never open a sandbox while the coding agent for the same repo worked fine.

## Fix

`provisionSandbox` (the single path both `SANDBOX_START` and `ensureSandbox` route through) now:

- checks that the recorded `connectionId` still resolves; when it does, nothing changes (one extra PK lookup);
- when it dangles, re-points at a live connection covering the same `owner/repo` via `findReusableRepoConnection` (org-shared wins, same rule as import dedupe);
- persists the healed metadata back onto the agent (best-effort, and only while the agent's own metadata still records the stale id — a thread-scoped repo or concurrent update is never overwritten), so git publish, credential sync, and the companion repo-reuse plan read the live id too;
- with no replacement, keeps the existing loud `GITHUB_NOT_AUTHENTICATED` failure — never a silent anonymous-clone downgrade for a repo that was linked authenticated.

## Testing

- Added `start.test.ts` cases: heal falls back to the live connection (runner receives it, healed metadata persisted with the replacement's `installationId`) and no-replacement keeps failing loudly.
- `bun test apps/api/src/tools/sandbox/` → 85 pass.
- `bun run check`, `bun run lint`, `bun run fmt` clean.

## Notes / follow-ups

- Delete paths still don't rewrite other agents' `metadata.githubRepo` — the heal-on-start covers all of them (including pre-existing corruption), so no per-delete-site cleanup was added.
- `planRepoReuse` (web, onboarding companion) still trusts the recorded id without checking liveness; after the first healed start the persisted metadata makes it correct again.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sandbox start failures when an agent’s recorded GitHub repo connection was deleted. We now heal a dangling `connectionId` by reusing a live connection for the same repo and persist the fix.

- **Bug Fixes**
  - Validate the recorded repo connection; if missing, select a live replacement for the same `owner/repo` via `findReusableRepoConnection` (org-shared preferred) from `@decocms/shared/github-repo-scope`.
  - Persist the healed `connectionId` (and `installationId` via `getRepoScope`) back to the agent’s metadata when still stale, so future actions use the live connection.
  - If no replacement exists, keep the existing `GITHUB_NOT_AUTHENTICATED` error (no anonymous clone downgrade).
  - Added tests for the heal path and the no-replacement path.

<sup>Written for commit beb26fc6c8266d66981adf0662efefee708a936e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

