### PR TITLE
fix(sandbox): the golden meta persisted the repo's git token

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -591,7 +591,28 @@ them in the **first** PR — they are the difference between "works in the demo"
 5. **Formatting**: The pre-commit hook will reject commits if code isn't formatted with Biome
 6. **Never modify knip configuration** (`knip.json`, `knip.config.ts`, etc.) to silence warnings. Knip warnings indicate dead code, unused exports, or unused dependencies—these are code smells that should be fixed by removing the unused code/export/dependency, not by adding exclusions to the knip config.
 7. **CI errors are always on your branch**. The `main` branch CI always passes. When CI fails, the problem is in the code you changed—do not assume it's a pre-existing issue or a flaky test. Investigate and fix your code.
-8. **The sandbox daemon is Go** (`packages/sandbox/daemon-go/**`) — one static binary per sandbox pod, the only daemon there is (the TypeScript one is deleted). Write Go there, not TypeScript. Its health probe is unforgiving: Studio polls it and marks the sandbox **dead** on a single miss, tearing the pod down mid-session, so never hold a lock across slow I/O on that path. The daemon's contract is asserted black-box in `packages/sandbox/daemon-e2e/` (swap the binary under test with `DAEMON_E2E_CMD`). Blocking work is still banned in Studio's own Bun processes — see [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+8. **Never persist, commit, or paste a real credential — redact at first sight.** Sandbox
+   clone URLs carry a live GitHub App token (`https://x-access-token:ghs_...@github.com/...`),
+   config payloads carry tenant secrets, and a node's cache is readable by every sandbox on
+   that node. So:
+   - **Strip at the write, not at the caller.** One guard at the single place a value is
+     persisted covers every caller present and future, and it must **fail closed** — an
+     unparseable URL persists nothing rather than falling through to the raw string. See
+     `stripCredentials` in `packages/sandbox/daemon-go/internal/setup/install.go`.
+   - **Assert on the artifact's bytes, not the struct.** The struct can be right while the
+     write path is wrong, and the file is what a co-tenant reads.
+   - **Fixtures are synthetic, always.** Never paste a real token into a test, not even
+     truncated — a committed test is not a place to keep a credential. Never a real
+     customer repo name either; shared artifacts stay neutral.
+   - **A force-push does NOT undo a leak.** GitHub keeps unreferenced objects and serves
+     them by SHA. Only GitHub Support purges, and [they refuse when the risk is mitigable
+     by rotating the credential](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository).
+     Rotate first; treat anything pushed as public forever.
+   - When you *read* a secret while debugging — a node's cache, a pod's env — redact it in
+     the very first message that mentions it. This entry exists because that step was
+     skipped and a customer's token reached a commit and a PR body.
+
+9. **The sandbox daemon is Go** (`packages/sandbox/daemon-go/**`) — one static binary per sandbox pod, the only daemon there is (the TypeScript one is deleted). Write Go there, not TypeScript. Its health probe is unforgiving: Studio polls it and marks the sandbox **dead** on a single miss, tearing the pod down mid-session, so never hold a lock across slow I/O on that path. The daemon's contract is asserted black-box in `packages/sandbox/daemon-e2e/` (swap the binary under test with `DAEMON_E2E_CMD`). Blocking work is still banned in Studio's own Bun processes — see [`CONTRIBUTING.md`](./CONTRIBUTING.md).
 
 ## API Path Convention
 

--- a/packages/sandbox/daemon-go/internal/setup/goldenmeta.go
+++ b/packages/sandbox/daemon-go/internal/setup/goldenmeta.go
@@ -36,9 +36,14 @@ type GoldenMeta struct {
 	// Owning organization. Empty means unknown, which makes the golden
 	// ineligible for a shared store.
 	OrgId string `json:"orgId"`
-	// Credential-stripped clone URL. Not used for keying — the repo hash in the
+	// Clone URL WITHOUT credentials. Not used for keying — the repo hash in the
 	// path is — but a hash is unreadable in an incident, and this is the only
 	// place the mapping exists outside the pod that wrote it.
+	//
+	// WriteGoldenMeta strips it, and that is load-bearing rather than tidy: a
+	// clone URL carries a GitHub App token, this file lives on a hostPath shared
+	// by every sandbox on the node, and it is chowned to the same uid the tenant
+	// runs as. Persisting the raw URL hands one tenant another tenant's token.
 	CloneUrl string `json:"cloneUrl,omitempty"`
 	// Package manager the tree was installed with, mirroring the directory name.
 	// Redundant on purpose: it makes a meta file self-describing when read alone.
@@ -64,6 +69,9 @@ func WriteGoldenMeta(goldenNodeModules string, meta GoldenMeta) {
 	if meta.OrgId == "" {
 		return // nothing worth recording; absence is the signal
 	}
+	// Strip here, not at every call site: this is the only place the URL is
+	// persisted, so one guard covers every caller present and future.
+	meta.CloneUrl = stripCredentials(meta.CloneUrl)
 	buf, err := json.Marshal(meta)
 	if err != nil {
 		return

--- a/packages/sandbox/daemon-go/internal/setup/goldenmeta_secret_test.go
+++ b/packages/sandbox/daemon-go/internal/setup/goldenmeta_secret_test.go
@@ -1,0 +1,85 @@
+package setup
+
+// A clone URL carries a short-lived GitHub App token
+// (`https://x-access-token:ghs_...@github.com/org/repo.git`). The golden meta is
+// written to a hostPath shared by every sandbox on the node and chowned to the
+// uid the tenant runs as, so persisting the raw URL hands one tenant another
+// tenant's credential. Observed in stg before this guard existed.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// SYNTHETIC. Never paste a real token here, not even truncated: this file is
+// committed, and a fixture is not a place to store a credential. The shape is
+// what matters — `x-access-token:ghs_<opaque>` is what a clone URL carries.
+const tokenUrl = "https://x-access-token:ghs_FAKE0000000000000000000000000000@github.com/acme/site.git"
+
+func TestGoldenMetaNeverPersistsCredentials(t *testing.T) {
+	dir := t.TempDir()
+	nm := filepath.Join(dir, "node_modules")
+	if err := os.MkdirAll(nm, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	WriteGoldenMeta(nm, GoldenMeta{OrgId: "org_a", CloneUrl: tokenUrl, Pm: "bun", Env: "stg"})
+
+	raw, err := os.ReadFile(goldenMetaPath(nm))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(raw)
+	// Assert on the file's bytes, not on the struct: the struct could be right
+	// while the write path is wrong, and it is the file a co-tenant can read.
+	for _, secret := range []string{"ghs_", "x-access-token", "FAKE0000000000000000000000000000"} {
+		if strings.Contains(body, secret) {
+			t.Fatalf("meta persisted a credential (%q):\n%s", secret, body)
+		}
+	}
+	// Still useful for an incident: the repo must remain identifiable.
+	if !strings.Contains(body, "github.com/acme/site.git") {
+		t.Fatalf("stripping removed the repo identity too:\n%s", body)
+	}
+
+	meta, ok := ReadGoldenMeta(nm)
+	if !ok {
+		t.Fatal("meta unreadable after stripping")
+	}
+	if strings.Contains(meta.CloneUrl, "ghs_") {
+		t.Fatalf("read-back still carries a credential: %q", meta.CloneUrl)
+	}
+}
+
+// An unparseable URL must yield nothing rather than fall through to the raw
+// string — a partial parse failure is exactly when a token would slip past.
+func TestStripCredentialsFailsClosed(t *testing.T) {
+	if got := stripCredentials("://x-access-token:ghs_abc@bad"); got != "" {
+		t.Fatalf("unparseable URL was persisted: %q", got)
+	}
+	if got := stripCredentials("https://github.com/acme/site.git"); got != "https://github.com/acme/site.git" {
+		t.Fatalf("a credential-free URL was altered: %q", got)
+	}
+}
+
+// The cache key must not shift because of this change: it already stripped
+// credentials, and a different key would orphan every archive already published.
+func TestRepoCacheKeyUnchangedByStripping(t *testing.T) {
+	bare := repoCacheKey("https://github.com/acme/site.git")
+	withToken := repoCacheKey(tokenUrl)
+	if bare != withToken {
+		t.Fatalf("key now depends on credentials:\n bare  %q\n token %q", bare, withToken)
+	}
+	// Anchored values: the guard is that the ALGORITHM is stable, because a
+	// changed key orphans every archive already in the store. Synthetic URLs on
+	// purpose — a test fixture must not name a customer's repository.
+	for url, want := range map[string]string{
+		"https://github.com/acme/site.git":       "2182d8011efb6345",
+		"https://github.com/acme/other-site.git": "ad745d22a5f67e77",
+	} {
+		if got := repoCacheKey(url); got != want {
+			t.Fatalf("key for %s changed to %q (want %q) — published archives would be orphaned", url, got, want)
+		}
+	}
+}

--- a/packages/sandbox/daemon-go/internal/setup/install.go
+++ b/packages/sandbox/daemon-go/internal/setup/install.go
@@ -17,11 +17,23 @@ import (
 // This per-repo partition is a security boundary — bun does not re-verify
 // cache integrity, so a shared writable cache across repos is cross-tenant
 // RCE. Do not widen.
+// stripCredentials removes any userinfo from a clone URL. Clone URLs carry a
+// short-lived GitHub App token (`x-access-token:ghs_...`), so anything that
+// records or hashes a URL must strip it first.
+func stripCredentials(cloneUrl string) string {
+	u, err := url.Parse(cloneUrl)
+	if err != nil {
+		// Unparseable: return nothing rather than risk persisting a token.
+		return ""
+	}
+	u.User = nil
+	return u.String()
+}
+
 func repoCacheKey(cloneUrl string) string {
-	key := cloneUrl
-	if u, err := url.Parse(cloneUrl); err == nil {
-		u.User = nil
-		key = u.String()
+	key := stripCredentials(cloneUrl)
+	if key == "" {
+		key = cloneUrl
 	}
 	sum := sha256.Sum256([]byte(key))
 	return hex.EncodeToString(sum[:])[:16]

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/sandbox",
-  "version": "1.48.1",
+  "version": "1.49.0",
   "private": true,
   "type": "module",
   "description": "Sandbox runtime for isolated Studio tool execution",


### PR DESCRIPTION
Found while validating the L2 cache on stg — the tier works, and this is a defect I introduced building it. Image `1.49.0`.

## The leak

The golden meta records the clone URL, and a clone URL carries a GitHub App token. Shape of what was on a stg node:

```json
{"orgId":"<org>","cloneUrl":"https://x-access-token:ghs_<REDACTED>@github.com/<org>/<repo>.git","pm":"bun"}
```

That file sits in the node's hostPath golden store, which:

- every sandbox on the node shares
- the chown init container hands to **uid 1000 — the uid the tenant runs as**

So one tenant could read another tenant's repo token from a predictable path. Two customer repos were affected on the node I inspected.

The codebase already had this right — `repoCacheKey` strips credentials before hashing, for exactly this reason. I wrote the raw URL beside it and undid that.

## Fix

Stripping happens at the point of **write**, not at each call site: this is the only place the URL is persisted, so one guard covers every caller present and future. And it **fails closed** — an unparseable URL persists nothing rather than falling through to the raw string, because a partial parse failure is precisely when a token slips past.

The repo stays identifiable for an incident; only the userinfo goes.

## The fixtures are fake, deliberately

The token in the test is **synthetic** — `ghs_FAKE0000000000000000000000000000` — and carries a comment saying never to paste a real one, not even truncated, because a committed test is not a place to keep a credential. The repos are `acme/site` and `acme/other-site`, not real customers: a shared artifact does not name one.

An earlier draft of this branch used a real (truncated) token and real customer repo names read off the node. Both are gone from the branch. Worth stating plainly rather than quietly fixing, because the same reflex is what caused the bug being fixed here.

## Tests

`TestGoldenMetaNeverPersistsCredentials` asserts the **file's bytes**, not the struct. The struct can be correct while the write path is wrong, and the file is what a co-tenant reads. Verified it catches the bug: reverting the strip fails with the credential present in the output.

`TestStripCredentialsFailsClosed` covers the unparseable case and confirms a credential-free URL passes through unchanged.

`TestRepoCacheKeyUnchangedByStripping` anchors the `repoCacheKey` values for the synthetic URLs. The guard proves the **algorithm** is stable — a changed key orphans every archive already in the store — and needs no real repo to do it. It earned its place immediately: it caught me pairing one repo's hash with another repo's URL.

`go build`, `go vet`, `gofmt` clean; 15 packages, zero failures uncached.

## AGENTS.md

Adds the rule this violated: redact a secret at first sight, strip at the write, keep fixtures synthetic, and do not expect a force-push to undo a leak — GitHub serves unreferenced objects by SHA, and [Support declines to purge when the risk is mitigable by rotating the credential](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository).

## Two things worth acting on separately

- **Secret scanning is disabled on this repository.** Nothing detected or auto-revoked the token I pushed. It would have caught this in seconds.
- Metas already on disk still contain tokens. They are `ghs_` installation tokens — 1h lifetime, gone when a node recycles. Not swept from under running pods; say the word.

## Context: the tier does work

From the same validation run:

```
published /golden-cache/golden/<org>/<repoHash>/bun-<lockHash>.tar.zst
swept 3 golden(s) in 33.554s: 1 uploaded, 0 without provenance, 2 from another env, 0 failed
```

First archive in the bucket, keyed by org, with the env filter correctly skipping two of prod's trees on a shared node.