### PR TITLE
fix(sections-editor): match variant row ids by label, not array position

### DIFF
--- a/apps/web/src/components/sections-editor/page-variant-tabs.test.ts
+++ b/apps/web/src/components/sections-editor/page-variant-tabs.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "bun:test";
+import { reuseVariantEntryIds } from "./page-variant-tabs";
+import type { PageVariant } from "./page-variants";
+
+function variant(label: string): PageVariant {
+  return { label, sections: [] };
+}
+
+describe("reuseVariantEntryIds", () => {
+  it("keeps a tab's id stable when a variant before it is deleted", () => {
+    const current = [
+      { id: "e0", index: 0, variant: variant("A") },
+      { id: "e1", index: 1, variant: variant("B") },
+      { id: "e2", index: 2, variant: variant("C") },
+      { id: "e3", index: 3, variant: variant("D") },
+    ];
+    // "B" (index 1) was deleted — the remaining variants shift up a position.
+    const variants = [variant("A"), variant("C"), variant("D")];
+
+    const next = reuseVariantEntryIds(current, variants);
+
+    expect(next.map((entry) => entry.id)).toEqual(["e0", "e2", "e3"]);
+    expect(next.map((entry) => entry.index)).toEqual([0, 1, 2]);
+  });
+
+  it("mints a fresh id for a duplicated tab and keeps the original's id", () => {
+    const current = [
+      { id: "e0", index: 0, variant: variant("A") },
+      { id: "e1", index: 1, variant: variant("B") },
+    ];
+    const variants = [variant("A"), variant("B"), variant("B (copy)")];
+
+    const next = reuseVariantEntryIds(current, variants);
+    const copy = next[2];
+
+    expect(next[0]?.id).toBe("e0");
+    expect(next[1]?.id).toBe("e1");
+    expect(copy?.id).not.toBe("e0");
+    expect(copy?.id).not.toBe("e1");
+  });
+});

--- a/apps/web/src/components/sections-editor/page-variant-tabs.tsx
+++ b/apps/web/src/components/sections-editor/page-variant-tabs.tsx
@@ -90,6 +90,29 @@ function createEntries(variants: PageVariant[]): VariantTabEntry[] {
   }));
 }
 
