### PR TITLE
fix(sandbox): the golden uploader emitted no metrics, and oversized itself

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -143,7 +143,7 @@ type: application
 # 0.8.0: org-fs sidecar (orgFs.*) — privileged rclone mounter + main-container
 # mounts. NOTE: the publish workflow skips existing versions, so this MUST
 # stay ahead of the latest published chart (0.7.5 at time of writing).
-version: 0.14.6
+version: 0.15.0
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "1.52.0"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/templates/sandbox-golden-uploader.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-golden-uploader.yaml
@@ -90,6 +90,19 @@ spec:
             # ship its neighbours' trees into a key prefix they never read.
             - name: SANDBOX_ENV
               value: {{ include "sandbox-env.envName" . | quote }}
+            {{- if .Values.telemetry.enabled }}
+            # Turns the sweep counters on. Without it the daemon's Init is a
+            # no-op and `sandbox.daemon.golden.upload` never reaches the
+            # collector, which leaves the shared tier observable only by reading
+            # this pod's log on every node.
+            #
+            # Unlike a sandbox this pod runs dnsPolicy: ClusterFirst with no
+            # netinit, so the collector is reachable by name too — but the same
+            # helper is used so the endpoint cannot drift between the two
+            # workloads that report to it.
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ include "sandbox-env.otlpEndpoint" . | quote }}
+            {{- end }}
           resources:
             {{- toYaml .Values.goldenUploader.resources | nindent 12 }}
           securityContext:

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -506,10 +506,23 @@ goldenUploader:
   # Deliberately small. Compression is CPU-bound and shares a node with tenant
   # sandboxes, whose NodePool has a CPU ceiling — a sweep that takes 60s
   # instead of 26s costs nobody anything, because no boot waits on it.
+  #
+  # Sized against measurement, not a guess: idle the container sits at 2.6 MiB
+  # average / 6.0 MiB peak RSS across the fleet. The request covers the
+  # compressing case instead — `zstd -3` holds a 1 MiB window per worker plus
+  # job buffers, so a sweep peaks in the low tens of MiB. 32Mi keeps roughly 2x
+  # headroom over that; the old 64Mi was ~10x idle with no measurement behind
+  # it. The limit stays generous because being OOM-killed mid-sweep is worse
+  # than being slow: the archive is written straight to its final key, so a
+  # killed publish leaves nothing readable and the next sweep redoes the work.
+  #
+  # This request is per NODE and, until the uploader becomes a cluster
+  # singleton, per ENVIRONMENT — prod and stg share one NodePool, so every node
+  # reserves this twice for work that is done once.
   resources:
     requests:
       cpu: 50m
-      memory: 64Mi
+      memory: 32Mi
     limits:
       cpu: 500m
       memory: 256Mi

