### PR TITLE
feat(sandbox): measure the dependency cache — pkg-cache warmth + uploader sweep metrics

### DIFF
--- a/packages/sandbox/daemon-go/internal/setup/depmetrics.go
+++ b/packages/sandbox/daemon-go/internal/setup/depmetrics.go
@@ -42,19 +42,23 @@ type depsRestoreLine struct {
 	RepoHash   string        `json:"repo_hash"`
 	DurationMs int64         `json:"duration_ms"`
 	BootId     string        `json:"bootId"`
+	// Whether the package-manager download cache was populated before this
+	// install. Omitted when unset so the line stays byte-compatible with what
+	// existing dashboard panels parse.
+	PkgCache string `json:"pkg_cache,omitempty"`
 }
 
 // BuildDepsRestoreLine renders one line per completed dependency step. The
 // golden cache cannot report its own hit rate — a hit needs the pod to land on
 // a node already warm for its repo, which is a property of fleet churn.
-func BuildDepsRestoreLine(source RestoreSource, cloneUrl string, durationMs int64, bootId string) string {
+func BuildDepsRestoreLine(source RestoreSource, cloneUrl string, durationMs int64, bootId, pkgCache string) string {
 	hash := "unknown"
 	if cloneUrl != "" {
 		hash = repoCacheKey(cloneUrl)
 	}
 	b, err := json.Marshal(depsRestoreLine{
 		Msg: depsRestoreMsg, Source: source, RepoHash: hash,
-		DurationMs: durationMs, BootId: bootId,
+		DurationMs: durationMs, BootId: bootId, PkgCache: pkgCache,
 	})
 	if err != nil {
 		return ""
@@ -62,15 +66,15 @@ func BuildDepsRestoreLine(source RestoreSource, cloneUrl string, durationMs int6
 	return string(b)
 }
 
-func EmitDepsRestore(source RestoreSource, cloneUrl string, durationMs int64, bootId string) {
-	if line := BuildDepsRestoreLine(source, cloneUrl, durationMs, bootId); line != "" {
+func EmitDepsRestore(source RestoreSource, cloneUrl string, durationMs int64, bootId, pkgCache string) {
+	if line := BuildDepsRestoreLine(source, cloneUrl, durationMs, bootId, pkgCache); line != "" {
 		os.Stdout.WriteString(line + "\n")
 	}
 	// Same event, second channel. The stdout line stays byte-compatible with
 	// the TS daemon and is what existing panels read; the metric is what
 	// survives the log pipeline, which samples info-level lines at 1% and so
 	// cannot be counted on at canary volume. No-op unless OTLP is configured.
-	telemetry.RecordDepsRestore(context.Background(), string(source), durationMs)
+	telemetry.RecordDepsRestore(context.Background(), string(source), durationMs, pkgCache)
 }
 
 // IsPackageManifest reports whether rel (relative to node_modules) is a real

--- a/packages/sandbox/daemon-go/internal/setup/depmetrics_test.go
+++ b/packages/sandbox/daemon-go/internal/setup/depmetrics_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestBuildDepsRestoreLineShape(t *testing.T) {
-	line := BuildDepsRestoreLine(RestoreMiss, "https://u:p@github.com/o/r.git", 1234, "boot-1")
+	line := BuildDepsRestoreLine(RestoreMiss, "https://u:p@github.com/o/r.git", 1234, "boot-1", "")
 	// Field order must match the TS emitter so the stored lines look identical.
 	if !strings.HasPrefix(line, `{"msg":"sandbox.deps.restore","source":"miss","repo_hash":"`) {
 		t.Fatalf("unexpected prefix: %s", line)
@@ -28,7 +28,7 @@ func TestBuildDepsRestoreLineShape(t *testing.T) {
 		t.Fatalf("repo_hash = %q, want 16 hex chars", hash)
 	}
 	// The same repo with and without credentials must hash identically.
-	bare := BuildDepsRestoreLine(RestoreMiss, "https://github.com/o/r.git", 1, "b")
+	bare := BuildDepsRestoreLine(RestoreMiss, "https://github.com/o/r.git", 1, "b", "")
 	var bareGot map[string]any
 	json.Unmarshal([]byte(bare), &bareGot)
 	if bareGot["repo_hash"] != hash {
@@ -37,7 +37,7 @@ func TestBuildDepsRestoreLineShape(t *testing.T) {
 }
 
 func TestBuildDepsRestoreLineUnknownRepo(t *testing.T) {
-	line := BuildDepsRestoreLine(RestoreNoInstall, "", 0, "b")
+	line := BuildDepsRestoreLine(RestoreNoInstall, "", 0, "b", "")
 	if !strings.Contains(line, `"repo_hash":"unknown"`) {
 		t.Fatalf("got %s", line)
 	}

--- a/packages/sandbox/daemon-go/internal/setup/goldenuploader.go
+++ b/packages/sandbox/daemon-go/internal/setup/goldenuploader.go
@@ -21,11 +21,14 @@ package setup
 // (org, repo, lockfile) across the whole fleet.
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"time"
+
+	"github.com/decocms/studio/sandbox-daemon/internal/telemetry"
 )
 
 // UploaderOpts configures one sweep of the node-local store.
@@ -203,6 +206,18 @@ func RunUploader(opts UploaderOpts, interval time.Duration, stop <-chan struct{}
 	sweep := func() {
 		started := time.Now()
 		s := UploadNodeGoldens(opts)
+		elapsed := time.Since(started)
+		// Unconditional, unlike the log line below: the log is for a human reading
+		// one node, the metric is for asking whether the tier is alive across the
+		// fleet, and "every node reported zero uploads" is exactly the answer that
+		// question needs. Cheap because it is one datapoint per node per interval.
+		telemetry.RecordGoldenSweep(context.Background(), elapsed.Milliseconds(), map[string]int{
+			"uploaded":      s.Uploaded,
+			"present":       s.Skipped,
+			"no-provenance": s.NoMeta,
+			"other-env":     s.OtherEnv,
+			"failed":        s.Failed,
+		})
 		// Silent when there was nothing to do: this runs on every node, forever,
 		// and a heartbeat per node per interval is noise that buries the lines
 		// that matter.
@@ -210,7 +225,7 @@ func RunUploader(opts UploaderOpts, interval time.Duration, stop <-chan struct{}
 			opts.log(fmt.Sprintf(
 				"[golden-uploader] swept %d golden(s) in %s: %d uploaded, %d already present, "+
 					"%d without provenance, %d from another env, %d failed",
-				s.Scanned, time.Since(started).Truncate(time.Millisecond),
+				s.Scanned, elapsed.Truncate(time.Millisecond),
 				s.Uploaded, s.Skipped, s.NoMeta, s.OtherEnv, s.Failed))
 		}
 	}

--- a/packages/sandbox/daemon-go/internal/setup/install.go
+++ b/packages/sandbox/daemon-go/internal/setup/install.go
@@ -67,6 +67,48 @@ func DepsCacheEnv(cfg *config.Enriched, repoDir string) map[string]string {
 	}
 }
 
+// PkgCacheWarmth reports whether this repo's package-manager download cache was
+// already populated BEFORE the install ran: "warm", "cold", or "unknown" when
+// there is no cache root or no repo to key on.
+//
+// It exists to answer a design question the existing timing cannot: the install
+// phase is measured as one number, so a slow `miss` is indistinguishable between
+// "downloaded every tarball" and "materialised 100k files from a warm cache".
+// That distinction decides whether the golden tiers are worth their machinery —
+// if a warm install is nearly free, skipping install buys little and the effort
+// belongs on the filesystem instead (bun links near-instantly only when the
+// cache and node_modules share a reflink-capable mount, which they do not while
+// /app is an emptyDir).
+//
+// Must be called BEFORE the install: afterwards every cache is warm.
+func PkgCacheWarmth(cfg *config.Enriched, repoDir string) string {
+	cacheRoot := os.Getenv("DEPS_CACHE_ROOT")
+	if cacheRoot == "" {
+		return "unknown"
+	}
+	cloneUrl := resolveCloneUrl(cfg, repoDir)
+	if cloneUrl == "" {
+		return "unknown"
+	}
+	var dir string
+	switch cfg.PmName() {
+	case "deno":
+		dir = filepath.Join(cacheRoot, "deno", repoCacheKey(cloneUrl))
+	case "bun":
+		dir = filepath.Join(cacheRoot, "bun", repoCacheKey(cloneUrl))
+	default:
+		// npm/pnpm/yarn are not pointed at the shared cache at all, so their
+		// installs always pay full price. Saying "cold" would read as a warmable
+		// miss; this is a different fact.
+		return "unpointed"
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil || len(entries) == 0 {
+		return "cold"
+	}
+	return "warm"
+}
+
 func DenoCacheEnv(cfg *config.Enriched, repoDir string) map[string]string {
 	cacheRoot := os.Getenv("DEPS_CACHE_ROOT")
 	if cacheRoot == "" {

--- a/packages/sandbox/daemon-go/internal/setup/orchestrator.go
+++ b/packages/sandbox/daemon-go/internal/setup/orchestrator.go
@@ -411,6 +411,9 @@ func (o *Orchestrator) stepInstallInner() bool {
 	depsStartedAt := time.Now()
 	cloneUrl := resolveCloneUrl(cfg, o.deps.RepoDir)
 	bootId := os.Getenv("DAEMON_BOOT_ID")
+	// Sampled BEFORE any restore or install touches the cache — afterwards every
+	// cache reads as warm and the attribute would be useless.
+	pkgCache := PkgCacheWarmth(cfg, o.deps.RepoDir)
 	elapsedMs := func() int64 { return time.Since(depsStartedAt).Milliseconds() }
 
 	// Golden fast path: reflink a cached node_modules for this exact lockfile and
@@ -427,7 +430,7 @@ func (o *Orchestrator) stepInstallInner() bool {
 		o.mu.Lock()
 		o.pendingGolden = nil // restored an existing golden — nothing to publish
 		o.mu.Unlock()
-		EmitDepsRestore(RestoreL1, cloneUrl, elapsedMs(), bootId)
+		EmitDepsRestore(RestoreL1, cloneUrl, elapsedMs(), bootId, pkgCache)
 		o.markInstallSucceeded(cfg)
 		return true
 	}
@@ -444,7 +447,7 @@ func (o *Orchestrator) stepInstallInner() bool {
 		o.mu.Lock()
 		o.pendingGolden = &golden
 		o.mu.Unlock()
-		EmitDepsRestore(RestoreL2, cloneUrl, elapsedMs(), bootId)
+		EmitDepsRestore(RestoreL2, cloneUrl, elapsedMs(), bootId, pkgCache)
 		o.markInstallSucceeded(cfg)
 		return true
 	}
@@ -464,7 +467,7 @@ func (o *Orchestrator) stepInstallInner() bool {
 		// Reported, not silent: this is the path every Deno project takes, and
 		// without a line here "no data" and "the cache is irrelevant for this
 		// runtime" look identical in the log store.
-		EmitDepsRestore(RestoreNoInstall, cloneUrl, elapsedMs(), bootId)
+		EmitDepsRestore(RestoreNoInstall, cloneUrl, elapsedMs(), bootId, pkgCache)
 		o.markInstallSucceeded(cfg)
 		return true
 	}
@@ -475,7 +478,7 @@ func (o *Orchestrator) stepInstallInner() bool {
 		o.deps.Lifecycle.Transition(events.LifecycleState{Phase: events.PhaseInstallFailed, Error: errMsg})
 		return false
 	}
-	EmitDepsRestore(RestoreMiss, cloneUrl, elapsedMs(), bootId)
+	EmitDepsRestore(RestoreMiss, cloneUrl, elapsedMs(), bootId, pkgCache)
 	o.markInstallSucceeded(cfg)
 
 	// Not published yet: PublishPendingGolden runs off the probe's `running`

--- a/packages/sandbox/daemon-go/internal/setup/pkgcachewarmth_test.go
+++ b/packages/sandbox/daemon-go/internal/setup/pkgcachewarmth_test.go
@@ -1,0 +1,92 @@
+package setup
+
+// The install phase is timed as ONE number, so a slow `miss` cannot be told apart
+// from "downloaded every tarball" versus "materialised 100k files from a warm
+// cache". That distinction decides whether the golden tiers earn their machinery,
+// so it has to be an attribute rather than a guess.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/decocms/studio/sandbox-daemon/internal/config"
+)
+
+func TestPkgCacheWarmthOmittedFromLineWhenUnset(t *testing.T) {
+	// Existing dashboard panels parse this line; an always-present key would
+	// change its shape for consumers that never asked for the field.
+	line := BuildDepsRestoreLine(RestoreMiss, "https://github.com/o/r.git", 5, "b", "")
+	if want := "pkg_cache"; contains(line, want) {
+		t.Fatalf("empty warmth still emitted the key:\n%s", line)
+	}
+	line = BuildDepsRestoreLine(RestoreMiss, "https://github.com/o/r.git", 5, "b", "warm")
+	if !contains(line, `"pkg_cache":"warm"`) {
+		t.Fatalf("warmth missing from the line:\n%s", line)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (func() bool {
+		for i := 0; i+len(sub) <= len(s); i++ {
+			if s[i:i+len(sub)] == sub {
+				return true
+			}
+		}
+		return false
+	})()
+}
+
+func TestPkgCacheWarmthUnknownWithoutARoot(t *testing.T) {
+	t.Setenv("DEPS_CACHE_ROOT", "")
+	if got := PkgCacheWarmth(nil, t.TempDir()); got != "unknown" {
+		t.Fatalf("got %q want unknown", got)
+	}
+}
+
+// A populated cache dir is warm, an absent or empty one is cold. Empty counts as
+// cold on purpose: a directory the chown init container created but nothing has
+// written to has saved no work.
+func TestPkgCacheWarmthReadsTheCacheDir(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("DEPS_CACHE_ROOT", root)
+	key := repoCacheKey("https://github.com/acme/site.git")
+
+	dir := filepath.Join(root, "bun", key)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := cfgWithPm("bun", "https://github.com/acme/site.git")
+	// Present but empty.
+	if got := PkgCacheWarmth(cfg, ""); got != "cold" {
+		t.Fatalf("an empty cache dir read as %q, want cold", got)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "some-tarball"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := PkgCacheWarmth(cfg, ""); got != "warm" {
+		t.Fatalf("a populated cache dir read as %q, want warm", got)
+	}
+}
+
+// npm/pnpm/yarn are never pointed at the shared cache, so their installs always
+// pay full price. Reporting "cold" would read as a warmable miss and skew the
+// very comparison this attribute exists for; it is a different fact.
+func TestPkgCacheWarmthUnpointedForNonBunNonDeno(t *testing.T) {
+	t.Setenv("DEPS_CACHE_ROOT", t.TempDir())
+	for _, pm := range []string{"npm", "pnpm", "yarn"} {
+		cfg := cfgWithPm(pm, "https://github.com/acme/site.git")
+		if got := PkgCacheWarmth(cfg, ""); got != "unpointed" {
+			t.Fatalf("%s read as %q, want unpointed", pm, got)
+		}
+	}
+}
+
+func cfgWithPm(pm, cloneUrl string) *config.Enriched {
+	return &config.Enriched{TenantConfig: config.TenantConfig{
+		Git: &config.GitConfig{Repository: &config.GitRepository{CloneUrl: &cloneUrl}},
+		Application: &config.Application{
+			PackageManager: &config.PackageManagerConfig{Name: &pm},
+		},
+	}}
+}

--- a/packages/sandbox/daemon-go/internal/telemetry/telemetry.go
+++ b/packages/sandbox/daemon-go/internal/telemetry/telemetry.go
@@ -51,9 +51,31 @@ const scopeName = "github.com/decocms/studio/sandbox-daemon"
 // real one once SetMeterProvider is called, so this works in both orders and
 // needs no nil checks at any call site. With no provider ever installed these
 // stay no-ops.
+//
+// They are assigned in bindInstruments rather than inline in the var block so a
+// test can point them at a ManualReader and assert on the datapoints a Record
+// call actually produces. That is not cosmetic: the global provider delegates
+// exactly ONCE per process, so a test that installs its own provider after any
+// other test has installed one silently observes nothing — every instrument
+// stays bound to the first. Attribute sets are the part of this file most likely
+// to be broken by a well-meant edit, and they are unassertable without this.
 var (
-	meter = otel.Meter(scopeName)
+	phaseDuration        metric.Int64Histogram
+	depsRestore          metric.Int64Counter
+	goldenUpload         metric.Int64Counter
+	goldenUploadDuration metric.Int64Histogram
+	depsRestoreDuration  metric.Int64Histogram
+	readyDuration        metric.Int64Histogram
+	loopLag              metric.Int64Histogram
+	proxyDuration        metric.Int64Histogram
+	devServerExit        metric.Int64Counter
+	publishDuration      metric.Int64Histogram
+)
 
+func init() { bindInstruments(otel.Meter(scopeName)) }
+
+// bindInstruments (re)creates every instrument from meter.
+func bindInstruments(meter metric.Meter) {
 	phaseDuration, _ = meter.Int64Histogram(
 		"sandbox.daemon.phase.duration",
 		metric.WithUnit("ms"),
@@ -67,6 +89,22 @@ var (
 		metric.WithUnit("{step}"),
 		metric.WithDescription(
 			"Dependency-install outcomes by cache tier (l1 / l2 / miss / no-install). The golden-cache hit rate. Also emitted as a stdout line for parity with the TS daemon, but that path is sampled at 1% by the log pipeline and cannot be counted on.",
+		),
+	)
+
+	goldenUpload, _ = meter.Int64Counter(
+		"sandbox.daemon.golden.upload",
+		metric.WithUnit("{golden}"),
+		metric.WithDescription(
+			"Node-local goldens seen by one uploader sweep, by outcome (uploaded / present / no-provenance / other-env / failed). Emitted by the golden-uploader DaemonSet, not by a sandbox. `failed` rising, or `no-provenance` staying non-zero, is the signal that the shared tier is quietly doing nothing — the latter means the org is not reaching the daemon, which is exactly how this tier stayed broken unnoticed.",
+		),
+	)
+
+	goldenUploadDuration, _ = meter.Int64Histogram(
+		"sandbox.daemon.golden.upload.duration",
+		metric.WithUnit("ms"),
+		metric.WithDescription(
+			"Wall-clock duration of one uploader sweep. Compression is the cost and it shares a node with tenant sandboxes, so this is what to watch if the sandbox NodePool starts provisioning extra nodes — a boot made faster by a node added is not a win.",
 		),
 	)
 
@@ -117,7 +155,7 @@ var (
 			"The SIGTERM git sync — the one irrecoverable step of a teardown, and the reason the pod grace period is 90s. How close this runs to the grace period is how much of the user's work is one slow push from being lost.",
 		),
 	)
-)
+}
 
 // Explicit buckets for the boot-cost histograms, shared verbatim with the TS
 // daemon's telemetry.ts. Two panels can only be compared if their buckets
@@ -266,6 +304,24 @@ func RecordPhase(ctx context.Context, name, status string, durationMs int64) {
 		attribute.String("phase", name),
 		attribute.String("status", status),
 	))
+}
+
+// RecordGoldenSweep reports one uploader sweep. Attributes are the outcome only:
+// no repo, no org, no node — those are log fields, and as metric attributes they
+// would be one series per repo. The uploader runs on every node, forever, so its
+// cardinality has to stay flat.
+func RecordGoldenSweep(ctx context.Context, durationMs int64, outcomes map[string]int) {
+	for outcome, n := range outcomes {
+		if n == 0 {
+			// Zeroes still cost a series. `present` is the steady state and would
+			// otherwise dominate a dashboard with nothing happening.
+			continue
+		}
+		goldenUpload.Add(ctx, int64(n), metric.WithAttributes(
+			attribute.String("outcome", outcome),
+		))
+	}
+	goldenUploadDuration.Record(ctx, durationMs)
 }
 
 // RecordDepsRestore reports one dependency step and which cache tier served it.

--- a/packages/sandbox/daemon-go/internal/telemetry/telemetry.go
+++ b/packages/sandbox/daemon-go/internal/telemetry/telemetry.go
@@ -269,8 +269,16 @@ func RecordPhase(ctx context.Context, name, status string, durationMs int64) {
 }
 
 // RecordDepsRestore reports one dependency step and which cache tier served it.
-func RecordDepsRestore(ctx context.Context, source string, durationMs int64) {
-	attrs := metric.WithAttributes(attribute.String("source", source))
+func RecordDepsRestore(ctx context.Context, source string, durationMs int64, pkgCache string) {
+	// pkg_cache splits a slow `miss` into "downloaded everything" and
+	// "materialised a warm cache", which the single install timing cannot.
+	if pkgCache == "" {
+		pkgCache = "unknown"
+	}
+	attrs := metric.WithAttributes(
+		attribute.String("source", source),
+		attribute.String("pkg_cache", pkgCache),
+	)
 	depsRestore.Add(ctx, 1, attrs)
 	depsRestoreDuration.Record(ctx, durationMs, attrs)
 }

--- a/packages/sandbox/daemon-go/internal/telemetry/telemetry_test.go
+++ b/packages/sandbox/daemon-go/internal/telemetry/telemetry_test.go
@@ -40,7 +40,7 @@ func TestInitExportsToEndpoint(t *testing.T) {
 	}
 
 	RecordPhase(context.Background(), "install", "done", 1234)
-	RecordDepsRestore(context.Background(), "no-install", 7)
+	RecordDepsRestore(context.Background(), "no-install", 7, "warm")
 	RecordReady(context.Background(), 9876)
 	RecordProxy(context.Background(), 12, "2xx")
 	RecordDevServerExit(context.Background(), false)
@@ -154,7 +154,7 @@ func TestInitIsNoopWithoutEndpoint(t *testing.T) {
 		t.Fatalf("Init without endpoint should not error: %v", err)
 	}
 	RecordPhase(context.Background(), "install", "done", 1)
-	RecordDepsRestore(context.Background(), "miss", 1)
+	RecordDepsRestore(context.Background(), "miss", 1, "warm")
 	if err := shutdown(context.Background()); err != nil {
 		t.Fatalf("no-op shutdown should not error: %v", err)
 	}

--- a/packages/sandbox/daemon-go/internal/telemetry/telemetry_test.go
+++ b/packages/sandbox/daemon-go/internal/telemetry/telemetry_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 )
@@ -165,4 +167,123 @@ func firstLine(s string) string {
 		return s[:i]
 	}
 	return s
+}
+
+func TestRecordGoldenSweepKeepsCardinalityFlat(t *testing.T) {
+	// The uploader runs on every node forever, so this is the instrument most able
+	// to blow up a metrics backend. Two invariants, both easy to break later by
+	// "just adding" a useful-looking attribute:
+	//   - the only attribute is the outcome, from a closed set. No repo, no org,
+	//     no node: those are one series per value and they live in the log line.
+	//   - a zero count emits nothing, so the steady state does not carry four
+	//     empty series per node per sweep.
+	// Bound directly, NOT via otel.SetMeterProvider: the global delegates once per
+	// process and another test in this package already claimed it, so going
+	// through the global here would observe nothing and pass vacuously.
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader), sdkmetric.WithView(views()...))
+	bindInstruments(provider.Meter(scopeName))
+	t.Cleanup(func() { bindInstruments(otel.Meter(scopeName)) })
+
+	RecordGoldenSweep(context.Background(), 33_554, map[string]int{
+		"uploaded":      1,
+		"present":       2,
+		"no-provenance": 0,
+		"other-env":     0,
+		"failed":        0,
+	})
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+
+	counts := map[string]int64{}
+	sawDuration := false
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			switch m.Name {
+			case "sandbox.daemon.golden.upload":
+				sum, ok := m.Data.(metricdata.Sum[int64])
+				if !ok {
+					t.Fatalf("golden.upload should be a counter, got %T", m.Data)
+				}
+				for _, dp := range sum.DataPoints {
+					if n := dp.Attributes.Len(); n != 1 {
+						t.Errorf("want exactly 1 attribute (outcome), got %d: %v", n, dp.Attributes.ToSlice())
+					}
+					outcome, _ := dp.Attributes.Value(attribute.Key("outcome"))
+					counts[outcome.AsString()] = dp.Value
+				}
+			case "sandbox.daemon.golden.upload.duration":
+				h, ok := m.Data.(metricdata.Histogram[int64])
+				if !ok || len(h.DataPoints) == 0 {
+					t.Fatalf("upload duration should have a datapoint, got %T", m.Data)
+				}
+				if h.DataPoints[0].Sum != 33_554 {
+					t.Errorf("duration sum = %d, want 33554", h.DataPoints[0].Sum)
+				}
+				sawDuration = true
+			}
+		}
+	}
+
+	if counts["uploaded"] != 1 || counts["present"] != 2 {
+		t.Errorf("uploaded/present = %d/%d, want 1/2", counts["uploaded"], counts["present"])
+	}
+	for _, zero := range []string{"no-provenance", "other-env", "failed"} {
+		if _, emitted := counts[zero]; emitted {
+			t.Errorf("outcome %q had count 0 and must not emit a series", zero)
+		}
+	}
+	if !sawDuration {
+		t.Error("sweep duration was never recorded")
+	}
+}
+
+func TestRecordDepsRestoreCarriesPkgCache(t *testing.T) {
+	// The whole point of pkg_cache is splitting a slow `miss` into "downloaded the
+	// internet" and "had a warm cache and still took 35s". If the attribute is
+	// dropped on the metric — it is carried separately on the stdout line, which is
+	// sampled — the two collapse into one bar and the question stays unanswerable.
+	reader := sdkmetric.NewManualReader()
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader), sdkmetric.WithView(views()...))
+	bindInstruments(provider.Meter(scopeName))
+	t.Cleanup(func() { bindInstruments(otel.Meter(scopeName)) })
+
+	RecordDepsRestore(context.Background(), "miss", 34_815, "warm")
+	// Empty must not become an empty-string attribute value: an unset series is
+	// findable, a series labelled "" reads as a real state that does not exist.
+	RecordDepsRestore(context.Background(), "l1", 900, "")
+
+	var rm metricdata.ResourceMetrics
+	if err := reader.Collect(context.Background(), &rm); err != nil {
+		t.Fatalf("collect: %v", err)
+	}
+
+	got := map[string]string{} // source -> pkg_cache
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "sandbox.daemon.deps.restore" {
+				continue
+			}
+			sum := m.Data.(metricdata.Sum[int64])
+			for _, dp := range sum.DataPoints {
+				source, _ := dp.Attributes.Value(attribute.Key("source"))
+				cache, ok := dp.Attributes.Value(attribute.Key("pkg_cache"))
+				if !ok {
+					t.Errorf("source=%s has no pkg_cache attribute", source.AsString())
+					continue
+				}
+				got[source.AsString()] = cache.AsString()
+			}
+		}
+	}
+
+	if got["miss"] != "warm" {
+		t.Errorf("miss pkg_cache = %q, want warm", got["miss"])
+	}
+	if got["l1"] != "unknown" {
+		t.Errorf("unset pkg_cache = %q, want it normalised to unknown", got["l1"])
+	}
 }

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/sandbox",
-  "version": "1.49.2",
+  "version": "1.50.0",
   "private": true,
   "type": "module",
   "description": "Sandbox runtime for isolated Studio tool execution",

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/sandbox",
-  "version": "1.50.0",
+  "version": "1.51.0",
   "private": true,
   "type": "module",
   "description": "Sandbox runtime for isolated Studio tool execution",


### PR DESCRIPTION
Measurement only. No behaviour change to any boot, no new failure mode: nothing here can make a sandbox slower or fail. Image `1.51.0`.

Two blind spots, both about the same question — **is the golden cache worth what it costs?**

## 1. `pkg_cache` on `deps.restore`

`sandbox.daemon.deps.restore` says which tier served a boot (`l1`/`l2`/`miss`/`no-install`) but not whether a `miss` had a warm package cache. Those are very different boots and they currently look identical:

- **cold** — downloaded every package. Slow, and nothing but a cache can fix it.
- **warm** — the packages were already on the node and it *still* took 35s. Then the time is going into linking `node_modules`, not the network.

That distinction decides whether the golden tiers are the right fix at all. If a warm `bun install` is nearly free, the tiers are working around `/app` being an `emptyDir` under `readOnlyRootFilesystem: true` — bun links near-instantly only when its cache and `node_modules` share a reflink-capable mount, and they do not. The cheaper fix would be the filesystem, not a second cache on top.

Sampled in the orchestrator **before** any restore or install touches the cache, so it reports the state the boot found:

| value | meaning |
|---|---|
| `warm` | cache dir is pointed at and populated |
| `cold` | pointed at and empty |
| `unpointed` | this package manager is never pointed at the shared cache (npm/pnpm/yarn) |
| `unknown` | no `DEPS_CACHE_ROOT` |

`unpointed` is kept apart from `cold` deliberately: folding them together would make npm look like a warmable miss when it pays full price every time.

## 2. Golden-uploader sweep metrics

The uploader was observable **only by log**. It runs on every sandbox node forever, its expensive work is compression, and the counters it needs already existed in `UploaderStats` — they just became text. So:

- "is the shared tier alive across the fleet?" meant grepping 14 pods
- `failed` climbing could not be alerted on
- `no-provenance` staying non-zero could not be alerted on — and that one is exactly the symptom of the org not reaching the daemon, i.e. the bug that kept this tier inert without anyone noticing

```
sandbox.daemon.golden.upload{outcome}   uploaded / present / no-provenance / other-env / failed
sandbox.daemon.golden.upload.duration   per-sweep wall clock
```

The duration matters on its own: compression shares the sandbox NodePool, so if this drives the pool to add nodes, a boot made faster by a node added is not a win.

Unlike the log line, the metric is **unconditional**. The log stays silent when a sweep did nothing — a heartbeat per node per interval buries the lines that matter. For the metric, "every node reported zero uploads" is the answer the fleet question needs.

## Cardinality

Flat by construction, which is the main risk in a metric emitted by a DaemonSet:

- `outcome` is a closed set and is the **only** attribute. No repo, no org, no node — those are one series per value, and they stay on the log line.
- `pkg_cache` is 4 closed values × `source`'s 4 = 16 series max on `deps.restore`.
- A zero count emits **nothing**, so the steady state does not carry four empty series per node per sweep.
- `repo_hash` remains log-only, as before.

## Why the instruments moved

Instruments move from inline `var` initialisers into `bindInstruments(meter)`. Load-bearing, not cosmetic: the otel **global provider delegates exactly once per process**, so a test that installs its own provider after another test has installed one observes nothing and passes vacuously. That is why no `Record*` function in this package had an emission test — attribute sets, the part of that file most likely to be broken by a well-meant edit, were unassertable.

Both new tests were verified to **fail when the invariant they guard is reverted**:

| reverted | caught by |
|---|---|
| zero counts emit a series | `outcome "failed" had count 0 and must not emit a series` |
| an extra attribute added | `want exactly 1 attribute (outcome), got 2: [{outcome uploaded} {repo x}]` |
| `pkg_cache` dropped from the metric | `source=miss has no pkg_cache attribute` |

15 packages green uncached, `bun run fmt` clean.

## After merge

Read `deps.restore` split by `pkg_cache` in stg, and the sweep outcomes across the fleet. Those two numbers are what should decide the prod rollout of the shared tier — not the assumption that a cache is obviously good.