### PR TITLE
fix(web): stop card description file drops leaking into the chat input

### DIFF
--- a/apps/web/src/components/markdown-editor/index.tsx
+++ b/apps/web/src/components/markdown-editor/index.tsx
@@ -132,21 +132,29 @@ export function MarkdownEditor({
       attributes: {
         class: cn(CONTENT_CLASS, PLACEHOLDER_CLASS),
       },
-      handlePaste: (view, event) =>
-        uploadInto(
-          view,
-          Array.from(event.clipboardData?.files ?? []),
-          view.state.selection.to,
-        ),
+      handlePaste: (view, event) => {
+        const files = Array.from(event.clipboardData?.files ?? []);
+        if (files.length === 0) return false;
+        // We own this file. Stop it bubbling to the chat composer's
+        // window-level drop/paste listener (input.tsx `useWindowFileDrop`),
+        // which would otherwise upload the same file into the chat input.
+        event.stopPropagation();
+        return uploadInto(view, files, view.state.selection.to);
+      },
       handleDrop: (view, event, _slice, moved) => {
         // A drag within the editor is a move, not an upload.
         if (moved) return false;
         const files = Array.from(event.dataTransfer?.files ?? []);
+        if (files.length === 0) return false;
         const at = view.posAtCoords({
           left: event.clientX,
           top: event.clientY,
         })?.pos;
         if (at === undefined) return false;
+        // We own this file. Stop it bubbling to the chat composer's
+        // window-level drop listener (input.tsx `useWindowFileDrop`), which
+        // would otherwise upload the same file into the chat input too.
+        event.stopPropagation();
         return uploadInto(view, files, at);
       },
     },


### PR DESCRIPTION
## Summary

Dropping (or pasting) an image into a card's **description** editor also uploaded the same file into the open **chat input**.

The chat composer registers **window-level** drop/paste listeners (`useWindowFileDrop`, `apps/web/src/components/chat/input.tsx`) so a file dropped anywhere on the screen lands in the chat. The `MarkdownEditor`'s ProseMirror `handleDrop`/`handlePaste` handled the file and called `preventDefault()` but **not** `stopPropagation()`, so the event kept bubbling to `window` and the chat listener grabbed the same file and uploaded it into the chat input too.

## Fix

`apps/web/src/components/markdown-editor/index.tsx` — the paste/drop handlers now call `event.stopPropagation()` once the editor takes ownership of the files, so the chat's global listener never sees the event. Propagation is only stopped when files are actually present, so plain-text paste is unaffected.

## Testing

- `bun run fmt` ✅
- `bun run --cwd=apps/web check` (tsc) ✅
- Manual: drop/paste an image into a task card description while a chat is open → image lands only in the card, not in the chat input.

## Note / follow-up

Not addressed here (separate from this bug): while dragging over the dialog, the chat's `dragenter`/`dragover` listeners still set `isDraggingOver`, so the "drop files here" overlay can light up behind the dialog. Cosmetic only — happy to scope those too if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where dropping or pasting an image into a card description also uploaded it into the chat input. The `MarkdownEditor` now calls `stopPropagation()` in `handlePaste`/`handleDrop` when files are present, preventing the chat’s window-level `useWindowFileDrop` listener from catching the same file.

<sup>Written for commit 83462fe22b974caf028405219dcc50a3ba16ce31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

