### PR TITLE
fix(web): redirect away from org after deleting it

### DIFF
--- a/apps/web/src/components/settings/delete-organization-section.tsx
+++ b/apps/web/src/components/settings/delete-organization-section.tsx
@@ -1,4 +1,5 @@
 import { invalidateOrganizationListCache } from "@/lib/auth-client";
+import { clearLastLocation, readLastLocation } from "@/lib/last-location";
 import { LOCALSTORAGE_KEYS } from "@/lib/localstorage-keys";
 import { track } from "@/lib/posthog-client";
 import { useStudioTools } from "@/lib/studio-tools";
@@ -43,6 +44,12 @@ export function DeleteOrganizationSection() {
       // Drop the cached slug so homeRoute doesn't try to redirect us back here
       if (localStorage.getItem(LOCALSTORAGE_KEYS.lastOrgSlug()) === org.slug) {
         localStorage.removeItem(LOCALSTORAGE_KEYS.lastOrgSlug());
+      }
+
+      // homeRoute reads lastLocation *before* lastOrgSlug, so drop it too or the
+      // loader redirects straight back to the just-deleted org's slug.
+      if (readLastLocation()?.org === org.slug) {
+        clearLastLocation();
       }
 
       // Drop the TTL-cached org list so the homeRoute loader doesn't redirect


### PR DESCRIPTION
## Summary

After deleting an organization, the browser stayed on the deleted org's URL (e.g. `/danielatombini-com-br`) and dead-ended on the "organization not found" error screen instead of navigating to a valid org.

<img width="600" alt="organization not found" src="dead-end screen from bug report" />

## Root cause

The home route (`router.tsx`) restores the last location from **two** independent localStorage keys, checking `lastLocation` *before* `lastOrgSlug`. The delete handler only cleared `lastOrgSlug`, leaving `lastLocation` pointing at the just-deleted org.

The dead-end loop:
1. Delete → clears `lastOrgSlug`, hard-redirects to `/`
2. `homeRoute.beforeLoad` reads `lastLocation` first → still the deleted slug → redirects to `/$org` for the deleted org
3. Shell fetches the org → null → `OrgAccessGate`
4. The gate's auto-bounce back to `/` is gated on `lastOrgSlug` matching — already cleared, so it never fires
5. User dead-ends on "organization not found"

## Fix

In `delete-organization-section.tsx` `onSuccess`, also clear `lastLocation` when it points at the deleted org, mirroring the existing `lastOrgSlug` cleanup. `homeRoute` then falls through both cached keys to `listOrganizationsCached()` and lands on the first valid org (or onboarding).

## Testing

- `bun run fmt` ✅
- `tsc --noEmit` (apps/web) ✅
- Manual: delete an org → now redirects to the first available org / onboarding instead of the not-found screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a redirect loop after deleting an organization. We now clear `lastLocation` if it matches the deleted org and invalidate the cached org list, so the home route lands on a valid org or onboarding instead of "organization not found."

<sup>Written for commit 6c8dd949ac175cc29b0827fd66f3de8dec2ea5ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5905?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

