### PR TITLE
fix(web): poll synced-repo status until the first sync lands

### DIFF
--- a/apps/web/src/hooks/use-org-repo-syncs.ts
+++ b/apps/web/src/hooks/use-org-repo-syncs.ts
@@ -16,12 +16,25 @@ import { useStudioTools } from "@/lib/studio-tools";
 export type OrgRepoSyncConfig =
   StudioToolIO["ORG_REPO_SYNC_LIST"]["output"]["configs"][number];
 
+/** Poll interval while a config is still waiting on its first sync (kicked
+ *  in the background — see useCreateOrgRepoSync) — otherwise the row's
+ *  "waiting for first sync" status only updates on the next manual visit. */
+const PENDING_FIRST_SYNC_POLL_MS = 5_000;
+
+function hasPendingFirstSync(configs: OrgRepoSyncConfig[] | undefined) {
+  return (configs ?? []).some((c) => !c.lastSyncedAt && !c.lastSyncError);
+}
+
 export function useOrgRepoSyncs() {
   const { org } = useProjectContext();
   const studio = useStudioTools();
   return useQuery({
     queryKey: KEYS.orgRepoSyncs(org.id),
     staleTime: 60_000,
+    refetchInterval: (query) =>
+      hasPendingFirstSync(query.state.data)
+        ? PENDING_FIRST_SYNC_POLL_MS
+        : false,
     queryFn: async () => (await studio.call("ORG_REPO_SYNC_LIST", {})).configs,
   });
 }


### PR DESCRIPTION
Follow-up hardening to #5866/#5879 (per-org GitHub repo → volume sync). The create mutation now kicks the first sync in the background so the create dialog doesn't hang, but `useOrgRepoSyncs` had no `refetchInterval` — a freshly-created row stays stuck on "waiting for first sync" in the Settings → Synced repos UI until the user navigates away and back (or the 60s `staleTime` happens to line up with a remount), even after the background sync completes seconds later.

`useOrgRepoSyncs` now polls every 5s while any config has neither `lastSyncedAt` nor `lastSyncError` (i.e. is still awaiting its first sync), and stops polling once every row has settled — mirroring the existing conditional-`refetchInterval` pattern already used in `use-org-fs.ts`/`use-commerce-diagnostic.ts`/`registry/use-monitor.ts`. No change to steady-state behavior: once all rows have a `lastSyncedAt` or an error, polling turns itself off again.

Failure scenario without this fix: user adds a repo sync, sees "waiting for first sync" in the row, and — unless they leave and come back to the Settings page — never sees it flip to "synced Xs ago" even though the sync actually finished.

Reviewer check: `cd apps/web && bunx tsc --noEmit` and `bunx oxlint apps/web/src/hooks/use-org-repo-syncs.ts` both pass. This hook has no existing unit test (it's a thin react-query wrapper, `KEYS`/`studio.call` are the only dependencies); full CI covers the rest.

Locally verified: `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, `bunx oxlint apps/web/src/hooks/use-org-repo-syncs.ts` — all clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Synced repos UI getting stuck on “waiting for first sync” by polling repo sync status every 5s until the first sync completes. Adds a conditional `refetchInterval` to `useOrgRepoSyncs` and stops polling once all rows settle.

- **Bug Fixes**
  - Polls when any config lacks `lastSyncedAt` and `lastSyncError`; otherwise no polling.
  - Preserves steady-state behavior with `staleTime`; polling turns off after sync or error.

<sup>Written for commit 21a3b2eba8e2cf926fb589583206862447e02ece. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

