### PR TITLE
fix(connections): translate hardcoded 'No description' fallback in ConnectionCard

### DIFF
--- a/apps/web/src/components/connections/connection-card.tsx
+++ b/apps/web/src/components/connections/connection-card.tsx
@@ -1,6 +1,7 @@
 import { Card } from "@decocms/ui/components/card.tsx";
 import { cn } from "@decocms/ui/lib/utils.ts";
 import type { ReactNode } from "react";
+import { useT } from "@/i18n/use-t.ts";
 import { IntegrationIcon } from "../integration-icon.tsx";
 
 export interface ConnectionCardData {
@@ -32,6 +33,7 @@ export function ConnectionCard({
   className,
   fallbackIcon,
 }: ConnectionCardProps) {
+  const t = useT();
   return (
     <Card
       className={cn(
@@ -76,7 +78,8 @@ export function ConnectionCard({
               {connection.title}
             </h3>
             <p className="text-sm text-muted-foreground line-clamp-2">
-              {connection.description || "No description"}
+              {connection.description ||
+                t("connections.connectionCard.noDescription")}
             </p>
           </div>
 

--- a/apps/web/src/i18n/en/connections.ts
+++ b/apps/web/src/i18n/en/connections.ts
@@ -1,4 +1,5 @@
 export const connections = {
+  "connections.connectionCard.noDescription": "No description",
   "connections.createConnectionDialog.argumentsLabel": "Arguments",
   "connections.createConnectionDialog.argumentsPlaceholder":
     "arg1 arg2 --flag value",

--- a/apps/web/src/i18n/pt-br/connections.ts
+++ b/apps/web/src/i18n/pt-br/connections.ts
@@ -1,6 +1,7 @@
 import type { connections as connectionsEn } from "../en/connections.ts";
 
 export const connections = {
+  "connections.connectionCard.noDescription": "Sem descrição",
   "connections.createConnectionDialog.argumentsLabel": "Argumentos",
   "connections.createConnectionDialog.argumentsPlaceholder":
     "arg1 arg2 --flag value",


### PR DESCRIPTION
**Source:** bug found while scanning the mcp-connections-support focus area (issue #5661's own scope — shared/user-owned MCP connections — was already confirmed dry by prior sessions across three separate audits of `apps/api/src/tools/connection/*` and `apps/web` connection UI; `COLLECTION_CONNECTIONS_UPDATE` in particular was just hardened in #5889). While reading the connections UI I found `ConnectionCard` (used by `routes/orgs/connections.tsx`, `views/virtual-mcp/connection-dialog-content.tsx`, and `routes/orgs/catalog-item-card.tsx`) rendering the hardcoded English literal `"No description"` for any connection missing a description, in violation of the repo's i18n rule (all `apps/web/src` user-facing strings must go through `t()`).

**Payoff:** pt-br users browsing connections without a description currently see English text baked into the UI regardless of their language preference.

**Fix:** added `connections.connectionCard.noDescription` to both `i18n/en/connections.ts` and `i18n/pt-br/connections.ts`, and swapped the hardcoded fallback in `connection-card.tsx` for `t("connections.connectionCard.noDescription")`.

**Reviewer check:** open the connections list in the web UI with a connection that has no description, switch language to Portuguese, confirm the card now shows "Sem descrição" instead of the English string.

**Local verification:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean — `TranslationKey` compile-checks both locale files stay in sync), `bunx oxlint` on the three touched files (0 warnings/errors). No test added — this is a straight string interpolation swap with no branching logic; full CI (`bun run check`/`lint`) covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the hardcoded "No description" in `ConnectionCard` with a translated string so the UI matches the user’s language. Added `connections.connectionCard.noDescription` to `i18n/en/connections.ts` and `i18n/pt-br/connections.ts`.

<sup>Written for commit 107e55a91e4c6f56a3296a7ce16f55face8efe86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

