### PR TITLE
fix(reports): keep polling when the run finishes before deck assembly

### DIFF
--- a/apps/web/src/routes/reports/orchestrate-scan.ts
+++ b/apps/web/src/routes/reports/orchestrate-scan.ts
@@ -92,7 +92,7 @@ export async function orchestrateScan(
       });
       return events.onPhase("blocked");
     }
-    const id = trig.state === "running" ? trig.id : null;
+    let id = trig.state === "running" ? trig.id : null;
     if (trig.state === "running") {
       events.onPhase("pending");
       captureReport("report_pending_screen_shown", {
@@ -115,27 +115,14 @@ export async function orchestrateScan(
         const st = await getScanStatus(id);
         if (signal.aborted) return;
         if (st.done) {
-          await sleep(POLL_MS, { signal });
-          const fin = await getReport(domain, undefined, lang);
-          if (signal.aborted) return;
-          if (fin.status === "ready" && fin.deck) {
-            clearPending(domain);
-            reportDrops(domain, fin.drops);
-            captureReport("report_scan_completed", {
-              domain,
-              surface: "deck_v2",
-            });
-            return events.onDeck(fin.deck);
-          }
-          reportDrops(domain, fin.drops);
-          clearPending(domain);
-          captureReport("report_scan_failed", {
+          // Run finished but deck assembly can lag behind it — show the
+          // "still assembling" note and keep polling instead of giving up.
+          id = null;
+          captureReport("report_run_done_deck_pending", {
             domain,
-            phase: "empty",
-            reason: "run_finished_empty",
             surface: "deck_v2",
           });
-          return events.onPhase("empty");
+          events.onPhase("empty");
         }
       }
       await sleep(POLL_MS, { signal });


### PR DESCRIPTION
## Summary

Users landed on the report progress screen with the last stage showing **Report ready (now)** plus the "We scanned your store, but the report is still being assembled. Check back soon." note — and stayed there forever, even though the report became ready seconds later. Confirmed via a session replay after a large email send drove traffic to the page.

Root cause: in `orchestrateScan`, when the durable run reported `done`, the client waited 4s, re-fetched the report **once**, and if the deck wasn't assembled yet it permanently bailed to the `empty` phase and stopped polling. Any assembly lag longer than that single 4s recheck stranded the user.

## Change

- When the run finishes but the deck isn't ready yet, show the same "still assembling" note but **keep polling** `getReport` every 4s until the deck appears (or the pre-existing 12-minute poll timeout, which still emits `report_scan_failed/poll_timeout`).
- Replaced the `report_scan_failed` capture with reason `run_finished_empty` by a new `report_run_done_deck_pending` event, since this is no longer a terminal failure — it now measures run→deck assembly lag.

Net -13 lines.

## Testing

- `bun run fmt` and `tsc --noEmit` (apps/web) pass.
- Flow is client-side polling over the reports proxy; verified the phase transitions by reading the state machine — `empty` now stays live until `getReport` returns `ready` with a deck.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where users got stuck on the “still assembling” state after a scan finished. The client now keeps polling until the deck is ready or the 12‑minute timeout hits.

- **Bug Fixes**
  - Keep polling `getReport` every 4s after the run finishes if the deck isn’t ready, instead of bailing after one recheck.
  - Emit `report_run_done_deck_pending` (replaces `report_scan_failed/run_finished_empty`) to track run→deck assembly lag.
  - Keep the `empty` phase active during assembly; transition to deck when ready.

<sup>Written for commit a99feca6782f9f2a7c116009a41ca37cc9f1a1dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

