### PR TITLE
fix(monitoring): scope heatmap color intensity to the agents actually shown

### DIFF
--- a/apps/web/src/routes/orgs/monitoring/overview.tsx
+++ b/apps/web/src/routes/orgs/monitoring/overview.tsx
@@ -43,6 +43,7 @@ import { getConnectionSlug } from "@decocms/shared/utils/connection-slug";
 import { useT } from "@/i18n/use-t.ts";
 import {
   buildFilledStatsData,
+  computeHeatmapView,
   formatCompactNumber,
   formatDuration,
   formatMetricValue,
@@ -306,40 +307,12 @@ function ToolAgentHeatmap({
     );
   }
 
-  const toolTotals = new Map<string, number>();
-  for (const cell of cells) {
-    toolTotals.set(
-      cell.toolName,
-      (toolTotals.get(cell.toolName) ?? 0) + cell[metric],
-    );
-  }
-  const topTools = [...toolTotals.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, HEATMAP_MAX_TOOLS)
-    .map(([name]) => name);
-  const toolSet = new Set(topTools);
-
-  const agentTotals = new Map<string, number>();
-  const cellMap = new Map<
-    string,
-    { calls: number; errors: number; outputSize: number }
-  >();
-  let maxValue = 0;
-  for (const cell of cells) {
-    if (!toolSet.has(cell.toolName)) continue;
-    const agentId = cell.virtualMcpId ?? "";
-    agentTotals.set(agentId, (agentTotals.get(agentId) ?? 0) + cell[metric]);
-    cellMap.set(`${agentId}::${cell.toolName}`, {
-      calls: cell.calls,
-      errors: cell.errors,
-      outputSize: cell.outputSize,
-    });
-    if (cell[metric] > maxValue) maxValue = cell[metric];
-  }
-  const topAgentIds = [...agentTotals.entries()]
-    .sort((a, b) => b[1] - a[1])
-    .slice(0, HEATMAP_MAX_AGENTS)
-    .map(([id]) => id);
+  const { topTools, topAgentIds, cellMap, maxValue } = computeHeatmapView(
+    cells,
+    metric,
+    HEATMAP_MAX_TOOLS,
+    HEATMAP_MAX_AGENTS,
+  );
 
   const agentNameOf = (id: string) =>
     id === ""

--- a/apps/web/src/routes/orgs/monitoring/utils.test.ts
+++ b/apps/web/src/routes/orgs/monitoring/utils.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, test } from "bun:test";
+import { computeHeatmapView } from "./utils.ts";
+
+describe("computeHeatmapView", () => {
+  test("maxValue only reflects cells for agents actually rendered", () => {
+    // agent "a" and "b" are the top-2 agents by total calls (10 each).
+    // agent "spike" has a lower overall total (8) so it doesn't make the
+    // top-2, but its single toolX cell (8) exceeds any cell of "a" or "b".
+    const cells = [
+      {
+        virtualMcpId: "a",
+        toolName: "toolX",
+        calls: 5,
+        errors: 0,
+        outputSize: 0,
+      },
+      {
+        virtualMcpId: "a",
+        toolName: "toolY",
+        calls: 5,
+        errors: 0,
+        outputSize: 0,
+      },
+      {
+        virtualMcpId: "b",
+        toolName: "toolX",
+        calls: 5,
+        errors: 0,
+        outputSize: 0,
+      },
+      {
+        virtualMcpId: "b",
+        toolName: "toolY",
+        calls: 5,
+        errors: 0,
+        outputSize: 0,
+      },
+      {
+        virtualMcpId: "spike",
+        toolName: "toolX",
+        calls: 8,
+        errors: 0,
+        outputSize: 0,
+      },
+    ];
+
+    const view = computeHeatmapView(cells, "calls", 12, 2);
+
+    expect(view.topAgentIds).toEqual(["a", "b"]);
+    // Must be 5 (the highest cell among rendered agents), not 8 from the
+    // excluded "spike" agent.
+    expect(view.maxValue).toBe(5);
+  });
+
+  test("caps tools and agents to the requested counts", () => {
+    const cells = Array.from({ length: 5 }, (_, i) => ({
+      virtualMcpId: `agent-${i}`,
+      toolName: `tool-${i}`,
+      calls: i + 1,
+      errors: 0,
+      outputSize: 0,
+    }));
+
+    const view = computeHeatmapView(cells, "calls", 2, 2);
+
+    expect(view.topTools).toHaveLength(2);
+    expect(view.topAgentIds).toHaveLength(2);
+  });
+});

--- a/apps/web/src/routes/orgs/monitoring/utils.ts
+++ b/apps/web/src/routes/orgs/monitoring/utils.ts
@@ -145,6 +145,81 @@ export function buildFilledStatsData(
   return data;
 }
 
