### PR TITLE
fix(sandbox-env): the uploader wedged forever on a node with no sandbox

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -143,7 +143,7 @@ type: application
 # 0.8.0: org-fs sidecar (orgFs.*) — privileged rclone mounter + main-container
 # mounts. NOTE: the publish workflow skips existing versions, so this MUST
 # stay ahead of the latest published chart (0.7.5 at time of writing).
-version: 0.15.2
+version: 0.15.3
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "1.53.2"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/templates/sandbox-golden-uploader.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-golden-uploader.yaml
@@ -113,8 +113,16 @@ spec:
           volumeMounts:
             # Read-only: this reads what sandboxes published and must never be
             # able to alter a node's cache.
+            # Mounted at the PARENT path, deliberately without subPath: a subPath
+            # on a hostPath volume is CREATED by kubelet when missing, as root —
+            # which is the very ownership trap this change exists to avoid. With
+            # the parent mounted at its own path the container resolves
+            # DEPS_CACHE_ROOT naturally when the node has a cache, sees nothing
+            # when it does not, and nothing is ever created. Read-only, and this
+            # is node infrastructure rather than tenant code, so the slightly
+            # broader view costs nothing.
             - name: deps-cache
-              mountPath: {{ .Values.depsCache.hostPath | quote }}
+              mountPath: {{ dir (.Values.depsCache.hostPath | trimSuffix "/") | quote }}
               readOnly: true
             # The ONLY writable mount of the shared store in this chart. Never
             # add it to the sandbox PodSpec.
@@ -123,12 +131,32 @@ spec:
             - name: tmp
               mountPath: /tmp
       volumes:
+        # The PARENT of the cache root, not the cache root itself.
+        #
+        # A DaemonSet lands on every matching node, including one Karpenter
+        # created seconds ago that has never run a sandbox — and on that node the
+        # cache root does not exist yet, because the SANDBOX creates it (its
+        # deps-cache-init container, which also chowns it to the sandbox uid;
+        # hostPath dirs are born root:root and fsGroup does not apply to them).
+        # Pointing this volume at the cache root with `type: Directory` therefore
+        # wedged the pod in ContainerCreating indefinitely:
+        #   MountVolume.SetUp failed for volume "deps-cache": hostPath type check
+        #   failed: /var/cache/studio-sandbox-deps is not a directory
+        # Observed in prod on 2 of 17 nodes, both environments' uploaders stuck on
+        # each, 20+ minutes, on nodes with no sandbox pod to unwedge them.
+        #
+        # DirectoryOrCreate would be worse, not better: this pod would win the
+        # race on a fresh node and create the cache root as root:root, and the
+        # sandbox — running as uid 1000 — could then not write its own cache. A
+        # stuck uploader traded for a broken cache on that node.
+        #
+        # So mount the parent, which every node image already has, and let the
+        # cache root be absent. UploadNodeGoldens already treats an unreadable
+        # golden root as "nothing published on this node yet" and returns. A node
+        # with no cache is a normal state, not a mount error.
         - name: deps-cache
           hostPath:
-            path: {{ .Values.depsCache.hostPath | quote }}
-            # Never DirectoryOrCreate: a node with no cache has nothing to
-            # upload, and creating the path would only mask a misconfigured
-            # hostPath as an empty store.
+            path: {{ dir (.Values.depsCache.hostPath | trimSuffix "/") | quote }}
             type: Directory
         - name: golden-remote-rw
           persistentVolumeClaim:

--- a/packages/sandbox/daemon-go/internal/setup/goldenuploader_test.go
+++ b/packages/sandbox/daemon-go/internal/setup/goldenuploader_test.go
@@ -257,6 +257,29 @@ func TestUploadNodeGoldens(t *testing.T) {
 		}
 	})
 
