### PR TITLE
feat(chat): show thread owner's avatar and name on the read-only banner

### DIFF
--- a/apps/web/src/components/chat/input.tsx
+++ b/apps/web/src/components/chat/input.tsx
@@ -25,7 +25,7 @@ import {
   Upload01,
   X,
 } from "@untitledui/icons";
-import type { FormEvent } from "react";
+import type { FormEvent, ReactNode } from "react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import type { Metadata } from "./types.ts";
@@ -57,6 +57,8 @@ import { isTiptapDocEmpty } from "./tiptap/utils";
 import { ToolsPopover } from "./tools-popover";
 import { SessionStats } from "./usage-stats";
 import { authClient } from "@/lib/auth-client.ts";
+import { Avatar } from "@decocms/ui/components/avatar.tsx";
+import { useMembersQuery } from "@/hooks/use-members";
 import { track } from "@/lib/posthog-client";
 import { useSound } from "@/hooks/use-sound.ts";
 import { question004Sound } from "@/lib/sounds/question-004.ts";
@@ -72,10 +74,16 @@ import { shouldBlockHostedRuntime } from "./hosted-runtime-guard";
 // useWindowFileDrop - Reusable hook for window-level file drag & drop
 // ============================================================================
 
-function ChatInputDisabledState({ message }: { message: string }) {
+function ChatInputDisabledState({
+  message,
+  icon,
+}: {
+  message: string;
+  icon?: ReactNode;
+}) {
   return (
     <div className="flex w-full items-center gap-2 px-3 py-2.5 rounded-xl border border-border bg-muted/40 text-muted-foreground">
-      <Lock01 size={14} className="shrink-0" />
+      {icon ?? <Lock01 size={14} className="shrink-0" />}
       <span className="text-sm">{message ?? ""}</span>
     </div>
   );
@@ -422,6 +430,23 @@ export function ChatInput({
   }, [voice.transcript, voice.interimTranscript, voice.status]);
 
   const task = taskCtx?.activeTask ?? null;
+  const ownerId = task?.created_by;
+  const isOthersThread = Boolean(userId && ownerId && ownerId !== userId);
+  // Only someone else's thread needs the member list — the read-only banner
+  // names its owner.
+  const { data: membersData } = useMembersQuery({ enabled: isOthersThread });
+  const owner = (
+    (membersData?.data?.members ?? []) as {
+      userId: string;
+      user?: {
+        name?: string | null;
+        email?: string | null;
+        image?: string | null;
+      };
+    }[]
+  ).find((m) => m.userId === ownerId);
+  const ownerName =
+    owner?.user?.name ?? owner?.user?.email?.split("@")[0] ?? null;
   const isDesktopApp = useIsDesktopApp();
   const hostedRuntimeBlocked = shouldBlockHostedRuntime({
     isDesktopApp,
@@ -567,9 +592,25 @@ export function ChatInput({
     }
   };
 
-  if (userId && task?.created_by && task.created_by !== userId) {
+  if (isOthersThread) {
     return (
-      <ChatInputDisabledState message={t("chat.input.readOnlyOthersChat")} />
+      <ChatInputDisabledState
+        message={
+          ownerName
+            ? t("chat.input.readOnlyOthersChatNamed", { name: ownerName })
+            : t("chat.input.readOnlyOthersChat")
+        }
+        icon={
+          ownerName ? (
+            <Avatar
+              shape="circle"
+              size="2xs"
+              url={owner?.user?.image ?? undefined}
+              fallback={ownerName.slice(0, 2).toUpperCase()}
+            />
+          ) : undefined
+        }
+      />
     );
   }
 

--- a/apps/web/src/i18n/en/chat.ts
+++ b/apps/web/src/i18n/en/chat.ts
@@ -238,6 +238,8 @@ export const chat = {
     "Continue this coding-agent chat in the Studio desktop app.",
   "chat.input.readOnlyOthersChat":
     "Read only - you're viewing someone else's chat",
+  "chat.input.readOnlyOthersChatNamed":
+    "Read only - you're viewing {name}'s chat",
   "chat.input.readOnlyThread":
     "Read only - this chat ran autonomously and takes no replies",
   "chat.input.sendMessage": "Send message",

--- a/apps/web/src/i18n/pt-br/chat.ts
+++ b/apps/web/src/i18n/pt-br/chat.ts
@@ -245,6 +245,8 @@ export const chat = {
     "Continue este chat do agente de código no aplicativo Studio para desktop.",
   "chat.input.readOnlyOthersChat":
     "Apenas leitura - você está visualizando um chat de outra pessoa",
+  "chat.input.readOnlyOthersChatNamed":
+    "Apenas leitura - você está visualizando o chat de {name}",
   "chat.input.readOnlyThread":
     "Apenas leitura - este chat rodou de forma autônoma e não aceita respostas",
   "chat.input.sendMessage": "Enviar mensagem",


### PR DESCRIPTION
## Summary
Opening someone else's thread showed a generic "Read only - you're viewing someone else's chat". It now names the owner and shows their avatar: "Read only - you're viewing Ana's chat".

- `ChatInputDisabledState` takes an optional `icon` (defaults to the lock).
- Owner resolved from `useMembersQuery({ enabled })` — only fetched when the thread isn't yours; the member list is already cached org-wide by the same query key.
- Falls back to the existing unnamed string + lock icon when the owner isn't in the member list (left the org, or list still loading).
- New i18n key `chat.input.readOnlyOthersChatNamed` in en + pt-br.

## Testing
`bun run --cwd=apps/web check` and `bun run lint` pass. No new tests — presentation-only branch with a fallback; the existing string stays covered.

## Screenshots
Not captured (UI copy + avatar in the composer's read-only state).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the thread owner’s avatar and name on the read-only chat banner when viewing someone else’s chat. This clarifies whose chat you’re in and falls back to the generic message if the owner can’t be resolved.

- **New Features**
  - Banner shows the owner’s name and avatar via `@decocms/ui` `Avatar`.
  - Owner fetched with `useMembersQuery({ enabled: isOthersThread })`; falls back to the generic read-only string.
  - `ChatInputDisabledState` now accepts an optional `icon` prop (defaults to lock).
  - Added i18n key `chat.input.readOnlyOthersChatNamed` in `en` and `pt-br`.

<sup>Written for commit f22215fcf1a8bc0ac0861005a31a4fa278ea8d59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

