### PR TITLE
fix(task-board): let mouse wheel scroll the board horizontally

### DIFF
--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -1209,6 +1209,54 @@ function Lanes({
   const [overrides, setOverrides] = useState<Map<string, Placement>>(new Map());
   const boardRef = useRef<HTMLDivElement>(null);
 
+  // A plain mouse wheel only emits vertical deltas, so on a board that overflows
+  // sideways the columns off-screen to the right are unreachable without a
+  // trackpad (two-finger swipe) or Shift+wheel — neither of which a mouse user
+  // has. Translate a vertical wheel into horizontal board scroll, but only when
+  // the pointer isn't over a lane that can still absorb that scroll itself, so
+  // scrolling a column's cards keeps working. Registered natively (not via
+  // React's passive onWheel) so preventDefault can suppress the browser's own
+  // vertical scroll/overscroll; React 19 ref cleanup unregisters it.
+  const attachBoard = (node: HTMLDivElement | null) => {
+    boardRef.current = node;
+    if (!node) return;
+    const onWheel = (event: WheelEvent) => {
+      // Trackpad / Shift+wheel already produce a horizontal delta — let the
+      // browser handle those natively.
+      if (event.deltaX !== 0 || event.deltaY === 0) return;
+      if (node.scrollWidth <= node.clientWidth) return;
+      // Walk up from the pointer target: if a lane under it can still scroll
+      // vertically in this direction, that's what the wheel is for.
+      for (
+        let el = event.target as HTMLElement | null;
+        el && el !== node;
+        el = el.parentElement
+      ) {
+        if (el.hasAttribute("data-lane-scroll")) {
+          const hasRoom =
+            event.deltaY < 0
+              ? el.scrollTop > 0
+              : el.scrollTop + el.clientHeight < el.scrollHeight - 1;
+          if (hasRoom) return;
+          break;
+        }
+      }
+      event.preventDefault();
+      const factor =
+        event.deltaMode === 1
+          ? 16
+          : event.deltaMode === 2
+            ? node.clientWidth
+            : 1;
+      node.scrollLeft += event.deltaY * factor;
+    };
+    node.addEventListener("wheel", onWheel, { passive: false });
+    return () => {
+      boardRef.current = null;
+      node.removeEventListener("wheel", onWheel);
+    };
+  };
+
   const placed =
     overrides.size > 0
       ? items.map((item) => {
@@ -1382,7 +1430,7 @@ function Lanes({
     >
       {/* Scroll container spans the full panel width so the wheel works even
           when the pointer is in the empty margins on wide monitors. */}
-      <div ref={boardRef} className="min-h-0 flex-1 overflow-x-auto">
+      <div ref={attachBoard} className="min-h-0 flex-1 overflow-x-auto">
         {/* Padding lives on the capped row (not the scroll container) so its
             left edge matches the header's max-w + px exactly. Bottom breathing
             room is handled per-lane by each column's own scrollable div — a pb


### PR DESCRIPTION
## Summary

On the Tasks **Board** ("Quadro") view the column container only overflows sideways (`overflow-x-auto`). That works for trackpad users (two-finger swipe) and `Shift`+wheel, but a plain mouse wheel emits only vertical deltas — so **mouse users had no way to reach columns off-screen to the right**, and there was no drag-to-scroll fallback either.

This adds a `wheel` listener on the board container that translates a vertical mouse wheel into horizontal board scroll.

## Behavior

- Only kicks in when the board actually overflows horizontally.
- If the pointer is over a lane (`data-lane-scroll`) that can still scroll its cards vertically in that direction, the lane scrolls as before — the conversion defers to it.
- Trackpad / `Shift`+wheel (which already produce a horizontal delta) are left to native handling.
- `deltaMode` (line/page) is normalized to pixels.

## Implementation notes

- Registered as a **non-passive** native `wheel` listener via a **callback ref** (not React's `onWheel`, which is passive and would ignore `preventDefault()` — needed to suppress the browser's own vertical scroll/overscroll).
- Cleanup uses the **React 19 ref-cleanup** return, so no `useEffect` (banned in this repo). The callback also keeps `boardRef.current` wired for `useFlipLanes`.

## Testing

- `bun run check` (tsc) ✅
- `bun run lint` ✅
- `bun run fmt:check` ✅
- Manual: verify on a board wide enough to overflow — mouse wheel scrolls columns sideways; scrolling within a full column still moves its cards vertically.

Did not add click-and-drag-to-scroll on the board background to avoid conflicting with dnd-kit card dragging and text selection; the wheel conversion covers the core complaint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets the mouse wheel scroll the task board horizontally so mouse users can reach off-screen columns. Converts vertical wheel input into horizontal scroll without affecting trackpad or Shift+wheel behavior.

- **Bug Fixes**
  - Converts vertical wheel to horizontal scroll only when the board overflows.
  - Defers to a lane’s vertical scroll if it can still scroll in that direction.
  - Uses a non-passive native wheel listener via a callback ref with React 19 ref cleanup; normalizes deltaMode and prevents default vertical overscroll.

<sup>Written for commit ad8696bc5baf061ad2d31b5489c75eaf2ae5a1da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

