### PR TITLE
feat(sandbox): cover image alt text input in the post editor

### DIFF
--- a/apps/web/src/components/sandbox/content/blog/blog-data.ts
+++ b/apps/web/src/components/sandbox/content/blog/blog-data.ts
@@ -499,6 +499,7 @@ export function emptyBlogPayload(kind: BlogKind): Record<string, unknown> {
         slug: `untitled-${randomHex(8)}`,
         date: new Date().toISOString().slice(0, 10),
         image: "",
+        alt: "",
         authors: [],
         categories: [],
         sections: [],

--- a/apps/web/src/components/sandbox/content/blog/post-editor.tsx
+++ b/apps/web/src/components/sandbox/content/blog/post-editor.tsx
@@ -261,17 +261,32 @@ function PostSettings({
           label={t("sandbox.postEditor.dateLabel")}
         />
       </div>
-      <ImageField
-        schema={{
-          type: "string",
-          format: "image-uri",
-          title: t("sandbox.postEditor.coverImageLabel"),
-        }}
-        value={post.image}
-        onChange={(v) => onChange("image", v)}
-        path="post-image"
-        label={t("sandbox.postEditor.coverImageLabel")}
-      />
+      {/* Cover image + its alt text: `alt` is the blog app's alt for `image`,
+          and the front falls back to the title when it is empty. */}
+      <div className="space-y-2">
+        <ImageField
+          schema={{
+            type: "string",
+            format: "image-uri",
+            title: t("sandbox.postEditor.coverImageLabel"),
+          }}
+          value={post.image}
+          onChange={(v) => onChange("image", v)}
+          path="post-image"
+          label={t("sandbox.postEditor.coverImageLabel")}
+        />
+        <StringField
+          schema={{
+            type: "string",
+            title: t("sandbox.postEditor.coverAltLabel"),
+            description: t("sandbox.postEditor.coverAltDescription"),
+          }}
+          value={str(post.alt)}
+          onChange={(v) => onChange("alt", v)}
+          path="post-alt"
+          label={t("sandbox.postEditor.coverAltLabel")}
+        />
+      </div>
       {/* Authors denormalize their FULL record onto the post — the blog app
           renders the author box (type, job title, company, avatar) from it. */}
       <RelationSelect

--- a/apps/web/src/i18n/en/sandbox.ts
+++ b/apps/web/src/i18n/en/sandbox.ts
@@ -317,6 +317,9 @@ export const sandbox = {
   "sandbox.postEditor.authorsLabel": "Authors",
   "sandbox.postEditor.categoriesLabel": "Categories",
   "sandbox.postEditor.contentTab": "Content",
+  "sandbox.postEditor.coverAltDescription":
+    "Describes the image for screen readers and when it fails to load. Empty: the post title is used.",
+  "sandbox.postEditor.coverAltLabel": "Cover image alt text",
   "sandbox.postEditor.coverImageLabel": "Cover image",
   "sandbox.postEditor.dateLabel": "Date",
   "sandbox.postEditor.excerptLabel": "Excerpt",

--- a/apps/web/src/i18n/pt-br/sandbox.ts
+++ b/apps/web/src/i18n/pt-br/sandbox.ts
@@ -327,6 +327,9 @@ export const sandbox = {
   "sandbox.postEditor.authorsLabel": "Autores",
   "sandbox.postEditor.categoriesLabel": "Categorias",
   "sandbox.postEditor.contentTab": "Conteúdo",
+  "sandbox.postEditor.coverAltDescription":
+    "Descreve a imagem para leitores de tela e para quando ela não carrega. Vazio: o título do post é usado.",
+  "sandbox.postEditor.coverAltLabel": "Texto alternativo da capa",
   "sandbox.postEditor.coverImageLabel": "Imagem de capa",
   "sandbox.postEditor.dateLabel": "Data",
   "sandbox.postEditor.excerptLabel": "Resumo",


### PR DESCRIPTION
## What

Adds an alt-text input for the blog post cover image, nested under the existing `ImageField` (both write to the same cover: `image` + `alt`).

- `post-editor.tsx` — `StringField` grouped with the cover `ImageField`
- `blog-data.ts` — `alt: ""` in `emptyBlogPayload("posts")`
- `i18n/{en,pt-br}/sandbox.ts` — `coverAltLabel` + `coverAltDescription`

## Why

`BlogPost.alt` already exists in `apps/blog/types.ts` (`@title Alt text for the image`) and every consumer already renders `post.alt ?? post.title` — the editor was the only missing piece, so the field was unreachable in practice. No new field was invented for this.

Kept optional: the front falls back to the post title, so `missingPostFields` is unchanged.

## Test

`bun test .../blog/blog-data.test.ts` → 50 pass. `tsc --noEmit` not run: deps aren't installed in this checkout (`Cannot find type definition file for 'vite/client'`), pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an alt-text input for the blog post cover image in the post editor to improve accessibility and let authors set `post.alt`. New posts start with `alt: ""`, and the field is grouped under the cover image picker.

- **New Features**
  - Stores value in `post.alt`; frontend already falls back to `post.title` when empty (no validation changes).
  - Seeds `alt: ""` in `emptyBlogPayload("posts")`.
  - Adds i18n keys `sandbox.postEditor.coverAltLabel` and `sandbox.postEditor.coverAltDescription` in `en` and `pt-br`.

<sup>Written for commit 5be5a42c89aa6d5e240c85f70a761d3b71c4b913. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