+	// A node that has never run a sandbox: the cache root does not exist at all,
+	// not merely empty. This is the state of every node Karpenter has just created,
+	// and the uploader lands there first because a DaemonSet does not wait for a
+	// tenant. The case above uses t.TempDir(), which exists — so it never covered
+	// this, and the chart relied on the mount to guarantee the directory instead.
+	// It cannot: see the deps-cache volume comment in sandbox-golden-uploader.yaml.
+	t.Run("a cache root that does not exist yet is not an error", func(t *testing.T) {
+		remote := t.TempDir()
+		absent := filepath.Join(t.TempDir(), "never-ran-a-sandbox")
+
+		s := UploadNodeGoldens(UploaderOpts{CacheRoot: absent, RemoteRoot: remote, Env: "prod"})
+
+		if s != (UploaderStats{}) {
+			t.Fatalf("a fresh node must sweep to nothing, got %+v", s)
+		}
+		if entries, _ := os.ReadDir(remote); len(entries) != 0 {
+			t.Fatal("wrote to the shared store from a node with no cache")
+		}
+		if _, err := os.Stat(absent); !os.IsNotExist(err) {
+			t.Fatal("the sweep created the cache root; the sandbox owns creating it, with the right uid")
+		}
+	})
+
 	// A golden directory mid-publish has no node_modules yet. Uploading one would
 	// mean shipping a partial tree fleet-wide.
 	t.Run("skips a directory with no node_modules", func(t *testing.T) {


### PR DESCRIPTION
Found in prod within an hour of enabling the uploader there ([deco-apps-cd#216](https://github.com/decocms/deco-apps-cd/pull/216)).

## The failure

```
MountVolume.SetUp failed for volume "deps-cache": hostPath type check
failed: /var/cache/studio-sandbox-deps is not a directory
```

**2 of 17 prod nodes, both environments' uploaders stuck on each, 20+ minutes**, and the nodes carried *no sandbox pod at all* — so nothing was coming to unwedge them.

A DaemonSet lands on every matching node, including one Karpenter created seconds ago. On that node the cache root does not exist: the **sandbox** creates it, in its `deps-cache-init` container, which also chowns it to the sandbox uid because hostPath directories are born `root:root` and `fsGroup` does not apply to them. The uploader mounted that path with `type: Directory`, so kubelet refused and the pod never started.

The comment I wrote in [#5843](https://github.com/decocms/studio/pull/5843) was right about intent and wrong about mechanism:

> `Never DirectoryOrCreate: a node with no cache has nothing to upload`

It assumed the uploader only runs where a sandbox already ran. It does not, and a DaemonSet cannot be made to wait for one. Same wrong assumption as the placement comment in that PR — a shared NodePool with no environment dimension, and nodes that arrive empty.

## Why not `DirectoryOrCreate`

It would be **worse**. This pod would win the race on a fresh node and create the cache root as `root:root`; the sandbox, running as uid 1000, could then not write its own cache. A stuck uploader traded for a broken cache on that node — one pod not running, versus every boot on that node losing L1.

## The fix

Mount the **parent** directory, which every node image already has, and let the cache root be absent.

```yaml
- name: deps-cache
  hostPath:
    path: /var/cache          # was /var/cache/studio-sandbox-deps
    type: Directory
```

Deliberately **without `subPath`**: a subPath on a hostPath volume is created by kubelet when missing, as root — the same ownership trap by another route. With the parent mounted at its own path the container resolves `DEPS_CACHE_ROOT` naturally when the node has a cache, sees nothing when it does not, and nothing is ever created. Read-only, and this is node infrastructure rather than tenant code, so the slightly broader view costs nothing.

`UploadNodeGoldens` already returns on an unreadable golden root — a node with no cache is a normal state, not an error.

## The test that should have caught it

There was one that looked like it did:

```go
t.Run("an empty node-local store is not an error", func(t *testing.T) {
    cache, remote := t.TempDir(), t.TempDir()   // EXISTS, merely empty
```

`t.TempDir()` exists. The absent case — the actual state of a fresh node — was never covered, which is exactly why the chart was left relying on the mount to guarantee the directory. Added it, and it asserts the sweep does **not** create the path, because creating it is the sandbox's job and only the sandbox knows the right uid:

```go
if _, err := os.Stat(absent); !os.IsNotExist(err) {
    t.Fatal("the sweep created the cache root; the sandbox owns creating it, with the right uid")
}
```

## Verification

Rendered against real prod values:

```
volumeMount: {name: deps-cache, mountPath: /var/cache, readOnly: true}
volume:      {name: deps-cache, hostPath: {path: /var/cache, type: Directory}}
subPath:     absent (the word appears only in the comment)
DEPS_CACHE_ROOT: /var/cache/studio-sandbox-deps   (unchanged)
```

17 documents parse as YAML, `helm lint` clean, Go suite green uncached.

## Impact while this is unmerged

Bounded and not worth a rollback: the affected nodes simply publish nothing, every other node publishes normally, and no sandbox is affected. The feature is otherwise working end to end in prod — **6 prod boots have restored from the shared store** and 8 archives have been published, verified in ClickHouse.

Nodes fix themselves the moment a sandbox is scheduled onto them, which is why this presented as intermittent rather than total.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the golden uploader DaemonSet from getting stuck on fresh nodes by mounting the parent cache directory and treating a missing cache as normal. Fixes kubelet hostPath errors while preserving correct cache ownership for the sandbox.

- **Bug Fixes**
  - Mount `/var/cache` (parent) instead of `/var/cache/studio-sandbox-deps`; no `subPath`, read-only.
  - Eliminates kubelet “hostPath type check failed” on nodes with no sandbox; avoids `DirectoryOrCreate` ownership traps.
  - Adds a test for an absent cache root to ensure the sweep does not create it; bumps chart to `0.15.3`.

<sup>Written for commit 06792b8dcd68092ed82776d276715f1ec26638ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

