### PR TITLE
fix(sandbox): stop leaking JSON.parse errors as the daemon error message

### DIFF
--- a/apps/api/src/api/routes/sandbox-proxy.test.ts
+++ b/apps/api/src/api/routes/sandbox-proxy.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "bun:test";
 import { delay } from "@decocms/shared/std";
+import type { SandboxProvider } from "@decocms/sandbox/provider";
 import {
   readBoundedText,
   UpstreamPayloadTooLargeError,
 } from "../../lib/bounded-text";
-import { redactRepoDir, withClaimGitLock } from "./sandbox-proxy";
+import {
+  fetchDaemonJson,
+  redactRepoDir,
+  withClaimGitLock,
+} from "./sandbox-proxy";
 
 describe("redactRepoDir", () => {
   it("nulls a container-internal repoDir while preserving other fields", () => {
@@ -90,5 +95,45 @@ describe("withClaimGitLock", () => {
 
     const after = await withClaimGitLock("claim-err", async () => "ok");
     expect(after).toBe("ok");
+  });
+});
+
+function fakeRunner(response: Response): SandboxProvider {
+  return {
+    kind: "agent-sandbox",
+    ensure: async () => {
+      throw new Error("unused");
+    },
+    delete: async () => {},
+    alive: async () => true,
+    getPreviewUrl: async () => null,
+    proxyDaemonRequest: async () => response,
+  } as unknown as SandboxProvider;
+}
+
+describe("fetchDaemonJson", () => {
+  it("surfaces the daemon's own error message on a JSON error body", async () => {
+    const runner = fakeRunner(
+      new Response(JSON.stringify({ error: "disk full" }), { status: 500 }),
+    );
+    await expect(
+      fetchDaemonJson(runner, "claim-a", "/_sandbox/git/status"),
+    ).rejects.toThrow("disk full");
+  });
+
+  it("falls back to a generic message on a non-JSON error body", async () => {
+    const runner = fakeRunner(
+      new Response("<html>502 Bad Gateway</html>", { status: 502 }),
+    );
+    await expect(
+      fetchDaemonJson(runner, "claim-a", "/_sandbox/git/status"),
+    ).rejects.toThrow("Daemon error (502)");
+  });
+
+  it("throws SANDBOX_GONE on a 404 with no adoptLiveClaim to retry", async () => {
+    const runner = fakeRunner(new Response("not found", { status: 404 }));
+    await expect(
+      fetchDaemonJson(runner, "claim-a", "/_sandbox/git/status"),
+    ).rejects.toThrow("SANDBOX_GONE");
   });
 });

--- a/apps/api/src/api/routes/sandbox-proxy.ts
+++ b/apps/api/src/api/routes/sandbox-proxy.ts
@@ -435,7 +435,7 @@ export function redactRepoDir(text: string): string {
   return text;
 }
 
-async function fetchDaemonJson<T>(
+export async function fetchDaemonJson<T>(
   runner: SandboxProvider,
   claimName: string,
   daemonPath: string,
@@ -475,15 +475,14 @@ async function fetchDaemonJson<T>(
 
   const text = await upstream.text();
   if (!upstream.ok) {
+    let message = `Daemon error (${upstream.status})`;
     try {
       const err = JSON.parse(text) as { error?: string };
-      throw new Error(err.error ?? `Daemon error (${upstream.status})`);
-    } catch (parseErr) {
-      if (parseErr instanceof Error && parseErr.message !== text) {
-        throw parseErr;
-      }
-      throw new Error(`Daemon error (${upstream.status})`);
+      message = err.error ?? message;
+    } catch {
+      /* non-JSON error body — keep the generic message */
     }
+    throw new Error(message);
   }
 
   return JSON.parse(text) as T;


### PR DESCRIPTION
Bug found while auditing sandbox pod resilience (issue #5815 area) — not a fix for #5815 itself, but a real bug in the daemon-proxy error path in the same file.

`fetchDaemonJson` (used by the git `suggest-commit` and `judge-review` routes to fetch `/_sandbox/git/status` and `/_sandbox/git/diff` from the sandbox daemon) built its error message like this:

```ts
try {
  const err = JSON.parse(text) as { error?: string };
  throw new Error(err.error ?? `Daemon error (${upstream.status})`);
} catch (parseErr) {
  if (parseErr instanceof Error && parseErr.message !== text) {
    throw parseErr;
  }
  throw new Error(`Daemon error (${upstream.status})`);
}
```

The intent was: parse a JSON error body and use its `.error` field, or fall back to a generic `Daemon error (status)` message. But the deliberate `throw` inside the `try` is caught by the *same* `catch`, so it can't tell "JSON.parse itself failed" apart from "we parsed fine and threw our own message" — it uses `parseErr.message !== text` as a proxy, which happens to work for the two JSON cases but not for a non-JSON error body: when the daemon (or an intermediate proxy) returns a plain-text or HTML error page, `JSON.parse` throws a `SyntaxError` like `Unexpected token '<', "<html>502..." is not valid JSON`, that message obviously differs from `text`, so the condition is true and the *SyntaxError* gets rethrown instead of the intended generic fallback. That cryptic message is then returned verbatim to the frontend as `{ error: message }` with a 502, in both call sites (git/suggest-commit and git/judge-review).

**Failure scenario:** the sandbox daemon or an ingress in front of it returns a non-JSON error body (e.g. a 502/504 HTML page, or a plain-text 500) for `/_sandbox/git/status` or `/_sandbox/git/diff`. Instead of "Daemon error (502)", the user sees something like `Unexpected token '<', "<html>502..." is not valid JSON`.

**Fix:** replaced the conflated try/catch with a straight try/catch around only the `JSON.parse` call, falling back to the generic `Daemon error (status)` message on any parse failure — removes the ambiguous heuristic entirely (net simpler: -8/+4 in the function body).

Added `apps/api/src/api/routes/sandbox-proxy.test.ts` cases (exported `fetchDaemonJson` for direct testing, with a minimal fake `SandboxProvider`): JSON error body surfaces its own `.error`, non-JSON error body falls back to the generic message, and a 404 still throws `SANDBOX_GONE` as before.

**To verify:** `bun test apps/api/src/api/routes/sandbox-proxy.test.ts`

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), `bunx oxlint` on both changed files (0 warnings/errors), targeted test file above (13 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sandbox daemon error handling so users no longer see raw JSON.parse errors. Routes that call `fetchDaemonJson` now show the daemon’s JSON `error` message when present, or a generic "Daemon error (status)" for non-JSON bodies.

- **Bug Fixes**
  - Reworked `fetchDaemonJson` to only try/catch the `JSON.parse` call and fall back to "Daemon error (status)" on parse failures; preserves daemon-provided `error` when present.
  - Exported `fetchDaemonJson` and added tests for JSON error bodies, non-JSON bodies, and 404 returning `SANDBOX_GONE`.

<sup>Written for commit e46b236e26d3e51835caa51e5465bb691088f682. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

