### PR TITLE
fix(reports): keep report header above the deck card

### DIFF
--- a/apps/web/src/routes/reports/signal-deck.tsx
+++ b/apps/web/src/routes/reports/signal-deck.tsx
@@ -545,7 +545,7 @@ export default function SignalDeck({
 
       {/* ───────── header — rounded translucent bar, deco logo, and the Share
           pill. Sits in the flow as the deck's top row. ───────── */}
-      <header className="relative shrink-0 px-3 pt-3 sm:px-6 sm:pt-4">
+      <header className="relative z-20 shrink-0 px-3 pt-3 sm:px-6 sm:pt-4">
         <div
           className="mx-auto flex h-14 max-w-[1360px] items-center gap-3 rounded-full border pl-4 pr-3 backdrop-blur-md sm:h-[60px] sm:pl-6 sm:pr-4"
           style={{


### PR DESCRIPTION
## What is this contribution about?
The report page (`/report/:domain`) header (avatar/user menu, language toggle, Share button) had no explicit z-index. The deck's slide card container asserts `z-10`, so it painted above the entire header subtree, hiding the user menu dropdown behind the card and swallowing clicks on "Sign out". Fix: give the header `z-20` so it, and the dropdown it contains, stack above the deck card.

## How did you verify your code works?
Verified manually: ran the app locally against a stubbed reports engine response (since report content isn't stored in local Postgres) and confirmed the previously-hidden user menu dropdown now renders above the slide card once signed in. No automated test covers this — it's a pure CSS stacking-context fix with no logic change.

## Screenshots/Demonstration
Before: the "email + Sign out" dropdown rendered behind the deck card, with "Sign out" unclickable.

## How to Test
1. Sign in and open `/report/:domain` for a domain with a completed report.
2. Click the avatar/user menu in the top-right pill.
3. Expected: the dropdown (email + "Sign out") renders on top of the deck card below it, and "Sign out" is clickable.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Set a higher z-index on the report page header so it stays above the deck card. This fixes the user menu dropdown rendering behind the card and makes "Sign out" clickable again.

<sup>Written for commit 3dd77ecc07974498b445c3b337b0389a39af9b5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

