### PR TITLE
fix(web): stop remaining file-drop zones leaking into the chat input

### DIFF
--- a/apps/web/src/components/file-picker/file-picker-dialog.tsx
+++ b/apps/web/src/components/file-picker/file-picker-dialog.tsx
@@ -262,6 +262,10 @@ function BucketPanel({
   }
   function onDrop(e: React.DragEvent) {
     e.preventDefault();
+    // Stop the drop from bubbling to the chat composer's window-level
+    // drop listener (input.tsx `useWindowFileDrop`), which would otherwise
+    // upload the same file into the chat input too.
+    e.stopPropagation();
     setIsDragging(false);
     handleFiles(e.dataTransfer.files);
   }

--- a/apps/web/src/components/sections-editor/fields/file-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/file-field.tsx
@@ -107,6 +107,10 @@ export function FileField({
   }
   function onDrop(e: React.DragEvent) {
     e.preventDefault();
+    // Stop the drop from bubbling to the chat composer's window-level
+    // drop listener (input.tsx `useWindowFileDrop`), which would otherwise
+    // upload the same file into the chat input too.
+    e.stopPropagation();
     setIsDragging(false);
     handleFiles(e.dataTransfer.files);
   }

--- a/apps/web/src/components/sections-editor/fields/image-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/image-field.tsx
@@ -124,6 +124,10 @@ export function ImageField({
   }
   function onDrop(e: React.DragEvent) {
     e.preventDefault();
+    // Stop the drop from bubbling to the chat composer's window-level
+    // drop listener (input.tsx `useWindowFileDrop`), which would otherwise
+    // upload the same file into the chat input too.
+    e.stopPropagation();
     setIsDragging(false);
     handleFiles(e.dataTransfer.files);
   }

--- a/apps/web/src/views/registry/image-upload.tsx
+++ b/apps/web/src/views/registry/image-upload.tsx
@@ -48,6 +48,10 @@ export function ImageUpload({
 
   const handleDrop = async (event: React.DragEvent) => {
     event.preventDefault();
+    // Stop the drop from bubbling to the chat composer's window-level
+    // drop listener (input.tsx `useWindowFileDrop`), which would otherwise
+    // upload the same file into the chat input too.
+    event.stopPropagation();
     setIsDragging(false);
     if (isUploading) return;
     const file = event.dataTransfer.files[0];

--- a/apps/web/src/views/virtual-mcp/files-section.tsx
+++ b/apps/web/src/views/virtual-mcp/files-section.tsx
@@ -341,6 +341,10 @@ export function FilesSection({ form }: { form: VirtualMcpFormReturn }) {
         onDragLeave={() => setIsDragging(false)}
         onDrop={(e) => {
           e.preventDefault();
+          // Stop the drop from bubbling to the chat composer's window-level
+          // drop listener (input.tsx `useWindowFileDrop`), which would
+          // otherwise upload the same file into the chat input too.
+          e.stopPropagation();
           setIsDragging(false);
           void handleUpload(e.dataTransfer.files);
         }}


### PR DESCRIPTION
Follows #5893, which fixed this leak only in `library/index.tsx`. Same root cause exists at every other OS-file drop zone in the app: each calls `preventDefault()` but not `stopPropagation()`, so the native `drop` event still bubbles up to the chat composer's window-level listener (`input.tsx` `useWindowFileDrop`), which then also uploads the dropped file into the chat input.

Fixed the remaining call sites with the identical one-line fix:
- `sections-editor/fields/image-field.tsx`
- `sections-editor/fields/file-field.tsx`
- `views/virtual-mcp/files-section.tsx`
- `views/registry/image-upload.tsx`
- `components/file-picker/file-picker-dialog.tsx`

To confirm: drop a local file onto, e.g., the sections-editor image field or the file picker dialog while the chat sidebar is visible — before this fix the file also appears in the chat composer; after, it doesn't.

Checked locally: `bun run fmt` and `bunx oxlint` on each changed file (both clean). No test added, matching #5893's own precedent for this exact fix — CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop dropped files from also being added to the chat composer by halting native drop event bubbling in all remaining file-drop zones. This prevents the chat input’s `useWindowFileDrop` listener from uploading the same file.

- **Bug Fixes**
  - Added `stopPropagation()` to onDrop handlers in: sections editor image/file fields, `file-picker-dialog`, registry image upload, and virtual MCP files section.
  - Verified: dropping onto these areas no longer adds the file to the chat input.

<sup>Written for commit 79ac93429007fe2441d03bebd1683feff0d8b231. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5896?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

