### PR TITLE
fix(decopilot): cap the browserless error body embedded in scrape_url's error

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/scrape-url.test.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/scrape-url.test.ts
@@ -83,4 +83,25 @@ describe("createScrapeUrlTool", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  test("caps an oversized browserless error body instead of embedding it whole", async () => {
+    const originalFetch = globalThis.fetch;
+    const hugeBody = "x".repeat(50_000);
+    globalThis.fetch = (async () =>
+      new Response(hugeBody, { status: 502 })) as never;
+    try {
+      const tool = createScrapeUrlTool(writer, {
+        browserless: { baseUrl: "https://bl.example", token: "t" },
+        objectStorage: { put: async () => ({ key: "k" }) } as never,
+        toolOutputMap: new Map(),
+      });
+      const result = (await tool.execute!({ url: "https://example.com" }, {
+        toolCallId: "tc4",
+      } as never)) as { success: boolean; error: string };
+      expect(result.success).toBe(false);
+      expect(result.error.length).toBeLessThan(600);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/scrape-url.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/scrape-url.ts
@@ -23,6 +23,9 @@ import { LARGE_RESULT_TOKEN_THRESHOLD } from "./constants";
 // inspect-page.ts's BROWSERLESS_FETCH_TIMEOUT_MS).
 const BROWSERLESS_FETCH_TIMEOUT_MS = 45_000;
 
+// Upstream error bodies are unbounded — cap what lands in the tool error.
+const ERROR_BODY_MAX_CHARS = 500;
+
 const ScrapeUrlInputSchema = z.object({
   url: z.string().url().describe("The URL of the web page to scrape."),
 });
@@ -82,7 +85,7 @@ export function createScrapeUrlTool(
           const errorText = await response.text().catch(() => "Unknown error");
           return {
             success: false,
-            error: `Browserless content fetch failed (${response.status}): ${errorText}`,
+            error: `Browserless content fetch failed (${response.status}): ${errorText.slice(0, ERROR_BODY_MAX_CHARS)}`,
             url: input.url,
           };
         }


### PR DESCRIPTION
**Source:** bug found while hardening `scrape_url`'s Browserless network path (assigned focus area: decopilot scrape-url robustness).

**Payoff:** when Browserless returns a non-2xx response (502/504/etc.), `scrape_url` spliced the entire raw response body into the tool's `error` field with no size bound. Unlike its own non-JSON-response branch (and `inspect-page.ts`'s equivalent, which already `.slice(0, 200)`s), this path had no cap — an upstream error page of arbitrary size lands whole in the model's context, wasting tokens or even blowing past message limits.

**Fix:** cap the error body to 500 chars (`ERROR_BODY_MAX_CHARS`) before embedding it, mirroring the existing truncation pattern already used elsewhere in this same tool family.

**Regression test:** `scrape-url.test.ts` — "caps an oversized browserless error body instead of embedding it whole" — mocks a 502 with a 50k-char body and asserts the resulting error string stays well under 600 chars.

**To verify:** `bun test apps/api/src/harnesses/lib/decopilot/built-in-tools/scrape-url.test.ts`

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/api), the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap Browserless error bodies in `scrape_url` to 500 chars to avoid embedding full upstream error pages in tool errors. This reduces token waste and prevents message limit overflows on non-2xx responses.

- **Bug Fixes**
  - Truncate Browserless error text to 500 chars (`ERROR_BODY_MAX_CHARS`) before building the error; aligns with existing truncation in related tools.
  - Add regression test that mocks a 502 with a 50k body and asserts the error string stays under 600 chars.

<sup>Written for commit d59532e785791c119096c483f1ed60fa27860d92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

