### PR TITLE
feat(sandbox-env): opt-in Karpenter do-not-disrupt for claimed sandbox pods

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,6 +9,14 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
+# 0.14.6: opt-in `disruptionProtection.doNotDisrupt` (default off) — annotates
+# sandbox pods with Karpenter's `do-not-disrupt` so voluntary node
+# consolidation/drift never evicts a claimed sandbox mid-session (#5815). A
+# PodDisruptionBudget doesn't fit here (a claimed sandbox is a singleton, no
+# replicas to shift load to — its minAvailable/maxUnavailable math can
+# deadlock Karpenter drift instead), so this is the narrower, safe mitigation.
+# Does not cover involuntary disruption (spot reclaim, node failure) — that's
+# terminationGracePeriodSeconds' job. Additive; no change unless enabled.
 # 0.14.0: scope the golden uploader by environment, and give its volume the key
 # prefix it was missing. Two defects, both of which made the tier silently do
 # nothing rather than fail:
@@ -135,7 +143,7 @@ type: application
 # 0.8.0: org-fs sidecar (orgFs.*) — privileged rclone mounter + main-container
 # mounts. NOTE: the publish workflow skips existing versions, so this MUST
 # stay ahead of the latest published chart (0.7.5 at time of writing).
-version: 0.14.5
+version: 0.14.6
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "1.52.0"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/README.md
+++ b/deploy/helm/sandbox-env/README.md
@@ -271,6 +271,7 @@ See `values.yaml` for the full set. The most-tuned ones:
 | `resources.*` | 0.5/2 CPU, 1/4Gi RAM | per sandbox pod |
 | `nodeSelector` / `tolerations` / `affinity` | `{}` | for sandbox isolation NodePool |
 | `topologySpreadConstraints` | `[]` | spread sandbox pods across AZs; see `values.yaml` for the recommended config |
+| `disruptionProtection.doNotDisrupt` | `false` | annotate pods with Karpenter's `do-not-disrupt` to block voluntary node consolidation/drift while a sandbox is claimed; trades cluster cost/upgrade cadence for session safety |
 | `readOnlyRootFilesystem` | `true` | RO rootfs + emptyDirs on /app, /tmp, /home |
 | `netinit.enabled` | `true` | installs the iptables egress policy before user code starts |
 | `telemetry.enabled` | `false` | let the daemon export OTLP metrics: opens ONE extra egress destination (the collector) and sets `OTEL_EXPORTER_OTLP_ENDPOINT` |

--- a/deploy/helm/sandbox-env/templates/sandbox-template.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-template.yaml
@@ -29,8 +29,9 @@ spec:
   networkPolicyManagement: Unmanaged
   podTemplate:
     metadata:
-      {{- if .Values.netinit.enabled }}
+      {{- if or .Values.netinit.enabled .Values.disruptionProtection.doNotDisrupt }}
       annotations:
+        {{- if .Values.netinit.enabled }}
         # Best-effort AWS VPC CNI opt-out. The real safety net is that no
         # NetworkPolicy selects these pods (networkPolicyManagement:
         # Unmanaged + no chart-rendered NP), so the agent's policy-endpoint
@@ -38,6 +39,12 @@ spec:
         # in aws-network-policy-agent's source — verify it's honored before
         # relying on it if a future NP starts matching these pods.
         vpc.amazonaws.com/v1alpha1.network-policy-enforcement: "disabled"
+        {{- end }}
+        {{- if .Values.disruptionProtection.doNotDisrupt }}
+        # Blocks Karpenter's voluntary node consolidation/drift from
+        # evicting this pod mid-session. See values.yaml disruptionProtection.
+        karpenter.sh/do-not-disrupt: "true"
+        {{- end }}
       {{- end }}
       labels:
         # Per-env name so each env's NetworkPolicy podSelector matches only

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -78,6 +78,22 @@ resources:
 # reclaim notice.
 terminationGracePeriodSeconds: 90
 
