### PR TITLE
fix(decopilot): bound the scrape_url browserless fetch with a timeout

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/scrape-url.test.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/scrape-url.test.ts
@@ -34,4 +34,53 @@ describe("createScrapeUrlTool", () => {
       else process.env.BROWSERLESS_TOKEN = prevEnv;
     }
   });
+
+  test("bounds the browserless fetch with a timeout signal", async () => {
+    const originalFetch = globalThis.fetch;
+    let sawSignal: AbortSignal | undefined;
+    globalThis.fetch = (async (_url: string, init?: RequestInit) => {
+      sawSignal = init?.signal ?? undefined;
+      return new Response("<html>ok</html>", {
+        status: 200,
+        headers: { "content-type": "text/html" },
+      });
+    }) as never;
+    try {
+      const tool = createScrapeUrlTool(writer, {
+        browserless: { baseUrl: "https://bl.example", token: "t" },
+        objectStorage: { put: async () => ({ key: "k" }) } as never,
+        toolOutputMap: new Map(),
+      });
+      await tool.execute!({ url: "https://example.com" }, {
+        toolCallId: "tc2",
+      } as never);
+      expect(sawSignal).toBeInstanceOf(AbortSignal);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("reports a timeout instead of hanging when browserless never responds", async () => {
+    // Simulates what fetch throws once AbortSignal.timeout fires, without
+    // waiting for the real 45s — the fix is the try/catch mapping this to a
+    // clear error, not the exact timer duration.
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      throw new DOMException("timed out", "TimeoutError");
+    }) as never;
+    try {
+      const tool = createScrapeUrlTool(writer, {
+        browserless: { baseUrl: "https://bl.example", token: "t" },
+        objectStorage: { put: async () => ({ key: "k" }) } as never,
+        toolOutputMap: new Map(),
+      });
+      const result = (await tool.execute!({ url: "https://example.com" }, {
+        toolCallId: "tc3",
+      } as never)) as { success: boolean; error: string };
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("timed out");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/scrape-url.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/scrape-url.ts
@@ -17,6 +17,12 @@ import { createOutputPreview, estimateJsonTokens } from "./read-tool-output";
 import { toStudioStorageUri } from "../studio-storage-uri";
 import { LARGE_RESULT_TOKEN_THRESHOLD } from "./constants";
 
+// Browserless call itself has no bound beyond the inner page render timeout —
+// if Browserless is unresponsive the outer fetch can hang the harness run
+// forever. Give it headroom instead of leaving it unbounded (mirrors
+// inspect-page.ts's BROWSERLESS_FETCH_TIMEOUT_MS).
+const BROWSERLESS_FETCH_TIMEOUT_MS = 45_000;
+
 const ScrapeUrlInputSchema = z.object({
   url: z.string().url().describe("The URL of the web page to scrape."),
 });
@@ -46,18 +52,31 @@ export function createScrapeUrlTool(
     execute: async (input, options) => {
       const startTime = performance.now();
       try {
-        const response = await fetch(
-          `${browserless.baseUrl}/content?token=${encodeURIComponent(
-            browserless.token,
-          )}`,
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              url: input.url,
-            }),
-          },
-        );
+        let response: Response;
+        try {
+          response = await fetch(
+            `${browserless.baseUrl}/content?token=${encodeURIComponent(
+              browserless.token,
+            )}`,
+            {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({
+                url: input.url,
+              }),
+              signal: AbortSignal.timeout(BROWSERLESS_FETCH_TIMEOUT_MS),
+            },
+          );
+        } catch (err) {
+          const isTimeout = err instanceof Error && err.name === "TimeoutError";
+          return {
+            success: false,
+            error: isTimeout
+              ? `Browserless content fetch timed out after ${BROWSERLESS_FETCH_TIMEOUT_MS}ms`
+              : `Browserless content fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+            url: input.url,
+          };
+        }
 
         if (!response.ok) {
           const errorText = await response.text().catch(() => "Unknown error");


### PR DESCRIPTION
Bug found while investigating open PR #5894 ("bound the portable scrape/inspect browserless fetches with a timeout") — that PR fixes `portable-built-ins.ts`'s Browserless calls but doesn't touch `scrape-url.ts`, the non-portable `scrape_url` built-in tool, which has the identical gap.

**Failure scenario:** `scrape_url`'s outer `fetch` to Browserless's `/content` endpoint has no `signal`/timeout. If Browserless is slow or unresponsive, the fetch (and the whole harness run) hangs indefinitely — there's no bound beyond Browserless's own internal page-render timeout, which doesn't cover the HTTP round-trip itself. `inspect-page.ts` in the same directory already carries this exact fix (`BROWSERLESS_FETCH_TIMEOUT_MS` + `AbortSignal.timeout`, with a comment explaining why); `scrape-url.ts` was missed when that hardening landed.

**Fix:** mirror inspect-page.ts's guard — a 45s `AbortSignal.timeout` on the fetch, with the request wrapped in its own try/catch so a timeout returns a clear `success: false` error (distinguished from other fetch failures) instead of throwing.

**Regression test:** `scrape-url.test.ts` gained two cases — one asserting the fetch call now receives an `AbortSignal`, one asserting a `TimeoutError`-named rejection surfaces as `error: "...timed out..."` rather than an unhandled throw. Both fail on the pre-fix code (no signal is passed; a thrown error isn't caught).

**To verify:** `bun test apps/api/src/harnesses/lib/decopilot/built-in-tools/scrape-url.test.ts`

**Locally ran:** `bun run fmt`, `bunx tsc --noEmit` (apps/api, no new errors in this file), `bunx oxlint` on both changed files (0 warnings/errors), and the targeted test file above (3 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the Browserless `/content` fetch in `scrape-url.ts` with a 45s timeout to prevent hangs and surface clear errors. Brings `scrape_url` in line with `inspect-page.ts`.

- **Bug Fixes**
  - Added `AbortSignal.timeout(45000)` to the Browserless fetch and wrapped it in try/catch.
  - On timeout, return `success: false` with a clear message; other fetch errors return a descriptive failure.
  - Added tests to verify a signal is passed and that timeouts are reported instead of hanging.

<sup>Written for commit 162a3c0b8b093c1d3897ce90483f5cff97bb9756. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