+// ── Tool-call heatmap ────────────────────────────────────────────────────────
+
+export interface HeatmapCell {
+  virtualMcpId: string | null;
+  toolName: string;
+  calls: number;
+  errors: number;
+  outputSize: number;
+}
+
+export interface HeatmapView {
+  topTools: string[];
+  topAgentIds: string[];
+  cellMap: Map<string, { calls: number; errors: number; outputSize: number }>;
+  /** Max cell value among the cells actually rendered (topAgentIds × topTools), for color scaling. */
+  maxValue: number;
+}
+
+/**
+ * Reduce raw heatmap cells to the top tools/agents to render, plus the max
+ * value among the rendered cells (used to scale cell color intensity).
+ * The max is computed only over cells that end up on screen — an agent with
+ * a high single-tool spike but a low overall total gets excluded from
+ * topAgentIds, and must not skew the color scale for the agents shown.
+ */
+export function computeHeatmapView(
+  cells: HeatmapCell[],
+  metric: "calls" | "outputSize",
+  maxTools: number,
+  maxAgents: number,
+): HeatmapView {
+  const toolTotals = new Map<string, number>();
+  for (const cell of cells) {
+    toolTotals.set(
+      cell.toolName,
+      (toolTotals.get(cell.toolName) ?? 0) + cell[metric],
+    );
+  }
+  const topTools = [...toolTotals.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, maxTools)
+    .map(([name]) => name);
+  const toolSet = new Set(topTools);
+
+  const agentTotals = new Map<string, number>();
+  const cellMap = new Map<
+    string,
+    { calls: number; errors: number; outputSize: number }
+  >();
+  for (const cell of cells) {
+    if (!toolSet.has(cell.toolName)) continue;
+    const agentId = cell.virtualMcpId ?? "";
+    agentTotals.set(agentId, (agentTotals.get(agentId) ?? 0) + cell[metric]);
+    cellMap.set(`${agentId}::${cell.toolName}`, {
+      calls: cell.calls,
+      errors: cell.errors,
+      outputSize: cell.outputSize,
+    });
+  }
+  const topAgentIds = [...agentTotals.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, maxAgents)
+    .map(([id]) => id);
+
+  let maxValue = 0;
+  for (const agentId of topAgentIds) {
+    for (const tool of topTools) {
+      const cell = cellMap.get(`${agentId}::${tool}`);
+      if (cell && cell[metric] > maxValue) maxValue = cell[metric];
+    }
+  }
+
+  return { topTools, topAgentIds, cellMap, maxValue };
+}
+
 // ── Connection metrics ──────────────────────────────────────────────────────
 
 export type ConnectionMetric = {


### PR DESCRIPTION
Follows #5865 (tool-call heatmap by agent), which just merged.

In `ToolAgentHeatmap` (Overview tab), the color-intensity scale (`maxValue`) was computed over *all* (agent, tool) cells that use a top tool — before narrowing down to the top-N agents actually rendered. An agent that doesn't make the top-N by overall total, but has one large spike on a single top tool, would still inflate `maxValue`, silently dimming every cell of the agents that *are* shown (their true max never reaches the top color bucket).

Why a maintainer wants this: the heatmap is a proxy for spotting the heaviest tool/agent combos at a glance — with the bug, the color scale can be stretched by data the user never sees, making the visible cells look uniformly lighter than they should.

Fix: extracted the tool/agent selection + color-scale calculation into a pure `computeHeatmapView()` helper (`apps/web/src/routes/orgs/monitoring/utils.ts`), and moved the `maxValue` computation to run only over the cells for the agents that end up in `topAgentIds`. Added `utils.test.ts` with a regression test reproducing the bug (an excluded agent's spike no longer sets the max) plus a basic top-N capping test.

How to confirm: `bun test apps/web/src/routes/orgs/monitoring/utils.test.ts`.

Locally ran: `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, `bunx oxlint` on the touched files, and the targeted test above — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes heatmap color intensity in Monitoring Overview by basing the scale only on the agents shown. Visible spikes now render with the correct intensity.

- **Bug Fixes**
  - Added `computeHeatmapView` in `apps/web/src/routes/orgs/monitoring/utils.ts` to select top tools/agents and compute `maxValue` only for rendered cells.
  - Updated `ToolAgentHeatmap` in `overview.tsx` to use `computeHeatmapView`; resolved merge conflict in `overview.tsx` after syncing with `main`.
  - Added `utils.test.ts` with a regression test (excluded-agent spike no longer skews scale) and a top‑N capping test.

<sup>Written for commit 2401bbc236c5b61975386a994bc27f52d4ddfad5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

