### PR TITLE
fix(task-board): re-delegating a To Do task to the Super Agent queues a run

### DIFF
--- a/apps/api/src/tools/task-board/rerun.ts
+++ b/apps/api/src/tools/task-board/rerun.ts
@@ -1,16 +1,21 @@
 /**
  * Re-run a task with the Super Agent.
  *
- * There was no way to do this. Every Super Agent dispatch hangs off a
- * TRANSITION — `TASK_BOARD_ITEM_UPDATE` fires a run only when `assigneeId`
- * *changes* to `super-agent` (`update.ts`, `becameSuperAgent`) — so a task
- * already assigned to the Super Agent has nothing left to transition. Sending
- * `assigneeId: "super-agent"` again is a silent no-op: the write happens, the
- * activity diff is empty, the board re-renders, and no run is queued. Observed
- * in prod as an entire board of 63 items, all `assignee_id = 'super-agent'`,
- * none of them re-runnable by any means the product exposed — not the card's
- * Auto-fix button (hidden once assigned), not the assignee picker (no diff, so
- * no Save), not a lane drag (status changes dispatch nothing).
+ * There was no way to do this. Every Super Agent dispatch hung off a
+ * TRANSITION — `TASK_BOARD_ITEM_UPDATE` fired a run only when `assigneeId`
+ * *changed* to `super-agent` — so a task already assigned to the Super Agent
+ * had nothing left to transition. Re-sending `assigneeId: "super-agent"` was a
+ * silent no-op: the write happened, the activity diff was empty, the board
+ * re-rendered, and no run was queued. Observed in prod as an entire board of 63
+ * items, all `assignee_id = 'super-agent'`, none of them re-runnable by any
+ * means the product exposed — not the card's Auto-fix button (hidden once
+ * assigned), not the assignee picker (no diff, so no Save), not a lane drag
+ * (status changes dispatch nothing).
+ *
+ * `delegatesToSuperAgent` (`update.ts`) now re-dispatches an explicit
+ * delegation of a card sitting in To Do, so that one lane recovers itself. This
+ * tool stays the answer for every other lane, and is the only path that TAKES
+ * OVER a card wedged behind a thread that will never finish.
  *
  * The other three ways a run gets re-queued are all reactions the user cannot
  * invoke: a reviewer's `request_changes`, an approved-PR merge conflict, and the

--- a/apps/api/src/tools/task-board/update.test.ts
+++ b/apps/api/src/tools/task-board/update.test.ts
@@ -7,7 +7,8 @@
  */
 import { describe, expect, it } from "bun:test";
 import type { TaskBoardItem } from "@/storage/types";
