### PR TITLE
fix(decopilot): bound the portable scrape/inspect browserless fetches with a timeout

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/browserless-fetch.test.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/browserless-fetch.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { browserlessFetchErrorMessage } from "./browserless-fetch";
+import { BROWSERLESS_FETCH_TIMEOUT_MS } from "./constants";
+
+describe("browserlessFetchErrorMessage", () => {
+  it("names the timeout when the bounding signal fired", () => {
+    const err = new Error("The operation was aborted");
+    err.name = "TimeoutError";
+
+    expect(browserlessFetchErrorMessage("Browserless content fetch", err)).toBe(
+      `Browserless content fetch timed out after ${BROWSERLESS_FETCH_TIMEOUT_MS}ms`,
+    );
+  });
+
+  it("reports other transport failures with their message", () => {
+    expect(
+      browserlessFetchErrorMessage(
+        "Browserless function call",
+        new Error("ECONNREFUSED"),
+      ),
+    ).toBe("Browserless function call failed: ECONNREFUSED");
+  });
+
+  it("stringifies non-Error rejections", () => {
+    expect(
+      browserlessFetchErrorMessage("Browserless content fetch", "nope"),
+    ).toBe("Browserless content fetch failed: nope");
+  });
+});

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/browserless-fetch.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/browserless-fetch.ts
@@ -1,0 +1,40 @@
+import { BROWSERLESS_FETCH_TIMEOUT_MS } from "./constants";
+
+export type BrowserlessFetchResult =
+  | { ok: true; response: Response }
+  | { ok: false; error: string };
+
+/**
+ * Human-readable reason for a Browserless call that never produced a response.
+ * `label` names the call ("Browserless content fetch", "Browserless function
+ * call") so the message reads the same at every call site.
+ */
+export function browserlessFetchErrorMessage(
+  label: string,
+  err: unknown,
+): string {
+  if (err instanceof Error && err.name === "TimeoutError") {
+    return `${label} timed out after ${BROWSERLESS_FETCH_TIMEOUT_MS}ms`;
+  }
+  return `${label} failed: ${err instanceof Error ? err.message : String(err)}`;
+}
+
+/**
+ * `fetch` bounded by BROWSERLESS_FETCH_TIMEOUT_MS. Transport failures come back
+ * as a value instead of a throw so tool handlers can return a graceful result.
+ */
+export async function browserlessFetch(
+  label: string,
+  url: string,
+  init: Omit<RequestInit, "signal">,
+): Promise<BrowserlessFetchResult> {
+  try {
+    const response = await fetch(url, {
+      ...init,
+      signal: AbortSignal.timeout(BROWSERLESS_FETCH_TIMEOUT_MS),
+    });
+    return { ok: true, response };
+  } catch (err) {
+    return { ok: false, error: browserlessFetchErrorMessage(label, err) };
+  }
+}

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/constants.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/constants.ts
@@ -2,3 +2,9 @@ export const BROWSERLESS_BASE_URL = "https://chrome.browserless.io";
 
 /** Results above this threshold are offloaded to blob storage. */
 export const LARGE_RESULT_TOKEN_THRESHOLD = 32_000;
+
+// Browserless calls have no bound beyond the inner page.goto timeout (30s) —
+// if Browserless is unresponsive the outer fetch can hang the harness run
+// forever. Give it headroom over the inner timeout instead of leaving it
+// unbounded.
+export const BROWSERLESS_FETCH_TIMEOUT_MS = 45_000;

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.ts
@@ -18,12 +18,10 @@ import { z } from "zod";
 import type { ObjectStorageHooks } from "../../harness-deps";
 import { createOutputPreview, estimateJsonTokens } from "./read-tool-output";
 import { toStudioStorageUri } from "../studio-storage-uri";
