### PR TITLE
fix(task-board): re-run stops the run it supersedes

### DIFF
--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -105,6 +105,7 @@ import {
 } from "./utils/paths";
 import { CredentialVault } from "../encryption/credential-vault";
 import type { CancelBroadcast } from "./routes/decopilot/cancel-broadcast";
+import { setCancelBroadcast } from "./routes/decopilot/cancel-registry";
 import {
   createNatsConnectionProvider,
   type NatsConnectionProvider,
@@ -1122,6 +1123,11 @@ export async function createApp(options: CreateAppOptions = {}) {
     asyncResearchJobStorage,
   );
   asyncResearchJobSweeper.start();
+
+  // Publish the broadcaster so callers outside the HTTP layer can stop a run
+  // (see cancel-registry.ts). After both assignment branches, so it holds the
+  // NATS broadcaster or the local stub, whichever this process built.
+  setCancelBroadcast(cancelBroadcast);
 
   cancelBroadcast
     .start((taskId) => {

--- a/apps/api/src/api/routes/decopilot/cancel-registry.ts
+++ b/apps/api/src/api/routes/decopilot/cancel-registry.ts
@@ -1,0 +1,31 @@
+/**
+ * Module-level handle on the app's `CancelBroadcast`.
+ *
+ * Stopping a run means reaching its `AbortController`, which lives in a
+ * `RunRegistry` on whichever pod owns the run. The only path there is
+ * `cancelBroadcast.broadcast()` — it invokes the local `onCancel` (abort
+ * background jobs + registry `CANCEL`) and publishes to every other pod. But
+ * the broadcaster is constructed in app wiring and handed to
+ * `createDecopilotRoutes` as a closure dep, so nothing outside the HTTP layer
+ * could ask for a cancel: an MCP tool that needs to stop a run had no way to.
+ *
+ * This is that seam, the same shape as `sseHub`. Registered once by app wiring.
+ */
+
+import type { CancelBroadcast } from "./cancel-broadcast";
+
+let broadcaster: CancelBroadcast | null = null;
+
+/** Called once by app wiring, right after the broadcaster is constructed. */
+export function setCancelBroadcast(next: CancelBroadcast): void {
+  broadcaster = next;
+}
+
+/**
+ * Ask every pod to abort the run on `threadId`. No-op when no broadcaster is
+ * registered (unit tests, the desktop path) — callers treat cancel as
+ * best-effort, never as a precondition.
+ */
+export function broadcastRunCancel(threadId: string): void {
+  broadcaster?.broadcast(threadId);
+}

--- a/apps/api/src/tools/task-board/rerun.ts
+++ b/apps/api/src/tools/task-board/rerun.ts
@@ -23,17 +23,25 @@
  * collapses by a fixed workflow id so it can never fire twice).
  *
  * So this is a deliberate, explicit user action, and it TAKES OVER: any linked
- * thread still holding the task open is failed first. That is the whole point —
- * the cards that need this are the ones wedged behind a thread that will never
- * finish. The confirmation belongs in the UI, where the human is; by the time
- * the tool is called the decision is made.
+ * thread still holding the task open is failed AND its run stopped (see
+ * `stopSupersededRun` — failing the row alone left the old agent running). That
+ * is the whole point — the cards that need this are the ones wedged behind a
+ * thread that will never finish. The confirmation belongs in the UI, where the
+ * human is; by the time the tool is called the decision is made.
  */
 
 import { z } from "zod";
 import { defineTool } from "@/core/define-tool";
-import { getUserId, requireAuth } from "@/core/studio-context";
+import {
+  getUserId,
+  requireAuth,
+  type StudioContext,
+} from "@/core/studio-context";
 import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
 import { TERMINAL_THREAD_STATUSES } from "@/storage/task-board";
+import { broadcastRunCancel } from "@/api/routes/decopilot/cancel-registry";
+import { cancelHostedHarness } from "@/dispatch-queue";
+import { cancelThreadGateHead } from "@/dispatch-queue/thread-gate-queue";
 import { recordTaskActivity } from "./activity";
 import { emitTaskBoardUpdated } from "./run-reactions";
 import { enqueueSuperAgentForTask } from "./enqueue-super-agent";
@@ -63,6 +71,62 @@ export function threadsToSupersede(item: {
         thread.status !== null && !TERMINAL_THREAD_STATUSES.has(thread.status),
     )
     .map((thread) => thread.threadId);
+}
+
+/**
+ * Stop the run behind a superseded thread — not just its row.
+ *
+ * The takeover used to be the DB write alone: `failIfNotTerminal` flipped the
+ * thread to `failed` and the agent kept running, because its `AbortController`
+ * lives in a pod's `RunRegistry` and nothing here reached it.
+ *
+ * Observed in prod (`board_EnT6dU9ltgxS4fxAZxVXC`): a card whose live stream
+ * had gone quiet looked frozen, so the user pressed Re-run at 16:23. The run
+ * was alive. Seven minutes later it pushed a branch, opened PR #306, commented
+ * on the card and moved it to In Review — while the re-run's own agent did the
+ * same work and opened PR #307 on the same files. Two Super Agent runs, one
+ * task, two conflicting PRs, and a "failed" thread that shipped one of them.
+ *
+ * Mirrors `cancelActiveThreadRun` (routes.ts) minus the ghost force-fail, which
+ * the caller's `failIfNotTerminal` has already done. Every step is best-effort
+ * and ordered after that write, so the superseded reason wins the race against
+ * the registry's own `cancelled` terminal (both are guarded on `in_progress`),
+ * and an unreachable old run never blocks queueing the new one.
+ */
+async function stopSupersededRun(
+  ctx: StudioContext,
+  threadId: string,
+  organizationId: string,
+): Promise<void> {
+  const onError = (step: string) => (err: unknown) =>
+    console.error("[task-board] rerun takeover step failed", {
+      threadId,
+      step,
+      err,
+    });
+
+  // Durable intent, so the ingest backstop rejects the old run's appends even
+  // if no pod is holding it in memory to abort.
+  await ctx.storage.threads
+    .setCancelRequested(threadId, organizationId)
+    .catch(onError("cancel-flag"));
+
+  // A run still parked as the PENDING gate head has no in-memory registry entry
+  // to abort; cancelling the workflow is what frees its partition slot.
+  await cancelThreadGateHead(threadId).catch(onError("gate-head"));
+
+  // The hosted child can't be interrupted mid-step, but cancelling it stops a
+  // still-queued attempt outright and bars DBOS from resurrecting this one.
+  const fence = await ctx.storage.threads
+    .getRunFence(threadId)
+    .catch(() => null);
+  if (fence) {
+    await cancelHostedHarness(threadId, fence).catch(onError("hosted-harness"));
+  }
+
+  // The one call that actually interrupts a running agent loop: local abort
+  // plus cross-pod fan-out to whichever pod owns the run.
+  broadcastRunCancel(threadId);
 }
 
 export const TASK_BOARD_ITEM_RERUN = defineTool({
@@ -133,7 +197,12 @@ export const TASK_BOARD_ITEM_RERUN = defineTool({
         SUPERSEDED_FAILURE_REASON,
         "superseded",
       );
-      if (marked) supersededThreadIds.push(threadId);
+      if (!marked) continue;
+      supersededThreadIds.push(threadId);
+      // Only for a thread this call really took over: a run that settled on its
+      // own in the gap above is already finished, and cancelling it would stamp
+      // a cancel over a real terminal.
+      await stopSupersededRun(ctx, threadId, organizationId);
     }
 
     // In Progress before dispatch, so the card reads as running the moment the


### PR DESCRIPTION
## What happened

Debugging a card that looked stuck (`board_EnT6dU9ltgxS4fxAZxVXC`, thread `thrd_o_rAWW9GQqQsJcAsWjjZb`) turned up a concurrency bug in the manual re-run, not a stall.

Timeline from prod:

| time | event |
|---|---|
| 15:57 | task delegated to the Super Agent, run 1 starts |
| 16:07 | run 1 dies — *"the sandbox stream broke mid-run: socket connection closed unexpectedly"*; auto-retry opens thread `thrd_o_rAWW…` |
| ~16:14 | that thread's live stream goes quiet — the card looks frozen |
| 16:23 | user presses **Re-run**. `failIfNotTerminal` stamps the thread `failed` / `superseded`, a second run starts |
| 16:25 | **the superseded run, still alive**, pushes a branch and opens PR #306, comments on the card, moves it to In Review |
| 16:29 | the re-run's agent opens **PR #307** on the same files |

Two Super Agent runs on one task, two conflicting PRs, and a thread reading `failed` that had in fact shipped one of them. The re-run's own board comment says it: *"só depois de mover a task para In Review eu vi que uma execução anterior desta task…"*.

## Why

`TASK_BOARD_ITEM_RERUN`'s takeover was a DB write and nothing else. Stopping a run means reaching its `AbortController`, which lives in a `RunRegistry` on whichever pod owns the run; the only path there is `cancelBroadcast.broadcast()`, and the broadcaster was a closure dep of `createDecopilotRoutes` — unreachable from a tool. So the tool did the one thing it could reach (flip the row) and the agent ran on.

## The fix

- **`cancel-registry.ts`** — a module-level handle on the app's `CancelBroadcast`, same shape as `sseHub`, registered once by app wiring (after both assignment branches, so it holds the NATS broadcaster or the local stub). `broadcast()` invokes the local `onCancel` (abort background jobs + registry `CANCEL`) and publishes to every other pod, so one call covers this pod and the owner.
- **`stopSupersededRun`** (rerun.ts) — durable cancel flag → gate-head cancel → hosted-child cancel → broadcast. That is `cancelActiveThreadRun` (routes.ts) minus the ghost force-fail, which the caller's `failIfNotTerminal` already did.

Two orderings that matter:

- **After `failIfNotTerminal`**, so the `superseded` reason wins the race against the registry's own `cancelled` terminal — both writes are guarded on `in_progress`, so whichever lands first wins and the loser no-ops.
- **Only for a thread this call actually took over** (`if (!marked) continue`). A run that settled on its own in the gap between the read and the write is finished; cancelling it would stamp a cancel over a real terminal.

Every step is best-effort and logs its own failure: an unreachable old run must never block queueing the new one.

## Testing

`bun run --cwd=apps/api check` clean, `bun run lint` 0 errors, `bun run fmt` applied. `apps/api/src/tools/task-board/` — same 11 pre-existing failures with and without this diff (integration tests that need a real Postgres); `rerun.test.ts` 6/6.

**No new test, deliberately.** The added code is I/O orchestration end to end — per `TESTING.md` that is e2e's tier, not unit's, and asserting *"the old sandbox agent really stopped"* needs a live hosted run. The pure part that decides **which** threads this applies to (`threadsToSupersede`) keeps its unit tests.

## Follow-up, not in this PR

A manual re-run never passes `opts.pr` to `enqueueSuperAgentForTask`, so it never pins the existing PR's head branch and always opens a new PR — the failure mode `enqueue-super-agent.ts` already documents ("one task reached four open PRs this way"). It wouldn't have helped here (#306 didn't exist yet at 16:23), but it is the same class of duplicate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-run now cancels the previously running agent for that task, preventing concurrent runs and conflicting PRs. This fixes cases where re-run only failed the DB row but left the original run alive.

- **Bug Fixes**
  - Added `apps/api/src/api/routes/decopilot/cancel-registry.ts` to expose an app-wide `CancelBroadcast`; `app.ts` registers it via `setCancelBroadcast`.
  - Implemented `stopSupersededRun` in `rerun.ts`: set durable cancel flag, cancel gate head, cancel hosted child, then broadcast cancel — all after `failIfNotTerminal`.
  - Only cancels threads actually taken over; each step is best-effort and logged.

<sup>Written for commit f6ad54ee88dfcf52b6e1d3d1b3bca432dbc8640b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

