### PR TITLE
fix(helm): translate Portuguese validation messages in the studio chart

### DIFF
--- a/deploy/helm/studio/templates/_helpers.tpl
+++ b/deploy/helm/studio/templates/_helpers.tpl
@@ -110,7 +110,7 @@ Resolves DATABASE_URL honoring database engine configuration.
 */}}
 {{- define "chart-deco-studio.databaseUrl" -}}
 {{- if eq (lower (default "sqlite" .Values.database.engine)) "postgresql" -}}
-{{- required "database.url deve ser definido quando database.engine=postgresql" .Values.database.url | trim -}}
+{{- required "database.url must be set when database.engine=postgresql" .Values.database.url | trim -}}
 {{- else -}}
 {{/* Historical filename retained so existing PVCs keep their database. */}}
 /app/data/mesh.db
@@ -127,13 +127,13 @@ Global validations to ensure scaling requirements are met.
 {{- $usesPostgres := eq $usesPostgresStr "true" -}}
 {{- $replicas := int (default 1 .Values.replicaCount) -}}
 {{- if and (not .Values.autoscaling.enabled) (not $distributed) (not $usesPostgres) (gt $replicas 1) }}
-{{- fail "chart-deco-studio: replicaCount > 1 exige storage distribuído (persistence.distributed=true ou accessMode=ReadWriteMany) ou database.engine=postgresql" -}}
+{{- fail "chart-deco-studio: replicaCount > 1 requires distributed storage (persistence.distributed=true or accessMode=ReadWriteMany) or database.engine=postgresql" -}}
 {{- end }}
 {{- if and .Values.autoscaling.enabled (not (or $distributed $usesPostgres)) }}
-{{- fail "chart-deco-studio: autoscaling.enabled=true exige storage distribuído (persistence.distributed=true ou accessMode=ReadWriteMany) ou database.engine=postgresql" -}}
+{{- fail "chart-deco-studio: autoscaling.enabled=true requires distributed storage (persistence.distributed=true or accessMode=ReadWriteMany) or database.engine=postgresql" -}}
 {{- end }}
 {{- if and $usesPostgres (not .Values.database.url) (not .Values.secret.secretName) (not .Values.externalSecret.enabled) }}
-{{- fail "chart-deco-studio: defina database.url quando database.engine=postgresql ou use secret.secretName para fornecer DATABASE_URL via Secret" -}}
+{{- fail "chart-deco-studio: set database.url when database.engine=postgresql, or use secret.secretName to provide DATABASE_URL via Secret" -}}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
**Source:** found while auditing `deploy/helm/studio` for template/rendering correctness (helm chart audit focus area).

**Payoff:** four of the studio chart's `fail`/`required` validation messages (`chart-deco-studio.databaseUrl`, `replicaCount > 1`, `autoscaling.enabled`, and the postgres-without-`database.url` guard) were in Portuguese while every other validation message and comment in the chart is in English. An operator running `helm install`/`helm template` against a misconfigured release hits one of these mid-deploy with no other Portuguese context anywhere in the chart — confusing and inconsistent for an open-source self-hosted chart.

**Fix:** translated the 4 messages to English, matching the wording style of the chart's other ~13 `fail"chart-deco-studio: ..."` messages. Pure string change, no logic touched — behavior (which conditions fail, when) is unchanged.

**Verify:**
```
cd deploy/helm/studio
helm lint .
helm template test . --set replicaCount=2                 # -> English error
helm template test . --set autoscaling.enabled=true         # -> English error
helm template test . --set database.engine=postgresql       # -> English error
```

**Checked locally:** `helm lint` (clean) and `helm template` against all 4 trigger conditions above, confirming each renders the new English message; grepped the repo for any leftover reference to the old Portuguese strings (none). `bun run fmt` run (no-op on `.tpl`). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Translated four Helm validation messages (`databaseUrl`, `replicaCount > 1`, `autoscaling.enabled`, Postgres `database.url` guard) in `deploy/helm/studio` from Portuguese to English for consistent, clear errors during install/template. Text-only change; no logic or behavior changes.

<sup>Written for commit 245c3817e8d0d1e78c96844b4ef432603b17f829. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