+/**
+ * Re-derive entries for a changed variant list, reusing each tab's existing
+ * id by matching on label rather than array position. A delete/duplicate
+ * before a tab shifts every later tab's position, so matching by position
+ * hands it a stale id — remounting its DnD-sortable identity and dropping
+ * e.g. an open row menu on an unrelated tab.
+ */
+export function reuseVariantEntryIds(
+  current: VariantTabEntry[],
+  variants: PageVariant[],
+): VariantTabEntry[] {
+  const byLabel = new Map(current.map((entry) => [entry.variant.label, entry]));
+  return variants.map((variant, index) => {
+    const prior = byLabel.get(variant.label);
+    if (prior) byLabel.delete(variant.label);
+    return {
+      id: prior?.id ?? crypto.randomUUID(),
+      index,
+      variant,
+    };
+  });
+}
+
 function remapEntryIndices(entries: VariantTabEntry[]): VariantTabEntry[] {
   return entries.map((entry, index) => ({
     ...entry,
@@ -344,22 +367,10 @@ export function PageVariantTabs({
     prevDisplayKey !== displayKey
   ) {
     // Duplicate/delete/reorder all land here (a count change always also
-    // changes the display key). Reuse each position's existing id rather than
-    // minting fresh ones for every row — otherwise duplicating or deleting one
-    // variant remounts every OTHER tab's DnD-sortable identity too, dropping
-    // e.g. an open row menu on an unrelated tab.
+    // changes the display key).
     setPrevVariantCount(variants.length);
     setPrevDisplayKey(displayKey);
-    setEntries((current) =>
-      variants.map((variant, index) => {
-        const prior = current[index];
-        return {
-          id: prior?.id ?? crypto.randomUUID(),
-          index,
-          variant,
-        };
-      }),
-    );
+    setEntries((current) => reuseVariantEntryIds(current, variants));
   }
 
   const sensors = useSensors(

--- a/apps/web/src/components/sections-editor/section-variant-list.test.ts
+++ b/apps/web/src/components/sections-editor/section-variant-list.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { reuseVariantEntryIds } from "./section-variant-list";
+
+describe("reuseVariantEntryIds", () => {
+  it("keeps a row's id stable when a variant before it is deleted", () => {
+    const current = [
+      { id: "e0", index: 0, label: "A" },
+      { id: "e1", index: 1, label: "B" },
+      { id: "e2", index: 2, label: "C" },
+      { id: "e3", index: 3, label: "D" },
+    ];
+    // "B" (index 1) was deleted — the remaining variants shift up a position.
+    const variants = [
+      { index: 0, label: "A" },
+      { index: 1, label: "C" },
+      { index: 2, label: "D" },
+    ];
+
+    const next = reuseVariantEntryIds(current, variants);
+
+    expect(next).toEqual([
+      { id: "e0", index: 0, label: "A" },
+      { id: "e2", index: 1, label: "C" },
+      { id: "e3", index: 2, label: "D" },
+    ]);
+  });
+
+  it("mints a fresh id for a duplicated row and keeps the original's id", () => {
+    const current = [
+      { id: "e0", index: 0, label: "A" },
+      { id: "e1", index: 1, label: "B" },
+    ];
+    const variants = [
+      { index: 0, label: "A" },
+      { index: 1, label: "B" },
+      { index: 2, label: "B (copy)" },
+    ];
+
+    const next = reuseVariantEntryIds(current, variants);
+
+    const copy = next[2];
+    expect(next[0]).toEqual({ id: "e0", index: 0, label: "A" });
+    expect(next[1]).toEqual({ id: "e1", index: 1, label: "B" });
+    expect(copy?.label).toBe("B (copy)");
+    expect(copy?.id).not.toBe("e0");
+    expect(copy?.id).not.toBe("e1");
+  });
+});

--- a/apps/web/src/components/sections-editor/section-variant-list.tsx
+++ b/apps/web/src/components/sections-editor/section-variant-list.tsx
@@ -79,6 +79,29 @@ function createEntries(
   }));
 }
 
+/**
+ * Re-derive entries for a changed variant list, reusing each row's existing
+ * id by matching on label rather than array position. A delete/duplicate
+ * before a row shifts every later row's position, so matching by position
+ * hands it a stale id — remounting its DnD-sortable identity and dropping
+ * e.g. an open row menu on an unrelated row.
+ */
+export function reuseVariantEntryIds(
+  current: SortableVariantEntry[],
+  variants: SectionVariantEntry[],
+): SortableVariantEntry[] {
+  const byLabel = new Map(current.map((entry) => [entry.label, entry]));
+  return variants.map((variant) => {
+    const prior = byLabel.get(variant.label);
+    if (prior) byLabel.delete(variant.label);
+    return {
+      id: prior?.id ?? crypto.randomUUID(),
+      index: variant.index,
+      label: variant.label,
+    };
+  });
+}
+
 function remapEntryIndices(
   entries: SortableVariantEntry[],
 ): SortableVariantEntry[] {
@@ -284,22 +307,10 @@ export function SectionVariantList({
     prevDisplayKey !== displayKey
   ) {
     // Duplicate/delete/reorder all land here (a count change always also
-    // changes the display key). Reuse each position's existing id rather than
-    // minting fresh ones for every row — otherwise duplicating or deleting one
-    // variant remounts every OTHER row's DnD-sortable identity too, dropping
-    // e.g. an open row menu on an unrelated row.
+    // changes the display key).
     setPrevVariantCount(variants.length);
     setPrevDisplayKey(displayKey);
-    setEntries((current) =>
-      variants.map((variant, index) => {
-        const prior = current[index];
-        return {
-          id: prior?.id ?? crypto.randomUUID(),
-          index: variant.index,
-          label: variant.label,
-        };
-      }),
-    );
+    setEntries((current) => reuseVariantEntryIds(current, variants));
   }
 
   const sensors = useSensors(


### PR DESCRIPTION
Follows #5888, which fixed duplicate/delete remounting every OTHER row's DnD-sortable identity — but its fix reuses each row's id by array *position* across the re-render, and delete/duplicate before a row shifts every later row's position by one. That hands each shifted row the wrong stale id, remounting it and dropping its state (e.g. an open row menu) again — the exact bug #5888 set out to fix, just for rows after the changed one instead of before it.

**Failure scenario:** open row menus on variants B, C, D in `SectionVariantList` (or `PageVariantTabs`); delete variant A. The remaining variants shift to positions 0/1/2, but position-based reuse hands B's old id to the new position-0 slot etc. — B, C, D all remount and lose their open menus.

**Fix:** match old entries to new variants by label instead of position — a label is stable across the position shift a delete/duplicate causes, so unaffected rows keep their id and only the actually-new/actually-removed row gets a fresh one. Extracted the matching logic into a pure `reuseVariantEntryIds` per file (mirroring the existing `computeHeatmapView` pattern) so it's unit-testable without mounting the component.

**Regression test:** `section-variant-list.test.ts` / `page-variant-tabs.test.ts` assert that deleting an earlier variant keeps every later variant's id (would have failed before this fix — position-based reuse assigns the wrong ids), and that a duplicated row still gets a fresh id while the original keeps its own.

Reviewer check: `bun test apps/web/src/components/sections-editor/section-variant-list.test.ts apps/web/src/components/sections-editor/page-variant-tabs.test.ts`

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/web, clean), the two test files above (4 pass), and `bunx oxlint` on all four touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes state loss in variant rows/tabs by reusing ids matched by label instead of array position, so delete/duplicate of earlier variants no longer remounts unaffected items. Keeps open menus and DnD identity stable.

- **Bug Fixes**
  - Introduced `reuseVariantEntryIds` in `section-variant-list.tsx` and `page-variant-tabs.tsx` to match entries by `label` and mint ids only for truly new variants.
  - Replaced position-based id reuse with label-based reuse in both components and added unit tests covering delete and duplicate scenarios.

<sup>Written for commit cc7c94bac68990e2b7ed42663174f02d46d9f89d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

