### PR TITLE
fix(web): don't hold the synced-repo create dialog on the first sync

### DIFF
--- a/apps/web/src/hooks/use-org-repo-syncs.ts
+++ b/apps/web/src/hooks/use-org-repo-syncs.ts
@@ -32,24 +32,29 @@ export function useOrgRepoSyncVolumes(): ReadonlySet<string> {
   return new Set((syncs.data ?? []).map((c) => c.volume));
 }
 
-/** Create a sync config and run its first sync inline, so the volume isn't
- *  empty until the next cron tick. */
+/**
+ * Create a sync config. Resolves as soon as the config exists — the first
+ * sync is kicked in the background (a large repo takes minutes; awaiting it
+ * held the create dialog open until the gateway timed the request out) and
+ * best-effort either way: the 10-minute cron is the reliable path, so a
+ * failed or interrupted first run only delays the content, never loses it.
+ */
 export function useCreateOrgRepoSync() {
   const { org } = useProjectContext();
   const studio = useStudioTools();
   const queryClient = useQueryClient();
+  const invalidate = () =>
+    queryClient.invalidateQueries({ queryKey: KEYS.orgRepoSyncs(org.id) });
   return useMutation({
-    mutationFn: async (input: { connectionId: string; volume: string }) => {
-      const { config } = await studio.call("ORG_REPO_SYNC_CREATE", input);
-      // First run is best-effort: the config exists, the cron will retry —
-      // a transport blip here must not fail the mutation (retrying CREATE
-      // would hit the unique volume constraint).
-      return studio
+    mutationFn: async (input: { connectionId: string; volume: string }) =>
+      (await studio.call("ORG_REPO_SYNC_CREATE", input)).config,
+    onSuccess: (config) => {
+      void studio
         .call("ORG_REPO_SYNC_RUN", { id: config.id })
-        .catch(() => null);
+        .catch(() => null)
+        .then(invalidate);
     },
-    onSettled: () =>
-      queryClient.invalidateQueries({ queryKey: KEYS.orgRepoSyncs(org.id) }),
+    onSettled: invalidate,
   });
 }
 

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -15,7 +15,8 @@ export const settings = {
   "settings.syncedRepos.cancel": "Cancel",
   "settings.syncedRepos.create": "Create",
   "settings.syncedRepos.creating": "Creating…",
-  "settings.syncedRepos.created": 'Repo synced into "{volume}"',
+  "settings.syncedRepos.created":
+    'Sync created — syncing into "{volume}" in the background',
   "settings.syncedRepos.emptyTitle": "No synced repos yet",
   "settings.syncedRepos.emptyDescription":
     "Pick a GitHub repository and it will appear in the library as a read-only folder, kept in sync automatically.",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -16,7 +16,8 @@ export const settings = {
   "settings.syncedRepos.cancel": "Cancelar",
   "settings.syncedRepos.create": "Criar",
   "settings.syncedRepos.creating": "Criando…",
-  "settings.syncedRepos.created": 'Repo sincronizado em "{volume}"',
+  "settings.syncedRepos.created":
+    'Sincronização criada — sincronizando em "{volume}" em segundo plano',
   "settings.syncedRepos.emptyTitle": "Nenhum repo sincronizado ainda",
   "settings.syncedRepos.emptyDescription":
     "Escolha um repositório do GitHub e ele aparecerá na biblioteca como uma pasta somente leitura, sincronizada automaticamente.",

--- a/apps/web/src/views/settings/synced-repos.tsx
+++ b/apps/web/src/views/settings/synced-repos.tsx
@@ -162,19 +162,14 @@ function SyncedReposContent() {
         volume: volumeName.trim(),
       },
       {
-        onSuccess: (run) => {
+        onSuccess: (config) => {
+          // The first sync runs in the background (see useCreateOrgRepoSync);
+          // the row's status flips from "waiting" once it lands or the cron
+          // covers it. A sync failure shows up as the row's error state.
           setPendingImport(null);
-          // run is null when the best-effort first sync call itself failed —
-          // the config exists and the cron will pick it up.
-          if (run && "error" in run.result) {
-            toast.error(run.result.error);
-          } else {
-            toast.success(
-              t("settings.syncedRepos.created", {
-                volume: run?.result.volume ?? volumeName.trim(),
-              }),
-            );
-          }
+          toast.success(
+            t("settings.syncedRepos.created", { volume: config.volume }),
+          );
         },
         onError: (err) => {
           toast.error(


### PR DESCRIPTION
## Summary

Follow-up to #5866, observed on staging: confirming the volume name after picking a repo left the dialog hanging on "Creating…". The create mutation awaited `ORG_REPO_SYNC_RUN` inline — for a real repo that's a tarball download plus one org-fs write per file, which outlives the request/gateway window. The config itself was created fine (the folder already showed behind the dialog); only the UX wedged, and a refresh left the row on "Waiting for first sync" until the next cron tick.

## Change

- `useCreateOrgRepoSync` resolves when `ORG_REPO_SYNC_CREATE` returns; the first `ORG_REPO_SYNC_RUN` is kicked fire-and-forget with a list invalidation when it lands. The 10-minute cron remains the reliable path — a failed or interrupted first run only delays content, never loses it.
- Dialog closes immediately; the row shows "Waiting for first sync" and flips once the background run (or the next cron tick) records a result.
- Success toast now says the sync continues in the background (en + pt-BR).

## Testing

- `bun run --cwd=apps/web check`, `bun run lint`, `bun run fmt` pass.
- Behavior change is client-side only; the server tools are untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the synced-repo create dialog hanging on "Creating…" by not awaiting the first sync. Creation now completes immediately; the first sync runs in the background and the list updates when it finishes.

- **Bug Fixes**
  - Resolve mutation on `ORG_REPO_SYNC_CREATE`; trigger `ORG_REPO_SYNC_RUN` in the background and invalidate the list when it lands.
  - Close the dialog right away; show "Waiting for first sync" until the run or 10‑minute cron updates the status.
  - Update success toast copy in `en` and `pt-br` to mention background syncing.

<sup>Written for commit 0adbb0beede2731144f9f4b604acc44e858b0c99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

