### PR TITLE
fix(sandbox-env): the uploader DaemonSet could not start at all

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,6 +9,12 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
+# 0.13.2: fix — the uploader DaemonSet crash-looped with
+# `Script not found "golden-uploader"`. The sandbox image's ENTRYPOINT comes from
+# the oven/bun base and its CMD is the daemon binary, so overriding `args` alone
+# handed the subcommand to bun. Now overrides `command` with the binary's full
+# path. 0.13.0 and 0.13.1 both ship an uploader that cannot start; it is
+# default-off, so only a consumer that enabled it saw this.
 # 0.13.1: fix — the goldenUploader DaemonSet rendered with NO tolerations, so it
 # could not schedule on the `decocms.com/sandbox=true:NoSchedule` NodePool where
 # the hostPath it reads exists. `fromYaml` on a LIST yields an empty map, so the
@@ -113,7 +119,7 @@ type: application
 # 0.8.0: org-fs sidecar (orgFs.*) — privileged rclone mounter + main-container
 # mounts. NOTE: the publish workflow skips existing versions, so this MUST
 # stay ahead of the latest published chart (0.7.5 at time of writing).
-version: 0.13.1
+version: 0.13.2
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "1.46.0"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/templates/sandbox-golden-uploader.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-golden-uploader.yaml
@@ -70,7 +70,13 @@ spec:
           # Same binary as the daemon, different role. Keeps the archive format
           # impossible to drift between writer and reader, and adds no second
           # image to build or keep in lockstep.
-          args: ["golden-uploader"]
+          #
+          # `command`, not `args`: the image's ENTRYPOINT comes from the oven/bun
+          # base and its CMD is the daemon binary. Overriding only `args` hands
+          # the subcommand to bun, which looks for a SCRIPT by that name and
+          # exits 1 with `Script not found "golden-uploader"`. Overriding
+          # `command` replaces the entrypoint, so the binary is exec'd directly.
+          command: ["/opt/sandbox-daemon/daemon-go", "golden-uploader"]
           env:
             - name: DEPS_CACHE_ROOT
               value: {{ .Values.depsCache.hostPath | quote }}


### PR DESCRIPTION
Chart `0.13.2`. The uploader crash-looped on every sandbox node the moment stg enabled it (decocms/deco-apps-cd#213).

```
$ kubectl -n agent-sandbox-system logs studio-sandbox-golden-uploader-stg-2vmsv
error: Script not found "golden-uploader"
```

## Cause

That is a **bun** message, not a Go one. The sandbox image ends with

```dockerfile
CMD ["/opt/sandbox-daemon/daemon-go"]
```

and inherits its ENTRYPOINT from the `oven/bun` base. Overriding `args` replaces only the CMD, so the entrypoint received `golden-uploader` and looked for a *script* by that name. Overriding `command` replaces the entrypoint, so the binary is exec'd directly:

```yaml
command: ["/opt/sandbox-daemon/daemon-go", "golden-uploader"]
```

## Proven against the running image

A render check cannot catch this, so I ran the real thing — an ephemeral pod on the sandbox NodePool with this exact command:

```
level=ERROR msg="golden-uploader needs DEPS_CACHE_ROOT (node-local store) and
GOLDEN_CACHE_REMOTE (shared store, writable here)"
```

That is the uploader's *own* error, refusing to start unconfigured — so the subcommand resolved and reached the code. (Throwaway pod, `--rm`, self-deleted.)

## Impact while broken

None to tenants. Only the DaemonSet pods errored; sandbox pods stayed `Running` (10/10), and since nothing was publishing the shared store just stayed empty — the same state as before stg was enabled.

## Honest note on this rollout

This is the third defect in this one template, all the same kind: I verified the *rendered manifest* and never exercised the *container*.

1. `0.13.0` — no tolerations (`fromYaml` on a list), so it could not schedule.
2. `0.13.1` — scheduled, but could not start.
3. `0.13.2` — this.

Render assertions catch a missing toleration. They cannot catch an entrypoint that swallows the argument. The check that would have caught both in one go is the one I finally ran here: start the container.

## After merge

`0.13.2` publishes, then a one-line bump in `deco-apps-cd` for stg. Both `0.13.0` and `0.13.1` are marked do-not-use in the chart changelog rather than removed, since a published version should stay pullable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the uploader DaemonSet crash loop by running the binary directly instead of passing the subcommand to the `bun` entrypoint. Updates the chart to `0.13.2`.

- **Bug Fixes**
  - Use `command: ["/opt/sandbox-daemon/daemon-go", "golden-uploader"]` instead of `args` to bypass the `bun` base image entrypoint.
  - Validated on a sandbox node via an ephemeral pod; the subcommand executed and returned the expected config error.
  - No tenant impact; only the DaemonSet pods failed while enabled.

<sup>Written for commit 32a728318b0e8aad8547e6839de9e106a6e8c3d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