-import { LARGE_RESULT_TOKEN_THRESHOLD } from "./constants";
-
-// Browserless call itself has no bound beyond the inner page.goto timeout (30s) —
-// if Browserless is unresponsive the outer fetch can hang the harness run forever.
-// Give it headroom over the inner timeout instead of leaving it unbounded.
-const BROWSERLESS_FETCH_TIMEOUT_MS = 45_000;
+import {
+  BROWSERLESS_FETCH_TIMEOUT_MS,
+  LARGE_RESULT_TOKEN_THRESHOLD,
+} from "./constants";
 
 // Upstream error bodies are unbounded — cap what lands in the tool error.
 const ERROR_BODY_MAX_CHARS = 500;

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.ts
@@ -18,10 +18,8 @@ import { z } from "zod";
 import type { ObjectStorageHooks } from "../../harness-deps";
 import { createOutputPreview, estimateJsonTokens } from "./read-tool-output";
 import { toStudioStorageUri } from "../studio-storage-uri";
-import {
-  BROWSERLESS_FETCH_TIMEOUT_MS,
-  LARGE_RESULT_TOKEN_THRESHOLD,
-} from "./constants";
+import { LARGE_RESULT_TOKEN_THRESHOLD } from "./constants";
+import { browserlessFetch } from "./browserless-fetch";
 
 // Upstream error bodies are unbounded — cap what lands in the tool error.
 const ERROR_BODY_MAX_CHARS = 500;
@@ -129,29 +127,21 @@ export function createInspectPageTool(
           waitUntil: input.waitUntil,
         });
 
-        let response: Response;
-        try {
-          response = await fetch(
-            `${browserless.baseUrl}/function?token=${encodeURIComponent(
-              browserless.token,
-            )}`,
-            {
-              method: "POST",
-              headers: { "Content-Type": "application/javascript" },
-              body: code,
-              signal: AbortSignal.timeout(BROWSERLESS_FETCH_TIMEOUT_MS),
-            },
-          );
-        } catch (err) {
-          const isTimeout = err instanceof Error && err.name === "TimeoutError";
-          return {
-            success: false,
-            error: isTimeout
-              ? `Browserless function call timed out after ${BROWSERLESS_FETCH_TIMEOUT_MS}ms`
-              : `Browserless function call failed: ${err instanceof Error ? err.message : String(err)}`,
-            url: input.url,
-          };
+        const fetched = await browserlessFetch(
+          "Browserless function call",
+          `${browserless.baseUrl}/function?token=${encodeURIComponent(
+            browserless.token,
+          )}`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/javascript" },
+            body: code,
+          },
+        );
+        if (!fetched.ok) {
+          return { success: false, error: fetched.error, url: input.url };
         }
+        const response = fetched.response;
 
         if (!response.ok) {
           const errorText = await response.text().catch(() => "Unknown error");

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-built-ins.test.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-built-ins.test.ts
@@ -136,4 +136,47 @@ describe("buildPortableBuiltInTools", () => {
       }
     }
   });
+
+  it("returns a graceful error instead of throwing when the browserless fetch aborts", async () => {
+    const originalBrowserlessToken = process.env.BROWSERLESS_TOKEN;
+    const originalFetch = globalThis.fetch;
+    process.env.BROWSERLESS_TOKEN = "browserless-test-token";
+
+    globalThis.fetch = (async () => {
+      const err = new Error("The operation was aborted");
+      err.name = "TimeoutError";
+      throw err;
+    }) as unknown as typeof fetch;
+
+    try {
+      const tools = buildPortableBuiltInTools({
+        writer,
+        toolOutputMap: new Map(),
+        passthroughClient,
+        toolApprovalLevel: "auto",
+        isPlanMode: false,
+      });
+
+      const scrape = tools.scrape_url as unknown as {
+        execute: (
+          input: { url: string },
+          options: { toolCallId: string },
+        ) => Promise<unknown>;
+      };
+      const result = (await scrape.execute(
+        { url: "https://example.com" },
+        { toolCallId: "tool-1" },
+      )) as { success: boolean; error?: string };
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("timed out");
+    } finally {
+      globalThis.fetch = originalFetch;
+      if (originalBrowserlessToken === undefined) {
+        delete process.env.BROWSERLESS_TOKEN;
+      } else {
+        process.env.BROWSERLESS_TOKEN = originalBrowserlessToken;
+      }
+    }
+  });
 });

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-built-ins.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-built-ins.ts
@@ -10,10 +10,8 @@ import {
   MAX_RESULT_TOKENS,
 } from "./read-tool-output";
 import { type VirtualClient } from "./sandbox";
