### PR TITLE
fix(web): translate the icon-picker's hardcoded aria-label

### DIFF
--- a/apps/web/src/components/simple-icon-picker.tsx
+++ b/apps/web/src/components/simple-icon-picker.tsx
@@ -65,7 +65,7 @@ export function SimpleIconPicker({
         <button
           type="button"
           disabled={disabled}
-          aria-label="Change icon"
+          aria-label={t("common.simpleIconPicker.changeIcon")}
           className={cn(
             "size-7 shrink-0 rounded-md transition-colors flex items-center justify-center",
             disabled

--- a/apps/web/src/i18n/en/common.ts
+++ b/apps/web/src/i18n/en/common.ts
@@ -243,6 +243,7 @@ export const common = {
   "common.requestToJoinScreen.title": "Request to join {orgName}?",
   "common.signInScreen.configLoadFailed": "Couldn't load sign-in options.",
   "common.signInScreen.tryAgain": "Try again",
+  "common.simpleIconPicker.changeIcon": "Change icon",
   "common.simpleIconPicker.filterPlaceholder": "Filter...",
   "common.simpleIconPicker.noIconsFound": "No icons found",
   "common.ssoRequiredScreen.goBack": "Go back",

--- a/apps/web/src/i18n/pt-br/common.ts
+++ b/apps/web/src/i18n/pt-br/common.ts
@@ -252,6 +252,7 @@ export const common = {
   "common.signInScreen.configLoadFailed":
     "Não foi possível carregar as opções de login.",
   "common.signInScreen.tryAgain": "Tentar novamente",
+  "common.simpleIconPicker.changeIcon": "Alterar ícone",
   "common.simpleIconPicker.filterPlaceholder": "Filtrar…",
   "common.simpleIconPicker.noIconsFound": "Nenhum ícone encontrado",
   "common.ssoRequiredScreen.goBack": "Voltar",


### PR DESCRIPTION
The rest of `SimpleIconPicker` (`apps/web/src/components/simple-icon-picker.tsx`) already routes its UI copy through `t()` (`common.simpleIconPicker.filterPlaceholder`, `common.simpleIconPicker.noIconsFound`), but the trigger button's `aria-label="Change icon"` was left as a raw English string, so screen-reader users on the pt-br locale hear untranslated English for this control — exactly the i18n gap this repo has a proven merge lane for (#5099, #5607, #5714, #5741, #5798, #5810).

Added a new `common.simpleIconPicker.changeIcon` key (en: "Change icon", pt-br: "Alterar ícone") to both dictionaries and swapped the hardcoded string for `t("common.simpleIconPicker.changeIcon")`.

A reviewer can confirm by opening the icon picker with the pt-br locale selected and inspecting the trigger button's accessible name (or reading the diff — it's a 3-line change plus 2 dictionary entries).

Verified locally: `bun run fmt`, `bunx tsc --noEmit` in `apps/web` (clean), `bunx oxlint` on the three touched files (0 warnings/errors). `en/index.ts`'s `TranslationKey` derivation means a missing pt-br key would be a compile error, so `tsc` passing proves dictionary parity. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translate the icon picker trigger's aria-label via `t("common.simpleIconPicker.changeIcon")`, fixing an i18n gap so screen readers use the selected locale. Adds the new key to `en` and `pt-br` dictionaries.

<sup>Written for commit c71cbbf944486f5dd6a14dbc7a82b733612db215. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

