### PR TITLE
fix(sandbox): respawn dead dev server instead of endless "starting"

### DIFF
--- a/packages/sandbox/daemon-e2e/daemon.devwatch.e2e.test.ts
+++ b/packages/sandbox/daemon-e2e/daemon.devwatch.e2e.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Daemon conformance suite — DEV-SERVER LIVENESS WATCHDOG.
+ *
+ * When the dev server dies out from under a live daemon (idle freeze, crash, a
+ * stale port after a reclaim), nothing used to respawn it: the proxy served
+ * "Server is starting…" forever and the preview never came back. The daemon now
+ * watches liveness and respawns a dead-but-known-port dev server, bounded, then
+ * surfaces a real start-failed if it can't stay up.
+ *
+ * Black-box: we drive a real `dev` HTTP server, kill it over the wire, and
+ * assert the daemon brings it back to `running` on its own. The watchdog's
+ * grace/tick are shrunk via env so the test doesn't wait the 20s default.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+
+import {
+  authHeaders,
+  type BareRepo,
+  bootstrapRepo,
+  type Daemon,
+  HOOK_TIMEOUT_MS,
+  freePort,
+  readSseUntil,
+  setupBareRepo,
+  startDaemon,
+  stopDaemon,
+  url,
+  waitForOrchestratorIdle,
+} from "./daemon.e2e.helpers";
+
+const SETUP_TIMEOUT_MS = 60_000;
+
+describe("daemon e2e: dev-server liveness watchdog", () => {
+  let d: Daemon;
+  let repo: BareRepo;
+  let devPort: number;
+
+  beforeEach(async () => {
+    devPort = await freePort();
+    // A dev server that actually serves HTML, so the daemon reaches `running`.
+    repo = setupBareRepo({
+      withPackageJson: true,
+      scripts: {
+        dev: `node -e "require('http').createServer((_q,s)=>{s.setHeader('content-type','text/html');s.end('<html>ok</html>')}).listen(process.env.PORT||3000)"`,
+      },
+    });
+    // Shrink the probe cadence and watchdog windows so a dead dev server is
+    // detected and respawned in a couple of seconds instead of the 30s slow
+    // probe + 20s production grace.
+    d = await startDaemon({
+      SANDBOX_PROBE_FAST_MS: "300",
+      SANDBOX_PROBE_SLOW_MS: "1000",
+      SANDBOX_DEV_WATCH_GRACE_MS: "1000",
+      SANDBOX_DEV_WATCH_TICK_MS: "500",
+    });
+  }, HOOK_TIMEOUT_MS);
+
+  afterEach(async () => {
+    await stopDaemon(d);
+    repo.cleanup();
+  }, HOOK_TIMEOUT_MS);
+
+  const lifecyclePhase = async (): Promise<string> => {
+    const { text } = await readSseUntil(url(d, "/_sandbox/events"), {
+      headers: authHeaders(),
+      predicate: (acc) => acc.includes("event: lifecycle"),
+    });
+    return (
+      (
+        JSON.parse(
+          /event: lifecycle\ndata: (.*)\n/.exec(text)?.[1] ?? "{}",
+        ) as { state?: { phase?: string } }
+      ).state?.phase ?? ""
+    );
+  };
+
+  const waitForPhase = async (
+    want: (phase: string) => boolean,
+    label: string,
+    deadlineMs = 25_000,
+  ): Promise<void> => {
+    const deadline = Date.now() + deadlineMs;
+    let last = "";
+    while (Date.now() < deadline) {
+      last = await lifecyclePhase();
+      if (want(last)) return;
+    }
+    throw new Error(`lifecycle never reached ${label} (last=${last})`);
+  };
+
+  const waitForRunning = (deadlineMs = 25_000) =>
+    waitForPhase((p) => p === "running", "running", deadlineMs);
+
+  it(
+    "respawns the dev server after it dies, returning to running",
+    async () => {
+      expect(
+        (
+          await bootstrapRepo(d, repo.url, {
+            application: { packageManager: { name: "npm" }, port: devPort },
+            env: { npm_config_offline: "true", PORT: String(devPort) },
+          })
+        ).status,
+      ).toBe(200);
+      await waitForOrchestratorIdle(d, SETUP_TIMEOUT_MS);
+      await waitForRunning();
+
+      // Kill the dev server over the wire — nothing else respawns it, so a
+      // return to `running` proves the watchdog restarted it.
+      const killed = await fetch(url(d, "/_sandbox/exec/dev/kill"), {
+        method: "POST",
+        headers: authHeaders(),
+      });
+      expect(killed.status).toBe(200);
+
+      // Observe the death first (the probe marks it crashed) so the subsequent
+      // recovery to `running` is unambiguously the watchdog, not a stale frame.
+      await waitForPhase((p) => p !== "running", "not-running");
+      await waitForRunning();
+      expect(d.stdout.value).toContain("restarting (attempt 1/");
+    },
+    SETUP_TIMEOUT_MS,
+  );
+});

