### PR TITLE
fix(org-fs): restore the integration suite the write guard broke

### DIFF
--- a/apps/api/src/api/routes/org-fs.integration.test.ts
+++ b/apps/api/src/api/routes/org-fs.integration.test.ts
@@ -33,6 +33,7 @@ import {
 } from "../../database/test-db-pg";
 import { ForbiddenError } from "../../core/access-control";
 import { OrgFsEntryStorage } from "../../storage/org-fs";
+import { OrgRepoSyncStorage } from "../../storage/org-repo-syncs";
 import { resolveOrgFromPath } from "../middleware/resolve-org-from-path";
 import { createOrgFsRoutes } from "./org-fs";
 
@@ -76,6 +77,12 @@ function buildApp(
         threads: { setOrganizationId: () => {} },
         asyncResearchJobs: { setOrganizationId: () => {} },
         orgFsEntries: new OrgFsEntryStorage(db.db),
+        // Real storage, not a stub: the write guard queries it, and a `as
+        // unknown as StudioContext` cast means a missing field is a runtime
+        // TypeError rather than a compile error. That is how #5866 turned every
+        // write route's 400/403/404 into a 500 here without CI noticing until
+        // it hit main.
+        orgRepoSyncs: new OrgRepoSyncStorage(db.db),
       },
       objectStorage: null,
       orgFs: null,

--- a/apps/api/src/api/routes/org-fs.ts
+++ b/apps/api/src/api/routes/org-fs.ts
@@ -410,6 +410,10 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
     // Repo-sync mirror volumes: the sync deletes anything not in the repo,
     // so direct writes are silent data loss. Server-side guard — the Library
     // read-only marking is UI-only. Delete the sync config to reclaim.
+    //
+    // Last of the guards on purpose: it is the only one that touches the
+    // database, so every cheap rejection above (unknown volume, public volume,
+    // denied permission) answers without a query.
     if (
       permission === "ORG_FS_WRITE" &&
       (await ctx.storage.orgRepoSyncs.isSyncVolume(ctx.organization.id, volume))

--- a/apps/api/src/file-storage/mount/webdav.integration.test.ts
+++ b/apps/api/src/file-storage/mount/webdav.integration.test.ts
@@ -31,6 +31,7 @@ import {
   resetTestPgDatabase,
 } from "../../database/test-db-pg";
 import { OrgFsEntryStorage } from "../../storage/org-fs";
+import { OrgRepoSyncStorage } from "../../storage/org-repo-syncs";
 import { OrgFsClient, createWebdavHandler } from "@decocms/sandbox/org-fs";
 
 const ORG = "org_wd";
@@ -58,6 +59,10 @@ function buildStudioApp(db: StudioDatabase) {
         threads: { setOrganizationId: () => {} },
         asyncResearchJobs: { setOrganizationId: () => {} },
         orgFsEntries: new OrgFsEntryStorage(db.db),
+        // Same reason as the org-fs route suite: the write guard queries this,
+        // and the `as unknown as StudioContext` cast below means a missing field
+        // is a runtime TypeError the compiler cannot see.
+        orgRepoSyncs: new OrgRepoSyncStorage(db.db),
       },
       objectStorage: null,
       orgFs: null,


### PR DESCRIPTION
`storage-integration` has been red on `main` since #5866, which blocks every PR through branch protection. Two files changed, 11 lines.

## Cause

#5866 added a repo-sync write guard:

```ts
if (permission === "ORG_FS_WRITE" &&
    (await ctx.storage.orgRepoSyncs.isSyncVolume(ctx.organization.id, volume)))
```

The route test builds its context with a partial storage stub and casts it:

```ts
storage: {
  threads: { setOrganizationId: () => {} },
  asyncResearchJobs: { setOrganizationId: () => {} },
  orgFsEntries: new OrgFsEntryStorage(db.db),
},
// ...
} as unknown as StudioContext);
```

`orgRepoSyncs` is `undefined` there, so the guard throws a `TypeError`, `app.ts`'s global `onError` collapses it to **500**, and every write route's `400`/`403`/`404` became a `500`. 9 of 12 tests in the file.

**The cast is what let this through.** On a fully-typed context a missing field would have been a compile error; `as unknown as` turned it into a runtime one that only CI could see.

The test that failed most usefully is the regression guard for exactly this class of bug, and its own comment says so:

> `app.ts`'s global onError turns every THROWN error (incl. HTTPException) into 500. The routes must return explicit responses so a 404/400 isn't collapsed. This app mounts that hostile handler.

## Fix

The stub uses the real `OrgRepoSyncStorage`, as it already does for `orgFsEntries`. The table exists (`168-org-repo-sync`) and CI runs migrations before the suite, so there is nothing to fake.

Also documents *why* the guard sits last among the checks — it is the only one that touches the database, so unknown-volume, public-volume and denied-permission all answer without a query. No behaviour change; it was already in that position. The comment is there so a future edit does not move it ahead of the cheap rejections.

## Verified against real Postgres, the way CI runs it

`postgres:16` in Docker with `bun run --cwd=apps/api migrate` applied:

| | result |
|---|---|
| `main` (before) | **3 pass / 9 fail** |
| this branch | **12 pass / 0 fail** |

The rest of `apps/api`'s integration suite passes on the same database. Confirmed from the CI log that `org-fs HTTP routes` was the **only** failing file in the run — every other file reported `0 fail` — so this is the whole of what is red.

## Worth a second look from #5866's author

`isSyncVolume` throwing was masked here by a stub, but the same call is on the real write path. If it can throw in production for any reason other than a missing stub, a legitimate org-fs `PUT` returns 500 rather than a useful status — the guard has no `try`, and `onError` collapses whatever it throws. I did not change that behaviour, because whether it *can* throw in production is a question for whoever wrote the sync layer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the org-fs and WebDAV integration suites by fixing test contexts for repo-sync guards. Uses real `OrgRepoSyncStorage` in tests so write/mount routes return correct statuses instead of 500; adds a small comment about guard order. No runtime behavior changes.

- **Bug Fixes**
  - Test contexts now provide `orgRepoSyncs` via real storage to prevent `TypeError` from `isSyncVolume` and `listEnabledVolumes`.
  - Verified with Postgres (+ MinIO for WebDAV): org-fs HTTP routes 12/12 pass; WebDAV 14/14 pass.

<sup>Written for commit 5e717708410f2be9a91fd978c6be478bf9f8dc7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

