### PR TITLE
feat(task-board): add tag filter to kanban board

### DIFF
--- a/apps/web/src/i18n/en/task-board.ts
+++ b/apps/web/src/i18n/en/task-board.ts
@@ -189,6 +189,10 @@ export const taskBoard = {
   "taskBoard.taskFilters.filterDrawerTitle": "Filters",
   "taskBoard.taskFilters.priorityAnyPriority": "Any priority",
   "taskBoard.taskFilters.priorityLabel": "Priority",
+  "taskBoard.taskFilters.tagsLabel": "Tags",
+  "taskBoard.taskFilters.tagsSelectedCount": "{count} tags",
+  "taskBoard.taskFilters.tagsFilterPlaceholder": "Filter by tag…",
+  "taskBoard.taskFilters.tagsNoTagsFound": "No tags found.",
   "taskBoard.rerun.title": "Re-run this task?",
   "taskBoard.rerun.description":
     "The Super Agent will start a fresh run on this task.",

--- a/apps/web/src/i18n/pt-br/task-board.ts
+++ b/apps/web/src/i18n/pt-br/task-board.ts
@@ -197,6 +197,10 @@ export const taskBoard = {
   "taskBoard.taskFilters.filterDrawerTitle": "Filtros",
   "taskBoard.taskFilters.priorityAnyPriority": "Qualquer prioridade",
   "taskBoard.taskFilters.priorityLabel": "Prioridade",
+  "taskBoard.taskFilters.tagsLabel": "Tags",
+  "taskBoard.taskFilters.tagsSelectedCount": "{count} tags",
+  "taskBoard.taskFilters.tagsFilterPlaceholder": "Filtrar por tag…",
+  "taskBoard.taskFilters.tagsNoTagsFound": "Nenhuma tag encontrada.",
   "taskBoard.rerun.title": "Executar esta tarefa de novo?",
   "taskBoard.rerun.description":
     "O Super Agent vai iniciar uma nova execução nesta tarefa.",

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -306,6 +306,7 @@ function AssigneeDisplay({
 export function TaskBoardPage() {
   const t = useT();
   const { items, isLoading } = useTaskBoardItems();
+  const { data: orgTags = [] } = useTags();
   const actions = useTaskBoardItemActions();
   const reportsOnly = useReportsOnly();
   // Handing a task to the Super Agent makes it open a PR — so it needs at
@@ -549,6 +550,7 @@ export function TaskBoardPage() {
                 <TaskFiltersDrawer
                   filters={filters}
                   members={members}
+                  tags={orgTags}
                   onChange={setFilters}
                 />
               </div>
@@ -556,6 +558,7 @@ export function TaskBoardPage() {
                 <TaskFiltersBar
                   filters={filters}
                   members={members}
+                  tags={orgTags}
                   onChange={setFilters}
                 />
               </div>

--- a/apps/web/src/layouts/task-board/task-filters.test.ts
+++ b/apps/web/src/layouts/task-board/task-filters.test.ts
@@ -14,6 +14,7 @@ function item(overrides: Partial<TaskBoardItem> = {}): TaskBoardItem {
     assignedBy: null,
     dueDate: null,
     threads: [],
+    tags: [],
     createdBy: "user-1",
     createdAt: new Date().toISOString(),
     updatedBy: "user-1",
@@ -53,6 +54,43 @@ describe("taskMatchesFilters — due date", () => {
       taskMatchesFilters(item({ dueDate: in10Days }), {
         ...EMPTY_FILTERS,
         due: "week",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("taskMatchesFilters — tags", () => {
+  const tag = (id: string) => ({
+    id,
+    name: id,
+    color: null,
+    createdBy: "user-1",
+    createdAt: new Date().toISOString(),
+  });
+
+  test("includes a task that has one of the selected tags", () => {
+    expect(
+      taskMatchesFilters(item({ tags: [tag("a"), tag("b")] }), {
+        ...EMPTY_FILTERS,
+        tags: ["b"],
+      }),
+    ).toBe(true);
+  });
+
+  test("excludes a task that has none of the selected tags", () => {
+    expect(
+      taskMatchesFilters(item({ tags: [tag("a")] }), {
+        ...EMPTY_FILTERS,
+        tags: ["b"],
+      }),
+    ).toBe(false);
+  });
+
+  test("excludes a task with no tags when a tag filter is active", () => {
+    expect(
+      taskMatchesFilters(item({ tags: [] }), {
+        ...EMPTY_FILTERS,
+        tags: ["b"],
       }),
     ).toBe(false);
   });

--- a/apps/web/src/layouts/task-board/task-filters.tsx
+++ b/apps/web/src/layouts/task-board/task-filters.tsx
@@ -39,9 +39,11 @@ import {
 import { cn } from "@decocms/ui/lib/utils.ts";
 import {
   Calendar,
+  Check,
   ChevronDown,
   Flag01,
   FilterLines,
+  Tag01,
   User01,
 } from "@untitledui/icons";
 import { SuperAgentIcon } from "@/components/super-agent-icon";
@@ -50,7 +52,9 @@ import {
   PRIORITIES,
   PRIORITY_CONFIG,
   SUPER_AGENT_ASSIGNEE_ID,
+  tagDotColor,
   type Member,
+  type OrgTag,
   type TaskBoardItem,
   type TaskBoardItemPriority,
 } from "./config";
@@ -65,23 +69,32 @@ export type TaskFilters = {
   assignee: string | null;
   priority: TaskBoardItemPriority | null;
   due: DueFilter | null;
+  /** Org tag ids — a task matches if it has at least one of these. */
+  tags: string[];
 };
 
 export const EMPTY_FILTERS: TaskFilters = {
   assignee: null,
   priority: null,
   due: null,
+  tags: [],
 };
 
 function hasActiveFilters(f: TaskFilters): boolean {
-  return f.assignee !== null || f.priority !== null || f.due !== null;
+  return (
+    f.assignee !== null ||
+    f.priority !== null ||
+    f.due !== null ||
+    f.tags.length > 0
+  );
 }
 
 function activeFilterCount(f: TaskFilters): number {
   return (
     (f.assignee !== null ? 1 : 0) +
     (f.priority !== null ? 1 : 0) +
-    (f.due !== null ? 1 : 0)
+    (f.due !== null ? 1 : 0) +
+    (f.tags.length > 0 ? 1 : 0)
   );
 }
 
@@ -120,6 +133,10 @@ export function taskMatchesFilters(
       if (f.due === "today" && !isSameDay(t, now)) return false;
       if (f.due === "week" && (t < now || t > now + 7 * DAY_MS)) return false;
     }
+  }
+  if (f.tags.length > 0) {
+    const itemTagIds = item.tags.map((tag) => tag.id);
+    if (!f.tags.some((id) => itemTagIds.includes(id))) return false;
   }
   return true;
 }
@@ -365,15 +382,101 @@ function DueDateFilter({
   );
 }
 
-/** The three filter controls, shared by the inline bar and the mobile drawer. */
+function TagFilter({
+  value,
+  tags,
+  onChange,
+  block,
+}: {
+  value: string[];
+  tags: OrgTag[];
+  onChange: (next: string[]) => void;
+  block?: boolean;
+}) {
+  const t = useT();
+  const [open, setOpen] = useState(false);
+  const toggle = (id: string) =>
+    onChange(
+      value.includes(id) ? value.filter((v) => v !== id) : [...value, id],
+    );
+  const label =
+    value.length === 0
+      ? t("taskBoard.taskFilters.tagsLabel")
+      : value.length === 1
+        ? (tags.find((tag) => tag.id === value[0])?.name ??
+          t("taskBoard.taskFilters.tagsLabel"))
+        : t("taskBoard.taskFilters.tagsSelectedCount", {
+            count: value.length,
+          });
+  const triggerClass = chipClass(value.length > 0, block);
+  const chevronClass = cn("shrink-0 opacity-60", block && "ml-auto");
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button type="button" className={triggerClass}>
+          {value.length === 1 ? (
+            <span
+              className="size-2 shrink-0 rounded-full"
+              style={{
+                backgroundColor: tagDotColor(
+                  tags.find((tag) => tag.id === value[0])?.color,
+                ),
+              }}
+            />
+          ) : (
+            <Tag01 size={14} className="shrink-0" />
+          )}
+          <span className="max-w-[10rem] truncate">{label}</span>
+          <ChevronDown size={12} className={chevronClass} />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-56 p-0">
+        <Command>
+          <CommandInput
+            placeholder={t("taskBoard.taskFilters.tagsFilterPlaceholder")}
+            className="h-9"
+          />
+          <CommandList>
+            <CommandEmpty>
+              {t("taskBoard.taskFilters.tagsNoTagsFound")}
+            </CommandEmpty>
+            <CommandGroup>
+              {tags.map((tag) => (
+                <CommandItem
+                  key={tag.id}
+                  value={tag.name}
+                  onSelect={() => toggle(tag.id)}
+                  className="gap-2"
+                >
+                  <span
+                    className="size-2 shrink-0 rounded-full"
+                    style={{ backgroundColor: tagDotColor(tag.color) }}
+                  />
+                  <span className="flex-1 truncate">{tag.name}</span>
+                  {value.includes(tag.id) && (
+                    <Check size={14} className="shrink-0 text-foreground" />
+                  )}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+/** The four filter controls, shared by the inline bar and the mobile drawer. */
 function FilterControls({
   filters,
   members,
+  tags,
   onChange,
   block,
 }: {
   filters: TaskFilters;
   members: Member[];
+  tags: OrgTag[];
   onChange: (next: TaskFilters) => void;
   block?: boolean;
 }) {
@@ -395,6 +498,12 @@ function FilterControls({
         value={filters.due}
         onChange={(due) => onChange({ ...filters, due })}
       />
+      <TagFilter
+        block={block}
+        value={filters.tags}
+        tags={tags}
+        onChange={(tags) => onChange({ ...filters, tags })}
+      />
     </>
   );
 }
@@ -403,10 +512,12 @@ function FilterControls({
 export function TaskFiltersBar({
   filters,
   members,
+  tags,
   onChange,
 }: {
   filters: TaskFilters;
   members: Member[];
+  tags: OrgTag[];
   onChange: (next: TaskFilters) => void;
 }) {
   const t = useT();
@@ -416,7 +527,12 @@ export function TaskFiltersBar({
         size={16}
         className="mr-0.5 shrink-0 text-muted-foreground"
       />
-      <FilterControls filters={filters} members={members} onChange={onChange} />
+      <FilterControls
+        filters={filters}
+        members={members}
+        tags={tags}
+        onChange={onChange}
+      />
       {hasActiveFilters(filters) && (
         <button
           type="button"
@@ -438,10 +554,12 @@ export function TaskFiltersBar({
 export function TaskFiltersDrawer({
   filters,
   members,
+  tags,
   onChange,
 }: {
   filters: TaskFilters;
   members: Member[];
+  tags: OrgTag[];
   onChange: (next: TaskFilters) => void;
 }) {
   const t = useT();
@@ -470,6 +588,7 @@ export function TaskFiltersDrawer({
             block
             filters={filters}
             members={members}
+            tags={tags}
             onChange={onChange}
           />
         </div>


### PR DESCRIPTION
## What is this contribution about?
The kanban task board had labels (tags) on tasks but no way to filter the board by them. This adds a tag filter alongside the existing assignee/priority/due-date filters, in both the desktop filter bar and the mobile filter drawer. A task matches when it has at least one of the selected tags.

## How did you verify your code works?
Added unit tests in `task-filters.test.ts` covering `taskMatchesFilters` with tag filters (matches on any selected tag, excludes when no overlap, excludes untagged tasks when a tag filter is active). Ran `bun run check`, `bun run fmt`, and `bun run lint` with no new errors.

## Screenshots/Demonstration
N/A — not captured for this session.

## How to Test
1. Open the task board with tasks that have different tags assigned.
2. Open the filter bar (desktop) or filter drawer (mobile) and select one or more tags.
3. Confirm only tasks with at least one of the selected tags remain visible, and that clearing filters restores the full list.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a multi-select tag filter to the Kanban task board so users can filter tasks by tags on desktop and mobile. Tasks remain visible if they contain at least one selected tag.

- **New Features**
  - Added tag filter to the filter bar and mobile drawer, sourced via `useTags()`.
  - Updated filter logic: tasks match if they have any selected tag; untagged tasks are excluded when a tag filter is active.
  - Added i18n strings for tag UI (EN and PT-BR) and unit tests covering tag matching behavior.

<sup>Written for commit 6668450b9552e2e96c25f355b4d6cd33d4cfa2a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

