### PR TITLE
fix(sandbox): read the golden's own mtime for TTL pruning, not its lockDir's

### DIFF
--- a/packages/sandbox/daemon-go/internal/setup/golden.go
+++ b/packages/sandbox/daemon-go/internal/setup/golden.go
@@ -275,11 +275,16 @@ func pruneGoldens(cacheRoot string, ttl time.Duration, maxPerRepo int, now time.
 			if strings.HasPrefix(name.Name(), goldenTmpPrefix) {
 				continue // in-flight publish
 			}
-			info, err := name.Info()
+			lockDir := filepath.Join(repoDir, name.Name())
+			// TryRestoreGolden touches the mtime of <lockDir>/node_modules, not the
+			// lockDir itself — a rename never touches it again after publish, so
+			// reading the lockDir's own mtime here would make the TTL reap an
+			// actively-restored golden right out from under a running fleet.
+			info, err := os.Stat(filepath.Join(lockDir, "node_modules"))
 			if err != nil {
 				continue
 			}
-			entries = append(entries, entry{filepath.Join(repoDir, name.Name()), info.ModTime()})
+			entries = append(entries, entry{lockDir, info.ModTime()})
 		}
 		// Newest first; anything past the cap or older than the TTL is pruned.
 		sort.Slice(entries, func(i, j int) bool { return entries[i].mtime.After(entries[j].mtime) })

--- a/packages/sandbox/daemon-go/internal/setup/golden_test.go
+++ b/packages/sandbox/daemon-go/internal/setup/golden_test.go
@@ -152,13 +152,15 @@ func TestSameFilesystem(t *testing.T) {
 }
 
 func TestPruneGoldens(t *testing.T) {
-	// A golden dir <root>/golden/<repo>/<name> with a given mtime.
+	// A golden dir <root>/golden/<repo>/<name>/node_modules with a given mtime —
+	// the mtime TryRestoreGolden actually touches, not the lockDir's own.
 	mkGolden := func(t *testing.T, root, repo, name string, mtime time.Time) string {
 		dir := filepath.Join(root, "golden", repo, name)
-		if err := os.MkdirAll(dir, 0o755); err != nil {
+		nodeModules := filepath.Join(dir, "node_modules")
+		if err := os.MkdirAll(nodeModules, 0o755); err != nil {
 			t.Fatal(err)
 		}
-		if err := os.Chtimes(dir, mtime, mtime); err != nil {
+		if err := os.Chtimes(nodeModules, mtime, mtime); err != nil {
 			t.Fatal(err)
 		}
 		return dir
@@ -207,6 +209,30 @@ func TestPruneGoldens(t *testing.T) {
 		pruneGoldens(root, time.Nanosecond, 0, now)
 		if !exists(inflight) {
 			t.Error("reaped an in-flight publish — that publish now renames onto nothing")
+		}
+	})
+
+	t.Run("a restore touching only node_modules' mtime still protects the golden", func(t *testing.T) {
+		// Mirrors TryRestoreGolden: the lockDir is created (and its own mtime set)
+		// long ago at publish time, then only node_modules is bumped by a later
+		// restore — exactly what os.Chtimes(paths.golden, ...) does in production.
+		root := t.TempDir()
+		lockDir := filepath.Join(root, "golden", "repoD", "bun-1")
+		nodeModules := filepath.Join(lockDir, "node_modules")
+		old := now.Add(-999 * day)
+		if err := os.MkdirAll(nodeModules, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Chtimes(lockDir, old, old); err != nil {
+			t.Fatal(err)
+		}
+		recent := now.Add(-time.Second)
+		if err := os.Chtimes(nodeModules, recent, recent); err != nil {
+			t.Fatal(err)
+		}
+		pruneGoldens(root, 7*day, 99, now)
+		if !exists(lockDir) {
+			t.Error("reaped a golden a restore just marked as in-use")
 		}
 	})
 


### PR DESCRIPTION
Follows #5824/#5843 (the L1/L2 golden-tier rework merged today) — a bug in the L1 pruning code, not a follow-up feature.

**Bug:** `pruneGoldens` (packages/sandbox/daemon-go/internal/setup/golden.go) computes each entry's mtime from the lockDir itself (`golden/<repo>/<pm>-<lockHash>`), but `TryRestoreGolden` marks a golden as recently-used by calling `os.Chtimes` on `.../node_modules` — the child directory, not the lockDir. Updating a child's mtime via `utimes` never touches its parent directory's own mtime, so the lockDir's mtime is set once at publish time (via the rename in `PublishGolden`) and never again. The code comment even claims the opposite ("Restore touches a golden's mtime, so an actively-used lockfile never ages out" — golden.go:22), but it touches the wrong path for that claim to hold.

**Failure scenario:** any lockfile whose golden was published more than `GoldenTTL` (7 days) ago keeps getting restored-from every day, but the periodic prune sweep still reaps it once past the TTL, because the mtime it reads never moved. Every subsequent boot for that lockfile silently falls back to a full install — the exact perf regression the golden cache exists to prevent — with no error or signal, since restore itself doesn't check TTL, only the sweep does.

**Fix:** `pruneGoldens` now stats `<lockDir>/node_modules` (the same path `TryRestoreGolden` touches) instead of the lockDir. Updated `TestPruneGoldens`'s `mkGolden` helper to build the real nested layout, and added a regression case (`a restore touching only node_modules' mtime still protects the golden`) that fails against the old code (verified locally by reverting golden.go and re-running: 3 of 6 subtests failed, including the new one) and passes with the fix.

**Verify:** `cd packages/sandbox/daemon-go && go test ./internal/setup/... -run TestPruneGoldens -v`

**Checked locally:** `go test ./internal/setup/...` (full package, green), `gofmt -l` (clean), `go vet ./internal/setup/...` (clean). Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes golden cache pruning to read `<lockDir>/node_modules` mtime so active goldens aren’t reaped by TTL. Prevents silent full installs when a golden is still in use.

- **Bug Fixes**
  - Updated `pruneGoldens` to stat `<lockDir>/node_modules` (matches `TryRestoreGolden`) instead of the lock directory.
  - Adjusted tests to use the real nested layout and added a regression case to ensure restore-only mtime updates prevent pruning.

<sup>Written for commit 96144dcea268521ee975aeecf3091b48485e25db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