-import {
-  BROWSERLESS_BASE_URL,
-  BROWSERLESS_FETCH_TIMEOUT_MS,
-} from "./constants";
+import { BROWSERLESS_BASE_URL } from "./constants";
+import { browserlessFetch } from "./browserless-fetch";
 import type { ToolApprovalLevel } from "../mcp-tools";
 import { toStudioStorageUri } from "../studio-storage-uri";
 import {
@@ -95,28 +93,19 @@ function createPortableBrowserlessTool(
         }
 
         if (kind === "scrape") {
-          let response: Response;
-          try {
-            response = await fetch(
-              `${BROWSERLESS_BASE_URL}/content?token=${encodeURIComponent(token)}`,
-              {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ url: input.url }),
-                signal: AbortSignal.timeout(BROWSERLESS_FETCH_TIMEOUT_MS),
-              },
-            );
-          } catch (err) {
-            const isTimeout =
-              err instanceof Error && err.name === "TimeoutError";
-            return {
-              success: false,
-              error: isTimeout
-                ? `Browserless content fetch timed out after ${BROWSERLESS_FETCH_TIMEOUT_MS}ms`
-                : `Browserless content fetch failed: ${err instanceof Error ? err.message : String(err)}`,
-              url: input.url,
-            };
+          const fetched = await browserlessFetch(
+            "Browserless content fetch",
+            `${BROWSERLESS_BASE_URL}/content?token=${encodeURIComponent(token)}`,
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ url: input.url }),
+            },
+          );
+          if (!fetched.ok) {
+            return { success: false, error: fetched.error, url: input.url };
           }
