### PR TITLE
fix(sandbox): the daemon threw away the orgId Studio sent it

### DIFF
--- a/packages/sandbox/daemon-go/internal/config/merge.go
+++ b/packages/sandbox/daemon-go/internal/config/merge.go
@@ -12,12 +12,17 @@ func DeepMerge(current *TenantConfig, patch *Patch) *TenantConfig {
 	if patch.CloneOnly != nil {
 		cloneOnly = patch.CloneOnly
 	}
+	orgId := base.OrgId
+	if patch.OrgId != nil {
+		orgId = *patch.OrgId
+	}
 	out := &TenantConfig{
 		Git:         mergeGit(base.Git, patch.Git),
 		Operator:    mergeOperator(base.Operator, patch.Operator),
 		CloneOnly:   cloneOnly,
 		Application: mergeApplication(base.Application, patch.Application),
 		Env:         mergeEnv(base.Env, patch),
+		OrgId:       orgId,
 	}
 	return out
 }

--- a/packages/sandbox/daemon-go/internal/config/merge_orgid_test.go
+++ b/packages/sandbox/daemon-go/internal/config/merge_orgid_test.go
@@ -1,0 +1,68 @@
+package config
+
+// The golden cache keys shared archives by org, and the org reaches the daemon
+// only through a config patch. DeepMerge REBUILDS TenantConfig field by field,
+// so a field missing from either Patch or the rebuild is dropped on every apply
+// — silently, because nothing in the boot path reads it. That is exactly what
+// happened: Studio sent orgId, ParsePatch ignored it, and every golden was
+// published without provenance, which made the uploader skip all of them.
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func parse(t *testing.T, body string) *Patch {
+	t.Helper()
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		t.Fatal(err)
+	}
+	p, err := ParsePatch(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestDeepMergeCarriesOrgId(t *testing.T) {
+	t.Run("a patch that sets it", func(t *testing.T) {
+		out := DeepMerge(nil, parse(t, `{"orgId":"org_abc"}`))
+		if out.OrgId != "org_abc" {
+			t.Fatalf("orgId lost through the patch: %q", out.OrgId)
+		}
+	})
+
+	// The real sequence: Studio pushes the full workload config on claim, then
+	// pushes narrower patches (git credential refresh, cloneOnly) afterwards. A
+	// later patch must not wipe the org, or the golden published after it loses
+	// provenance and the uploader skips it.
+	t.Run("a later patch that omits it keeps it", func(t *testing.T) {
+		first := DeepMerge(nil, parse(t, `{"orgId":"org_abc","cloneOnly":false}`))
+		second := DeepMerge(first, parse(t, `{"cloneOnly":true}`))
+		if second.OrgId != "org_abc" {
+			t.Fatalf("a patch without orgId wiped it: %q", second.OrgId)
+		}
+		if second.CloneOnly == nil || !*second.CloneOnly {
+			t.Fatal("the patch's own field did not apply")
+		}
+	})
+
+	t.Run("a patch can change it", func(t *testing.T) {
+		first := DeepMerge(nil, parse(t, `{"orgId":"org_a"}`))
+		second := DeepMerge(first, parse(t, `{"orgId":"org_b"}`))
+		if second.OrgId != "org_b" {
+			t.Fatalf("got %q want org_b", second.OrgId)
+		}
+	})
+
+	// Absent is not the same as empty: a warm pod's first patch may carry only a
+	// token rotation, and treating that as "clear the org" is the bug this file
+	// exists to prevent.
+	t.Run("an empty patch keeps it", func(t *testing.T) {
+		first := DeepMerge(nil, parse(t, `{"orgId":"org_abc"}`))
+		if got := DeepMerge(first, parse(t, `{}`)).OrgId; got != "org_abc" {
+			t.Fatalf("an empty patch wiped it: %q", got)
+		}
+	})
+}

--- a/packages/sandbox/daemon-go/internal/config/types.go
+++ b/packages/sandbox/daemon-go/internal/config/types.go
@@ -73,6 +73,10 @@ type Patch struct {
 	Application *Application
 	Env         map[string]*string
 	HasEnv      bool
+	// Pointer, not string: DeepMerge rebuilds TenantConfig field by field, so a
+	// field absent from BOTH the patch and the merge is silently dropped on every
+	// apply. Nil here means "not in this patch, keep current".
+	OrgId *string
 }
 
 func ParsePatch(raw map[string]json.RawMessage) (*Patch, error) {
@@ -84,6 +88,11 @@ func ParsePatch(raw map[string]json.RawMessage) (*Patch, error) {
 	}
 	if v, ok := raw["operator"]; ok && !isNull(v) {
 		if err := json.Unmarshal(v, &p.Operator); err != nil {
+			return nil, err
+		}
+	}
+	if v, ok := raw["orgId"]; ok && !isNull(v) {
+		if err := json.Unmarshal(v, &p.OrgId); err != nil {
 			return nil, err
 		}
 	}

--- a/packages/sandbox/daemon-go/internal/setup/goldenmeta_e2e_test.go
+++ b/packages/sandbox/daemon-go/internal/setup/goldenmeta_e2e_test.go
@@ -1,0 +1,74 @@
+package setup
+
+// The whole chain, in one test: the JSON Studio actually POSTs to /config, through
+// the config merge, into GoldenParams, out as a golden's provenance file, and read
+// back by the uploader.
+//
+// Every earlier test covered one link and all of them passed while the chain was
+// broken: Studio sent orgId, the Patch struct did not declare it, DeepMerge
+// rebuilt TenantConfig without it, so every golden was published with no
+// provenance and the uploader skipped all of them. Nothing failed — the tier just
+// silently did nothing. This asserts the seam, not the parts.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/decocms/studio/sandbox-daemon/internal/config"
+)
+
+func TestOrgIdReachesGoldenMeta(t *testing.T) {
+	// Verbatim shape of buildConfigPayload's output for a claimed sandbox
+	// (packages/sandbox/server/provider/shared/build-config-payload.ts).
+	body := `{
+	  "git": {"repository": {"cloneUrl": "https://github.com/acme/site.git"}},
+	  "operator": {"userName": "Jane"},
+	  "cloneOnly": false,
+	  "application": {"packageManager": {"name": "bun"}, "runtime": "node"},
+	  "orgId": "org_1rT2srZfM75G"
+	}`
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(body), &raw); err != nil {
+		t.Fatal(err)
+	}
+	patch, err := config.ParsePatch(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg := config.DeepMerge(nil, patch)
+	if cfg.OrgId == "" {
+		t.Fatal("orgId did not survive the config merge — the golden would have no owner")
+	}
+
+	// What the orchestrator builds from that config, and what publish records.
+	installRoot := t.TempDir()
+	golden := filepath.Join(installRoot, "golden", "node_modules")
+	if err := os.MkdirAll(golden, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	p := GoldenParams{
+		CloneUrl:    cfg.CloneUrl(),
+		InstallRoot: installRoot,
+		Pm:          "bun",
+		OrgId:       cfg.OrgId,
+		Env:         "stg",
+	}
+	WriteGoldenMeta(golden, GoldenMeta{OrgId: p.OrgId, CloneUrl: p.CloneUrl, Pm: p.Pm, Env: p.Env})
+
+	// And what the uploader reads back before deciding to publish.
+	meta, ok := ReadGoldenMeta(golden)
+	if !ok {
+		t.Fatal("the uploader would skip this golden as having no provenance")
+	}
+	if meta.OrgId != "org_1rT2srZfM75G" {
+		t.Fatalf("org lost end to end: %q", meta.OrgId)
+	}
+	if meta.Env != "stg" {
+		t.Fatalf("env lost end to end: %q", meta.Env)
+	}
+	if meta.CloneUrl != "https://github.com/acme/site.git" {
+		t.Fatalf("clone url lost end to end: %q", meta.CloneUrl)
+	}
+}

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/sandbox",
-  "version": "1.47.1",
+  "version": "1.48.0",
   "private": true,
   "type": "module",
   "description": "Sandbox runtime for isolated Studio tool execution",


### PR DESCRIPTION
The shared golden cache has been publishing nothing, and this is why. Image `1.48.0`; chart unchanged.

## What stg showed

A boot on `1.47.0` installed for 15.4s and published its golden. The uploader on that node:

```
swept 5 golden(s): 0 uploaded, 0 already present, 5 without provenance, 0 from another env, 0 failed
```

Inspecting the node's hostPath directly — no meta file beside **any** golden:

```
SEM META: /var/cache/studio-sandbox-deps/golden/f5242bbcbc6b3523/bun-5493bd.../
```

`f5242bbcbc6b3523` is the `repo_hash` from that boot's `sandbox.deps.restore{source="miss"}`. The golden was written; its provenance was not.

## Cause — mine

`DeepMerge` **rebuilds** `TenantConfig` field by field. I added `OrgId` to the struct and to the orchestrator, and never to `Patch`, `ParsePatch`, or the rebuild:

```go
type Patch struct {
	Git, Operator, CloneOnly, Application, Env ...   // no OrgId
}
```

So `ParsePatch` ignored the field and `DeepMerge` produced a config without it, on every apply. Studio sent it correctly — `start.ts` builds `tenant: { orgId, ... }` and `buildConfigPayload` puts it on the wire — and the daemon threw it away. `WriteGoldenMeta` then returned early on the empty value, by design: an archive whose owner is unknown must not exist.

Ruled out first, so this is not a rollout-timing story: both Studio images live in stg (`4.197.5` and `4.197.8`, mid-rollout) contain the `orgId` payload change.

## Pointer, not string

`Patch.OrgId` is `*string` so **absent** stays distinguishable from **empty**. Studio pushes the full workload config on claim and narrower patches afterwards — credential refresh, `cloneOnly` — and treating an omitted field as "clear it" would strip the org from a live sandbox. Any golden published after that point loses provenance again, which is the same silent failure one layer along.

## Why the tests are shaped this way

Five defects in this feature were caught by asserting a rendered manifest or one function in isolation. **This one was invisible to both**: every link had a passing test while the chain was broken end to end.

So the new tests assert the *seam*. `TestOrgIdReachesGoldenMeta` takes the verbatim JSON `buildConfigPayload` emits, runs it through `ParsePatch` → `DeepMerge` → `GoldenParams` → `WriteGoldenMeta`, and reads it back the way the uploader does.

And I verified they actually catch it. Reverting only the `ParsePatch` line:

```
--- FAIL: TestOrgIdReachesGoldenMeta
    orgId did not survive the config merge — the golden would have no owner
--- FAIL: TestDeepMergeCarriesOrgId/a_patch_that_sets_it
    orgId lost through the patch: ""
```

Restoring it passes. A test that cannot fail proves nothing, and that is what I had before.

`TestDeepMergeCarriesOrgId` also covers patch sequencing, which is how this regresses: a later patch without `orgId` keeps it, an empty patch keeps it, an explicit one replaces it.

## Validation

`go build`, `go vet` clean. Full daemon suite uncached: **15 packages ok, zero failures**. `bun run fmt` clean.

## After this

`1.48.0` publishes, the auto-bump carries it to stg and prod, and then the first stg boot that installs writes a golden **with** provenance. The uploader picks it up within its 5-minute sweep and the bucket gets its first object. A later boot of the same repo landing on a different node is what finally reports `sandbox.deps.restore{source="l2"}`.

Goldens already on the nodes stay skipped — they were written without provenance and are not retroactively fixable, which is correct.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sandbox daemon dropping `orgId` from config patches, restoring golden provenance so the uploader can publish shared archives. Goldens now include `orgId`, preventing “no provenance” skips.

- **Bug Fixes**
  - Added `OrgId` to `Patch`, `ParsePatch`, and `DeepMerge` so `orgId` from Studio is preserved in `TenantConfig`.
  - Made `Patch.OrgId` a `*string` to distinguish “absent” from “empty” and avoid wiping `orgId` on later patches.
  - Added end-to-end tests to ensure `orgId` reaches golden meta and is read back by the uploader.

<sup>Written for commit 1424ae9f8086a511b255f8ebb3eb757302c77dcb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5895?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

