### PR TITLE
fix(connections): stop COLLECTION_CONNECTIONS_UPDATE from writing immutable fields

### DIFF
--- a/apps/api/src/tools/connection/update.test.ts
+++ b/apps/api/src/tools/connection/update.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { stripImmutableUpdateFields } from "./update";
+
+describe("stripImmutableUpdateFields", () => {
+  test("drops organization_id so a connection can't be reassigned to another org", () => {
+    const sanitized = stripImmutableUpdateFields({
+      title: "New title",
+      organization_id: "org_attacker",
+    });
+
+    expect(sanitized).toEqual({ title: "New title" });
+  });
+
+  test("drops id, created_by, and created_at alongside organization_id", () => {
+    const sanitized = stripImmutableUpdateFields({
+      id: "conn_forged",
+      organization_id: "org_attacker",
+      created_by: "user_forged",
+      created_at: "1970-01-01T00:00:00.000Z",
+      title: "Still allowed",
+    });
+
+    expect(sanitized).toEqual({ title: "Still allowed" });
+  });
+
+  test("leaves mutable fields untouched", () => {
+    const sanitized = stripImmutableUpdateFields({
+      title: "New title",
+      description: "New description",
+    });
+
+    expect(sanitized).toEqual({
+      title: "New title",
+      description: "New description",
+    });
+  });
+});

--- a/apps/api/src/tools/connection/update.ts
+++ b/apps/api/src/tools/connection/update.ts
@@ -28,9 +28,35 @@ import {
   buildVirtualUrl,
   type ConnectionEntity,
   ConnectionEntitySchema,
+  type ConnectionUpdateData,
   ConnectionUpdateDataSchema,
   parseVirtualUrl,
 } from "./schema";
+
+/**
+ * Fields that are system-managed and must never be settable through
+ * COLLECTION_CONNECTIONS_UPDATE. ConnectionUpdateDataSchema is
+ * ConnectionEntitySchema.partial(), so without this a caller with ordinary
+ * connection-update permission could reassign a connection to a different
+ * organization (organization_id), forge its creator (created_by), backdate
+ * it (created_at), or rewrite its primary key (id).
+ */
+const IMMUTABLE_UPDATE_FIELDS = [
+  "id",
+  "organization_id",
+  "created_by",
+  "created_at",
+] as const;
+
+export function stripImmutableUpdateFields(
+  data: ConnectionUpdateData,
+): ConnectionUpdateData {
+  const sanitized = { ...data };
+  for (const field of IMMUTABLE_UPDATE_FIELDS) {
+    delete sanitized[field];
+  }
+  return sanitized;
+}
 
 /**
  * Input schema for updating connections
@@ -85,7 +111,8 @@ export const COLLECTION_CONNECTIONS_UPDATE = defineTool({
       throw new Error("User ID required to update connection");
     }
 
-    const { id, data } = input;
+    const { id } = input;
+    const data = stripImmutableUpdateFields(input.data);
     const configChanged =
       data.configuration_state !== undefined ||
       data.configuration_scopes !== undefined;


### PR DESCRIPTION
While hunting the MCP connection ownership area (#5661), found a real cross-org data-integrity/exfiltration bug in the existing update path.

**Bug**: `ConnectionUpdateDataSchema` is `ConnectionEntitySchema.partial()` (packages/shared/src/sdk/types/connection.ts), so it accepts `organization_id`, `id`, `created_by`, and `created_at` as optional input fields. `apps/api/src/tools/connection/update.ts` spread the whole `data` object into the storage update payload verbatim (`{ ...data, ... }`), and `apps/api/src/storage/connection.ts`'s `serializeConnection()` forwards every present key straight into the SQL `SET` clause with no allowlist. Result: any caller with ordinary connection-update permission on their own org's connection could pass `organization_id: "<some-other-org>"` in the update body and move that connection (including its encrypted credentials/tokens) to a different organization, or forge `created_by`, rewrite the row's `id`, or backdate `created_at`.

**Fix**: strip those four system-managed fields (`id`, `organization_id`, `created_by`, `created_at`) from the update payload before merging, via a small pure `stripImmutableUpdateFields()` helper (exported from update.ts for testability). `updated_at`/`status` were already safely recomputed elsewhere in the storage layer, so this only needed to cover the four unguarded fields.

**Verify**: `bun test apps/api/src/tools/connection/update.test.ts` — asserts `organization_id`/`id`/`created_by`/`created_at` are dropped while ordinary fields like `title`/`description` pass through untouched.

**Checks run locally**: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint apps/api/src/tools/connection/update.ts apps/api/src/tools/connection/update.test.ts` (0 warnings/errors), and the targeted test above (3 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `COLLECTION_CONNECTIONS_UPDATE` from persisting immutable fields to prevent cross-org reassignment and forged metadata. Blocks updates to `id`, `organization_id`, `created_by`, and `created_at`.

- **Bug Fixes**
  - Added `stripImmutableUpdateFields()` to remove those fields before applying updates.
  - Added tests verifying the fields are dropped and mutable fields (e.g., `title`, `description`) pass through.

<sup>Written for commit a1812ecdb7a939a09ef4b034ed476af746d8befe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