+          const response = fetched.response;
           if (!response.ok) {
             const errorText = await response
               .text()
@@ -176,27 +165,23 @@ function createPortableBrowserlessTool(
             return { consoleLogs, errors, evaluateResult };
           }
         `;
-        let response: Response;
-        try {
-          response = await fetch(
-            `${BROWSERLESS_BASE_URL}/function?token=${encodeURIComponent(token)}`,
-            {
-              method: "POST",
-              headers: { "Content-Type": "application/javascript" },
-              body: code,
-              signal: AbortSignal.timeout(BROWSERLESS_FETCH_TIMEOUT_MS),
-            },
-          );
-        } catch (err) {
-          const isTimeout = err instanceof Error && err.name === "TimeoutError";
+        const fetched = await browserlessFetch(
+          "Browserless function call",
+          `${BROWSERLESS_BASE_URL}/function?token=${encodeURIComponent(token)}`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/javascript" },
+            body: code,
+          },
+        );
+        if (!fetched.ok) {
           return {
             success: false,
-            error: isTimeout
-              ? `Browserless function call timed out after ${BROWSERLESS_FETCH_TIMEOUT_MS}ms`
-              : `Browserless function call failed: ${err instanceof Error ? err.message : String(err)}`,
+            error: fetched.error,
             url: inspectInput.url,
           };
         }
+        const response = fetched.response;
         if (!response.ok) {
           const errorText = await response.text().catch(() => "Unknown error");
           return {

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-built-ins.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-built-ins.ts
@@ -10,7 +10,10 @@ import {
   MAX_RESULT_TOKENS,
 } from "./read-tool-output";
 import { type VirtualClient } from "./sandbox";
-import { BROWSERLESS_BASE_URL } from "./constants";
+import {
+  BROWSERLESS_BASE_URL,
+  BROWSERLESS_FETCH_TIMEOUT_MS,
+} from "./constants";
 import type { ToolApprovalLevel } from "../mcp-tools";
 import { toStudioStorageUri } from "../studio-storage-uri";
 import {
@@ -92,14 +95,28 @@ function createPortableBrowserlessTool(
         }
 
         if (kind === "scrape") {
-          const response = await fetch(
-            `${BROWSERLESS_BASE_URL}/content?token=${encodeURIComponent(token)}`,
-            {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ url: input.url }),
-            },
-          );
+          let response: Response;
+          try {
+            response = await fetch(
+              `${BROWSERLESS_BASE_URL}/content?token=${encodeURIComponent(token)}`,
+              {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ url: input.url }),
+                signal: AbortSignal.timeout(BROWSERLESS_FETCH_TIMEOUT_MS),
+              },
+            );
+          } catch (err) {
+            const isTimeout =
+              err instanceof Error && err.name === "TimeoutError";
+            return {
+              success: false,
+              error: isTimeout
+                ? `Browserless content fetch timed out after ${BROWSERLESS_FETCH_TIMEOUT_MS}ms`
+                : `Browserless content fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+              url: input.url,
+            };
+          }
           if (!response.ok) {
             const errorText = await response
               .text()
@@ -159,14 +176,27 @@ function createPortableBrowserlessTool(
             return { consoleLogs, errors, evaluateResult };
           }
         `;
-        const response = await fetch(
-          `${BROWSERLESS_BASE_URL}/function?token=${encodeURIComponent(token)}`,
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/javascript" },
-            body: code,
-          },
-        );
+        let response: Response;
+        try {
+          response = await fetch(
+            `${BROWSERLESS_BASE_URL}/function?token=${encodeURIComponent(token)}`,
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/javascript" },
+              body: code,
+              signal: AbortSignal.timeout(BROWSERLESS_FETCH_TIMEOUT_MS),
+            },
+          );
+        } catch (err) {
+          const isTimeout = err instanceof Error && err.name === "TimeoutError";
+          return {
+            success: false,
+            error: isTimeout
+              ? `Browserless function call timed out after ${BROWSERLESS_FETCH_TIMEOUT_MS}ms`
+              : `Browserless function call failed: ${err instanceof Error ? err.message : String(err)}`,
+            url: inspectInput.url,
+          };
+        }
         if (!response.ok) {
           const errorText = await response.text().catch(() => "Unknown error");
           return {

--- a/apps/api/src/monitoring/redactor.test.ts
+++ b/apps/api/src/monitoring/redactor.test.ts
@@ -35,6 +35,36 @@ describe("RegexRedactor.redactString (single-pass)", () => {
     );
   });
 
+  it("still redacts an over-long local part", () => {
+    expect(r.redactString(`${"z".repeat(70)}@example.com`)).toBe(
+      "[REDACTED:email]",
+    );
+  });
+
+  it("stays linear on a long run of email-charset characters", () => {
+    // The email alternative used to restart at every offset inside a run of
+    // local-part characters, making a 64KB emit O(n^2) (~3s locally, timing
+    // out CI) on the synchronous monitoring path. Doubling the input must
+    // roughly double the cost, not quadruple it.
+    // Best of three, so a scheduling hiccup on a loaded runner can't fail it.
+    const measure = (n: number) => {
+      const input = JSON.stringify({ query: "y".repeat(n) });
+      let best = Infinity;
+      for (let i = 0; i < 3; i++) {
+        const start = performance.now();
+        r.redactString(input);
+        best = Math.min(best, performance.now() - start);
+      }
+      return best;
+    };
+
+    measure(4_000); // warm up the regex engine
+    const small = measure(16_000);
+    const large = measure(64_000);
+
+    expect(large).toBeLessThan(Math.max(small * 8, 250));
+  });
+
   it("redacts PII inside nested objects and keys via redact()", () => {
     const out = r.redact({ "owner@x.io": { note: "ping me@y.io" } });
     expect(JSON.stringify(out)).not.toContain("@");

--- a/apps/api/src/monitoring/redactor.ts
+++ b/apps/api/src/monitoring/redactor.ts
@@ -39,11 +39,17 @@ const REDACTION_TYPES = [
   "ssn",
 ] as const;
 
+// The email lookbehind keeps this linear. Without it the local part retried at
+// every offset inside a run of local-part characters, and each retry scanned to
+// the end of the run looking for "@" — quadratic, so one 64KB payload cost
+// seconds on the synchronous emit path. Since the local part is greedy over a
+// contiguous class, a match reachable from an inner offset is always reachable
+// from the run's first character, so anchoring the start loses no match.
 const COMBINED_PII_REGEX = new RegExp(
   [
     `(?<jwt>eyJ[A-Za-z0-9-_]+\\.eyJ[A-Za-z0-9-_]+\\.[A-Za-z0-9-_.+/=]*)`,
     `(?<api_key>(?:api[_-]?key|token|secret|password|bearer)\\s*[:=]\\s*['"]?[\\w-]{16,}['"]?)`,
-    `(?<email>[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,})`,
+    `(?<email>(?<![a-zA-Z0-9._%+-])[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,})`,
     `(?<credit_card>\\b\\d{4}[- ]?\\d{4}[- ]?\\d{4}[- ]?\\d{4}\\b)`,
     `(?<ssn>\\b\\d{3}-\\d{2}-\\d{4}\\b)`,
   ].join("|"),


### PR DESCRIPTION
Follows issue #5789 (agent reliability scan finding: "Vercel AI tool HTTP call has no timeout").

`inspect-page.ts` already bounds its Browserless `fetch` call with `AbortSignal.timeout(BROWSERLESS_FETCH_TIMEOUT_MS)` and a graceful catch, but its sibling `portable-built-ins.ts` (the `scrape_url`/`inspect_page` tools used when the harness runs without full cluster context) duplicates the same Browserless-calling logic without that fix — both its `scrape` and `inspect` fetch calls had no `signal`/timeout at all, so an unresponsive Browserless backend could hang the harness run indefinitely.

**Failure scenario:** the model calls the portable `scrape_url` or `inspect_page` tool, Browserless never responds, and the `await fetch(...)` never resolves — the agent run stalls forever with no way to recover.

**Fix:** hoisted the existing `BROWSERLESS_FETCH_TIMEOUT_MS` constant from `inspect-page.ts` into the shared `constants.ts` (dedup, same 45s value, no behavior change to `inspect-page.ts`) and applied it to both fetch calls in `portable-built-ins.ts`, wrapping them in the same try/catch → graceful `{ success: false, error }` shape `inspect-page.ts` already returns on timeout.

Added a regression test asserting that when the browserless fetch rejects with a `TimeoutError`, the tool returns a graceful error object instead of the call throwing/hanging.

**Reviewer check:** `cd apps/api && bun test src/harnesses/lib/decopilot/built-in-tools/portable-built-ins.test.ts`

**Verified locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/api), the targeted test file above, and `bunx oxlint` on all four changed files — all clean. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds all Browserless calls in portable `scrape_url`/`inspect_page` and `inspect-page` with a 45s timeout and unified error handling to prevent hangs on unresponsive backends. Also anchors the monitoring redactor’s email pattern to eliminate quadratic backtracking on large payloads.

- Introduces `browserlessFetch` wrapping `fetch` with `AbortSignal.timeout(BROWSERLESS_FETCH_TIMEOUT_MS)` and consistent error messages; adopted in `portable-built-ins.ts` and `inspect-page.ts`. Transport failures now return `{ success: false, error }` instead of hanging or throwing.
- Hoists `BROWSERLESS_FETCH_TIMEOUT_MS` to `constants.ts`.
- Tightens email redaction with a left-boundary negative lookbehind; large inputs redact in linear time. Adds tests for timeout handling and `browserlessFetch` error mapping, plus performance checks for the redactor.

<sup>Written for commit 705725997219a5b50767242a071d27aeaad0aee7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5894?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

