### PR TITLE
[chore]: pull MinIO from Docker Hub + retry container image pulls in CI

### DIFF
--- a/.github/actions/start-minio/action.yml
+++ b/.github/actions/start-minio/action.yml
@@ -25,6 +25,16 @@ runs:
   steps:
     - shell: bash
       run: |
+        # Pull explicitly with retry/backoff: quay.io intermittently times out
+        # ('Get "https://quay.io/v2/": context deadline exceeded'), and the
+        # implicit pull inside `docker run` has no retry, so one transient
+        # registry failure kills the whole job. Same pattern as the NATS pull
+        # in e2e.yml and the compose retry in resilience.yml.
+        for attempt in 1 2 3 4 5; do
+          docker pull ${{ inputs.image }} && break
+          echo "docker pull ${{ inputs.image }} failed (attempt $attempt); retrying in $((attempt * 5))s"
+          sleep $((attempt * 5))
+        done
         docker run -d --name minio -p ${{ inputs.port }}:9000 \
           -e MINIO_ROOT_USER=${{ inputs.root-user }} \
           -e MINIO_ROOT_PASSWORD=${{ inputs.root-password }} \

--- a/.github/actions/start-minio/action.yml
+++ b/.github/actions/start-minio/action.yml
@@ -9,7 +9,10 @@ description: >-
 inputs:
   image:
     description: MinIO container image — single source of truth for the pinned version.
-    default: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
+    # Docker Hub, not quay.io: same official image/tags, but quay.io
+    # intermittently times out in CI, and GitHub-hosted runners are exempt
+    # from Docker Hub rate limits for public images.
+    default: minio/minio:RELEASE.2025-09-07T16-13-09Z
   port:
     description: Host port to publish and probe for readiness.
     default: "9000"
@@ -25,11 +28,10 @@ runs:
   steps:
     - shell: bash
       run: |
-        # Pull explicitly with retry/backoff: quay.io intermittently times out
-        # ('Get "https://quay.io/v2/": context deadline exceeded'), and the
-        # implicit pull inside `docker run` has no retry, so one transient
-        # registry failure kills the whole job. Same pattern as the NATS pull
-        # in e2e.yml and the compose retry in resilience.yml.
+        # Pull explicitly with retry/backoff: the implicit pull inside
+        # `docker run` has no retry, so one transient registry failure kills
+        # the whole job. Same pattern as the NATS pull in e2e.yml and the
+        # compose retry in resilience.yml.
         for attempt in 1 2 3 4 5; do
           docker pull ${{ inputs.image }} && break
           echo "docker pull ${{ inputs.image }} failed (attempt $attempt); retrying in $((attempt * 5))s"


### PR DESCRIPTION
## Summary

E2E shards intermittently fail at the **Start MinIO** step: the implicit image pull inside `docker run` hits a transient quay.io timeout (`Get "https://quay.io/v2/": context deadline exceeded`, docker exit 125) and the whole shard dies before any test runs. Example: https://github.com/decocms/studio/actions/runs/31396046698/job/93479132865

Two changes to the `start-minio` composite action (the only composite action that pulls a registry image — covers both consumers, `e2e.yml` and `storage-integration.yml`):

1. **Switch the default image from `quay.io/minio/minio` to Docker Hub (`minio/minio`)** — the same official image and pinned tag is published to both registries (verified: `RELEASE.2025-09-07T16-13-09Z` exists on Docker Hub, amd64+arm64). quay.io is the registry that keeps timing out from CI, and GitHub-hosted runners are exempt from Docker Hub rate limits for public images.
2. **Explicit `docker pull` with retry/backoff** (5 attempts, 5s/10s/.../25s) before the `docker run`, as a safety net against transient failures on any registry — the same pattern already used for the NATS pull in `e2e.yml` and the compose startup retry in `resilience.yml`.

## Testing

- Shell loop mirrors the already-proven NATS retry in `.github/workflows/e2e.yml`.
- Verified the pinned tag exists on Docker Hub via the registry API before switching.
- `bun run fmt` and `bun run lint` pass (no-op for this yaml-only change).