--- a/packages/sandbox/daemon-e2e/daemon.devwatch.e2e.test.ts
+++ b/packages/sandbox/daemon-e2e/daemon.devwatch.e2e.test.ts
@@ -11,6 +11,10 @@
  * assert the daemon brings it back to `running` on its own. The watchdog's
  * grace/tick are shrunk via env so the test doesn't wait the 20s default.
  */
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 
 import {
@@ -20,6 +24,7 @@ import {
   type Daemon,
   HOOK_TIMEOUT_MS,
   freePort,
+  postConfig,
   readSseUntil,
   setupBareRepo,
   startDaemon,
@@ -29,6 +34,35 @@ import {
 } from "./daemon.e2e.helpers";
 
 const SETUP_TIMEOUT_MS = 60_000;
+
+const lifecyclePhaseOf = async (d: Daemon): Promise<string> => {
+  const { text } = await readSseUntil(url(d, "/_sandbox/events"), {
+    headers: authHeaders(),
+    predicate: (acc) => acc.includes("event: lifecycle"),
+  });
+  return (
+    (
+      JSON.parse(/event: lifecycle\ndata: (.*)\n/.exec(text)?.[1] ?? "{}") as {
+        state?: { phase?: string };
+      }
+    ).state?.phase ?? ""
+  );
+};
+
+const waitForPhaseOf = async (
+  d: Daemon,
+  want: (phase: string) => boolean,
+  label: string,
+  deadlineMs = 25_000,
+): Promise<void> => {
+  const deadline = Date.now() + deadlineMs;
+  let last = "";
+  while (Date.now() < deadline) {
+    last = await lifecyclePhaseOf(d);
+    if (want(last)) return;
+  }
+  throw new Error(`lifecycle never reached ${label} (last=${last})`);
+};
 
 describe("daemon e2e: dev-server liveness watchdog", () => {
   let d: Daemon;
@@ -60,33 +94,11 @@ describe("daemon e2e: dev-server liveness watchdog", () => {
     repo.cleanup();
   }, HOOK_TIMEOUT_MS);
 
-  const lifecyclePhase = async (): Promise<string> => {
-    const { text } = await readSseUntil(url(d, "/_sandbox/events"), {
-      headers: authHeaders(),
-      predicate: (acc) => acc.includes("event: lifecycle"),
-    });
-    return (
-      (
-        JSON.parse(
-          /event: lifecycle\ndata: (.*)\n/.exec(text)?.[1] ?? "{}",
-        ) as { state?: { phase?: string } }
-      ).state?.phase ?? ""
-    );
-  };
-
-  const waitForPhase = async (
+  const waitForPhase = (
     want: (phase: string) => boolean,
     label: string,
     deadlineMs = 25_000,
-  ): Promise<void> => {
-    const deadline = Date.now() + deadlineMs;
-    let last = "";
-    while (Date.now() < deadline) {
-      last = await lifecyclePhase();
-      if (want(last)) return;
-    }
-    throw new Error(`lifecycle never reached ${label} (last=${last})`);
-  };
+  ) => waitForPhaseOf(d, want, label, deadlineMs);
 
   const waitForRunning = (deadlineMs = 25_000) =>
     waitForPhase((p) => p === "running", "running", deadlineMs);
@@ -118,6 +130,70 @@ describe("daemon e2e: dev-server liveness watchdog", () => {
       await waitForPhase((p) => p !== "running", "not-running");
       await waitForRunning();
       expect(d.stdout.value).toContain("restarting (attempt 1/");
+    },
+    SETUP_TIMEOUT_MS,
+  );
+});
+
+// Fix #2: a dev server that crashed (non-zero exit) latches `status:"error"` +
+// `start-failed`; a later reclaim/branch-change must clear that latch so the
+// start step runs again — without it, `stepStartInner` silently skips every
+// start and the sandbox stays start-failed forever. The watchdog cannot help
+// here (start-failed is not a restartable phase), so this exercises the
+// orchestrator's clearCrashError path specifically.
+describe("daemon e2e: reclaim clears a latched dev-crash error", () => {
+  let d: Daemon;
+  let repo: BareRepo;
+  let devPort: number;
+  let marker: string;
+
+  beforeEach(async () => {
+    devPort = await freePort();
+    marker = join(tmpdir(), `devwatch-reclaim-${devPort}`);
+    rmSync(marker, { force: true });
+    // The dev script exits 1 on its first run (creating the marker) and serves
+    // on every run after — so the first start crashes (→ start-failed + error
+    // latch) and a restarted start succeeds, isolating the latch-clear.
+    repo = setupBareRepo({
+      withPackageJson: true,
+      scripts: {
+        dev: `node -e "const fs=require('fs'),m='${marker.replace(/\\/g, "\\\\")}';if(!fs.existsSync(m)){fs.writeFileSync(m,'1');process.exit(1)}require('http').createServer((_q,s)=>{s.setHeader('content-type','text/html');s.end('<html>ok</html>')}).listen(process.env.PORT)"`,
+      },
+    });
+    d = await startDaemon();
+  }, HOOK_TIMEOUT_MS);
+
+  afterEach(async () => {
+    await stopDaemon(d);
+    repo.cleanup();
+    rmSync(marker, { force: true });
+  }, HOOK_TIMEOUT_MS);
+
+  it(
+    "a branch-change after a crash restarts the dev server",
+    async () => {
+      expect(
+        (
+          await bootstrapRepo(d, repo.url, {
+            application: { packageManager: { name: "npm" }, port: devPort },
+            env: { npm_config_offline: "true", PORT: String(devPort) },
+          })
+        ).status,
+      ).toBe(200);
+      await waitForOrchestratorIdle(d, SETUP_TIMEOUT_MS);
+      // First start crashed → terminal start-failed with the error latched.
+      await waitForPhaseOf(d, (p) => p === "start-failed", "start-failed");
+
+      // A branch-change reclaim. Without clearCrashError the start step is
+      // skipped (status still "error") and this stays start-failed.
+      const res = await postConfig(d, {
+        git: { repository: { cloneUrl: repo.url, branch: "thread-x" } },
+      });
+      expect(((await res.json()) as { transition: string }).transition).toBe(
+        "branch-change",
+      );
+      await waitForOrchestratorIdle(d, SETUP_TIMEOUT_MS);
+      await waitForPhaseOf(d, (p) => p === "running", "running");
     },
     SETUP_TIMEOUT_MS,
   );

--- a/packages/sandbox/daemon-go/internal/devwatch/devwatch.go
+++ b/packages/sandbox/daemon-go/internal/devwatch/devwatch.go
@@ -1,0 +1,84 @@
+// Package devwatch holds the pure decision for the dev-server liveness
+// watchdog: given how long the dev server has been unreachable (while a port
+// was known) and how many restarts already fired this episode, decide whether
+// to respawn it, give up, or do nothing.
+//
+// The rule exists because a dev server can die out from under a live daemon —
+// the idle reaper freezes the pod, the process crashes, or it binds a stale
+// port after a reclaim — and nothing respawns it. The daemon's proxy then
+// serves "Server is starting…" forever (a connection error to a known-but-dead
+// port) and the user's preview never comes back. This watchdog turns that dead
+// end into an automatic restart, bounded so a genuinely broken app surfaces a
+// terminal error instead of an endless loop.
+//
+// Kept dependency-free (no events/lifecycle import) so it stays trivially
+// unit-testable; the caller maps its lifecycle phase to Restartable and its
+// probe/timer state to the rest.
+package devwatch
+
+import "time"
+
+// DefaultGracePeriod is how long the dev server may be unreachable — while a
+// port was known — before it is treated as dead and respawned. Long enough not
+// to interrupt a server that has opened its port but is still doing
+// first-request compilation (the probe's own HEAD timeout is 5s), short enough
+// that recovery feels automatic. The caller passes the effective grace to
+// Decide so it stays overridable (env tuning, fast tests).
+const DefaultGracePeriod = 20 * time.Second
+
+// MaxRestarts is how many respawns are attempted per dead episode before giving
+// up. On give-up the caller surfaces a terminal start-failed, so a genuinely
+// broken dev server shows a real error rather than "Server is starting…"
+// forever. Reset once the server is serving again.
+const MaxRestarts = 3
+
+// Action is the watchdog's verdict for one tick.
+type Action int
+
+const (
+	// ActionNone: leave it alone (serving, still within grace, mid-build, or a
+	// restart is already in flight).
+	ActionNone Action = iota
+	// ActionRestart: respawn the dev server now.
+	ActionRestart
+	// ActionGiveUp: restarts are exhausted — surface a terminal failure.
+	ActionGiveUp
+)
+
+// Input is the state Decide reasons over. All fields are caller-computed so the
+// decision keeps no dependency on the daemon's internals.
+type Input struct {
+	// Serving is true when the probe reports the dev server reachable.
+	Serving bool
+	// Restartable is true only in phases where a dev server is meant to be up
+	// (running/starting/crashed) — never during install/clone (a legit slow
+	// build must not be interrupted) or a terminal *-failed phase.
+	Restartable bool
+	// PortKnown is true once a dev port has been learned — sniffed now, or one
+	// that served earlier this episode. Gates out the legitimate "still
+	// building, no port yet" case, whose port-0 state must not trigger a
+	// restart.
+	PortKnown bool
+	// UnreachableFor is how long the server has been not-serving while a port
+	// was known. Zero while serving.
+	UnreachableFor time.Duration
+	// Attempts already fired this dead episode.
+	Attempts int
+	// RestartInFlight guards against overlapping restarts.
+	RestartInFlight bool
+}
+
+// Decide returns the action for the current tick. grace is the effective
+// unreachable-window before a restart (see DefaultGracePeriod).
+func Decide(in Input, grace time.Duration) Action {
+	if in.Serving || !in.Restartable || !in.PortKnown || in.RestartInFlight {
+		return ActionNone
+	}
+	if in.UnreachableFor < grace {
+		return ActionNone
+	}
+	if in.Attempts >= MaxRestarts {
+		return ActionGiveUp
+	}
+	return ActionRestart
+}

--- a/packages/sandbox/daemon-go/internal/devwatch/devwatch.go
+++ b/packages/sandbox/daemon-go/internal/devwatch/devwatch.go
@@ -1,43 +1,55 @@
-// Package devwatch holds the pure decision for the dev-server liveness
-// watchdog: given how long the dev server has been unreachable (while a port
-// was known) and how many restarts already fired this episode, decide whether
-// to respawn it, give up, or do nothing.
+// Package devwatch holds the dev-server liveness watchdog's decision state: how
+// long the dev server has been unreachable *while a restart could help*, how
+// many restarts already fired this episode, and whether to respawn it, give up,
+// or wait.
 //
 // The rule exists because a dev server can die out from under a live daemon —
-// the idle reaper freezes the pod, the process crashes, or it binds a stale
-// port after a reclaim — and nothing respawns it. The daemon's proxy then
+// the idle reaper freezes the pod, the process exits cleanly, or it binds a
+// stale port after a reclaim — and nothing respawns it. The daemon's proxy then
 // serves "Server is starting…" forever (a connection error to a known-but-dead
-// port) and the user's preview never comes back. This watchdog turns that dead
-// end into an automatic restart, bounded so a genuinely broken app surfaces a
+// port) and the preview never comes back. This watchdog turns that dead end
+// into an automatic restart, bounded so a genuinely broken app surfaces a
 // terminal error instead of an endless loop.
 //
-// Kept dependency-free (no events/lifecycle import) so it stays trivially
-// unit-testable; the caller maps its lifecycle phase to Restartable and its
-// probe/timer state to the rest.
+// The stateful bookkeeping lives here (not in the daemon's main loop) with an
+// injected clock, so the two subtle properties it rests on are unit-testable:
+//   - grace is measured from "a port became known while in a restartable phase",
+//     NOT from process boot — else a slow install would consume the whole grace
+//     window before the dev server even starts, and the watchdog would kill a
+//     legitimately-still-starting server (see TestTracker_GraceFromPortKnown).
+//   - the restart budget only resets after the server has served *continuously*
+//     for StableWindow — else a flapping crash-loop that serves for one probe
+//     cycle between deaths would reset the budget every time and never give up
+//     (see TestTracker_FlappingDoesNotResetBudget).
 package devwatch
 
 import "time"
 
-// DefaultGracePeriod is how long the dev server may be unreachable — while a
-// port was known — before it is treated as dead and respawned. Long enough not
-// to interrupt a server that has opened its port but is still doing
-// first-request compilation (the probe's own HEAD timeout is 5s), short enough
-// that recovery feels automatic. The caller passes the effective grace to
-// Decide so it stays overridable (env tuning, fast tests).
+// DefaultGracePeriod is the unreachable window — measured from when a port
+// becomes known in a restartable phase — before the dev server is treated as
+// dead and respawned. It is a heuristic threshold, not a guarantee: a dev
+// server that opens its port and then blocks on a first-request compile longer
+// than this will be restarted (and, after MaxRestarts, fail). Tune via
+// SANDBOX_DEV_WATCH_GRACE_MS for frameworks with long first compiles.
 const DefaultGracePeriod = 20 * time.Second
 
-// MaxRestarts is how many respawns are attempted per dead episode before giving
-// up. On give-up the caller surfaces a terminal start-failed, so a genuinely
-// broken dev server shows a real error rather than "Server is starting…"
-// forever. Reset once the server is serving again.
-const MaxRestarts = 3
+// DefaultStableWindow is how long the server must serve continuously before the
+// restart budget resets. Longer than a flap so a crash-loop that briefly serves
+// can't keep re-arming the budget and escape the MaxRestarts bound.
+const DefaultStableWindow = 60 * time.Second
 
-// Action is the watchdog's verdict for one tick.
+// DefaultMaxRestarts is how many respawns are attempted per dead episode before
+// giving up. On give-up the caller surfaces a terminal start-failed, so a
+// genuinely broken dev server shows a real error rather than "Server is
+// starting…" forever.
+const DefaultMaxRestarts = 3
+
+// Action is the tracker's verdict for one tick.
 type Action int
 
 const (
-	// ActionNone: leave it alone (serving, still within grace, mid-build, or a
-	// restart is already in flight).
+	// ActionNone: leave it alone (serving, still within grace, mid-build, or
+	// already given up).
 	ActionNone Action = iota
 	// ActionRestart: respawn the dev server now.
 	ActionRestart
@@ -45,40 +57,110 @@ const (
 	ActionGiveUp
 )
 
-// Input is the state Decide reasons over. All fields are caller-computed so the
-// decision keeps no dependency on the daemon's internals.
-type Input struct {
+// Config parameterizes a Tracker. Zero values fall back to the Default* consts.
+type Config struct {
+	Grace        time.Duration
+	StableWindow time.Duration
+	MaxRestarts  int
+}
+
+func (c Config) withDefaults() Config {
+	if c.Grace <= 0 {
+		c.Grace = DefaultGracePeriod
+	}
+	if c.StableWindow <= 0 {
+		c.StableWindow = DefaultStableWindow
+	}
+	if c.MaxRestarts <= 0 {
+		c.MaxRestarts = DefaultMaxRestarts
+	}
+	return c
+}
+
+// Snapshot is the caller-observed state for one tick. Now is injected so the
+// time-based logic is testable without real sleeps.
+type Snapshot struct {
+	Now time.Time
 	// Serving is true when the probe reports the dev server reachable.
 	Serving bool
 	// Restartable is true only in phases where a dev server is meant to be up
 	// (running/starting/crashed) — never during install/clone (a legit slow
 	// build must not be interrupted) or a terminal *-failed phase.
 	Restartable bool
-	// PortKnown is true once a dev port has been learned — sniffed now, or one
-	// that served earlier this episode. Gates out the legitimate "still
-	// building, no port yet" case, whose port-0 state must not trigger a
-	// restart.
+	// PortKnown is true once a dev port has been announced — sniffed from the
+	// dev output, or confirmed serving earlier this session. A merely
+	// *configured* application.port does NOT count: it is set before the server
+	// binds, so it must not make a still-starting server look dead.
 	PortKnown bool
-	// UnreachableFor is how long the server has been not-serving while a port
-	// was known. Zero while serving.
-	UnreachableFor time.Duration
-	// Attempts already fired this dead episode.
-	Attempts int
-	// RestartInFlight guards against overlapping restarts.
-	RestartInFlight bool
 }
 
-// Decide returns the action for the current tick. grace is the effective
-// unreachable-window before a restart (see DefaultGracePeriod).
-func Decide(in Input, grace time.Duration) Action {
-	if in.Serving || !in.Restartable || !in.PortKnown || in.RestartInFlight {
+// Tracker accumulates liveness over ticks and decides the next Action. Not
+// safe for concurrent use — the caller drives it from a single goroutine (or
+// under its own lock).
+type Tracker struct {
+	cfg Config
+	// notServingSince is when the current *eligible* dead window began (zero
+	// while serving, mid-build, or no port yet). Grace is measured from here.
+	notServingSince time.Time
+	// servingSince is when the current continuous serving window began (zero
+	// while not serving). The budget resets once it exceeds StableWindow.
+	servingSince time.Time
+	attempts     int
+	gaveUp       bool
+}
+
+func NewTracker(cfg Config) *Tracker {
+	return &Tracker{cfg: cfg.withDefaults()}
+}
+
+// Attempts is how many restarts have fired this dead episode.
+func (t *Tracker) Attempts() int { return t.attempts }
+
+// MaxRestarts is the effective budget (after defaults), for log messages.
+func (t *Tracker) MaxRestarts() int { return t.cfg.MaxRestarts }
+
+// Observe advances the tracker with one tick's snapshot and returns the action
+// to take. On ActionRestart it has already charged one attempt and reset the
+// grace window; on ActionGiveUp it latches the given-up state until the server
+// serves continuously again.
+func (t *Tracker) Observe(s Snapshot) Action {
+	// Budget/gave-up reset only after a *sustained* serving window, so a flap
+	// that serves for one tick between deaths can't keep re-arming the budget.
+	if s.Serving {
+		if t.servingSince.IsZero() {
+			t.servingSince = s.Now
+		}
+		if s.Now.Sub(t.servingSince) >= t.cfg.StableWindow {
+			t.attempts = 0
+			t.gaveUp = false
+		}
+	} else {
+		t.servingSince = time.Time{}
+	}
+
+	// The unreachable clock runs ONLY while a restart could actually help: a
+	// known port, a restartable phase, not serving. This measures grace from
+	// "port known", not from process boot — the whole point of the field.
+	eligible := !s.Serving && s.Restartable && s.PortKnown
+	if !eligible {
+		t.notServingSince = time.Time{}
 		return ActionNone
 	}
-	if in.UnreachableFor < grace {
+	if t.notServingSince.IsZero() {
+		t.notServingSince = s.Now
+	}
+
+	if t.gaveUp || s.Now.Sub(t.notServingSince) < t.cfg.Grace {
 		return ActionNone
 	}
-	if in.Attempts >= MaxRestarts {
+	if t.attempts >= t.cfg.MaxRestarts {
+		t.gaveUp = true
 		return ActionGiveUp
 	}
+	t.attempts++
+	// Reset the grace window so the next restart is measured from now — this is
+	// also the guard against firing a second restart before the first has had a
+	// chance to come up.
+	t.notServingSince = s.Now
 	return ActionRestart
 }

--- a/packages/sandbox/daemon-go/internal/devwatch/devwatch_test.go
+++ b/packages/sandbox/daemon-go/internal/devwatch/devwatch_test.go
@@ -5,83 +5,179 @@ import (
 	"time"
 )
 
-func TestDecide(t *testing.T) {
-	// A dead-but-known-port server past the grace window, with budget → restart.
-	base := Input{
-		Serving:         false,
-		Restartable:     true,
-		PortKnown:       true,
-		UnreachableFor:  DefaultGracePeriod,
-		Attempts:        0,
-		RestartInFlight: false,
-	}
+var epoch = time.Unix(1_700_000_000, 0)
 
-	cases := []struct {
-		name string
-		in   Input
-		want Action
-	}{
-		{"dead past grace with budget → restart", base, ActionRestart},
-		{
-			"serving → none",
-			with(base, func(i *Input) { i.Serving = true }),
-			ActionNone,
-		},
-		{
-			"not restartable phase (installing/clone-failed) → none",
-			with(base, func(i *Input) { i.Restartable = false }),
-			ActionNone,
-		},
-		{
-			"no port known yet (legit slow build) → none",
-			with(base, func(i *Input) { i.PortKnown = false }),
-			ActionNone,
-		},
-		{
-			"within grace → none",
-			with(base, func(i *Input) { i.UnreachableFor = DefaultGracePeriod - time.Millisecond }),
-			ActionNone,
-		},
-		{
-			"restart already in flight → none",
-			with(base, func(i *Input) { i.RestartInFlight = true }),
-			ActionNone,
-		},
-		{
-			"budget exhausted → give up",
-			with(base, func(i *Input) { i.Attempts = MaxRestarts }),
-			ActionGiveUp,
-		},
-		{
-			"budget exhausted but serving → none (server recovered)",
-			with(base, func(i *Input) {
-				i.Attempts = MaxRestarts
-				i.Serving = true
-			}),
-			ActionNone,
-		},
-		{
-			"last attempt still has budget → restart",
-			with(base, func(i *Input) { i.Attempts = MaxRestarts - 1 }),
-			ActionRestart,
-		},
-		{
-			"exactly at grace boundary → restart",
-			with(base, func(i *Input) { i.UnreachableFor = DefaultGracePeriod }),
-			ActionRestart,
-		},
-	}
+func cfg() Config {
+	return Config{Grace: 20 * time.Second, StableWindow: 60 * time.Second, MaxRestarts: 3}
+}
 
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := Decide(tc.in, DefaultGracePeriod); got != tc.want {
-				t.Fatalf("Decide() = %v, want %v", got, tc.want)
-			}
-		})
+// A dead-but-known-port server, past grace, in a restartable phase → restart.
+func TestTracker_RestartsDeadServer(t *testing.T) {
+	tr := NewTracker(cfg())
+	// t=0: port just became known, not serving → arms the clock, no restart yet.
+	if a := tr.Observe(Snapshot{Now: epoch, Restartable: true, PortKnown: true}); a != ActionNone {
+		t.Fatalf("t=0 want None, got %v", a)
+	}
+	// t=19s: still within grace.
+	if a := tr.Observe(Snapshot{Now: epoch.Add(19 * time.Second), Restartable: true, PortKnown: true}); a != ActionNone {
+		t.Fatalf("t=19 want None, got %v", a)
+	}
+	// t=20s: grace elapsed → restart.
+	if a := tr.Observe(Snapshot{Now: epoch.Add(20 * time.Second), Restartable: true, PortKnown: true}); a != ActionRestart {
+		t.Fatalf("t=20 want Restart, got %v", a)
+	}
+	if tr.Attempts() != 1 {
+		t.Fatalf("want 1 attempt, got %d", tr.Attempts())
 	}
 }
 
-func with(in Input, mut func(*Input)) Input {
-	mut(&in)
-	return in
+// The blocker regression: time spent unreachable *before* a port is known (a
+// slow install) must NOT count toward grace. When the port finally becomes
+// known, the newly-started server gets the full grace window, not zero.
+func TestTracker_GraceFromPortKnownNotBoot(t *testing.T) {
+	tr := NewTracker(cfg())
+	// 40s of install: not restartable, no port. Clock must stay disarmed.
+	for i := 0; i <= 40; i += 5 {
+		if a := tr.Observe(Snapshot{Now: epoch.Add(time.Duration(i) * time.Second), Restartable: false, PortKnown: false}); a != ActionNone {
+			t.Fatalf("install t=%ds want None, got %v", i, a)
+		}
+	}
+	// t=41s: phase→starting, port sniffed. Despite 41s since boot, this is the
+	// first eligible tick → the server gets a fresh grace window, no restart.
+	if a := tr.Observe(Snapshot{Now: epoch.Add(41 * time.Second), Restartable: true, PortKnown: true}); a != ActionNone {
+		t.Fatalf("first-eligible tick want None (fresh grace), got %v", a)
+	}
+	// t=60s (19s after eligible) still within grace.
+	if a := tr.Observe(Snapshot{Now: epoch.Add(60 * time.Second), Restartable: true, PortKnown: true}); a != ActionNone {
+		t.Fatalf("t=60 (19s in) want None, got %v", a)
+	}
+	// t=61s (20s after eligible) → restart.
+	if a := tr.Observe(Snapshot{Now: epoch.Add(61 * time.Second), Restartable: true, PortKnown: true}); a != ActionRestart {
+		t.Fatalf("t=61 (20s in) want Restart, got %v", a)
+	}
+}
+
+// No port yet (still building) never triggers a restart, however long.
+func TestTracker_NoPortNeverRestarts(t *testing.T) {
+	tr := NewTracker(cfg())
+	if a := tr.Observe(Snapshot{Now: epoch.Add(5 * time.Minute), Restartable: true, PortKnown: false}); a != ActionNone {
+		t.Fatalf("want None with no port known, got %v", a)
+	}
+}
+
+// A serving server is left alone and its grace clock stays disarmed.
+func TestTracker_ServingLeftAlone(t *testing.T) {
+	tr := NewTracker(cfg())
+	if a := tr.Observe(Snapshot{Now: epoch.Add(time.Hour), Serving: true, Restartable: true, PortKnown: true}); a != ActionNone {
+		t.Fatalf("want None while serving, got %v", a)
+	}
+}
+
+// After MaxRestarts consecutive dead windows → give up (once).
+func TestTracker_GivesUpAfterMaxRestarts(t *testing.T) {
+	tr := NewTracker(cfg())
+	now := epoch
+	dead := func() Snapshot {
+		return Snapshot{Now: now, Restartable: true, PortKnown: true}
+	}
+	// Arm, then each 20s window past grace charges one restart.
+	tr.Observe(dead())
+	for i := 1; i <= 3; i++ {
+		now = now.Add(20 * time.Second)
+		if a := tr.Observe(dead()); a != ActionRestart {
+			t.Fatalf("attempt %d want Restart, got %v", i, a)
+		}
+	}
+	now = now.Add(20 * time.Second)
+	if a := tr.Observe(dead()); a != ActionGiveUp {
+		t.Fatalf("want GiveUp after budget, got %v", a)
+	}
+	// Latched: no repeated give-ups / restarts.
+	now = now.Add(20 * time.Second)
+	if a := tr.Observe(dead()); a != ActionNone {
+		t.Fatalf("want None after give-up latched, got %v", a)
+	}
+}
+
+// A flapping server that serves briefly (< StableWindow) between deaths must not
+// reset its budget — otherwise the bound never triggers.
+func TestTracker_FlappingDoesNotResetBudget(t *testing.T) {
+	tr := NewTracker(cfg())
+	now := epoch
+	for i := 1; i <= 3; i++ {
+		// Dead window → restart.
+		tr.Observe(Snapshot{Now: now, Restartable: true, PortKnown: true})
+		now = now.Add(20 * time.Second)
+		if a := tr.Observe(Snapshot{Now: now, Restartable: true, PortKnown: true}); a != ActionRestart {
+			t.Fatalf("cycle %d want Restart, got %v", i, a)
+		}
+		// Serves for 2s (< 60s StableWindow) then dies — budget must survive.
+		now = now.Add(1 * time.Second)
+		tr.Observe(Snapshot{Now: now, Serving: true, Restartable: true, PortKnown: true})
+		now = now.Add(1 * time.Second)
+		tr.Observe(Snapshot{Now: now, Serving: true, Restartable: true, PortKnown: true})
+	}
+	// Budget exhausted (attempts==3) despite the brief serves. Arm a fresh dead
+	// window and let grace elapse → give up (the budget was never reset).
+	tr.Observe(Snapshot{Now: now, Restartable: true, PortKnown: true})
+	now = now.Add(20 * time.Second)
+	if a := tr.Observe(Snapshot{Now: now, Restartable: true, PortKnown: true}); a != ActionGiveUp {
+		t.Fatalf("flapping want GiveUp (budget not reset), got %v (attempts=%d)", a, tr.Attempts())
+	}
+}
+
+// A server that serves continuously past StableWindow resets the budget and
+// clears a prior give-up, so a *later* death gets a fresh set of restarts.
+func TestTracker_SustainedServingResetsBudget(t *testing.T) {
+	tr := NewTracker(cfg())
+	now := epoch
+	// Burn the whole budget → give up.
+	tr.Observe(Snapshot{Now: now, Restartable: true, PortKnown: true})
+	for i := 0; i < 4; i++ {
+		now = now.Add(20 * time.Second)
+		tr.Observe(Snapshot{Now: now, Restartable: true, PortKnown: true})
+	}
+	if !tr.gaveUp {
+		t.Fatal("precondition: expected gaveUp")
+	}
+	// Serve continuously for > StableWindow.
+	now = now.Add(1 * time.Second)
+	tr.Observe(Snapshot{Now: now, Serving: true, Restartable: true, PortKnown: true})
+	now = now.Add(61 * time.Second)
+	tr.Observe(Snapshot{Now: now, Serving: true, Restartable: true, PortKnown: true})
+	if tr.gaveUp || tr.Attempts() != 0 {
+		t.Fatalf("sustained serving should reset budget: gaveUp=%v attempts=%d", tr.gaveUp, tr.Attempts())
+	}
+	// A fresh death now earns a restart again.
+	tr.Observe(Snapshot{Now: now, Restartable: true, PortKnown: true})
+	now = now.Add(20 * time.Second)
+	if a := tr.Observe(Snapshot{Now: now, Restartable: true, PortKnown: true}); a != ActionRestart {
+		t.Fatalf("post-recovery want Restart, got %v", a)
+	}
+}
+
+// Leaving a restartable phase (e.g. a checkout → installing) disarms the clock,
+// so grace restarts when it re-enters.
+func TestTracker_LeavingRestartablePhaseDisarms(t *testing.T) {
+	tr := NewTracker(cfg())
+	tr.Observe(Snapshot{Now: epoch, Restartable: true, PortKnown: true})
+	// 15s in, phase leaves restartable (install kicked off).
+	tr.Observe(Snapshot{Now: epoch.Add(15 * time.Second), Restartable: false, PortKnown: true})
+	// Back to restartable — clock re-arms from here, not from the original t=0.
+	if a := tr.Observe(Snapshot{Now: epoch.Add(16 * time.Second), Restartable: true, PortKnown: true}); a != ActionNone {
+		t.Fatalf("re-armed clock want None, got %v", a)
+	}
+	if a := tr.Observe(Snapshot{Now: epoch.Add(35 * time.Second), Restartable: true, PortKnown: true}); a != ActionNone {
+		t.Fatalf("t=35 (19s after re-arm) want None, got %v", a)
+	}
+	if a := tr.Observe(Snapshot{Now: epoch.Add(36 * time.Second), Restartable: true, PortKnown: true}); a != ActionRestart {
+		t.Fatalf("t=36 (20s after re-arm) want Restart, got %v", a)
+	}
+}
+
+func TestConfig_Defaults(t *testing.T) {
+	tr := NewTracker(Config{})
+	if tr.cfg.Grace != DefaultGracePeriod || tr.cfg.StableWindow != DefaultStableWindow || tr.cfg.MaxRestarts != DefaultMaxRestarts {
+		t.Fatalf("zero config should use defaults, got %+v", tr.cfg)
+	}
 }

--- a/packages/sandbox/daemon-go/internal/devwatch/devwatch_test.go
+++ b/packages/sandbox/daemon-go/internal/devwatch/devwatch_test.go
@@ -1,0 +1,87 @@
+package devwatch
+
+import (
+	"testing"
+	"time"
+)
+
+func TestDecide(t *testing.T) {
+	// A dead-but-known-port server past the grace window, with budget → restart.
+	base := Input{
+		Serving:         false,
+		Restartable:     true,
+		PortKnown:       true,
+		UnreachableFor:  DefaultGracePeriod,
+		Attempts:        0,
+		RestartInFlight: false,
+	}
+
+	cases := []struct {
+		name string
+		in   Input
+		want Action
+	}{
+		{"dead past grace with budget → restart", base, ActionRestart},
+		{
+			"serving → none",
+			with(base, func(i *Input) { i.Serving = true }),
+			ActionNone,
+		},
+		{
+			"not restartable phase (installing/clone-failed) → none",
+			with(base, func(i *Input) { i.Restartable = false }),
+			ActionNone,
+		},
+		{
+			"no port known yet (legit slow build) → none",
+			with(base, func(i *Input) { i.PortKnown = false }),
+			ActionNone,
+		},
+		{
+			"within grace → none",
+			with(base, func(i *Input) { i.UnreachableFor = DefaultGracePeriod - time.Millisecond }),
+			ActionNone,
+		},
+		{
+			"restart already in flight → none",
+			with(base, func(i *Input) { i.RestartInFlight = true }),
+			ActionNone,
+		},
+		{
+			"budget exhausted → give up",
+			with(base, func(i *Input) { i.Attempts = MaxRestarts }),
+			ActionGiveUp,
+		},
+		{
+			"budget exhausted but serving → none (server recovered)",
+			with(base, func(i *Input) {
+				i.Attempts = MaxRestarts
+				i.Serving = true
+			}),
+			ActionNone,
+		},
+		{
+			"last attempt still has budget → restart",
+			with(base, func(i *Input) { i.Attempts = MaxRestarts - 1 }),
+			ActionRestart,
+		},
+		{
+			"exactly at grace boundary → restart",
+			with(base, func(i *Input) { i.UnreachableFor = DefaultGracePeriod }),
+			ActionRestart,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Decide(tc.in, DefaultGracePeriod); got != tc.want {
+				t.Fatalf("Decide() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func with(in Input, mut func(*Input)) Input {
+	mut(&in)
+	return in
+}

--- a/packages/sandbox/daemon-go/internal/probe/probe.go
+++ b/packages/sandbox/daemon-go/internal/probe/probe.go
@@ -70,6 +70,16 @@ func Start(deps Deps) *Prober {
 	return p
 }
 
+// Current returns the latest observed state — read synchronously, unlike the
+// goroutine-dispatched OnChange callback, so a consumer gating on liveness
+// (the dev-server watchdog) sees a consistent value instead of a mirror that
+// out-of-order callbacks can leave stale.
+func (p *Prober) Current() State {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.state
+}
+
 func (p *Prober) Reset() {
 	p.mu.Lock()
 	p.state = State{Status: StatusBooting}

--- a/packages/sandbox/daemon-go/internal/probe/probe.go
+++ b/packages/sandbox/daemon-go/internal/probe/probe.go
@@ -33,6 +33,11 @@ type Deps struct {
 	GetPort  func() int
 	OnChange func(s State)
 	OnLog    func(msg string)
+	// Fast/Slow override the poll cadence; zero uses FastInterval/SlowInterval.
+	// Exposed so a healthy server's dead-detection latency is tunable (and so
+	// tests don't wait the 30s slow interval).
+	Fast time.Duration
+	Slow time.Duration
 }
 
 type Prober struct {
@@ -40,13 +45,25 @@ type Prober struct {
 	state               State
 	consecutiveFailures int
 	deps                Deps
+	fast                time.Duration
+	slow                time.Duration
 	stop                chan struct{}
 }
 
 func Start(deps Deps) *Prober {
+	fast := deps.Fast
+	if fast <= 0 {
+		fast = FastInterval
+	}
+	slow := deps.Slow
+	if slow <= 0 {
+		slow = SlowInterval
+	}
 	p := &Prober{
 		state: State{Status: StatusBooting},
 		deps:  deps,
+		fast:  fast,
+		slow:  slow,
 		stop:  make(chan struct{}),
 	}
 	go p.loop()
@@ -67,9 +84,9 @@ func (p *Prober) Stop() {
 func (p *Prober) loop() {
 	for {
 		p.mu.Lock()
-		delay := SlowInterval
+		delay := p.slow
 		if p.state.Status != StatusOnline || p.consecutiveFailures > 0 {
-			delay = FastInterval
+			delay = p.fast
 		}
 		p.mu.Unlock()
 		select {

--- a/packages/sandbox/daemon-go/internal/setup/orchestrator.go
+++ b/packages/sandbox/daemon-go/internal/setup/orchestrator.go
@@ -94,16 +94,43 @@ func NewOrchestrator(deps OrchestratorDeps) *Orchestrator {
 }
 
 func (o *Orchestrator) ResumeFrom(step Step) {
+	o.clearCrashError()
+	o.enqueue(step)
+}
+
+// RestartDev force-respawns the dev server. It clears a latched crash error
+// (so the start step below isn't skipped) and unconditionally stops the current
+// dev task before restarting, so it recovers a process that is alive-but-wedged
+// (bound the wrong port, hung after a reclaim) as well as one that has already
+// died. Used by the liveness watchdog (see internal/devwatch); a plain
+// ResumeFrom(StepStart) would short-circuit on "dev already running".
+func (o *Orchestrator) RestartDev() {
+	o.clearCrashError()
+	o.stopDevTask()
+	o.enqueue(StepStart)
+}
+
+// clearCrashError un-latches the `error` status a non-zero dev-script exit sets
+// (see OnTaskExit). Without this, stepStartInner's `status != running` guard
+// silently skips every subsequent start — so a reclaim or watchdog restart onto
+// a VM whose dev server had crashed would never bring it back.
+func (o *Orchestrator) clearCrashError() {
 	if o.deps.GetStatus().State == "error" {
 		o.deps.SetStatus(events.DaemonStatus{State: "running"})
 	}
-	o.enqueue(step)
 }
 
 func (o *Orchestrator) Handle(t config.Transition) {
 	if t.Kind == config.KindGitCredentialRefresh {
 		o.syncGitRemoteCredentials(t.CloneUrl)
 		return
+	}
+	// A fresh claim/reclaim or branch switch is an explicit "start over" — clear
+	// a latched dev-crash error so the pipeline's start step isn't skipped. This
+	// is what makes a SANDBOX_START reclaim onto a VM whose dev server had
+	// crashed actually restart it, instead of reusing the wedged process.
+	if t.Kind == config.KindBootstrap || t.Kind == config.KindBranchChange {
+		o.clearCrashError()
 	}
 	step, ok := transitionToStep(t)
 	if !ok {

--- a/packages/sandbox/daemon-go/main.go
+++ b/packages/sandbox/daemon-go/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/decocms/studio/sandbox-daemon/internal/auth"
 	"github.com/decocms/studio/sandbox-daemon/internal/config"
 	"github.com/decocms/studio/sandbox-daemon/internal/decofile"
+	"github.com/decocms/studio/sandbox-daemon/internal/devwatch"
 	"github.com/decocms/studio/sandbox-daemon/internal/dispatch"
 	"github.com/decocms/studio/sandbox-daemon/internal/events"
 	"github.com/decocms/studio/sandbox-daemon/internal/gitx"
@@ -78,6 +79,16 @@ type daemon struct {
 	lastRunningPort int
 	baselineTimer   *time.Timer
 	firstWorkLogged bool
+
+	// Dev-server liveness watchdog state (see internal/devwatch). Guarded by its
+	// own mutex so a probe callback never contends with the hot d.mu.
+	devWatchMu         sync.Mutex
+	probeOnline        bool
+	notServingSince    time.Time // zero while serving
+	devRestartCount    int       // restarts fired this dead episode
+	devRestartInFlight bool
+	devGaveUp          bool
+	devWatchGrace      time.Duration // effective unreachable window (env-tunable)
 
 	broadcaster  *events.Broadcaster
 	sniffer      *proc.PortSniffer
@@ -228,6 +239,8 @@ func (d *daemon) getDecofileVersion() (string, bool) {
 }
 
 func (d *daemon) onProbeChange(s probe.State) {
+	// Feed the liveness watchdog every probe change (online/offline/booting).
+	d.setProbeOnline(s.Status == probe.StatusOnline && s.Port != 0)
 	phase := d.lifecycle.Current().Phase
 	if s.Status == probe.StatusOnline && s.Port != 0 {
 		d.mu.Lock()
@@ -270,6 +283,138 @@ func (d *daemon) onProbeChange(s probe.State) {
 		}
 		d.mu.Unlock()
 		d.branchStatus.ClearBaseline()
+	}
+}
+
+func (d *daemon) setProbeOnline(online bool) {
+	d.devWatchMu.Lock()
+	d.probeOnline = online
+	d.devWatchMu.Unlock()
+}
+
+// restartablePhase reports the phases where a dev server is meant to be up, so
+// the watchdog respawns a dead one there but never interrupts a legitimate
+// build (installing/cloning/checking-out) or loops on a terminal *-failed.
+func restartablePhase(phase string) bool {
+	switch phase {
+	case events.PhaseRunning, events.PhaseStarting, events.PhaseCrashed:
+		return true
+	default:
+		return false
+	}
+}
+
+// devWatchLoop respawns the dev server when it dies out from under a live daemon
+// (idle-freeze, crash, or a stale port after a reclaim) — the case the proxy
+// otherwise papers over with an endless "Server is starting…". Bounded by
+// devwatch.MaxRestarts; on exhaustion it surfaces a real start-failed.
+func (d *daemon) devWatchLoop() {
+	tick := envDuration("SANDBOX_DEV_WATCH_TICK_MS", 3*time.Second)
+	d.devWatchMu.Lock()
+	d.devWatchGrace = envDuration("SANDBOX_DEV_WATCH_GRACE_MS", devwatch.DefaultGracePeriod)
+	d.devWatchMu.Unlock()
+	for {
+		time.Sleep(tick)
+		d.mu.Lock()
+		down := d.shuttingDown
+		d.mu.Unlock()
+		if down {
+			return
+		}
+		d.devWatchTick()
+	}
+}
+
+// envDuration reads a millisecond count from env, falling back to def when unset
+// or unparseable. Used to shrink the watchdog's grace/tick in tests.
+func envDuration(name string, def time.Duration) time.Duration {
+	if v := os.Getenv(name); v != "" {
+		if ms, err := strconv.Atoi(v); err == nil && ms > 0 {
+			return time.Duration(ms) * time.Millisecond
+		}
+	}
+	return def
+}
+
+func (d *daemon) devWatchTick() {
+	phase := d.lifecycle.Current().Phase
+	sniffed := d.sniffer.Current()
+	d.mu.Lock()
+	lastRunning := d.lastRunningPort
+	d.mu.Unlock()
+	// A port is "known" only once the dev server has actually announced one — it
+	// was sniffed from the dev output, or the probe confirmed it serving earlier
+	// this session. A merely *configured* application.port does NOT count: it is
+	// set before the server binds, so treating it as known would let the
+	// watchdog restart a dev server that is simply still starting up.
+	portKnown := sniffed != 0 || lastRunning != 0
+
+	d.devWatchMu.Lock()
+	serving := d.probeOnline
+	if serving {
+		d.notServingSince = time.Time{}
+		d.devRestartCount = 0
+		d.devGaveUp = false
+	} else if d.notServingSince.IsZero() {
+		d.notServingSince = time.Now()
+	}
+	var unreachableFor time.Duration
+	if !d.notServingSince.IsZero() {
+		unreachableFor = time.Since(d.notServingSince)
+	}
+	in := devwatch.Input{
+		Serving:         serving,
+		Restartable:     restartablePhase(phase),
+		PortKnown:       portKnown,
+		UnreachableFor:  unreachableFor,
+		Attempts:        d.devRestartCount,
+		RestartInFlight: d.devRestartInFlight,
+	}
+	grace := d.devWatchGrace
+	gaveUp := d.devGaveUp
+	d.devWatchMu.Unlock()
+
+	if gaveUp {
+		return
+	}
+
+	switch devwatch.Decide(in, grace) {
+	case devwatch.ActionRestart:
+		d.devWatchMu.Lock()
+		d.devRestartInFlight = true
+		d.devRestartCount++
+		attempt := d.devRestartCount
+		// Reset the grace window so the next restart is measured from now.
+		d.notServingSince = time.Now()
+		d.devWatchMu.Unlock()
+
+		d.broadcaster.BroadcastChunk("setup", fmt.Sprintf(
+			"[orchestrator] dev server unreachable for %s — restarting (attempt %d/%d)\r\n",
+			grace, attempt, devwatch.MaxRestarts))
+		// Drop the stale sniffed port and probe state so the respawned dev
+		// server's port is relearned from its fresh output.
+		d.sniffer.Reset()
+		d.prober.Reset()
+		go func() {
+			d.orchestrator.RestartDev()
+			d.devWatchMu.Lock()
+			d.devRestartInFlight = false
+			d.devWatchMu.Unlock()
+		}()
+	case devwatch.ActionGiveUp:
+		d.devWatchMu.Lock()
+		d.devGaveUp = true
+		d.devWatchMu.Unlock()
+		d.broadcaster.BroadcastChunk("setup", fmt.Sprintf(
+			"[orchestrator] dev server did not stay up after %d restarts — giving up\r\n",
+			devwatch.MaxRestarts))
+		d.lifecycle.Transition(events.LifecycleState{
+			Phase: events.PhaseStartFailed,
+			Error: fmt.Sprintf(
+				"dev server did not stay up after %d automatic restarts",
+				devwatch.MaxRestarts),
+		})
+	case devwatch.ActionNone:
 	}
 }
 
@@ -725,7 +870,12 @@ func main() {
 		GetPort:  d.getDevPort,
 		OnChange: d.onProbeChange,
 		OnLog:    func(msg string) { d.broadcaster.BroadcastChunk("setup", msg) },
+		Fast:     envDuration("SANDBOX_PROBE_FAST_MS", 0),
+		Slow:     envDuration("SANDBOX_PROBE_SLOW_MS", 0),
 	})
+	// Respawn the dev server if it dies out from under the live daemon (idle
+	// freeze, crash, stale port after a reclaim). Dies with the process.
+	go d.devWatchLoop()
 
 	d.proxyHandler = proxy.New(proxy.Deps{
 		GetDevPort: d.getDevPort,

--- a/packages/sandbox/daemon-go/main.go
+++ b/packages/sandbox/daemon-go/main.go
@@ -80,15 +80,10 @@ type daemon struct {
 	baselineTimer   *time.Timer
 	firstWorkLogged bool
 
-	// Dev-server liveness watchdog state (see internal/devwatch). Guarded by its
-	// own mutex so a probe callback never contends with the hot d.mu.
-	devWatchMu         sync.Mutex
-	probeOnline        bool
-	notServingSince    time.Time // zero while serving
-	devRestartCount    int       // restarts fired this dead episode
-	devRestartInFlight bool
-	devGaveUp          bool
-	devWatchGrace      time.Duration // effective unreachable window (env-tunable)
+	// Dev-server liveness watchdog (see internal/devwatch). devTracker owns the
+	// grace/budget bookkeeping; devWatchMu guards it (kept off the hot d.mu).
+	devWatchMu sync.Mutex
+	devTracker *devwatch.Tracker
 
 	broadcaster  *events.Broadcaster
 	sniffer      *proc.PortSniffer
@@ -239,8 +234,6 @@ func (d *daemon) getDecofileVersion() (string, bool) {
 }
 
 func (d *daemon) onProbeChange(s probe.State) {
-	// Feed the liveness watchdog every probe change (online/offline/booting).
-	d.setProbeOnline(s.Status == probe.StatusOnline && s.Port != 0)
 	phase := d.lifecycle.Current().Phase
 	if s.Status == probe.StatusOnline && s.Port != 0 {
 		d.mu.Lock()
@@ -286,12 +279,6 @@ func (d *daemon) onProbeChange(s probe.State) {
 	}
 }
 
-func (d *daemon) setProbeOnline(online bool) {
-	d.devWatchMu.Lock()
-	d.probeOnline = online
-	d.devWatchMu.Unlock()
-}
-
 // restartablePhase reports the phases where a dev server is meant to be up, so
 // the watchdog respawns a dead one there but never interrupts a legitimate
 // build (installing/cloning/checking-out) or loops on a terminal *-failed.
@@ -306,12 +293,16 @@ func restartablePhase(phase string) bool {
 
 // devWatchLoop respawns the dev server when it dies out from under a live daemon
 // (idle-freeze, crash, or a stale port after a reclaim) — the case the proxy
-// otherwise papers over with an endless "Server is starting…". Bounded by
-// devwatch.MaxRestarts; on exhaustion it surfaces a real start-failed.
+// otherwise papers over with an endless "Server is starting…". Bounded by the
+// tracker's MaxRestarts; on exhaustion it surfaces a real start-failed.
 func (d *daemon) devWatchLoop() {
-	tick := envDuration("SANDBOX_DEV_WATCH_TICK_MS", 3*time.Second)
+	tick := envDuration("SANDBOX_DEV_WATCH_TICK_MS", 3*time.Second, 100*time.Millisecond)
 	d.devWatchMu.Lock()
-	d.devWatchGrace = envDuration("SANDBOX_DEV_WATCH_GRACE_MS", devwatch.DefaultGracePeriod)
+	d.devTracker = devwatch.NewTracker(devwatch.Config{
+		Grace:        envDuration("SANDBOX_DEV_WATCH_GRACE_MS", devwatch.DefaultGracePeriod, time.Second),
+		StableWindow: envDuration("SANDBOX_DEV_WATCH_STABLE_MS", devwatch.DefaultStableWindow, time.Second),
+		MaxRestarts:  envInt("SANDBOX_DEV_WATCH_MAX_RESTARTS", devwatch.DefaultMaxRestarts, 1),
+	})
 	d.devWatchMu.Unlock()
 	for {
 		time.Sleep(tick)
@@ -325,12 +316,30 @@ func (d *daemon) devWatchLoop() {
 	}
 }
 
-// envDuration reads a millisecond count from env, falling back to def when unset
-// or unparseable. Used to shrink the watchdog's grace/tick in tests.
-func envDuration(name string, def time.Duration) time.Duration {
+// envDuration reads a millisecond count from env, clamped to at least min, and
+// falls back to def when unset or unparseable. The floor stops a fat-fingered
+// value (ms entered as if seconds) from turning a poll loop into a hot spin.
+func envDuration(name string, def, min time.Duration) time.Duration {
 	if v := os.Getenv(name); v != "" {
 		if ms, err := strconv.Atoi(v); err == nil && ms > 0 {
-			return time.Duration(ms) * time.Millisecond
+			d := time.Duration(ms) * time.Millisecond
+			if d < min {
+				return min
+			}
+			return d
+		}
+	}
+	return def
+}
+
+// envInt reads an int from env, clamped to at least min, def when unset/bad.
+func envInt(name string, def, min int) int {
+	if v := os.Getenv(name); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			if n < min {
+				return min
+			}
+			return n
 		}
 	}
 	return def
@@ -348,71 +357,39 @@ func (d *daemon) devWatchTick() {
 	// set before the server binds, so treating it as known would let the
 	// watchdog restart a dev server that is simply still starting up.
 	portKnown := sniffed != 0 || lastRunning != 0
+	// Read synchronously, not via a mirror an out-of-order callback could
+	// leave stale (see probe.Prober.Current).
+	serving := d.prober.Current().Status == probe.StatusOnline
 
 	d.devWatchMu.Lock()
-	serving := d.probeOnline
-	if serving {
-		d.notServingSince = time.Time{}
-		d.devRestartCount = 0
-		d.devGaveUp = false
-	} else if d.notServingSince.IsZero() {
-		d.notServingSince = time.Now()
-	}
-	var unreachableFor time.Duration
-	if !d.notServingSince.IsZero() {
-		unreachableFor = time.Since(d.notServingSince)
-	}
-	in := devwatch.Input{
-		Serving:         serving,
-		Restartable:     restartablePhase(phase),
-		PortKnown:       portKnown,
-		UnreachableFor:  unreachableFor,
-		Attempts:        d.devRestartCount,
-		RestartInFlight: d.devRestartInFlight,
-	}
-	grace := d.devWatchGrace
-	gaveUp := d.devGaveUp
+	action := d.devTracker.Observe(devwatch.Snapshot{
+		Now:         time.Now(),
+		Serving:     serving,
+		Restartable: restartablePhase(phase),
+		PortKnown:   portKnown,
+	})
+	attempt, maxRestarts := d.devTracker.Attempts(), d.devTracker.MaxRestarts()
 	d.devWatchMu.Unlock()
 
-	if gaveUp {
-		return
-	}
-
-	switch devwatch.Decide(in, grace) {
+	switch action {
 	case devwatch.ActionRestart:
-		d.devWatchMu.Lock()
-		d.devRestartInFlight = true
-		d.devRestartCount++
-		attempt := d.devRestartCount
-		// Reset the grace window so the next restart is measured from now.
-		d.notServingSince = time.Now()
-		d.devWatchMu.Unlock()
-
 		d.broadcaster.BroadcastChunk("setup", fmt.Sprintf(
-			"[orchestrator] dev server unreachable for %s — restarting (attempt %d/%d)\r\n",
-			grace, attempt, devwatch.MaxRestarts))
+			"[orchestrator] dev server unreachable — restarting (attempt %d/%d)\r\n",
+			attempt, maxRestarts))
 		// Drop the stale sniffed port and probe state so the respawned dev
 		// server's port is relearned from its fresh output.
 		d.sniffer.Reset()
 		d.prober.Reset()
-		go func() {
-			d.orchestrator.RestartDev()
-			d.devWatchMu.Lock()
-			d.devRestartInFlight = false
-			d.devWatchMu.Unlock()
-		}()
+		go d.orchestrator.RestartDev()
 	case devwatch.ActionGiveUp:
-		d.devWatchMu.Lock()
-		d.devGaveUp = true
-		d.devWatchMu.Unlock()
 		d.broadcaster.BroadcastChunk("setup", fmt.Sprintf(
 			"[orchestrator] dev server did not stay up after %d restarts — giving up\r\n",
-			devwatch.MaxRestarts))
+			maxRestarts))
 		d.lifecycle.Transition(events.LifecycleState{
 			Phase: events.PhaseStartFailed,
 			Error: fmt.Sprintf(
 				"dev server did not stay up after %d automatic restarts",
-				devwatch.MaxRestarts),
+				maxRestarts),
 		})
 	case devwatch.ActionNone:
 	}
@@ -870,8 +847,8 @@ func main() {
 		GetPort:  d.getDevPort,
 		OnChange: d.onProbeChange,
 		OnLog:    func(msg string) { d.broadcaster.BroadcastChunk("setup", msg) },
-		Fast:     envDuration("SANDBOX_PROBE_FAST_MS", 0),
-		Slow:     envDuration("SANDBOX_PROBE_SLOW_MS", 0),
+		Fast:     envDuration("SANDBOX_PROBE_FAST_MS", 0, 100*time.Millisecond),
+		Slow:     envDuration("SANDBOX_PROBE_SLOW_MS", 0, 100*time.Millisecond),
 	})
 	// Respawn the dev server if it dies out from under the live daemon (idle
 	// freeze, crash, stale port after a reclaim). Dies with the process.


### PR DESCRIPTION
## Summary

Fixes the recurring **"Blocos indisponíveis" / "Server is starting…"** dead end where a sandbox preview never recovers after the tab goes idle — and clicking **Retry** doesn't help.

Diagnosed from a user HAR: after ~10min idle the pod's dev server dies, but nothing respawns it. The in-pod proxy serves `StartingHTML` (503) forever (a connection error to a **known-but-dead** port), Studio's Blocks tab shows `errorStateSandbox`, and the web Retry fires a `SANDBOX_START` that returns `isNewVm:false` — reusing the wedged VM, so it's a no-op. The control plane is healthy throughout; the failure is entirely in the sandbox data plane.

## What changed (daemon, Go)

**1. Dev-server liveness watchdog**
- `internal/devwatch/devwatch.go` (new) — pure `Decide()` → restart / give-up / none, unit-tested.
- `main.go` `devWatchLoop` — when the probe reports not-serving in a restartable phase (running/starting/crashed) with a **known** port (sniffed OR previously-served — a *merely-configured* `application.port` does **not** count, so a slow first boot is never interrupted) for `GracePeriod` (default 20s), it resets sniffer+prober and calls `orchestrator.RestartDev()`. Bounded by `MaxRestarts` (3); on exhaustion it transitions to a real `start-failed` (honest error instead of an endless "Server is starting…").

**2. Un-latch the crash `error` status so restarts aren't skipped**
- `orchestrator.RestartDev()` clears the `error` a non-zero dev-script exit latches (else `stepStartInner`'s `status != running` guard skips every start), force-stops the dev task, and re-enqueues `StepStart`.
- `Handle()` clears the same latch on `bootstrap`/`branch-change`, so a `SANDBOX_START` reclaim onto a VM with a crashed dev server actually restarts it.

**Tunables (defaults unchanged):** probe cadence `SANDBOX_PROBE_FAST_MS`/`_SLOW_MS`, watchdog windows `SANDBOX_DEV_WATCH_GRACE_MS`/`_TICK_MS`. The 30s healthy-probe `SlowInterval` bounds detection latency and is now adjustable.

## User impact

Before: idle → dead preview → "Blocos indisponíveis" forever, Retry no-op. After: the daemon respawns the dev server automatically (no click); if it genuinely can't stay up after 3 tries, it shows a real error instead of looping.

Note: the `[::1]` proxy dial is **not** a cause — the proxy transport already uses `probe.DialLoopback`, which falls back to `127.0.0.1`.

## Testing

- `go test ./...` (all daemon packages), `go vet`, `gofmt` — pass
- `internal/devwatch` unit test (10 cases)
- **New black-box e2e** `daemon-e2e/daemon.devwatch.e2e.test.ts` — kills the dev server over the wire, asserts auto-recovery to `running` + the restart log; stable across runs (~5–6s)
- `daemon.proxy` + `daemon.warmpool` e2e — 15/15, no regression
- `tsc --noEmit` — pass

## Affected areas

`packages/sandbox/daemon-go` (probe, setup/orchestrator, main), plus one new e2e in `packages/sandbox/daemon-e2e`. No Studio server/web changes.

## Follow-up (not in this PR)

Wire the web **Retry** button to trigger a real daemon dev-server restart (today a `SANDBOX_START` on an unchanged config is a daemon no-op). With the automatic watchdog, the click is rarely needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically respawn dead dev servers to stop endless “Server is starting…” loops in sandbox previews. Handles slow first boots and flapping crashes correctly, and shows a real start-failed after repeated attempts.

- **Bug Fixes**
  - Add a liveness watchdog that restarts the dev server when not-serving in restartable phases and a port is known; grace now starts at “port known,” not boot. Reset sniffer/prober and call `RestartDev()`; cap attempts (default 3), then transition to start-failed.
  - Bound flapping: the restart budget resets only after continuous serving for a stable window, so brief serves can’t re-arm the budget indefinitely.
  - Unlatch dev crash errors so restarts aren’t skipped: `RestartDev()` force-stops the dev task and re-enqueues start; also clear the latch on bootstrap/branch-change so a `SANDBOX_START` reclaim actually restarts.
  - Make probe cadence and watchdog knobs tunable and safe: `SANDBOX_PROBE_FAST_MS`, `SANDBOX_PROBE_SLOW_MS`, `SANDBOX_DEV_WATCH_GRACE_MS`, `SANDBOX_DEV_WATCH_TICK_MS`, `SANDBOX_DEV_WATCH_STABLE_MS`, `SANDBOX_DEV_WATCH_MAX_RESTARTS`; clamp to sane floors and read liveness via `probe.Prober.Current()` to avoid stale mirrors.

<sup>Written for commit 7e8e591e63fc2c5e01378f489737d2cea4eec659. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5919?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

