### PR TITLE
fix(sections-editor): stop variant tab/row remount on duplicate or delete

### DIFF
--- a/apps/web/src/components/sections-editor/page-variant-tabs.tsx
+++ b/apps/web/src/components/sections-editor/page-variant-tabs.tsx
@@ -339,11 +339,16 @@ export function PageVariantTabs({
     setPrevVariantCount(variants.length);
     setPrevDisplayKey(displayKey);
     setEntries(createEntries(variants));
-  } else if (prevVariantCount !== variants.length) {
+  } else if (
+    prevVariantCount !== variants.length ||
+    prevDisplayKey !== displayKey
+  ) {
+    // Duplicate/delete/reorder all land here (a count change always also
+    // changes the display key). Reuse each position's existing id rather than
+    // minting fresh ones for every row — otherwise duplicating or deleting one
+    // variant remounts every OTHER tab's DnD-sortable identity too, dropping
+    // e.g. an open row menu on an unrelated tab.
     setPrevVariantCount(variants.length);
-    setPrevDisplayKey(displayKey);
-    setEntries(createEntries(variants));
-  } else if (prevDisplayKey !== displayKey) {
     setPrevDisplayKey(displayKey);
     setEntries((current) =>
       variants.map((variant, index) => {

--- a/apps/web/src/components/sections-editor/section-variant-list.tsx
+++ b/apps/web/src/components/sections-editor/section-variant-list.tsx
@@ -279,11 +279,16 @@ export function SectionVariantList({
     setPrevVariantCount(variants.length);
     setPrevDisplayKey(displayKey);
     setEntries(createEntries(variants));
-  } else if (prevVariantCount !== variants.length) {
+  } else if (
+    prevVariantCount !== variants.length ||
+    prevDisplayKey !== displayKey
+  ) {
+    // Duplicate/delete/reorder all land here (a count change always also
+    // changes the display key). Reuse each position's existing id rather than
+    // minting fresh ones for every row — otherwise duplicating or deleting one
+    // variant remounts every OTHER row's DnD-sortable identity too, dropping
+    // e.g. an open row menu on an unrelated row.
     setPrevVariantCount(variants.length);
-    setPrevDisplayKey(displayKey);
-    setEntries(createEntries(variants));
-  } else if (prevDisplayKey !== displayKey) {
     setPrevDisplayKey(displayKey);
     setEntries((current) =>
       variants.map((variant, index) => {


### PR DESCRIPTION
**Source**: bug found while auditing the sections-editor drilldown/variant components for state-drift after the recent breadcrumb-hardening streak (#5861, #5862, #5885).

**The bug**: `PageVariantTabs` and `SectionVariantList` each track a local `entries` list (stable DnD-sortable ids, since `variants[i]` itself has no id). Three branches update it: list-key change (full reset, correct), a plain reorder/rename (`prevDisplayKey !== displayKey`, which correctly *reuses* each position's existing id), and a variant-count change (duplicate/delete), which called `createEntries(variants)` — minting a **brand-new id for every row**, not just the one that moved. Since `key={entry.id}` drives both React's reconciliation and dnd-kit's sortable identity, duplicating or deleting one page/section variant remounted every *other* tab/row too — dropping any open row-actions dropdown, and defeating dnd-kit's layout-animation on unrelated rows. `apps/web/src/components/sections-editor/fields/array-entries.ts` already solves the identical problem correctly for array-item rows (position-preserving `insertEntryAfter`/`removeEntryAt`); these two components just never got the same treatment.

**The fix**: merge the count-changed branch into the display-key-changed branch — both now do the same position-based id reuse (`current[index]?.id ?? crypto.randomUUID()`), so only rows whose position actually shifted lose their id (unavoidable without threading the mutated index down, and no worse than before), while everything before/after the change keeps its identity. Also removes one duplicated `createEntries` call in each file.

**How to verify**: open the sections editor, open a page with 2+ variants, expand a variant row's `⋯` menu on one tab, then click Duplicate/Delete on a *different* tab — before the fix every tab's dropdown/hover state resets; after, only the tabs whose position actually changed do. `apps/web/ct/tests/page-variant-tabs.ct.tsx` / `section-variant-list.ct.tsx` cover this component's DnD identity but need a real browser (Playwright CT) to run, so I didn't add a new one — verified locally by tracing the branch logic against `array-entries.ts`'s existing pattern.

**Checks run locally**: `bun run fmt` (clean), `bunx tsc --noEmit` in `apps/web` (clean), `bunx oxlint` on both changed files (0 warnings/errors). No `bun test` target — this is pure state-management logic with no existing unit-test file; full CI (including the CT suite) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops remounting of variant tabs/rows when duplicating or deleting in the sections editor. Reuses position-based ids so DnD identity, open menus, and animations are preserved.

- **Bug Fixes**
  - Merged count-change and display-key-change paths to reuse `current[index]?.id ?? crypto.randomUUID()` per position.
  - Removed duplicate `createEntries` calls; only shifted items get new ids.
  - Duplicating/deleting a variant no longer resets other tabs/rows or their dropdowns.

<sup>Written for commit 983bb49ac4672577d039d9e3921ae29030323196. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

