### PR TITLE
fix(ui): update design system URL to design.decocms.com

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "source": "./packages/ui",
       "description": "Build UI with the decocms product design system (@decocms/ui): install, tokens, components, and conventions.",
       "author": { "name": "decocms" },
-      "homepage": "https://designsystem.decocms.com/"
+      "homepage": "https://design.decocms.com/"
     }
   ]
 }

--- a/packages/ui/.claude-plugin/plugin.json
+++ b/packages/ui/.claude-plugin/plugin.json
@@ -3,5 +3,5 @@
   "description": "Build UI with the decocms product design system (@decocms/ui)",
   "version": "1.0.0",
   "author": { "name": "decocms" },
-  "homepage": "https://designsystem.decocms.com/"
+  "homepage": "https://design.decocms.com/"
 }


### PR DESCRIPTION
## Summary
Update the UI package design system homepage URL from `designsystem.decocms.com` to `design.decocms.com` in the plugin configuration files.

## Changes
- Updated `packages/ui/.claude-plugin/plugin.json`
- Updated `.claude-plugin/marketplace.json`

## Test plan
- Verify the URL in the plugin metadata points to the correct domain

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the design system homepage URL for `@decocms/ui` from https://designsystem.decocms.com to https://design.decocms.com. This fixes the outdated link in the plugin metadata.

<sup>Written for commit cf0c2dd3edd10b7f28294fa20ea69c5ede0a4705. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

