### PR TITLE
fix(web): stop library file drops leaking into the chat input

### DIFF
--- a/apps/web/src/layouts/library/index.tsx
+++ b/apps/web/src/layouts/library/index.tsx
@@ -236,6 +236,10 @@ export function LibraryPage({
   function handleDrop(e: React.DragEvent) {
     if (!canDrop) return;
     e.preventDefault();
+    // We own this file. Stop it bubbling to the chat composer's
+    // window-level drop listener (input.tsx `useWindowFileDrop`), which
+    // would otherwise upload the same file into the chat input too.
+    e.stopPropagation();
     dragDepth.current = 0;
     setIsDragging(false);
     if (e.dataTransfer.files.length > 0) {


### PR DESCRIPTION
Follows #5887 (which fixed the same leak class in the markdown editor).

`agent-shell-layout` renders the chat composer alongside `MainPanelWithDrawer`, which includes the Library tab (`layouts/library/index.tsx`). The chat composer's `useWindowFileDrop` (input.tsx) attaches a window-level `drop` listener that uploads any dropped file into the chat input, unless something downstream stops propagation first.

The Library tab's own `onDrop` handler (drag-and-drop upload into the browsed folder) called `e.preventDefault()` but never `e.stopPropagation()`, so a file dropped onto the Library view bubbled past its own handler up to `window`, and the chat composer's listener uploaded the same file into the chat input too — a duplicate, unintended attachment landing in an unrelated part of the UI.

Fix: call `e.stopPropagation()` in the Library drop handler, same pattern used in #5887's markdown-editor fix.

**To verify:** open a thread with the Library tab active in the main panel, drag a file onto the Library view and drop it — it should upload only into the Library folder, not also appear as an attachment in the chat input below.

Local checks run: `bun run fmt`, `bunx tsc --noEmit` (apps/web), `bunx oxlint apps/web/src/layouts/library/index.tsx` (0 warnings/errors). No existing test covers this event-wiring path; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop file drops on the Library view from also attaching to the chat input and creating duplicates. The Library `onDrop` now calls `e.stopPropagation()` after `e.preventDefault()`, so the chat composer's window-level `useWindowFileDrop` listener doesn't upload the same file.

<sup>Written for commit 5d221b1a64fddc9924e668725bfa57595f07c86e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

