### PR TITLE
fix(helm): render the studio chart's topologySpreadConstraints error in English

### DIFF
--- a/deploy/helm/studio/templates/deployment.yaml
+++ b/deploy/helm/studio/templates/deployment.yaml
@@ -313,7 +313,7 @@ spec:
       topologySpreadConstraints:
         {{- range .Values.topologySpreadConstraints }}
         - {{- if not .labelSelector }}
-          {{- fail "labelSelector é obrigatório em topologySpreadConstraints. Especifique explicitamente os labels." }}
+          {{- fail "labelSelector is required in topologySpreadConstraints. Specify the labels explicitly." }}
           {{- else }}
           labelSelector:
             {{- toYaml .labelSelector | nindent 12 }}


### PR DESCRIPTION
The Studio chart's `deployment.yaml` has a `fail` guard that requires `labelSelector` on every `topologySpreadConstraints` entry. That guard's message was left in Portuguese (`"labelSelector é obrigatório em topologySpreadConstraints. Especifique explicitamente os labels."`) since it was introduced in #3213 — every other comment/message in the chart (English/en-only repo convention for infra) is English, so any operator who supplies an incomplete `topologySpreadConstraints` entry gets an unreadable error out of an otherwise all-English chart.

Fix: translate the message to English, matching the rest of the chart. No behavior change — same guard, same condition, only the string differs.

How to confirm: run
```
helm template deploy/helm/studio --set database.url=postgresql://x --set-json 'topologySpreadConstraints=[{"maxSkew":1,"topologyKey":"kubernetes.io/hostname","whenUnsatisfiable":"ScheduleAnyway"}]'
```
which now fails with the English message (previously Portuguese).

Locally verified: `helm template` with default values renders unchanged, `helm lint deploy/helm/studio --set database.url=postgresql://x` passes, and the forced-failure render above shows the new message. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the Studio Helm chart to show the `topologySpreadConstraints` guard error in English when `labelSelector` is missing. No behavior change; only the error string was translated for clearer operator feedback.

<sup>Written for commit a5619dc1fa77e663285bb3aedd7a11f0e4f8d6b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

