### PR TITLE
fix(ui): update design system URL to design.decocms.com

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "source": "./packages/ui",
       "description": "Build UI with the decocms product design system (@decocms/ui): install, tokens, components, and conventions.",
       "author": { "name": "decocms" },
-      "homepage": "https://designsystem.decocms.com/"
+      "homepage": "https://design.decocms.com/"
     }
   ]
 }

--- a/packages/ui/.claude-plugin/plugin.json
+++ b/packages/ui/.claude-plugin/plugin.json
@@ -3,5 +3,5 @@
   "description": "Build UI with the decocms product design system (@decocms/ui)",
   "version": "1.0.0",
   "author": { "name": "decocms" },
-  "homepage": "https://designsystem.decocms.com/"
+  "homepage": "https://design.decocms.com/"
 }


### PR DESCRIPTION
## Summary
Update the UI package design system homepage URL from `designsystem.decocms.com` to `design.decocms.com` in the plugin configuration files.

## Changes
- Updated `packages/ui/.claude-plugin/plugin.json`
- Updated `.claude-plugin/marketplace.json`

## Test plan
- Verify the URL in the plugin metadata points to the correct domain

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the design system homepage URL to https://design.decocms.com in `@decocms/ui` plugin metadata so users land on the correct docs. Updated `.claude-plugin/marketplace.json` and `packages/ui/.claude-plugin/plugin.json`.

<sup>Written for commit 7d8a8e932ff04b0f48a5f2207193327661acfb23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