+# ── disruption protection ───────────────────────────────────────────────
+# Opt-in, off by default. A claimed sandbox pod is a singleton (no replicas
+# to shift load to), so a PodDisruptionBudget's minAvailable/maxUnavailable
+# math doesn't help it and can deadlock Karpenter drift instead — see #5815.
+# `doNotDisrupt` takes the narrower, safe mitigation: annotate the pod with
+# Karpenter's `do-not-disrupt`, which blocks only VOLUNTARY node disruption
+# (consolidation, drift, manual `kubectl delete node`) for as long as the pod
+# lives. It does nothing for involuntary disruption (spot reclaim, node
+# failure) — terminationGracePeriodSeconds above already covers that via the
+# daemon's SIGTERM git-sync.
+# Default off because it trades cluster cost/upgrade cadence for session
+# safety: a long-lived claimed sandbox can hold its node back from
+# consolidation or an AMI/drift rollout indefinitely.
+disruptionProtection:
+  doNotDisrupt: false
+
 # ── daemon telemetry (OTLP metrics) ───────────────────────────────────
 # Opens exactly ONE in-cluster destination in the sandbox egress boundary —
 # the OTel collector — and hands the daemon the matching


### PR DESCRIPTION
Closes #5815 (partially). Node replacement (Karpenter consolidation/drift) can kill a live sandbox session mid-work. The issue's own text warns that a PodDisruptionBudget doesn't fit here — a claimed sandbox is a singleton, no replicas to shift load to, so its minAvailable/maxUnavailable math can deadlock Karpenter drift instead of protecting anything.

This adds the narrower, safe mitigation Karpenter already recommends for singleton/stateful pods: a new opt-in `disruptionProtection.doNotDisrupt` value (default `false`) that annotates the sandbox pod with `karpenter.sh/do-not-disrupt`. That blocks only *voluntary* node disruption (consolidation, drift) for the pod's lifetime — a maintainer can enable it per-environment without touching PDB semantics at all. Involuntary disruption (spot reclaim, real node failure) is unaffected by this annotation and is already covered by the existing `terminationGracePeriodSeconds` (90s) SIGTERM git-sync window.

Default is off because holding a node back from consolidation/drift trades cluster cost and upgrade cadence for session safety — a tradeoff an operator should opt into knowingly, matching this chart's existing convention for every other risk-bearing toggle (netinit, depsCache, warmPool, nodePlaceholder, etc. are all additive/off-by-default).

Failure scenario without this: an org's sandbox pod is running mid-session; Karpenter decides to consolidate or drift-replace the underlying node for cost/version reasons; the pod is evicted and the session is lost even though nothing was actually wrong with it.

Commands a reviewer can run to confirm:
```
helm lint deploy/helm/sandbox-env --set envName=t1
helm template test deploy/helm/sandbox-env --set envName=t1 --set disruptionProtection.doNotDisrupt=true | grep -A2 'karpenter.sh/do-not-disrupt'
```

Locally verified: `helm lint` (0 chart(s) failed) and `helm template` rendered correctly with the flag off (default, unchanged output), on, and on combined with `netinit.enabled=false` — confirming the merged `annotations:` block stays valid YAML in every combination. No TS/JS touched, so no `bun run fmt`/`tsc`/oxlint needed; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in flag to annotate claimed sandbox pods with `karpenter.sh/do-not-disrupt`, preventing Karpenter consolidation/drift from evicting live sessions. Addresses #5815 without using a PodDisruptionBudget, which doesn’t fit singleton pods.

- **New Features**
  - `disruptionProtection.doNotDisrupt` (default `false`) adds `karpenter.sh/do-not-disrupt` to sandbox pods; opt-in due to cost/upgrade tradeoffs.
  - Blocks only voluntary node disruption (consolidation/drift); involuntary events (spot reclaim, node failure) still rely on `terminationGracePeriodSeconds`.

<sup>Written for commit 73ff79a0aa2fd666e8bc772c603fa5186175d6c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

