### PR TITLE
refactor(sections-editor): dedupe repeated variant-row color classes

### DIFF
--- a/apps/web/src/components/sections-editor/page-variant-tabs.tsx
+++ b/apps/web/src/components/sections-editor/page-variant-tabs.tsx
@@ -47,11 +47,10 @@ import { resolveEffectiveMatcherRule } from "./matcher-rules";
 import { resolveMatcherIconName } from "./matcher-icons";
 import type { PageVariant } from "./page-variants";
 import type { LiveMeta } from "./resolve-schema";
-
-const VARIANT_ROW_CLASS =
-  "text-[oklch(0.45_0.15_160)] hover:bg-[oklch(0.65_0.15_160/0.12)] dark:text-[oklch(0.78_0.15_160)] dark:hover:bg-[oklch(0.65_0.15_160/0.15)]";
-const VARIANT_SELECTED_ROW_CLASS =
-  "text-[oklch(0.45_0.15_160)] bg-[oklch(0.65_0.15_160/0.18)] dark:text-[oklch(0.78_0.15_160)] dark:bg-[oklch(0.65_0.15_160/0.2)]";
+import {
+  VARIANT_ROW_CLASS,
+  VARIANT_SELECTED_ROW_CLASS,
+} from "./section-variant-list";
 
 export function VariantTabIcon({
   rule,

--- a/apps/web/src/components/sections-editor/section-list.tsx
+++ b/apps/web/src/components/sections-editor/section-list.tsx
@@ -47,7 +47,10 @@ import {
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { canMakeSectionReusable } from "./page-sections";
-import { VARIANT_MENU_ITEM_CLASS } from "./section-variant-list";
+import {
+  VARIANT_MENU_ITEM_CLASS,
+  VARIANT_ROW_CLASS,
+} from "./section-variant-list";
 import { canAddSectionVariant } from "./section-variants";
 import { isLazyResolveType } from "./section-lazy";
 import { getSectionPreviewImageSrc } from "./section-preview-image";
@@ -195,7 +198,7 @@ function sectionRowClassName(section: ParsedSection, selected: boolean) {
       : saved
         ? GLOBAL_SECTION_ROW_CLASS
         : multivariate
-          ? "text-[oklch(0.45_0.15_160)] hover:bg-[oklch(0.65_0.15_160/0.12)] dark:text-[oklch(0.78_0.15_160)] dark:hover:bg-[oklch(0.65_0.15_160/0.15)]"
+          ? VARIANT_ROW_CLASS
           : "text-foreground/80 hover:bg-accent hover:text-accent-foreground",
   );
 }

--- a/apps/web/src/components/sections-editor/section-variant-list.tsx
+++ b/apps/web/src/components/sections-editor/section-variant-list.tsx
@@ -45,9 +45,11 @@ import { CSS } from "@dnd-kit/utilities";
 import { useT } from "@/i18n/use-t.ts";
 
 const VARIANT_ICON_COLOR = "oklch(0.65 0.15 160)";
-const VARIANT_ROW_CLASS =
+// Exported: page-variant-tabs.tsx and section-list.tsx share this exact
+// variant-row styling and import it here rather than re-declaring it.
+export const VARIANT_ROW_CLASS =
   "text-[oklch(0.45_0.15_160)] hover:bg-[oklch(0.65_0.15_160/0.12)] dark:text-[oklch(0.78_0.15_160)] dark:hover:bg-[oklch(0.65_0.15_160/0.15)]";
-const VARIANT_SELECTED_ROW_CLASS =
+export const VARIANT_SELECTED_ROW_CLASS =
   "text-[oklch(0.45_0.15_160)] bg-[oklch(0.65_0.15_160/0.18)] dark:text-[oklch(0.78_0.15_160)] dark:bg-[oklch(0.65_0.15_160/0.2)]";
 export const VARIANT_MENU_ITEM_CLASS =
   "text-[oklch(0.45_0.15_160)] focus:bg-[oklch(0.65_0.15_160/0.12)] focus:text-[oklch(0.45_0.15_160)] dark:text-[oklch(0.78_0.15_160)] dark:focus:bg-[oklch(0.65_0.15_160/0.15)] dark:focus:text-[oklch(0.78_0.15_160)]";


### PR DESCRIPTION
**Source**: reduction found while hunting the sections-editor UI-polish focus area — no open PR touches these files.

**What**: `VARIANT_ROW_CLASS` and `VARIANT_SELECTED_ROW_CLASS` (the hover/active oklch color classes for a multivariate section row) were byte-for-byte duplicated as private consts in both `section-variant-list.tsx` and `page-variant-tabs.tsx`, plus inlined a third time in `section-list.tsx`. `section-list.tsx` already imports a sibling constant (`VARIANT_MENU_ITEM_CLASS`) from `section-variant-list.tsx`, so that file is the established single home for this styling — this PR exports the other two constants from it and has the other two files import instead of re-declaring/inlining.

**Why a maintainer wants it**: one styling change today means editing 3 near-duplicate string literals across 3 files by hand — easy to update one and miss another (there's precedent: `sections-editor-panels.tsx`'s similarly-named `VARIANT_TAB_ACTIVE_CLASS` already drifted to a different dark-mode opacity than these two). This collapses the styling to one source of truth.

**Net diff**: +13/-9 lines, but the real win is removing 2 duplicate string definitions (kept the exact same literal values — verified byte-identical via `grep` before extracting), so this is purely mechanical/behavior-preserving, not a rewrite.

**How to verify**: `grep -c 'oklch(0.45_0.15_160)' apps/web/src/components/sections-editor/*.tsx` shows the literal now lives in one file (`section-variant-list.tsx`) instead of three; the rendered classes are unchanged since the string values are identical.

**Checked locally**: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint` on the three touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduped variant-row color classes in the sections editor by centralizing them in `section-variant-list.tsx` and importing where used. This reduces drift risk and keeps behavior the same.

- **Refactors**
  - Export `VARIANT_ROW_CLASS` and `VARIANT_SELECTED_ROW_CLASS` from `section-variant-list.tsx`.
  - Replace duplicate/inlined definitions in `page-variant-tabs.tsx` and `section-list.tsx` with imports.
  - Class values are unchanged; no UI or behavior changes.

<sup>Written for commit 4736b4694df23aa3d720b79b3cec1c893aa56769. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

