### PR TITLE
fix(sections-editor): shift multivariate field selection after an earlier-variant delete

### DIFF
--- a/apps/web/src/components/sections-editor/fields/media-variants.test.ts
+++ b/apps/web/src/components/sections-editor/fields/media-variants.test.ts
@@ -6,6 +6,7 @@ import {
   flattenMultivariate,
   isMultivariateWrapper,
   reorderVariant,
+  selectedIndexAfterDelete,
   updateVariantRule,
   updateVariantValue,
   wrapAsMultivariate,
@@ -146,6 +147,20 @@ describe("deleteVariant", () => {
   test("returns null when only 1 variant", () => {
     const wrapper = makeWrapper(["a.png"]);
     expect(deleteVariant(wrapper, 0)).toBeNull();
+  });
+});
+
+describe("selectedIndexAfterDelete", () => {
+  test("shifts the selection down when a variant before it is deleted", () => {
+    expect(selectedIndexAfterDelete(2, 0, 3)).toBe(1);
+  });
+
+  test("keeps the selection when a variant after it is deleted", () => {
+    expect(selectedIndexAfterDelete(0, 2, 2)).toBe(0);
+  });
+
+  test("clamps to the last remaining variant when the selected one is deleted", () => {
+    expect(selectedIndexAfterDelete(2, 2, 2)).toBe(1);
   });
 });
 

--- a/apps/web/src/components/sections-editor/fields/media-variants.ts
+++ b/apps/web/src/components/sections-editor/fields/media-variants.ts
@@ -83,6 +83,16 @@ export function duplicateVariant(
   return { ...wrapper, variants };
 }
 
+/** Selected index to keep pointing at the same variant after a deletion. */
+export function selectedIndexAfterDelete(
+  selectedIndex: number,
+  deletedIndex: number,
+  remainingCount: number,
+): number {
+  if (deletedIndex < selectedIndex) return selectedIndex - 1;
+  return Math.min(selectedIndex, remainingCount - 1);
+}
+
 /** Reorder variants by moving from one index to another. */
 export function reorderVariant(
   wrapper: MultivariateWrapper,

--- a/apps/web/src/components/sections-editor/fields/multivariate-field-wrapper.tsx
+++ b/apps/web/src/components/sections-editor/fields/multivariate-field-wrapper.tsx
@@ -44,6 +44,7 @@ import {
   flattenMultivariate,
   isMultivariateWrapper,
   reorderVariant,
+  selectedIndexAfterDelete,
   updateVariantRule,
   updateVariantValue,
   wrapAsMultivariate,
@@ -135,9 +136,9 @@ export function MultivariateFieldWrapper({
     const next = deleteVariant(wrapper, index);
     if (!next) return;
     onChange(next);
-    if (safeIndex >= next.variants.length) {
-      setSelectedIndex(next.variants.length - 1);
-    }
+    setSelectedIndex(
+      selectedIndexAfterDelete(safeIndex, index, next.variants.length),
+    );
   };
 
   const handleDuplicate = (index: number) => {


### PR DESCRIPTION
Bug found while auditing `apps/web/src/components/sections-editor/` for lingering state bugs in the recently-touched variant-tab/variant-list code.

**The bug:** `MultivariateFieldWrapper.handleDelete` (`fields/multivariate-field-wrapper.tsx`) only clamped `selectedIndex` when it fell *past* the end of the shrunk variants array (`safeIndex >= next.variants.length`). It never accounted for deleting a variant *before* the selected one — every later variant shifts down a position, but `selectedIndex` stayed put, so the field editor silently rendered the *next* variant's rule/value instead of the one the user still had selected. Its sibling in `sections-editor.tsx`, `handleDeletePageVariant`, already has this exact shift logic (`variantIndex < safeVariantIndex → safeVariantIndex - 1`); the field-level multivariate wrapper never got it.

**Fix:** extracted the shift/clamp math into a small pure helper, `selectedIndexAfterDelete` (`fields/media-variants.ts`, alongside the wrapper's other pure variant helpers), and use it from `handleDelete`.

**Failure scenario:** a multivariate image/media field with variants `[A, B, C]`, user selects `C` (index 2), deletes `A` (index 0) — variants become `[B, C]` but `selectedIndex` stays `2`, which is now out of range and falls back to showing `C`... but with 4 variants (`[A,B,C,D]`, select `D` at index 3, delete `A`) selection stays `3` while the array is now length 3, so it clamps to `2` = `D` — accidentally right by clamping in that case, but with a variant selected in the *middle* (`[A,B,C,D]`, select `C` at index 2, delete `A`) selection stays `2`, which after the shift now points at `D`, not `C`. The regression test covers this exact case.

**Verify:** `cd apps/web && bun test src/components/sections-editor/fields/media-variants.test.ts` (added 3 cases for `selectedIndexAfterDelete`).

**Checked locally:** `bun run fmt`, `bunx tsc --noEmit -p apps/web` (clean), `bunx oxlint` on the 3 touched files (0 warnings/errors), targeted test file above (27 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multivariate media/image field selection so deleting a variant before the selected one keeps the selection on the same variant and avoids showing the wrong rule/value.
Introduces `selectedIndexAfterDelete` to shift/clamp the index and adds regression tests for the shift and clamp cases.

<sup>Written for commit 8c9c3a3cfecfb5c798569e958bde4276315f8301. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

