### PR TITLE
feat(analytics): capture subscription checkout intent

### DIFF
--- a/apps/api/src/tools/organization/billing-checkout.ts
+++ b/apps/api/src/tools/organization/billing-checkout.ts
@@ -9,6 +9,7 @@ import { createOrgCheckoutSession } from "../../billing/stripe-api";
 import { getPublicUrl } from "../../core/server-constants";
 import { defineTool } from "../../core/define-tool";
 import { requireAuth } from "../../core/studio-context";
+import { captureOrgEvent } from "@/posthog";
 
 export const ORGANIZATION_BILLING_CHECKOUT_START = defineTool({
   name: "ORGANIZATION_BILLING_CHECKOUT_START",
@@ -57,6 +58,12 @@ export const ORGANIZATION_BILLING_CHECKOUT_START = defineTool({
       organizationId,
       successUrl: `${membersUrl}?checkout=success`,
       cancelUrl: `${membersUrl}?checkout=canceled`,
+    });
+    // Intent half of the funnel — completion (subscription_started) arrives via webhook.
+    captureOrgEvent({
+      event: "subscription_checkout_started",
+      organizationId,
+      ...(ctx.auth?.user?.id ? { userId: ctx.auth.user.id } : {}),
     });
     return { url };
   },


### PR DESCRIPTION
## Summary

Follow-up to #5860. `subscription_started` (Stripe webhook) records completions, but nothing recorded the **attempt** — the checkout→paid conversion of the org subscription was unmeasurable, and an org that opens checkout and never pays was invisible in the PLG funnel.

`ORGANIZATION_BILLING_CHECKOUT_START` now captures `subscription_checkout_started` after the Stripe session is created, attributed to the acting user (interactive tool call) with the org group attached — pairing with `subscription_started` for the conversion rate.

## Testing

- Existing `billing-checkout.integration.test.ts` green against real Postgres (guards unchanged; capture is fire-and-forget and no-ops under NODE_ENV=test).
- `bun run check` clean across workspaces, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Track subscription checkout intent by emitting `subscription_checkout_started` after creating the Stripe session. This makes checkout→paid conversion measurable and ties events to the acting user and org.

- **New Features**
  - Emit `subscription_checkout_started` in `ORGANIZATION_BILLING_CHECKOUT_START` via `captureOrgEvent`.
  - Include `organizationId` and optional `userId`.
  - Complements webhook `subscription_started` for conversion tracking; no-op without PostHog config.

<sup>Written for commit 2d7c978e97b4d099ca18d2cdcb0693d0d1827832. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

