### PR TITLE
fix(sections-editor): drilling into an array item shows only that item's fields

### DIFF
--- a/apps/web/ct/tests/array-object-drilldown.ct.tsx
+++ b/apps/web/ct/tests/array-object-drilldown.ct.tsx
@@ -175,9 +175,11 @@ test("editing a label field whose value equals the array label keeps the editor 
   mount,
 }) => {
   // Regression: an array labelled "Banner" whose single item is ALSO labelled
-  // "Banner" (its label comes from `alt` via titleBy). The breadcrumb is
-  // ["Banner", "Banner"]; editing `alt` must not collapse the trail and kick
-  // you back to the list. Guards the SchemaForm consumed-prefix re-prepend.
+  // "Banner" (its label comes from `alt` via titleBy). The array's disambiguator
+  // now rides ON the item crumb (`arrayLabel`), so the breadcrumb is a single
+  // ["Banner"] — no standalone array-list stop. Drilling in, then editing `alt`,
+  // must keep the item's editor open (breadcrumbPathForActiveField must not strip
+  // the item crumb, and updateItem must preserve the folded arrayLabel).
   const meta = sectionWithProps({
     banner: {
       type: "array",
@@ -199,9 +201,7 @@ test("editing a label field whose value equals the array label keeps the editor 
   );
 
   await itemRow(component, "Banner").click();
-  await expect
-    .poll(() => readBreadcrumb(component))
-    .toEqual(["Banner", "Banner"]);
+  await expect.poll(() => readBreadcrumb(component)).toEqual(["Banner"]);
 
   const altInput = component.getByLabel("Alt");
   await expect(altInput).toHaveAttribute("id", "banner.0.alt");

--- a/apps/web/src/components/sections-editor/fields/array-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/array-field.tsx
@@ -331,10 +331,13 @@ export function ArrayField({
       const newLabel = itemLabel(next[index], index);
       if (oldLabel !== newLabel) {
         const updatedBreadcrumb = [...breadcrumbPath];
-        updatedBreadcrumb[selection.crumbIndex] = {
-          label: newLabel,
-          itemIndex: index,
-        };
+        const existing = breadcrumbPath[selection.crumbIndex];
+        // Preserve the crumb's `arrayLabel` disambiguator (if any) — only the
+        // display label changed, not which array this item belongs to.
+        updatedBreadcrumb[selection.crumbIndex] =
+          existing != null && typeof existing === "object"
+            ? { ...existing, label: newLabel, itemIndex: index }
+            : { label: newLabel, itemIndex: index };
         onBreadcrumbChange?.(updatedBreadcrumb);
       }
     }

--- a/apps/web/src/components/sections-editor/fields/field-props.ts
+++ b/apps/web/src/components/sections-editor/fields/field-props.ts
@@ -26,6 +26,14 @@ export interface FieldProps {
    * siblings exist the array label is kept as a disambiguator.
    */
   hasSiblingDrillDownFields?: boolean;
+  /**
+   * True when this field is the sole field its parent narrowed to for the active
+   * breadcrumb (i.e. the form is drilled into it). Object fields use it to render
+   * their contents flat — no collapsible header, no indentation — since the
+   * breadcrumb already conveys the location, so drilling into a deeply nested
+   * item shows just the item's fields instead of a stack of wrapper headers.
+   */
+  focused?: boolean;
   meta?: LiveMeta;
   decofile?: Record<string, unknown>;
   containerResolveType?: string;

--- a/apps/web/src/components/sections-editor/fields/object-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/object-field.tsx
@@ -34,29 +34,31 @@ export function ObjectField({
 
   if (!schema.properties) return null;
 
+  // Single source for the nested form so the focused (flat) and collapsible
+  // branches can't drift apart when a prop is added.
+  const form = (
+    <SchemaForm
+      schema={schema}
+      value={objValue}
+      onChange={onChange}
+      basePath={path}
+      breadcrumbPath={breadcrumbPath}
+      onBreadcrumbChange={onBreadcrumbChange}
+      meta={meta}
+      decofile={decofile}
+      onSaveReferencedBlock={onSaveReferencedBlock}
+      previewBaseUrl={previewBaseUrl}
+      onAddSectionItem={onAddSectionItem}
+      onRequestAddSection={onRequestAddSection}
+      sandbox={sandbox}
+    />
+  );
+
   // Drilled into via the breadcrumb: render the fields flat, without this
   // object's collapsible header or indentation. The breadcrumb already shows
   // where we are, so stacking wrapper headers (e.g. Props > ShelfProps >
   // CardLayout) just buries the item's own fields.
-  if (focused) {
-    return (
-      <SchemaForm
-        schema={schema}
-        value={objValue}
-        onChange={onChange}
-        basePath={path}
-        breadcrumbPath={breadcrumbPath}
-        onBreadcrumbChange={onBreadcrumbChange}
-        meta={meta}
-        decofile={decofile}
-        onSaveReferencedBlock={onSaveReferencedBlock}
-        previewBaseUrl={previewBaseUrl}
-        onAddSectionItem={onAddSectionItem}
-        onRequestAddSection={onRequestAddSection}
-        sandbox={sandbox}
-      />
-    );
-  }
+  if (focused) return form;
 
   const fieldKey = path.split(".").pop() ?? path;
   const breadcrumbInside = isBreadcrumbInsideObject(
@@ -101,21 +103,7 @@ export function ObjectField({
           id={contentId}
           className="ml-3 min-w-0 max-w-full overflow-hidden border-l border-border/80 pl-5"
         >
-          <SchemaForm
-            schema={schema}
-            value={objValue}
-            onChange={onChange}
-            basePath={path}
-            breadcrumbPath={breadcrumbPath}
-            onBreadcrumbChange={onBreadcrumbChange}
-            meta={meta}
-            decofile={decofile}
-            onSaveReferencedBlock={onSaveReferencedBlock}
-            previewBaseUrl={previewBaseUrl}
-            onAddSectionItem={onAddSectionItem}
-            onRequestAddSection={onRequestAddSection}
-            sandbox={sandbox}
-          />
+          {form}
         </div>
       )}
     </div>

--- a/apps/web/src/components/sections-editor/fields/object-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/object-field.tsx
@@ -16,6 +16,7 @@ export function ObjectField({
   label,
   breadcrumbPath = [],
   onBreadcrumbChange,
+  focused,
   meta,
   decofile,
   onSaveReferencedBlock,
@@ -32,6 +33,30 @@ export function ObjectField({
       : {};
 
   if (!schema.properties) return null;
+
+  // Drilled into via the breadcrumb: render the fields flat, without this
+  // object's collapsible header or indentation. The breadcrumb already shows
+  // where we are, so stacking wrapper headers (e.g. Props > ShelfProps >
+  // CardLayout) just buries the item's own fields.
+  if (focused) {
+    return (
+      <SchemaForm
+        schema={schema}
+        value={objValue}
+        onChange={onChange}
+        basePath={path}
+        breadcrumbPath={breadcrumbPath}
+        onBreadcrumbChange={onBreadcrumbChange}
+        meta={meta}
+        decofile={decofile}
+        onSaveReferencedBlock={onSaveReferencedBlock}
+        previewBaseUrl={previewBaseUrl}
+        onAddSectionItem={onAddSectionItem}
+        onRequestAddSection={onRequestAddSection}
+        sandbox={sandbox}
+      />
+    );
+  }
 
   const fieldKey = path.split(".").pop() ?? path;
   const breadcrumbInside = isBreadcrumbInsideObject(

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -12,7 +12,7 @@ import {
   findBreadcrumbLabelIndex,
   isArrayDrillDownField,
   normalizeBreadcrumbLabel,
-  objectSiblingNeedsAncestorCrumb,
+  objectSiblingsNeedingAncestorCrumb,
   prependCrumbIfAbsent,
   resolveActiveFieldKey,
   resolveArrayItemSelection,
@@ -309,16 +309,13 @@ describe("resolveActiveFieldKey — distinct-titled siblings with an array crumb
     ).toBe("shelfPropsOffer");
   });
 
-  test("objectSiblingNeedsAncestorCrumb flags both confusable containers", () => {
-    expect(
-      objectSiblingNeedsAncestorCrumb("shelfProps", keys, properties),
-    ).toBe(true);
-    expect(
-      objectSiblingNeedsAncestorCrumb("shelfPropsOffer", keys, properties),
-    ).toBe(true);
+  test("objectSiblingsNeedingAncestorCrumb flags both confusable containers", () => {
+    const needing = objectSiblingsNeedingAncestorCrumb(keys, properties);
+    expect(needing.has("shelfProps")).toBe(true);
+    expect(needing.has("shelfPropsOffer")).toBe(true);
   });
 
-  test("objectSiblingNeedsAncestorCrumb is false without a confusable sibling", () => {
+  test("objectSiblingsNeedingAncestorCrumb is empty without a confusable sibling", () => {
     const lone = {
       shelfProps: {
         type: "object",
@@ -328,8 +325,91 @@ describe("resolveActiveFieldKey — distinct-titled siblings with an array crumb
       title: { type: "string", title: "Title" },
     } satisfies Record<string, SchemaProperty>;
     expect(
-      objectSiblingNeedsAncestorCrumb("shelfProps", Object.keys(lone), lone),
-    ).toBe(false);
+      objectSiblingsNeedingAncestorCrumb(Object.keys(lone), lone).size,
+    ).toBe(0);
+  });
+});
+
+describe("array drill-down pipeline — item label collides with array label/key", () => {
+  // Regression guard for the `arrayLabel` fold: when the item's label equals the
+  // array's own label (or property key), the disambiguator rides ON the item
+  // crumb. `breadcrumbPathForActiveField` must NOT strip that item crumb (it's
+  // the array's selection, not the array's own crumb) — otherwise ArrayField gets
+  // an empty relative trail, `resolveArrayItemSelection` returns null, and the
+  // item can't be opened (it snaps back to the list). This walks the full
+  // SchemaForm pipeline: build → resolveActiveFieldKey → breadcrumbPathForActiveField
+  // → resolveArrayItemSelection.
+  function drillAndSelect(
+    key: string,
+    properties: Record<string, SchemaProperty>,
+    objValue: Record<string, unknown>,
+    arrayLabel: string,
+    itemLabel: string,
+    opts: { arrayKey?: string; hasSiblingDrillDownFields?: boolean },
+  ) {
+    const keys = Object.keys(properties);
+    const trail = buildArrayDrillDownBreadcrumb(
+      [],
+      arrayLabel,
+      itemLabel,
+      0,
+      opts,
+    );
+    const activeKey = resolveActiveFieldKey(keys, properties, objValue, trail);
+    expect(activeKey).toBe(key);
+    const relative = breadcrumbPathForActiveField(
+      key,
+      properties[key]!,
+      trail,
+      siblingFieldLabel(key, keys, properties),
+    );
+    return resolveArrayItemSelection(
+      siblingFieldLabel(key, keys, properties),
+      relative,
+      objValue[key] as unknown[],
+      properties[key]!.items,
+      null,
+    );
+  }
+
+  test("item label equals the array label — item still opens", () => {
+    const properties = {
+      banner: {
+        type: "array",
+        title: "Banner",
+        items: { type: "object", properties: { alt: { type: "string" } } },
+      },
+    } as Record<string, SchemaProperty>;
+    const objValue = { banner: [{ alt: "Banner" }] };
+    const selection = drillAndSelect(
+      "banner",
+      properties,
+      objValue,
+      "Banner",
+      "Banner",
+      {},
+    );
+    expect(selection?.index).toBe(0);
+  });
+
+  test("item label equals the array KEY — item still opens", () => {
+    const properties = {
+      items: {
+        type: "array",
+        title: "Products",
+        items: { type: "object", properties: { label: { type: "string" } } },
+      },
+    } as Record<string, SchemaProperty>;
+    const objValue = { items: [{ label: "items" }] };
+    const selection = drillAndSelect(
+      "items",
+      properties,
+      objValue,
+      "Products",
+      "items",
+      { arrayKey: "items" },
+    );
+    expect(selection?.index).toBe(0);
   });
 });
 
@@ -1182,7 +1262,8 @@ describe("editing an item's label keeps it selected (crumb re-sync)", () => {
 
   // Mirror ArrayField.updateItem's crumb re-sync exactly: the item's base label
   // (no siblings → no positional suffix) plus the stable `itemIndex`, rewritten
-  // in place at `selection.crumbIndex`.
+  // in place at `selection.crumbIndex` — spreading the existing crumb so a folded
+  // `arrayLabel` disambiguator survives the label edit.
   const rewriteAndReresolve = (
     items: unknown[],
     trail: Crumb[],
@@ -1202,10 +1283,11 @@ describe("editing an item's label keeps it selected (crumb re-sync)", () => {
     let nextTrail = trail;
     if (oldLabel !== newLabel) {
       nextTrail = [...trail];
-      nextTrail[selection.crumbIndex] = {
-        label: newLabel,
-        itemIndex: openIndex,
-      };
+      const existing = trail[selection.crumbIndex];
+      nextTrail[selection.crumbIndex] =
+        existing != null && typeof existing === "object"
+          ? { ...existing, label: newLabel, itemIndex: openIndex }
+          : { label: newLabel, itemIndex: openIndex };
     }
     return {
       nextTrail,
@@ -1296,6 +1378,27 @@ describe("editing an item's label keeps it selected (crumb re-sync)", () => {
       innerPath: ["Inner"],
       crumbIndex: 0,
     });
+  });
+
+  test("editing the label preserves a folded arrayLabel disambiguator", () => {
+    // updateItem spreads the existing crumb, so a label edit must not drop
+    // `arrayLabel` — otherwise the item would re-resolve ambiguously across
+    // same-shaped sibling arrays (the very thing the fold disambiguates).
+    const items = [{ title: "Cozinha" }, { title: "Cozinha" }];
+    const trail: Crumb[] = [
+      { label: "Cozinha", itemIndex: 1, arrayLabel: "Banners" },
+    ];
+    const edited = [{ title: "Cozinha" }, { title: "Cozinha Nova" }];
+    const { nextTrail, selection } = rewriteAndReresolve(
+      items,
+      trail,
+      1,
+      edited,
+    );
+    expect(nextTrail).toEqual([
+      { label: "Cozinha Nova", itemIndex: 1, arrayLabel: "Banners" },
+    ]);
+    expect(selection).toEqual({ index: 1, innerPath: [], crumbIndex: 0 });
   });
 });
 

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -6,11 +6,13 @@ import {
   buildArrayDrillDownBreadcrumb,
   consumedBreadcrumbPrefix,
   type Crumb,
+  crumbLabel,
   headerBackTargetIndex,
   fieldDisplayLabel,
   findBreadcrumbLabelIndex,
   isArrayDrillDownField,
   normalizeBreadcrumbLabel,
+  objectSiblingNeedsAncestorCrumb,
   prependCrumbIfAbsent,
   resolveActiveFieldKey,
   resolveArrayItemSelection,
@@ -226,6 +228,108 @@ describe("resolveActiveFieldKey — sibling props with identical titles", () => 
         "Shelf Props Offer",
       ),
     ).toEqual(["Free shipping"]);
+  });
+});
+
+describe("resolveActiveFieldKey — distinct-titled siblings with an array crumb", () => {
+  // The real-world ProductShelfGroup shape: `shelfProps` and `shelfPropsOffer`
+  // have DIFFERENT titles (so they don't collide by display label), yet each
+  // holds an identical `cardLayout.productTags` whose items share labels. Because
+  // `cardLayout` has TWO arrays (`productTags` + `productSquareTags`), drilling
+  // keeps the array-label crumb "ProductTags" in the trail — which matches the
+  // array in BOTH siblings. Only the ancestor crumb tells them apart.
+  const cardLayout = {
+    type: "object",
+    title: "CardLayout",
+    properties: {
+      productTags: {
+        type: "array",
+        title: "ProductTags",
+        items: { type: "object", properties: { label: { type: "string" } } },
+      },
+      productSquareTags: {
+        type: "array",
+        title: "ProductSquareTags",
+        items: { type: "object", properties: { label: { type: "string" } } },
+      },
+    },
+  } satisfies SchemaProperty;
+  const properties = {
+    shelfPropsOffer: {
+      type: "object",
+      title: "ShelfPropsOffer",
+      properties: { cardLayout },
+    },
+    shelfProps: {
+      type: "object",
+      title: "ShelfProps",
+      properties: { cardLayout },
+    },
+  } satisfies Record<string, SchemaProperty>;
+  const keys = Object.keys(properties);
+  const tags = [
+    { label: "frete grátis geral" },
+    { label: "frete grátis smt" },
+    { label: "OFERTAS 8.8" },
+  ];
+  const objValue = {
+    shelfPropsOffer: {
+      cardLayout: { productTags: tags, productSquareTags: [] },
+    },
+    shelfProps: { cardLayout: { productTags: tags, productSquareTags: [] } },
+  };
+
+  // The array label rides on the item crumb as `arrayLabel` (folded), which is
+  // what `buildArrayDrillDownBreadcrumb` now produces — no standalone
+  // "ProductTags" crumb.
+  const item = {
+    label: "frete grátis smt",
+    itemIndex: 1,
+    arrayLabel: "ProductTags",
+  };
+
+  test("without an ancestor crumb the shared item stays ambiguous (shows both)", () => {
+    expect(
+      resolveActiveFieldKey(keys, properties, objValue, [item]),
+    ).toBeNull();
+  });
+
+  test("the ancestor crumb pins the sibling even with the folded array label present", () => {
+    // This is the regression: pre-fix the array label matched the nested array in
+    // BOTH siblings via the loose path, so it returned null (mixed panel) despite
+    // the "ShelfProps" ancestor crumb naming exactly one.
+    expect(
+      resolveActiveFieldKey(keys, properties, objValue, ["ShelfProps", item]),
+    ).toBe("shelfProps");
+    expect(
+      resolveActiveFieldKey(keys, properties, objValue, [
+        "ShelfPropsOffer",
+        item,
+      ]),
+    ).toBe("shelfPropsOffer");
+  });
+
+  test("objectSiblingNeedsAncestorCrumb flags both confusable containers", () => {
+    expect(
+      objectSiblingNeedsAncestorCrumb("shelfProps", keys, properties),
+    ).toBe(true);
+    expect(
+      objectSiblingNeedsAncestorCrumb("shelfPropsOffer", keys, properties),
+    ).toBe(true);
+  });
+
+  test("objectSiblingNeedsAncestorCrumb is false without a confusable sibling", () => {
+    const lone = {
+      shelfProps: {
+        type: "object",
+        title: "ShelfProps",
+        properties: { cardLayout },
+      },
+      title: { type: "string", title: "Title" },
+    } satisfies Record<string, SchemaProperty>;
+    expect(
+      objectSiblingNeedsAncestorCrumb("shelfProps", Object.keys(lone), lone),
+    ).toBe(false);
   });
 });
 
@@ -712,34 +816,35 @@ describe("buildArrayDrillDownBreadcrumb", () => {
     ).toEqual([{ label: "Partiu ferias", itemIndex: 0 }]);
   });
 
-  test("keeps the array label to disambiguate an item labelled like the array", () => {
-    // Item label == array label (e.g. label driven by `alt`): keep the array
-    // crumb so breadcrumbPathForActiveField can tell the two levels apart.
+  test("carries the array label on the item crumb when the item is labelled like the array", () => {
+    // Item label == array label (e.g. label driven by `alt`): the array label
+    // rides on the item crumb so breadcrumbPathForActiveField can still tell the
+    // levels apart — without a separate, navigable "array list" crumb.
     expect(buildArrayDrillDownBreadcrumb([], "Banner", "Banner", 0)).toEqual([
-      "Banner",
-      { label: "Banner", itemIndex: 0 },
+      { label: "Banner", itemIndex: 0, arrayLabel: "Banner" },
     ]);
   });
 
-  test("keeps the array label to disambiguate an item labelled like the array KEY", () => {
+  test("carries the array label on the item crumb when the item is labelled like the array KEY", () => {
     // Item label == array's property key: breadcrumbPathForActiveField strips a
-    // head crumb matching the key too, so the array crumb must be kept.
+    // head crumb matching the key too, so the array label must travel — as crumb
+    // metadata, not a standalone stop.
     expect(
       buildArrayDrillDownBreadcrumb([], "Products", "items", 0, {
         arrayKey: "items",
       }),
-    ).toEqual(["Products", { label: "items", itemIndex: 0 }]);
+    ).toEqual([{ label: "items", itemIndex: 0, arrayLabel: "Products" }]);
   });
 
-  test("keeps the array label when a sibling array/drill-down field exists", () => {
+  test("carries the array label on the item crumb when a sibling drill-down field exists", () => {
     // A bare [itemLabel] trail can't say WHICH sibling array the item belongs to
-    // (two label-less arrays both fall back to "Item N"), so keep the array
-    // label as a disambiguator when siblings are present.
+    // (two label-less arrays both fall back to "Item N"), so the array label
+    // rides on the item crumb as a disambiguator when siblings are present.
     expect(
       buildArrayDrillDownBreadcrumb([], "Logos", "Item 1", 0, {
         hasSiblingDrillDownFields: true,
       }),
-    ).toEqual(["Logos", { label: "Item 1", itemIndex: 0 }]);
+    ).toEqual([{ label: "Item 1", itemIndex: 0, arrayLabel: "Logos" }]);
   });
 
   test("omits the array label when it is the sole drill-down field in scope", () => {
@@ -749,6 +854,18 @@ describe("buildArrayDrillDownBreadcrumb", () => {
         hasSiblingDrillDownFields: false,
       }),
     ).toEqual([{ label: "Item 1", itemIndex: 0 }]);
+  });
+
+  test("never yields a standalone array-list navigation stop", () => {
+    // The array label rides on the item crumb, never as its own crumb, so no
+    // crumb renders as the bare array label — back from the item lands on the
+    // array's parent form, not on a redundant "array list only" view.
+    const trail = buildArrayDrillDownBreadcrumb([], "ProductTags", "Tag A", 2, {
+      arrayKey: "productTags",
+      hasSiblingDrillDownFields: true,
+    });
+    expect(trail).toHaveLength(1);
+    expect(trail.map(crumbLabel)).not.toContain("ProductTags");
   });
 
   test("does not duplicate crumbs already in trail", () => {
@@ -782,8 +899,8 @@ describe("buildArrayDrillDownBreadcrumb", () => {
 describe("sibling array disambiguation (regression)", () => {
   // Two sibling arrays of label-less objects: getArrayItemLabel falls back to
   // "Item N" for both, so a bare ["Item 1"] trail is ambiguous. The array label
-  // must be kept, and the correct array must resolve — otherwise clicking one
-  // array's item opens the other (the wrong-array bug).
+  // must travel on the item crumb, and the correct array must resolve —
+  // otherwise clicking one array's item opens the other (the wrong-array bug).
   const itemSchema = {
     type: "object",
     properties: { src: { type: "string", title: "Src" } },
@@ -794,12 +911,14 @@ describe("sibling array disambiguation (regression)", () => {
   } as Record<string, SchemaProperty>;
   const objValue = { images: [{ src: "a" }], logos: [{ src: "b" }] };
 
-  test("keeps array label and resolves to the clicked array, not the first sibling", () => {
+  test("carries array label on the crumb and resolves to the clicked array, not the first sibling", () => {
     const trail = buildArrayDrillDownBreadcrumb([], "Logos", "Item 1", 0, {
       arrayKey: "logos",
       hasSiblingDrillDownFields: true,
     });
-    expect(trail).toEqual(["Logos", { label: "Item 1", itemIndex: 0 }]);
+    expect(trail).toEqual([
+      { label: "Item 1", itemIndex: 0, arrayLabel: "Logos" },
+    ]);
     expect(
       resolveActiveFieldKey(
         Object.keys(properties),

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -9,8 +9,17 @@ import { unwrapBlockReference } from "./unwrap-section";
  * additionally carries the item's exact array index, so it re-resolves to that
  * item after a form remount without leaking a positional number into the label
  * the UI renders — the crumb is addressed by `itemIndex`, displayed by `label`.
+ *
+ * When the array needs disambiguating (a sibling drill-down array in the same
+ * scope, or an item label that collides with the array's own label/key), the
+ * array's label rides on the item crumb as `arrayLabel` rather than as a
+ * SEPARATE crumb. That keeps resolution unambiguous WITHOUT creating a standalone
+ * "array list only" navigation stop the user would have to click back through —
+ * the array's list is already shown inline in its parent form.
  */
-export type Crumb = string | { label: string; itemIndex: number };
+export type Crumb =
+  | string
+  | { label: string; itemIndex: number; arrayLabel?: string };
 
 /** The human-visible text of a crumb (the label part of an item crumb). */
 export function crumbLabel(crumb: Crumb): string {
@@ -20,8 +29,13 @@ export function crumbLabel(crumb: Crumb): string {
 /** Whether a crumb addresses an array item (carries an `itemIndex`). */
 function isItemCrumb(
   crumb: Crumb,
-): crumb is { label: string; itemIndex: number } {
+): crumb is { label: string; itemIndex: number; arrayLabel?: string } {
   return typeof crumb === "object";
+}
+
+/** The disambiguating array label riding on an item crumb, if any. */
+function crumbArrayLabel(crumb: Crumb): string | undefined {
+  return isItemCrumb(crumb) ? crumb.arrayLabel : undefined;
 }
 
 function humanize(key: string): string {
@@ -99,14 +113,17 @@ function arrayCrumbNeededForDisambiguation(
  * The array field itself is an implementation detail: its list is already shown
  * inline in the parent form, so drilling into an item jumps straight from the
  * section to the item. We deliberately do NOT add the array's own label as a
- * crumb — it would show a redundant "list only" step the user has to click back
- * through (and, once nested, could even appear twice). Resolution
+ * standalone crumb — it would show a redundant "list only" step the user has to
+ * click back through (and, once nested, could even appear twice). Resolution
  * ({@link resolveActiveFieldKey}, {@link resolveArrayItemSelection}) already
  * matches an item by its label without the array crumb present.
  *
- * The exception is when the crumb would be ambiguous — see
- * {@link arrayCrumbNeededForDisambiguation}: then the array label is kept so the
- * right array (and item) still resolves.
+ * When the crumb would be ambiguous — see
+ * {@link arrayCrumbNeededForDisambiguation} — the array label still has to travel
+ * with the trail so the right array (and item) resolves. It rides on the item
+ * crumb as `arrayLabel` INSTEAD of as a separate crumb, so disambiguation costs
+ * no extra navigation stop: back from the item lands on the array's parent form,
+ * never on a bare array list.
  */
 export function buildArrayDrillDownBreadcrumb(
   breadcrumbPath: Crumb[],
@@ -125,15 +142,14 @@ export function buildArrayDrillDownBreadcrumb(
   ) {
     return breadcrumbPath;
   }
-  const trail = [...breadcrumbPath];
-  if (
-    arrayCrumbNeededForDisambiguation(arrayLabel, itemLabel, opts) &&
-    !trail.some((crumb) => labelsMatch(crumbLabel(crumb), arrayLabel))
-  ) {
-    trail.push(arrayLabel);
-  }
-  trail.push({ label: itemLabel, itemIndex });
-  return trail;
+  const itemCrumb = arrayCrumbNeededForDisambiguation(
+    arrayLabel,
+    itemLabel,
+    opts,
+  )
+    ? { label: itemLabel, itemIndex, arrayLabel }
+    : { label: itemLabel, itemIndex };
+  return [...breadcrumbPath, itemCrumb];
 }
 
 /**
@@ -258,6 +274,58 @@ export function isArrayDrillDownField(
   return Array.isArray(value);
 }
 
+/**
+ * Whether an array (drill-down) field exists anywhere inside this object schema.
+ * Depth-bounded so a deeply nested schema can't stall the check.
+ */
+function schemaHasNestedArrayField(schema: SchemaProperty, depth = 0): boolean {
+  if (depth > 6 || !schema.properties) return false;
+  for (const key of Object.keys(schema.properties)) {
+    const child = schema.properties[key];
+    if (!child) continue;
+    if (child.type === "array" && child.items) return true;
+    if (
+      child.type === "object" &&
+      schemaHasNestedArrayField(child, depth + 1)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Whether drilling into an array item inside object field `key` needs `key`'s
+ * own label stamped onto the breadcrumb trail to stay unambiguous.
+ *
+ * True when `key` is an object holding a nested drill-down array AND a sibling is
+ * also such an object: a bare `[arrayLabel, itemLabel]` trail then matches the
+ * nested array in BOTH siblings (e.g. `shelfProps` / `shelfPropsOffer`, each with
+ * `cardLayout.productTags`), so {@link resolveActiveFieldKey} can't tell them
+ * apart and the panel falls back to showing every sibling. Stamping `key`'s
+ * disambiguated label makes the trail name the right one — the resolver's
+ * strong-match path then pins it.
+ *
+ * Complements the same-display-label collision check in `schema-form.tsx`:
+ * distinct-titled siblings like these don't collide by label, so that check
+ * alone misses them.
+ */
+export function objectSiblingNeedsAncestorCrumb(
+  key: string,
+  keys: string[],
+  properties: Record<string, SchemaProperty>,
+): boolean {
+  const schema = properties[key];
+  if (schema?.type !== "object" || !schemaHasNestedArrayField(schema)) {
+    return false;
+  }
+  return keys.some((k) => {
+    if (k === key) return false;
+    const other = properties[k];
+    return other?.type === "object" && schemaHasNestedArrayField(other);
+  });
+}
+
 function asObjectRecord(value: unknown): Record<string, unknown> {
   return value != null && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -354,12 +422,24 @@ function resolveActiveFieldKeyInScope(
     if (!schema || !isArrayDrillDownField(schema, objValue[key])) continue;
     const label = siblingFieldLabel(key, keys, properties);
     if (labelsMatch(head, label) || labelsMatch(head, key)) return key;
+    // The array's disambiguating label rides on an item crumb's `arrayLabel`
+    // (see buildArrayDrillDownBreadcrumb), so match against that too — it's what
+    // tells sibling drill-down arrays (e.g. `productTags` vs `productSquareTags`)
+    // apart now that the array label is no longer a standalone crumb.
     if (
-      breadcrumbPath.some(
-        (crumb) =>
+      breadcrumbPath.some((crumb) => {
+        if (
           labelsMatch(crumbLabel(crumb), label) ||
-          labelsMatch(crumbLabel(crumb), key),
-      )
+          labelsMatch(crumbLabel(crumb), key)
+        ) {
+          return true;
+        }
+        const arrayLabel = crumbArrayLabel(crumb);
+        return (
+          arrayLabel != null &&
+          (labelsMatch(arrayLabel, label) || labelsMatch(arrayLabel, key))
+        );
+      })
     ) {
       return key;
     }
@@ -382,8 +462,21 @@ function resolveActiveFieldKeyInScope(
   // the wrong prop; if the trail can't tell them apart, return null so the panel
   // keeps both visible instead of editing the wrong sibling. A crumb carrying the
   // disambiguated ancestor label (its `siblingFieldLabel`) matches exactly one.
-  let objMatch: string | null = null;
-  let objAmbiguous = false;
+  // A "strong" match is one where the head crumb NAMES this object sibling (its
+  // disambiguated label or key), so it's consumed and we recurse into only this
+  // sibling. A "loose" match is against the full trail — the item's own crumb
+  // identifies it, but that crumb (or a nested array-label crumb like
+  // "ProductTags") can match the same-shaped array in MULTIPLE siblings, so it's
+  // inherently ambiguous. Strong matches take precedence: when a disambiguating
+  // ancestor crumb pins one sibling, a loose match on another must not veto it.
+  // Without this, drilling into `shelfProps.cardLayout.productTags[i]` while
+  // `shelfPropsOffer.cardLayout.productTags` holds the same item — even WITH the
+  // "Shelf Props" ancestor crumb present — resolves ambiguously (both own the
+  // "ProductTags" crumb) and the panel shows every sibling mixed together.
+  let strongMatch: string | null = null;
+  let strongAmbiguous = false;
+  let looseMatch: string | null = null;
+  let looseAmbiguous = false;
   for (const key of keys) {
     const schema = properties[key];
     if (schema?.type !== "object" || !schema.properties) continue;
@@ -391,17 +484,8 @@ function resolveActiveFieldKeyInScope(
     const childObj = asObjectRecord(objValue[key]);
     const label = siblingFieldLabel(key, keys, properties);
 
-    let matched =
-      resolveActiveFieldKeyInScope(
-        childKeys,
-        schema.properties,
-        childObj,
-        breadcrumbPath,
-        decofile,
-      ) != null;
-
-    if (!matched && (labelsMatch(head, label) || labelsMatch(head, key))) {
-      matched =
+    if (labelsMatch(head, label) || labelsMatch(head, key)) {
+      const matchedStrong =
         resolveActiveFieldKeyInScope(
           childKeys,
           schema.properties,
@@ -409,13 +493,28 @@ function resolveActiveFieldKeyInScope(
           breadcrumbPath.slice(1),
           decofile,
         ) != null;
+      if (matchedStrong) {
+        if (strongMatch === null) strongMatch = key;
+        else strongAmbiguous = true;
+        continue;
+      }
     }
 
-    if (!matched) continue;
-    if (objMatch === null) objMatch = key;
-    else objAmbiguous = true;
+    const matchedLoose =
+      resolveActiveFieldKeyInScope(
+        childKeys,
+        schema.properties,
+        childObj,
+        breadcrumbPath,
+        decofile,
+      ) != null;
+    if (matchedLoose) {
+      if (looseMatch === null) looseMatch = key;
+      else looseAmbiguous = true;
+    }
   }
-  if (objMatch !== null) return objAmbiguous ? null : objMatch;
+  if (strongMatch !== null) return strongAmbiguous ? null : strongMatch;
+  if (looseMatch !== null) return looseAmbiguous ? null : looseMatch;
 
   // Inline-union fields ("A or B" plain-data unions) store the chosen branch's
   // fields flat on the value, so a nested array inside a branch (e.g.

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -189,8 +189,17 @@ export function breadcrumbPathForActiveField(
   overrideLabel?: string,
 ): Crumb[] {
   if (breadcrumbPath.length === 0) return breadcrumbPath;
+  const first = breadcrumbPath[0]!;
+  // Only a field/context crumb (a plain string — an object's disambiguated label
+  // or, formerly, a standalone array crumb) can be the active field's OWN crumb
+  // to consume. An item crumb (carries `itemIndex`) is the array's selection and
+  // must pass through untouched — otherwise, now that the array's disambiguator
+  // rides ON the item crumb as `arrayLabel`, an item whose label equals the
+  // array's label/key would be stripped here, leaving ArrayField an empty trail
+  // and making the item impossible to open (it snaps back to the list).
+  if (isItemCrumb(first)) return breadcrumbPath;
   const label = overrideLabel ?? fieldDisplayLabel(activeKey, schema);
-  const head = crumbLabel(breadcrumbPath[0]!);
+  const head = crumbLabel(first);
   if (labelsMatch(head, label) || labelsMatch(head, activeKey)) {
     return breadcrumbPath.slice(1);
   }
@@ -276,14 +285,16 @@ export function isArrayDrillDownField(
 
 /**
  * Whether an array (drill-down) field exists anywhere inside this object schema.
- * Depth-bounded so a deeply nested schema can't stall the check.
+ * Depth-bounded so a deeply nested schema can't stall the check. Uses the
+ * canonical {@link isArrayDrillDownField} for the leaf test so "drill-down array"
+ * means the same thing here as in the resolver (which gates on it too).
  */
 function schemaHasNestedArrayField(schema: SchemaProperty, depth = 0): boolean {
   if (depth > 6 || !schema.properties) return false;
   for (const key of Object.keys(schema.properties)) {
     const child = schema.properties[key];
     if (!child) continue;
-    if (child.type === "array" && child.items) return true;
+    if (isArrayDrillDownField(child)) return true;
     if (
       child.type === "object" &&
       schemaHasNestedArrayField(child, depth + 1)
@@ -295,35 +306,32 @@ function schemaHasNestedArrayField(schema: SchemaProperty, depth = 0): boolean {
 }
 
 /**
- * Whether drilling into an array item inside object field `key` needs `key`'s
- * own label stamped onto the breadcrumb trail to stay unambiguous.
+ * The object field keys in this scope that need their own label stamped onto the
+ * breadcrumb trail when drilling into a nested array item, to stay unambiguous.
  *
- * True when `key` is an object holding a nested drill-down array AND a sibling is
- * also such an object: a bare `[arrayLabel, itemLabel]` trail then matches the
- * nested array in BOTH siblings (e.g. `shelfProps` / `shelfPropsOffer`, each with
- * `cardLayout.productTags`), so {@link resolveActiveFieldKey} can't tell them
- * apart and the panel falls back to showing every sibling. Stamping `key`'s
+ * A key qualifies when it's an object holding a nested drill-down array AND at
+ * least one sibling is also such an object: a bare `[…, itemLabel]` trail then
+ * matches the nested array in BOTH (e.g. `shelfProps` / `shelfPropsOffer`, each
+ * with `cardLayout.productTags`), so {@link resolveActiveFieldKey} can't tell
+ * them apart and the panel falls back to showing every sibling. Stamping the
  * disambiguated label makes the trail name the right one — the resolver's
- * strong-match path then pins it.
+ * strong-match path (the `labelsMatch(head, label)` branch of the object loop)
+ * then pins it.
  *
  * Complements the same-display-label collision check in `schema-form.tsx`:
  * distinct-titled siblings like these don't collide by label, so that check
- * alone misses them.
+ * alone misses them. Computed in a single pass over `keys` (one schema walk per
+ * object sibling) so callers don't re-walk every sibling per rendered field.
  */
-export function objectSiblingNeedsAncestorCrumb(
-  key: string,
+export function objectSiblingsNeedingAncestorCrumb(
   keys: string[],
   properties: Record<string, SchemaProperty>,
-): boolean {
-  const schema = properties[key];
-  if (schema?.type !== "object" || !schemaHasNestedArrayField(schema)) {
-    return false;
-  }
-  return keys.some((k) => {
-    if (k === key) return false;
-    const other = properties[k];
-    return other?.type === "object" && schemaHasNestedArrayField(other);
+): Set<string> {
+  const withNestedArray = keys.filter((key) => {
+    const schema = properties[key];
+    return schema?.type === "object" && schemaHasNestedArrayField(schema);
   });
+  return withNestedArray.length > 1 ? new Set(withNestedArray) : new Set();
 }
 
 function asObjectRecord(value: unknown): Record<string, unknown> {

--- a/apps/web/src/components/sections-editor/schema-form.tsx
+++ b/apps/web/src/components/sections-editor/schema-form.tsx
@@ -31,6 +31,7 @@ import {
   type Crumb,
   fieldDisplayLabel,
   isArrayDrillDownField,
+  objectSiblingNeedsAncestorCrumb,
   prependCrumbIfAbsent,
   resolveActiveFieldKey,
   siblingFieldLabel,
@@ -595,8 +596,17 @@ export function SchemaForm({
               fieldDisplayLabel(k, other) === plainLabel
             );
           });
+        // Distinct-titled object siblings that each hold a nested drill-down
+        // array (e.g. `shelfProps` / `shelfPropsOffer`, both with
+        // `cardLayout.productTags`) don't collide by label, but a bare item trail
+        // still resolves ambiguously across them. Stamp this field's label so the
+        // trail names the right sibling. See `objectSiblingNeedsAncestorCrumb`.
+        const needsAncestorCrumb =
+          collidesWithSibling ||
+          (consumedPrefix.length === 0 &&
+            objectSiblingNeedsAncestorCrumb(key, keys, properties));
         const fieldOnBreadcrumbChangeForKey =
-          collidesWithSibling && fieldOnBreadcrumbChange
+          needsAncestorCrumb && fieldOnBreadcrumbChange
             ? (next: Crumb[]) =>
                 fieldOnBreadcrumbChange(prependCrumbIfAbsent(label, next))
             : fieldOnBreadcrumbChange;
@@ -610,6 +620,10 @@ export function SchemaForm({
           breadcrumbPath: fieldBreadcrumbPath,
           onBreadcrumbChange: fieldOnBreadcrumbChangeForKey,
           hasSiblingDrillDownFields,
+          // When the trail narrows to a single field, the form is drilled into
+          // it — object fields then render flat (no wrapper header) so a deep
+          // drill shows just the leaf item's fields, not a stack of headers.
+          focused: activeKey === key,
           meta,
           decofile,
           onSaveReferencedBlock,

--- a/apps/web/src/components/sections-editor/schema-form.tsx
+++ b/apps/web/src/components/sections-editor/schema-form.tsx
@@ -31,7 +31,7 @@ import {
   type Crumb,
   fieldDisplayLabel,
   isArrayDrillDownField,
-  objectSiblingNeedsAncestorCrumb,
+  objectSiblingsNeedingAncestorCrumb,
   prependCrumbIfAbsent,
   resolveActiveFieldKey,
   siblingFieldLabel,
@@ -531,6 +531,14 @@ export function SchemaForm({
       return s != null && isArrayDrillDownField(s, objValue[key]);
     }).length > 1;
 
+  // Object siblings whose drill trails would collide (each holds a nested
+  // drill-down array). Computed once per scope, not per rendered field, so the
+  // schema walk doesn't run O(keys) times on every keystroke.
+  const siblingsNeedingAncestorCrumb = objectSiblingsNeedingAncestorCrumb(
+    keys,
+    properties,
+  );
+
   const activeKey =
     breadcrumbPath.length > 0
       ? resolveActiveFieldKey(
@@ -600,11 +608,11 @@ export function SchemaForm({
         // array (e.g. `shelfProps` / `shelfPropsOffer`, both with
         // `cardLayout.productTags`) don't collide by label, but a bare item trail
         // still resolves ambiguously across them. Stamp this field's label so the
-        // trail names the right sibling. See `objectSiblingNeedsAncestorCrumb`.
+        // trail names the right sibling. See `objectSiblingsNeedingAncestorCrumb`.
         const needsAncestorCrumb =
           collidesWithSibling ||
           (consumedPrefix.length === 0 &&
-            objectSiblingNeedsAncestorCrumb(key, keys, properties));
+            siblingsNeedingAncestorCrumb.has(key));
         const fieldOnBreadcrumbChangeForKey =
           needsAncestorCrumb && fieldOnBreadcrumbChange
             ? (next: Crumb[]) =>


### PR DESCRIPTION
## Summary

Fixes the section editor's array-item drill-down for nested, same-shaped sibling objects (surfaced on a `ProductShelfGroup` whose `shelfProps` / `shelfPropsOffer` each hold `cardLayout.productTags` with identically-labelled items). Reported in four rounds of feedback; each commit addresses one symptom:

1. **Mixed panel** — clicking an item showed *every* sibling field mixed together instead of just the item. The ambiguity resolver returned `null` (its documented "show both" fallback) because the item's crumb matched the nested array in both siblings.
2. **No ancestor disambiguator** — the crumb that would pin the right sibling was only stamped for siblings sharing a display *title*; these have distinct titles.
3. **Tower of headers** — even once narrowed, the item's fields sat under a stack of auto-expanded wrapper headers (`Props > ShelfProps > CardLayout > …`).
4. **Dead-end "array list" stop** — going back from an item landed on a bare array-list view that shouldn't exist as a navigation step.

## What changed (`apps/web/src/components/sections-editor/`)

- **Resolver** (`schema-form-breadcrumb.ts`): a *strong* match (head crumb naming an object sibling) now takes precedence over a *loose* full-trail match, so a disambiguating ancestor crumb pins one sibling even when a nested array-label crumb matches several.
- **Ancestor stamping** (`schema-form.tsx` + `objectSiblingNeedsAncestorCrumb`): stamp the ancestor label for distinct-titled sibling objects that each contain a nested drill-down array.
- **Focus flattening** (`object-field.tsx` + `focused` in `field-props.ts`): when the form is focused on a breadcrumb path, object fields render flat (no collapsible header/indentation) — a deep drill shows just the leaf item's fields.
- **Folded array label** (`schema-form-breadcrumb.ts` + `array-field.tsx`): a disambiguating array label rides on the item crumb (`arrayLabel`) instead of a standalone crumb, so back from an item lands on the array's parent form, never a bare array list.

## Testing

- `bun test` (sections-editor): **598 pass, 0 fail** — includes new tests for the distinct-titled + folded-array-label case, the strong/loose precedence, `objectSiblingNeedsAncestorCrumb`, and "never yields a standalone array-list navigation stop". The four tests that asserted the old separate-array-crumb behavior were inverted to the new folded model.
- `bun run check` (tsc): clean.
- `bun run fmt` / `bun run lint`: no new issues (pre-existing warnings only, unrelated files).

Behavior change is presentational (breadcrumb narrowing/flattening); logic is covered by the unit suite. Verify visually in the branch preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sections editor drill-down: clicking an array item now opens only that item’s fields, disambiguates same-shaped siblings, and removes the redundant “array list” stop. Also fixes an edge case where an item label equals its array label/key.

- **Bug Fixes**
  - Resolver now favors a strong match (head crumb naming the object sibling) and stamps ancestor labels for distinct-titled siblings with nested arrays, so the right sibling is pinned even when nested array labels collide.
  - Guarded breadcrumb consumption: never strip an item crumb, so drilling works when an item’s label equals the array’s label or key.
  - Object fields render flat when focused by the breadcrumb (no wrapper header/indent).
  - Folds the array label onto the item crumb as `arrayLabel` (no standalone array crumb), so “Back” returns to the array’s parent form. Preserves `arrayLabel` when an item’s display label changes, and updates the component test to assert the new single-crumb trail.

- **Refactors**
  - Compute `objectSiblingsNeedingAncestorCrumb` once per scope for better performance.
  - `ObjectField` now renders a single shared `SchemaForm`; nested-array detection delegates to `isArrayDrillDownField` for consistency.

<sup>Written for commit d3a9357b6066518acaf176a58ed80bce6c795363. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