-import { diffTaskActivityEntries } from "./update";
+import { SUPER_AGENT_ASSIGNEE_ID } from "./schema";
+import { delegatesToSuperAgent, diffTaskActivityEntries } from "./update";
 
 function item(overrides: Partial<TaskBoardItem> = {}): TaskBoardItem {
   return {
@@ -88,5 +89,50 @@ describe("diffTaskActivityEntries", () => {
     const previous = item({ sortOrder: 0 });
     const next = item({ sortOrder: 5 });
     expect(diffTaskActivityEntries(previous, next)).toEqual([]);
+  });
+});
+
+describe("delegatesToSuperAgent", () => {
+  it("delegates when the assignee changes to the Super Agent", () => {
+    expect(
+      delegatesToSuperAgent(
+        SUPER_AGENT_ASSIGNEE_ID,
+        item({ assigneeId: null, status: "todo" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("re-delegates a card parked in To Do already assigned to the Super Agent", () => {
+    // A run that failed out of its retry budget returns the card to To Do
+    // WITHOUT clearing the assignee. Gating on "the assignee changed" made the
+    // Auto fix click a silent no-op and stranded the card in To Do.
+    expect(
+      delegatesToSuperAgent(
+        SUPER_AGENT_ASSIGNEE_ID,
+        item({ assigneeId: SUPER_AGENT_ASSIGNEE_ID, status: "todo" }),
+      ),
+    ).toBe(true);
+  });
+
+  it("does not re-delegate a Super Agent card outside To Do", () => {
+    for (const status of ["in_progress", "in_review", "done"] as const) {
+      expect(
+        delegatesToSuperAgent(
+          SUPER_AGENT_ASSIGNEE_ID,
+          item({ assigneeId: SUPER_AGENT_ASSIGNEE_ID, status }),
+        ),
+      ).toBe(false);
+    }
+  });
+
+  it("does not delegate for any other assignee, or when none was passed", () => {
+    const previous = item({ assigneeId: null, status: "todo" });
+    expect(delegatesToSuperAgent("user_2", previous)).toBe(false);
+    expect(delegatesToSuperAgent(null, previous)).toBe(false);
+    expect(delegatesToSuperAgent(undefined, previous)).toBe(false);
+  });
+
+  it("does not delegate without a pre-update item", () => {
+    expect(delegatesToSuperAgent(SUPER_AGENT_ASSIGNEE_ID, null)).toBe(false);
   });
 });

--- a/apps/api/src/tools/task-board/update.ts
+++ b/apps/api/src/tools/task-board/update.ts
@@ -73,6 +73,33 @@ export function diffTaskActivityEntries(
   return entries;
 }
 
+/**
+ * Does this update delegate the task to the Super Agent, i.e. queue a run?
+ *
+ * Not "did the assignee change": a run that fails out of its retry budget puts
+ * the card back in To Do with the Super Agent still assigned
+ * (`returnToTodoAfterFailure`), so the obvious recovery — clicking Auto fix
+ * again — was a silent no-op and the card sat in To Do forever. An explicit
+ * delegation to the Super Agent on a card sitting in To Do re-dispatches it.
+ *
+ * Any other lane keeps the old assignee-changed gate: In Progress already has
+ * a run in flight, and In Review / Done have their own Rerun path — none of
+ * them should be yanked back to To Do by a stray Auto fix click.
+ *
+ * Pure so the gate is unit-tested; `previous` is null only when nothing else
+ * changed either, which can't be a delegation.
+ */
+export function delegatesToSuperAgent(
+  inputAssigneeId: string | null | undefined,
+  previous: Pick<TaskBoardItem, "assigneeId" | "status"> | null,
+): boolean {
+  if (inputAssigneeId !== SUPER_AGENT_ASSIGNEE_ID) return false;
+  if (!previous) return false;
+  return previous.assigneeId !== SUPER_AGENT_ASSIGNEE_ID
+    ? true
+    : previous.status === "todo";
+}
+
 export const TASK_BOARD_ITEM_UPDATE = defineTool({
   name: "TASK_BOARD_ITEM_UPDATE",
   description:
@@ -165,8 +192,7 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
       input.assigneeId !== (previous?.assigneeId ?? null);
     // Delegating a task to the Super Agent queues it to run — force To Do,
     // overriding any status the caller passed alongside the reassignment.
-    const becameSuperAgent =
-      assigneeChanged && input.assigneeId === SUPER_AGENT_ASSIGNEE_ID;
+    const becameSuperAgent = delegatesToSuperAgent(input.assigneeId, previous);
 
     if (previous && isReportsTask(previous)) {
       // Reports-pushed tasks are the report's findings — their CONTENT is

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -572,8 +572,21 @@ export function TaskBoardItemDialog({
                     <AssigneePickerContent
                       members={members}
                       onSelect={(userId) => {
-                        setAssigneeId(userId);
                         setAssigneeOpen(false);
+                        // Re-picking the Super Agent on a card it already owns
+                        // leaves the form clean, so Save never appears and the
+                        // pick is silently discarded — which is what "I
+                        // assigned it to Auto fix and it stayed in To Do"
+                        // actually was. That intent is a re-run; hand it to the
+                        // same confirm the Rerun button uses.
+                        if (
+                          userId === SUPER_AGENT_ASSIGNEE_ID &&
+                          item?.assigneeId === SUPER_AGENT_ASSIGNEE_ID
+                        ) {
+                          onRerun?.();
+                          return;
+                        }
+                        setAssigneeId(userId);
                       }}
                     />
                   </PopoverContent>


### PR DESCRIPTION
## The bug

A card assigned to **Auto fix** sits in **To Do** and never moves to In Progress.

Reported on the `deco-studio` board; reproduced in prod on `board_JIpjDACFCFhwg8cg6I45W`
("Elevar contraste do token `--color-muted-foreground`"), parked in To Do with
`assignee_id = 'super-agent'` since 2026-08-07 with no activity since.

## Root cause

Every path that starts a Super Agent run hangs off a **diff**, and after a failed
run there is nothing left to diff:

1. A run that exhausts its retry budget returns the card to To Do **without clearing
   the assignee** (`run-reactions.ts` → `returnToTodoAfterFailure`). Its last activity
   entry is `{"to": "todo", "from": "in_progress", "retriesSpent": 1}`.
2. `TASK_BOARD_ITEM_UPDATE` dispatched only when `assigneeId` *changed* to
   `super-agent`. Re-sending the same id wrote the row and queued nothing — the
   activity diff is empty too, so the timeline shows no trace either.
3. In the task dialog the assignee picker only sets **form state**. Re-picking the
   Super Agent leaves the form clean, so the Save button never appears and the pick
   is discarded — no request ever leaves the browser. That matches the DB: the card's
   `updated_at` never moved.

`TASK_BOARD_ITEM_RERUN` exists for already-assigned cards, but it's a second button
the user has to know about; picking Auto fix again is the obvious move and it did
nothing, silently.

## The fix

Gate the dispatch on the **delegation**, not on the diff — extracted as a pure
`delegatesToSuperAgent(inputAssigneeId, previous)`:

- assignee changes to `super-agent` → dispatch (unchanged)
- already `super-agent` **and the card is in To Do** → dispatch (this is the fix)
- already `super-agent` in any other lane → no dispatch (unchanged)

In Progress already has a run in flight; In Review / Done keep `TASK_BOARD_ITEM_RERUN`
as the deliberate path, since only that one takes over a wedged thread and carries a
confirm dialog. Nothing gets yanked back to To Do by a stray click.

Frontend: re-picking the Super Agent in the dialog on a card it already owns now opens
that same Rerun confirm instead of quietly discarding the pick.

## Testing

- `delegatesToSuperAgent` unit tests in `apps/api/src/tools/task-board/update.test.ts`
  (5 cases, incl. the regression: parked-in-To-Do re-delegation must dispatch).
- `bun test apps/api/src/tools/task-board/update.test.ts` — 11 pass.
- `bun run --cwd=apps/api check`, `bun run --cwd=apps/web check`, `bun run fmt`,
  `bun run lint` clean.
- The `*.integration.test.ts` failures in that directory are a local no-Postgres
  environment issue, unrelated to this diff.

## Affected areas

Task board delegation: card assignee picker, bulk-assign toolbar, task dialog,
and any MCP/API caller of `TASK_BOARD_ITEM_UPDATE`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a bug where re-delegating a To Do task to the Super Agent didn’t queue a run, leaving cards stuck. Now, an explicit delegation to `super-agent` in To Do queues a run, and re-picking the Super Agent in the dialog triggers a rerun confirm.

- **Bug Fixes**
  - Gate dispatch on delegation via `delegatesToSuperAgent`: queue a run when `assigneeId` is `super-agent` and the card is in To Do; other lanes keep existing behavior (In Progress unchanged; In Review/Done use `TASK_BOARD_ITEM_RERUN`).
  - Task dialog: re-selecting the Super Agent on an already-owned card opens the Rerun confirm instead of doing nothing.
  - Added unit tests for `delegatesToSuperAgent`; minor copy/clarity updates in `rerun.ts`.

<sup>Written for commit 13de5fa4e859cee434d54bdb02fe05e154d7d2c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

