### PR TITLE
fix(sections-editor): match same-label variant tabs/rows FIFO, not last-wins

### DIFF
--- a/apps/web/src/components/sections-editor/page-variant-tabs.test.ts
+++ b/apps/web/src/components/sections-editor/page-variant-tabs.test.ts
@@ -38,4 +38,17 @@ describe("reuseVariantEntryIds", () => {
     expect(copy?.id).not.toBe("e0");
     expect(copy?.id).not.toBe("e1");
   });
+
+  it("keeps two same-label tabs' ids stable in order across an unrelated rebuild", () => {
+    // Un-renamed duplicates share a label — matching must not collapse them.
+    const current = [
+      { id: "e0", index: 0, variant: variant("A") },
+      { id: "e1", index: 1, variant: variant("A") },
+    ];
+    const variants = [variant("A"), variant("A")];
+
+    const next = reuseVariantEntryIds(current, variants);
+
+    expect(next.map((entry) => entry.id)).toEqual(["e0", "e1"]);
+  });
 });

--- a/apps/web/src/components/sections-editor/page-variant-tabs.tsx
+++ b/apps/web/src/components/sections-editor/page-variant-tabs.tsx
@@ -101,10 +101,15 @@ export function reuseVariantEntryIds(
   current: VariantTabEntry[],
   variants: PageVariant[],
 ): VariantTabEntry[] {
-  const byLabel = new Map(current.map((entry) => [entry.variant.label, entry]));
+  // Duplicate tabs clone the label as-is, so match same-label entries FIFO.
+  const byLabel = new Map<string, VariantTabEntry[]>();
+  for (const entry of current) {
+    const queue = byLabel.get(entry.variant.label);
+    if (queue) queue.push(entry);
+    else byLabel.set(entry.variant.label, [entry]);
+  }
   return variants.map((variant, index) => {
-    const prior = byLabel.get(variant.label);
-    if (prior) byLabel.delete(variant.label);
+    const prior = byLabel.get(variant.label)?.shift();
     return {
       id: prior?.id ?? crypto.randomUUID(),
       index,

--- a/apps/web/src/components/sections-editor/section-variant-list.test.ts
+++ b/apps/web/src/components/sections-editor/section-variant-list.test.ts
@@ -45,4 +45,20 @@ describe("reuseVariantEntryIds", () => {
     expect(copy?.id).not.toBe("e0");
     expect(copy?.id).not.toBe("e1");
   });
+
+  it("keeps two same-label rows' ids stable in order across an unrelated rebuild", () => {
+    // Un-renamed duplicates share a label — matching must not collapse them.
+    const current = [
+      { id: "e0", index: 0, label: "A" },
+      { id: "e1", index: 1, label: "A" },
+    ];
+    const variants = [
+      { index: 0, label: "A" },
+      { index: 1, label: "A" },
+    ];
+
+    const next = reuseVariantEntryIds(current, variants);
+
+    expect(next.map((entry) => entry.id)).toEqual(["e0", "e1"]);
+  });
 });

--- a/apps/web/src/components/sections-editor/section-variant-list.tsx
+++ b/apps/web/src/components/sections-editor/section-variant-list.tsx
@@ -90,10 +90,15 @@ export function reuseVariantEntryIds(
   current: SortableVariantEntry[],
   variants: SectionVariantEntry[],
 ): SortableVariantEntry[] {
-  const byLabel = new Map(current.map((entry) => [entry.label, entry]));
+  // Duplicate rows clone the label as-is, so match same-label entries FIFO.
+  const byLabel = new Map<string, SortableVariantEntry[]>();
+  for (const entry of current) {
+    const queue = byLabel.get(entry.label);
+    if (queue) queue.push(entry);
+    else byLabel.set(entry.label, [entry]);
+  }
   return variants.map((variant) => {
-    const prior = byLabel.get(variant.label);
-    if (prior) byLabel.delete(variant.label);
+    const prior = byLabel.get(variant.label)?.shift();
     return {
       id: prior?.id ?? crypto.randomUUID(),
       index: variant.index,


### PR DESCRIPTION
Follows #5912, which fixed `reuseVariantEntryIds` (page-variant-tabs.tsx and its twin in section-variant-list.tsx) matching a tab/row's stable id by label instead of array position.

Duplicating a page variant (`duplicatePageVariantEntry`) or a section variant (`duplicateMultivariateSectionVariant`) clones the label verbatim — no "(copy)" suffix, no rename. So having two entries share an identical label is the *normal* state right after a duplicate, not an edge case.

`reuseVariantEntryIds` built its lookup as `new Map(current.map((e) => [e.label, e]))`. When two current entries share a label, the `Map` constructor keeps only the last one inserted — the earlier entry silently vanishes from the lookup. Any later unrelated change elsewhere in the variants array (a totally different tab renamed/reordered/deleted) still forces a full rebuild of every entry, because `displayKey` is derived from every variant's label. On that rebuild, the surviving map entry gets reused for the *first* of the two same-labeled positions, and the second one — which should have kept its own id — gets a fresh random id instead. That's exactly the bug #5912 fixed (stale DnD-sortable identity, a dropped open row-menu landing on the wrong tab), just reintroduced for the one case duplication itself produces.

Failure scenario: duplicate a variant twice without renaming (now 3 entries share a label) → rename/reorder an unrelated 4th variant elsewhere → the DnD identity and any open menu state for the duplicated group jumps to the wrong tab.

Fix: replace the single-entry Map with a per-label FIFO queue (`Map<string, Entry[]>`), shifting the first queued entry off on each match. Same-label entries then keep matching in their original relative order across rebuilds, whether there are 1, 2, or N of them.

Added a regression test to each file's test suite reproducing two same-label entries surviving an unrelated rebuild (`page-variant-tabs.test.ts`, `section-variant-list.test.ts`) — both fail against the prior Map-based implementation.

Reviewer check: `bun test apps/web/src/components/sections-editor/page-variant-tabs.test.ts apps/web/src/components/sections-editor/section-variant-list.test.ts`

Verified locally: `bun run fmt`, `bunx tsc --noEmit` in `apps/web`, the two targeted test files (6 pass), and `bunx oxlint` on all four touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes id reuse for same‑label variant tabs/rows by matching entries FIFO instead of last-wins. This keeps DnD identity and open menu state stable after duplicates and unrelated edits.

- **Bug Fixes**
  - Switch label lookup to per-label FIFO queues (shift on match) in `page-variant-tabs.tsx` and `section-variant-list.tsx`.
  - Add regression tests to ensure two same-label entries keep their ids in order across rebuilds.
  - Stabilizes ids when variants are duplicated without renaming, even after renames/reorders/deletes elsewhere.

<sup>Written for commit ac0f90fdaced99fc700242a0a34134d4c96dfd44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

