### PR TITLE
feat(settings): default top-up currency to BRL for pt-BR users

### DIFF
--- a/apps/web/src/views/settings/ai-providers/deco-credits-hero.tsx
+++ b/apps/web/src/views/settings/ai-providers/deco-credits-hero.tsx
@@ -29,6 +29,7 @@ import { useStudioTools } from "@/lib/studio-tools";
 import { KEYS } from "@/lib/query-keys";
 import { cn } from "@decocms/ui/lib/utils.ts";
 import { useT } from "@/i18n/use-t.ts";
+import { usePreferences } from "@/hooks/use-preferences.ts";
 
 // ── Quick Top-Up presets ──────────────────────────────────────────────
 
@@ -40,6 +41,7 @@ const TOP_UP_PRESETS = {
 function QuickTopUp() {
   const t = useT();
   const studio = useStudioTools();
+  const [preferences] = usePreferences();
   const [customOpen, setCustomOpen] = useState(false);
 
   const { mutate: topUp, isPending } = useMutation({
@@ -62,7 +64,9 @@ function QuickTopUp() {
   });
 
   const [customAmount, setCustomAmount] = useState("");
-  const [currency, setCurrency] = useState<"usd" | "brl">("usd");
+  const [currency, setCurrency] = useState<"usd" | "brl">(
+    preferences.language === "pt-BR" ? "brl" : "usd",
+  );
   const customNum = parseFloat(customAmount);
   const isCustomValid = !isNaN(customNum) && customNum >= 1;
   const currencySymbol = currency === "brl" ? "R$" : "$";


### PR DESCRIPTION
## Summary
The AI Gateway credit top-up (Deco Credits card) had its currency **hardcoded to USD**. This defaults the initial currency from the user's language preference: **pt-BR → BRL**, every other locale → **USD**.

It only seeds the initial value — the USD/BRL toggle still lets the user switch, and existing behavior for non-pt-BR users is unchanged.

## Changes
- `apps/web/src/views/settings/ai-providers/deco-credits-hero.tsx`: read `language` from `usePreferences()` and seed `currency` state (`pt-BR ? "brl" : "usd"`).

## Testing notes
- Affects only the initial selected currency of the quick top-up in Settings → AI Providers → Deco AI Gateway.
- `bun run fmt` passing.

## Follow-up (not in this PR)
Since it's just the initial state, switching the UI language while the card is mounted won't re-seed the currency. Making it reactive would need a rule for when the user has already toggled manually — deferred pending a product call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default the Deco Credits quick top-up currency based on user language: pt-BR starts in BRL; all other locales start in USD. This only sets the initial selection; users can still toggle, and non-pt-BR behavior is unchanged.

<sup>Written for commit 886fba8abe8907194deef510aa9557099091dfba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

