### PR TITLE
fix(sandbox-env): the uploader DaemonSet could not schedule on sandbox nodes

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,6 +9,13 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
+# 0.13.1: fix — the goldenUploader DaemonSet rendered with NO tolerations, so it
+# could not schedule on the `decocms.com/sandbox=true:NoSchedule` NodePool where
+# the hostPath it reads exists. `fromYaml` on a LIST yields an empty map, so the
+# `with` dropped the block; `fromYamlArray` is correct, as the neighbouring
+# nodePlaceholder template already had it. nodeSelector was unaffected (a map),
+# which is why it hid. 0.13.0 shipped the DaemonSet unschedulable — it is
+# default-off, so nothing deployed it.
 # 0.13.0: opt-in `goldenUploader` (default off) — a DaemonSet that carries L1
 # goldens from a node's hostPath into the shared L2 store, plus its own WRITABLE
 # PV/PVC over that store. Without it the shared store stays empty: a sandbox

--- a/deploy/helm/sandbox-env/templates/sandbox-golden-uploader.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-golden-uploader.yaml
@@ -42,11 +42,14 @@ spec:
       automountServiceAccountToken: false
       # Placement follows the sandbox pods by default: the hostPath it reads only
       # exists on nodes that ran one.
-      {{- with (include "sandbox-env.goldenUploaderNodeSelector" . | fromYaml) }}
+      {{- with (fromYaml (include "sandbox-env.goldenUploaderNodeSelector" .)) }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with (include "sandbox-env.goldenUploaderTolerations" . | fromYaml) }}
+      {{- /* fromYamlArray, not fromYaml: tolerations are a LIST, and fromYaml on
+             a list yields an empty map — `with` then drops the block and this
+             cannot schedule on the tainted sandbox NodePool at all. */ -}}
+      {{- with (fromYamlArray (include "sandbox-env.goldenUploaderTolerations" .)) }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
Chart `0.13.1`. One-line template fix plus the changelog note; `0.13.0` shipped the DaemonSet **unschedulable**.

## The bug

```
{{- with (include "sandbox-env.goldenUploaderTolerations" . | fromYaml) }}
```

`fromYaml` on a **list** yields an empty map, so `with` dropped the whole block and the DaemonSet rendered with no tolerations. The sandbox NodePool carries `decocms.com/sandbox=true:NoSchedule`, so it could never have scheduled on a node that has a hostPath for it to read — it would have looked deployed and uploaded nothing.

`nodeSelector` was fine and rendered correctly, which is precisely why this hid: it *is* a map, so `fromYaml` is right there. The neighbouring `sandbox-node-placeholder.yaml` already had both halves correct —

```
{{- with (fromYaml      (include "sandbox-env.nodePlaceholderNodeSelector" .)) }}
{{- with (fromYamlArray (include "sandbox-env.nodePlaceholderTolerations"  .)) }}
```

— and I copied the wrong one.

## How it surfaced

Asserting the *rendered* DaemonSet against the sandbox pods' placement while preparing the stg rollout, rather than trusting the helper to have worked:

```
nodeSelector nodepool sandbox: sim
tolerations com o taint     : NÃO      ← before
tolerations com o taint     : sim      ← after
```

"Inherits the sandbox placement" is the entire reason it lands on nodes with a hostPath to read, so it was worth checking rather than assuming.

## Blast radius

None. `goldenUploader` is default-off and no consumer had enabled it — decocms/deco-apps-cd's stg PR is still open and pins `0.13.1`. `0.13.0` is marked do-not-use in the changelog rather than deleted, since a published chart version should stay pullable.

`helm lint` clean; re-rendered against the real stg values with the taint asserted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Helm template so the `goldenUploader` DaemonSet schedules on tainted sandbox nodes; it previously rendered without tolerations and never ran. Ships as chart `0.13.1`; `0.13.0` is marked do-not-use.

- **Bug Fixes**
  - Use `fromYamlArray` for `tolerations` so it inherits sandbox placement and schedules on `decocms.com/sandbox=true:NoSchedule` nodes.

<sup>Written for commit 34bba762ed064f7aed7b4811427f82abf688f37a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