--- a/packages/sandbox/daemon-go/internal/setup/remotegolden.go
+++ b/packages/sandbox/daemon-go/internal/setup/remotegolden.go
@@ -51,8 +51,16 @@ const (
 // 168k-file tree it produced 450 MB in 26s, where -19 spent 85s to reach
 // 332 MB. Publish is off the critical path but not free, and restore-side
 // decompression is ~1.6s either way, so the extra 59s buys nothing that
-// matters. -T0 uses all available cores.
-var zstdPublishArgs = []string{"-3", "-T0"}
+// matters.
+//
+// Single-threaded on purpose. -T0 sizes the worker pool to the machine's core
+// count, which does not know about the cgroup: the sandbox NodePool runs
+// 2-vCPU nodes and the uploader is capped at 500m, so -T0 spawned two workers
+// to share half a core. Under a fixed CPU quota extra threads buy no
+// throughput — the quota is the throughput — while each one adds its own
+// window and job buffers, and the switching competes with the tenant dev
+// server on the same 2-core box. Raise this only together with the CPU limit.
+var zstdPublishArgs = []string{"-3", "-T1"}
 
 // RemoteGoldenParams identifies the shared archive for one install step. Mirrors
 // GoldenParams so the orchestrator can derive one from the other — the two tiers

--- a/packages/sandbox/daemon-go/main.go
+++ b/packages/sandbox/daemon-go/main.go
@@ -538,6 +538,30 @@ func runGoldenUploader() {
 	slog.Info("golden-uploader start", "cache_root", opts.CacheRoot,
 		"remote_root", opts.RemoteRoot, "interval", interval.String())
 
+	// Metrics on the same terms as the daemon: opt-in via
+	// OTEL_EXPORTER_OTLP_ENDPOINT, best-effort, no-op when unset.
+	//
+	// NOT optional in practice, and the reason this call exists at all: main()
+	// dispatches this subcommand and returns before reaching the daemon's own
+	// Init, so without this line the sweep counters are recorded into the global
+	// no-op provider and emit nothing. The uploader runs on every sandbox node,
+	// so the alternative to a metric is grepping a log line across the fleet —
+	// which is how this tier already sat inert for months unnoticed.
+	otelShutdown, err := telemetry.Init(context.Background(), randomUUID(), "go")
+	if err != nil {
+		slog.Warn("otlp metrics disabled: exporter init failed", "err", err)
+	}
+	// Runs after RunUploader returns, i.e. after SIGTERM closed `stop`. Flushes
+	// the sweep that just finished; nothing here is on a boot's critical path,
+	// so it can have the full grace period rather than the daemon's clipped one.
+	defer func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := otelShutdown(ctx); err != nil {
+			slog.Warn("otlp shutdown", "err", err)
+		}
+	}()
+
 	stop := make(chan struct{})
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decocms/sandbox",
-  "version": "1.52.0",
+  "version": "1.53.0",
   "private": true,
   "type": "module",
   "description": "Sandbox runtime for isolated Studio tool execution",


### PR DESCRIPTION
Three fixes to the golden-cache uploader. All three were found by querying what it *actually* reports, not by reading the code that reports it.

## 1. It emitted no metrics at all

```
main.go:559   if os.Args[1] == "golden-uploader" { runGoldenUploader(); return }
main.go:607   telemetry.Init(...)          <- never reached on that path
```

The subcommand returns from `main()` before `telemetry.Init`, so no meter provider is ever installed and every `RecordGoldenSweep` went into the global no-op. Confirmed against ClickHouse rather than inferred:

| metric | datapoints, 24h |
|---|---|
| `sandbox.daemon.deps.restore` | 20673 |
| `sandbox.daemon.devserver.exit` | 1554 |
| `sandbox.daemon.golden.upload` | **absent** |

The container also had no `OTEL_EXPORTER_OTLP_ENDPOINT`, so it would have stayed a no-op even with the init in place. Both are fixed: `Init` on the uploader path (with a bounded flush on SIGTERM, since nothing here is on a boot's critical path) and the env wired in the chart behind the existing `telemetry.enabled`.

Why it matters beyond tidiness: `no-provenance` staying non-zero is the only automatic signal that the org stopped reaching the daemon, and `failed` is the only signal that publishing broke. **That exact blindness is why this tier sat inert for months without anyone noticing.** Today the only view is `swept N golden(s) …` in the log of every node.

## 2. `zstd -T0` on a 2-vCPU node capped at 500m

The sandbox NodePool runs `.large` instances — 2 vCPU, 1.9 allocatable:

```
i7ie.large 5   r8in.large 5   r8idb.large 3
```

`-T0` sizes the worker pool to the machine's core count, which knows nothing about the cgroup, so it spawned two workers to share half a core. Under a fixed CPU quota extra threads buy no throughput — the quota *is* the throughput — while each adds its own window and job buffers, and the switching competes with the tenant's dev server on the same two cores. Now `-T1`, with a comment to raise it only together with the CPU limit.

## 3. Memory request was 10x the measured usage

Measured across the fleet: **2.6 MiB average, 6.0 MiB peak RSS**. The request was `64Mi`.

Now `32Mi`, sized for the *compressing* case rather than idle: `zstd -3` holds a 1 MiB window per worker plus job buffers, so a sweep peaks in the low tens of MiB, and 32Mi keeps roughly 2x headroom.

**The limit deliberately stays at `256Mi`.** Being OOM-killed mid-sweep is worse than being slow: the archive is written straight to its final key, so a killed publish leaves nothing readable and the next sweep redoes the work from scratch.

Honest caveat on the sizing: the 10-minute sample that produced those numbers caught **no sweep that actually compressed** — CPU throttling measured 0, which confirms it. So the compressing peak is reasoned from zstd's documented memory model, not observed. The `256Mi` limit is what makes that acceptable to ship.

## Context worth carrying

The request is per **node** and, until the uploader becomes a cluster singleton, per **environment**. prod and stg share a single Karpenter NodePool named `sandbox` with no env dimension, so a DaemonSet per env lands on every node twice:

```
nodes in the sandbox pool ............. 13
nodes running the stg uploader ........ 13   (all of them)
nodes running a prod sandbox .......... 11
nodes running BOTH .................... 11
nodes running an stg sandbox ...........  0
```

So the stg uploader is currently walking a hostPath full of prod's goldens and discarding all of them via the `OtherEnv` skip — visible in its own log as `2 from another env`. Enabling prod ([deco-apps-cd#216](https://github.com/decocms/deco-apps-cd/pull/216)) gives those 11 nodes an uploader that can actually publish, but leaves 26 pods doing work that needs 13.

The real fix is one uploader per cluster mounting the bucket at its root and deriving `<env>/` from each golden's own `.golden-meta.json` — the field the `OtherEnv` skip already reads. That is a chart and ownership change (which release owns a cluster singleton?), so it is not in this PR.

## Verification

Rendered against the real prod and stg values:

```
stg   mem=32Mi cpu=50m | OTLP=http://172.20.146.131:4318
prod  mem=32Mi cpu=50m | OTLP=http://172.20.146.131:4318
```

And with `telemetry.enabled=false` the env does not render at all. Go suite green uncached, 15 packages, 5 consecutive runs. `bun run fmt` clean.

Note on CI: `TestInitExportsToEndpoint` failed for me once under full-suite load and passed 5/5 afterwards, isolated and in the suite. It sleeps `2*lagSampleInterval + 400ms` waiting for an export, so it is timing-tight under CPU contention — pre-existing, not from this change, and worth loosening separately.

`sandbox-env` `0.14.6` → `0.15.0`, `studio-sandbox-go` `1.52.0` → `1.53.0`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable telemetry for the `golden-uploader` and right-size its resources to make fleet health visible and avoid wasted CPU/memory. This restores `sandbox.daemon.golden.upload` metrics and reduces contention on 2 vCPU nodes.

- **Bug Fixes**
  - Initialize telemetry in the `golden-uploader` path and set `OTEL_EXPORTER_OTLP_ENDPOINT` via Helm; metrics flush on SIGTERM so `sandbox.daemon.golden.upload` is emitted.
  - Right-size compression and memory: use `zstd -3 -T1` to match the `500m` CPU cap, and lower memory request to `32Mi` (limit stays `256Mi`).

- **Dependencies**
  - Bump `sandbox-env` chart to `0.15.0`.
  - Bump `@decocms/sandbox` to `1.53.0`.

<sup>Written for commit a2f8ae15880fee44cfe6a4fa025ac58e672719ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

