### PR TITLE
fix(monitoring): scale tool-call heatmap colors by displayed cells only

### DIFF
--- a/apps/web/src/routes/orgs/monitoring/overview.tsx
+++ b/apps/web/src/routes/orgs/monitoring/overview.tsx
@@ -324,7 +324,6 @@ function ToolAgentHeatmap({
     string,
     { calls: number; errors: number; outputSize: number }
   >();
-  let maxValue = 0;
   for (const cell of cells) {
     if (!toolSet.has(cell.toolName)) continue;
     const agentId = cell.virtualMcpId ?? "";
@@ -334,12 +333,22 @@ function ToolAgentHeatmap({
       errors: cell.errors,
       outputSize: cell.outputSize,
     });
-    if (cell[metric] > maxValue) maxValue = cell[metric];
   }
   const topAgentIds = [...agentTotals.entries()]
     .sort((a, b) => b[1] - a[1])
     .slice(0, HEATMAP_MAX_AGENTS)
     .map(([id]) => id);
+  const topAgentSet = new Set(topAgentIds);
+
+  // Normalize the color scale against only the cells actually rendered
+  // (top agents × top tools) — an outlier from an agent that didn't make
+  // the top-8 must not dilute the colors of the cells shown.
+  let maxValue = 0;
+  for (const cell of cells) {
+    if (!toolSet.has(cell.toolName)) continue;
+    if (!topAgentSet.has(cell.virtualMcpId ?? "")) continue;
+    if (cell[metric] > maxValue) maxValue = cell[metric];
+  }
 
   const agentNameOf = (id: string) =>
     id === ""


### PR DESCRIPTION
Follows #5865 (tool-call heatmap by agent), which merged just before this tick.

**Bug:** `ToolAgentHeatmap` picks the top 12 tools and top 8 agents by total volume, then colors each cell with `heatmapLevelClass(value, maxValue)`. But `maxValue` was computed by scanning every cell that matched the top-12 *tools*, without also restricting to the top-8 *agents* actually rendered. An agent that gets filtered out of the top 8 (low total across all its tools) can still have a single outlier cell higher than anything shown in the rendered grid — that outlier silently becomes the color-scale ceiling, so every displayed cell renders duller than its real share of the visible data, including the actual max cell shown.

**Fix:** compute `maxValue` only over cells whose tool AND agent both made the top lists — i.e. the same set that's actually rendered in the grid.

**How to verify:** `cd apps/web && bunx tsc --noEmit` (no errors touching overview.tsx) and `bunx oxlint apps/web/src/routes/orgs/monitoring/overview.tsx` (0 warnings/errors). This is a pure rendering-logic fix with no new dependency or schema change; full CI validates the rest.

Checked locally: `bun run fmt`, targeted `tsc --noEmit` in apps/web, `bunx oxlint` on the changed file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix heatmap color scaling in `ToolAgentHeatmap` by normalizing against only the displayed cells (top 12 tools × top 8 agents). This prevents hidden outliers from setting the scale and makes visible cells reflect their true relative values.

- **Bug Fixes**
  - Compute the color-scale max using only cells whose tool and agent are in the rendered top lists; previously included filtered agents, which washed out colors.

<sup>Written for commit 377814859b793c7bfce88f62ad91d01fd1ae5b48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

