### PR TITLE
fix(connections): make clickable connection cards keyboard-reachable

### DIFF
--- a/apps/web/src/components/connections/connection-card.tsx
+++ b/apps/web/src/components/connections/connection-card.tsx
@@ -42,6 +42,18 @@ export function ConnectionCard({
         className,
       )}
       onClick={onClick}
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={
+        onClick
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onClick();
+              }
+            }
+          : undefined
+      }
     >
       <div className="flex flex-col flex-1">
         {/* Top Section: Icon, Title, Description, Header Actions */}


### PR DESCRIPTION
ConnectionCard renders a plain `<div>` (via the shared `Card` primitive) with an `onClick` handler when used as a selectable card — in the connections list, the connection-group picker, and the virtual-mcp connection dialog. It has no `role`, no `tabIndex`, and no keydown handler, so it's mouse-only: a keyboard or screen-reader user tabbing through the page skips it entirely and has no way to activate it.

This matters because connections.tsx uses these cards as the primary way to select/open a connection — keyboard users are currently locked out of that flow.

**Fix**: when `onClick` is provided, add `role="button"`, `tabIndex={0}`, and an `onKeyDown` handler that activates on Enter/Space (matching the existing hover-to-focusable pattern already fixed for task-board in #5727/#5809/#5752). No behavior change when `onClick` is absent (footer-only/display cards).

**To confirm**: tab to a connection card on `/orgs/:org/connections` and press Enter/Space — it should activate like a click.

**Checks run locally**: `bun run fmt`, `bunx tsc --noEmit` (apps/web, clean), `bunx oxlint apps/web/src/components/connections/connection-card.tsx` (0 warnings/errors). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make clickable connection cards keyboard-accessible so users can select connections without a mouse. When onClick is present, the card now acts like a button with role=button, tabIndex=0, and Enter/Space activation.

<sup>Written for commit 4dd5c332897d568e142102c2c810f51fda7c09ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

