### PR TITLE
fix(registry): correct image upload size limit copy to 5MB

### DIFF
--- a/apps/web/src/i18n/en/registry.ts
+++ b/apps/web/src/i18n/en/registry.ts
@@ -53,7 +53,7 @@ export const registry = {
   "registry.imageUpload.orPasteImageUrl": "Or paste an image URL",
   "registry.imageUpload.previewAlt": "Preview",
   "registry.imageUpload.remove": "Remove",
-  "registry.imageUpload.supportedFormats": "PNG, JPG, SVG up to 2MB",
+  "registry.imageUpload.supportedFormats": "PNG, JPG, SVG up to 5MB",
   "registry.imageUpload.uploadingImage": "Uploading image...",
   "registry.imageUpload.urlPlaceholder": "https://example.com/logo.png",
   "registry.monitorConfiguration.aboutLabel": "About {label}",

--- a/apps/web/src/i18n/pt-br/registry.ts
+++ b/apps/web/src/i18n/pt-br/registry.ts
@@ -55,7 +55,7 @@ export const registry = {
   "registry.imageUpload.orPasteImageUrl": "Ou cole um URL de imagem",
   "registry.imageUpload.previewAlt": "Visualização",
   "registry.imageUpload.remove": "Remover",
-  "registry.imageUpload.supportedFormats": "PNG, JPG, SVG até 2MB",
+  "registry.imageUpload.supportedFormats": "PNG, JPG, SVG até 5MB",
   "registry.imageUpload.uploadingImage": "Enviando imagem...",
   "registry.imageUpload.urlPlaceholder": "https://example.com/logo.png",
   "registry.monitorConfiguration.aboutLabel": "Sobre {label}",


### PR DESCRIPTION
The registry image-upload dropzone told users "PNG, JPG, SVG up to 2MB" (`apps/web/src/i18n/en/registry.ts` / `pt-br/registry.ts`), but the actual enforced limit in `apps/web/src/hooks/registry/use-image-upload.ts` (`file.size > 5 * 1024 * 1024`) is 5MB. A user with a 3-4MB icon would be told it's too big by the copy but the upload would actually succeed — or, worse, they'd shrink a perfectly fine file based on wrong guidance.

Why it matters: mismatched limit copy directly misleads users about what the upload will accept, in the exact registry image-upload flow this focus area asked to audit.

Fix: updated both the `en` and `pt-br` `registry.imageUpload.supportedFormats` strings from "2MB"/"até 2MB" to "5MB"/"até 5MB" to match the enforced limit.

To confirm: open the registry item dialog's image upload, compare the displayed hint text against `use-image-upload.ts`'s 5MB check.

Locally verified: `bun run fmt` (clean) and `bunx oxlint` on both changed files (0 warnings/errors). Pure i18n string change, no types touched, so no targeted test/typecheck was needed. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the registry image upload hint to “PNG, JPG, SVG up to 5MB” in both `en` and `pt-br` locales to match the enforced 5MB limit. This removes the 2MB mismatch so users aren’t misled about acceptable file sizes.

<sup>Written for commit 91bef6d1426916c492132dc94b34699fd979c0e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

