### PR TITLE
fix(web): poll the OAuth callback key and raise the consent timeout

### DIFF
--- a/apps/web/src/sdk/lib/mcp-oauth.ts
+++ b/apps/web/src/sdk/lib/mcp-oauth.ts
@@ -124,6 +124,22 @@ export function setMcpOAuthBrowserAdapter(
 /** How often to ask the adapter whether the callback has landed. */
 const ADAPTER_POLL_INTERVAL_MS = 600;
 
+/** How often to read the localStorage callback key directly. The `storage`
+ * event is not delivered reliably everywhere (observed lost in Edge after
+ * GitHub's COOP hop severs `window.opener`, leaving localStorage as the only
+ * channel home), so the event listener gets this poll as a belt. */
+const STORAGE_POLL_INTERVAL_MS = 1_000;
+
+/**
+ * Default ceiling for the whole consent round trip. First-time authorizations
+ * routinely take minutes (provider login, 2FA, org/app install screens), and a
+ * shorter timer was killing flows the user then completed into a void — the
+ * popup reported success while nobody was listening anymore. We cannot watch
+ * the popup instead: after a COOP-severing hop (github.com) its WindowProxy is
+ * disowned and `closed` reads true mid-flow.
+ */
+const DEFAULT_OAUTH_TIMEOUT_MS = 10 * 60_000;
+
 /**
  * Options for the MCP OAuth provider
  */
@@ -335,7 +351,7 @@ interface FullTokenResult {
  * @param params.clientName - OAuth client name
  * @param params.clientUri - OAuth client URI
  * @param params.callbackUrl - OAuth callback URL (defaults to current origin + /oauth/callback)
- * @param params.timeout - Timeout in ms (default 120000)
+ * @param params.timeout - Timeout in ms (default 600000 — see DEFAULT_OAUTH_TIMEOUT_MS)
  * @param params.scope - OAuth scopes to request
  * @param params.windowMode - "popup" (default) or "tab" (for devices that block popups)
  */
@@ -379,9 +395,10 @@ export async function authenticateMcp(params: {
     // Uses both postMessage (primary) and localStorage (fallback for when opener is lost)
     const oauthCompletePromise = new Promise<FullTokenResult>(
       (resolve, reject) => {
-        const timeout = params.timeout || 120000;
+        const timeout = params.timeout || DEFAULT_OAUTH_TIMEOUT_MS;
         let timeoutId: ReturnType<typeof setTimeout>;
         let pollId: ReturnType<typeof setInterval> | undefined;
+        let storagePollId: ReturnType<typeof setInterval> | undefined;
         let resolved = false;
         // Use the OAuth state as the storage key - it's already unique per flow
         // and will be available to the callback page via URL params
@@ -395,6 +412,7 @@ export async function authenticateMcp(params: {
           window.removeEventListener("storage", handleStorageEvent);
           clearTimeout(timeoutId);
           clearInterval(pollId);
+          clearInterval(storagePollId);
           // Clean up storage key
           try {
             localStorage.removeItem(storageKey);
@@ -516,6 +534,25 @@ export async function authenticateMcp(params: {
 
         window.addEventListener("message", handleMessage);
         window.addEventListener("storage", handleStorageEvent);
+
+        // Belt for the storage listener above — read the key directly too,
+        // since the event alone is what gets lost (see
+        // STORAGE_POLL_INTERVAL_MS). processCallback dedupes via `resolved`.
+        storagePollId = setInterval(() => {
+          if (resolved) return;
+          let raw: string | null = null;
+          try {
+            raw = localStorage.getItem(storageKey);
+          } catch {
+            return; // Storage unavailable — rely on the other channels.
+          }
+          if (!raw) return;
+          try {
+            void processCallback(JSON.parse(raw));
+          } catch {
+            // Ignore parse errors, same as the storage-event path.
+          }
+        }, STORAGE_POLL_INTERVAL_MS);
 
         // Third channel: when consent completes in a separate browser process
         // neither listener above can ever fire, so ask the adapter instead.


### PR DESCRIPTION
## Summary

MCP OAuth popup flows were failing with **"OAuth authentication timeout"** even when the provider consent succeeded. Session analytics for affected users showed two distinct failure modes:

1. **Consent slower than the 120s timer.** First-time GitHub authorizations (login + 2FA + app install screens) routinely take >2 minutes. The callback page then arrived after the parent had already timed out and torn down its listeners — the popup reported success while nobody was listening.
2. **Callback delivery lost (observed on Microsoft Edge).** The callback landed on `/oauth/callback` within seconds, but the parent never processed it. After the COOP-severing hop through `github.com`, `window.opener` is null, so the popup falls back to writing the result to localStorage — and the parent relied solely on the `storage` **event**, which was not delivered.

## Changes (`apps/web/src/sdk/lib/mcp-oauth.ts`)

- **Default timeout 120s → 10min** (`DEFAULT_OAUTH_TIMEOUT_MS`). We can't watch the popup instead: after a COOP-severing navigation its WindowProxy is disowned and `popup.closed` reads `true` mid-flow. An explicit `params.timeout` still wins.
- **Poll the localStorage callback key every 1s** (`STORAGE_POLL_INTERVAL_MS`) alongside the existing `storage`-event listener. The direct `getItem` read doesn't depend on event delivery. `processCallback` already dedupes via `resolved`; the key is unique per flow (state UUID) and the poll is cleared in `cleanup()`.

## Testing

- `bun run fmt`, `bun run lint` (no findings in the changed file), and `tsc --noEmit` for `apps/web` pass.
- No new unit test: the changed logic is browser timer/event glue — a mocked-DOM unit test is out per TESTING.md, and an e2e would need a real third-party OAuth consent round trip in a popup. Verification plan is session replay / `connection_oauth_failed` rates for affected users after deploy.

## Follow-ups (separate issues)

- Runtime PKCE mode embeds raw provider tokens in the authorization `code` URL param (leaks into analytics/history) — needs an opaque one-time code.
- The oauth-proxy's DCR `metadata` injection is rejected by strict DCR servers (`Unrecognized key(s) in object: 'metadata'`).
- `use-auto-install-github` deletes the connection on every OAuth failure, erasing the user's progress.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing MCP OAuth popup flows by raising the default consent timeout to 10 minutes and polling the callback key in localStorage to catch dropped `storage` events. Prevents “OAuth authentication timeout” and lost callbacks (notably on Edge after COOP hops).

- **Bug Fixes**
  - Default timeout increased from 120s to 10min via `DEFAULT_OAUTH_TIMEOUT_MS` (still overridable by `params.timeout`).
  - Poll localStorage callback key every 1s via `STORAGE_POLL_INTERVAL_MS` in addition to the `storage` event; timers cleaned up on completion.
  - Updated param docs to reflect new default.

<sup>Written for commit 6c48f7f12497182581daf5884b185e6da366e9d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

