### PR TITLE
fix(sandbox): cap tools/list pagination in the daemon's MCP catalog client

### DIFF
--- a/packages/sandbox/daemon-go/internal/toolscatalog/mcp.go
+++ b/packages/sandbox/daemon-go/internal/toolscatalog/mcp.go
@@ -24,6 +24,11 @@ const protocolVersion = "2025-06-18"
 
 const clientName = "@decocms/sandbox-tools-catalog"
 
+// maxCatalogPages bounds the tools/list pagination loop: a misbehaving or
+// malicious endpoint that never returns an empty nextCursor would otherwise
+// hang FetchCatalog indefinitely and grow `out` without bound.
+const maxCatalogPages = 1000
+
 type mcpClient struct {
 	http      *http.Client
 	url       string
@@ -61,7 +66,10 @@ func FetchCatalog(ctx context.Context, ep Endpoint) ([]Tool, error) {
 
 	out := []Tool{}
 	cursor := ""
-	for {
+	for page := 0; ; page++ {
+		if page >= maxCatalogPages {
+			return nil, fmt.Errorf("tools/list: exceeded %d pages", maxCatalogPages)
+		}
 		params := map[string]any{}
 		if cursor != "" {
 			params["cursor"] = cursor
@@ -70,15 +78,15 @@ func FetchCatalog(ctx context.Context, ep Endpoint) ([]Tool, error) {
 		if err != nil {
 			return nil, err
 		}
-		var page listToolsResult
-		if err := json.Unmarshal(raw, &page); err != nil {
+		var result listToolsResult
+		if err := json.Unmarshal(raw, &result); err != nil {
 			return nil, fmt.Errorf("tools/list: %w", err)
 		}
-		out = append(out, page.Tools...)
-		if page.NextCursor == "" {
+		out = append(out, result.Tools...)
+		if result.NextCursor == "" {
 			return out, nil
 		}
-		cursor = page.NextCursor
+		cursor = result.NextCursor
 	}
 }
 

--- a/packages/sandbox/daemon-go/internal/toolscatalog/mcp_test.go
+++ b/packages/sandbox/daemon-go/internal/toolscatalog/mcp_test.go
@@ -1,0 +1,65 @@
+package toolscatalog
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// TestFetchCatalogBoundsPagination guards against a misbehaving or malicious
+// Virtual MCP endpoint that never returns an empty nextCursor: without a page
+// cap, FetchCatalog would loop and grow its result slice forever.
+func TestFetchCatalogBoundsPagination(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Method string `json:"method"`
+			ID     *int   `json:"id"`
+			Params struct {
+				Cursor string `json:"cursor"`
+			} `json:"params"`
+		}
+		json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+
+		if req.ID == nil {
+			// notification (e.g. notifications/initialized): no response body.
+			w.WriteHeader(200)
+			return
+		}
+
+		switch req.Method {
+		case "initialize":
+			json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0", "id": *req.ID, "result": map[string]any{},
+			})
+		case "tools/list":
+			next := "0"
+			if req.Params.Cursor != "" {
+				n, _ := strconv.Atoi(req.Params.Cursor)
+				next = strconv.Itoa(n + 1)
+			}
+			json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0", "id": *req.ID,
+				"result": map[string]any{
+					"tools":      []Tool{{Name: "t" + next}},
+					"nextCursor": next, // never empty — simulates an endpoint stuck in a loop
+				},
+			})
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	defer srv.Close()
+
+	_, err := FetchCatalog(context.Background(), Endpoint{URL: srv.URL})
+	if err == nil {
+		t.Fatal("expected FetchCatalog to give up on unbounded pagination, got nil error")
+	}
+	if !strings.Contains(err.Error(), "exceeded") {
+		t.Fatalf("expected a page-limit error, got: %v", err)
+	}
+}


### PR DESCRIPTION
**Source:** bug found while auditing `packages/sandbox/daemon-go/internal/toolscatalog/` (this tick's sandbox-go-dispatch focus area — the actual `internal/dispatch/` package is the target of an open, unmerged full-deletion PR, #5650, so I avoided it and widened the hunt within `daemon-go`).

**The bug:** `FetchCatalog` (`internal/toolscatalog/mcp.go`) pages through a Virtual MCP endpoint's `tools/list` by following `nextCursor` in an unbounded `for` loop. A misbehaving or malicious endpoint that never returns an empty `nextCursor` makes this loop run forever, appending to the `out` slice without bound — pinning the `/tools/sync` HTTP handler and the per-endpoint coalescer's in-flight slot indefinitely (the coalescer's own comment notes it relies on the MCP client's per-request 30s timeout to eventually free the slot, but that only bounds one page, not the whole loop).

**The fix:** cap the loop at 1000 pages (`maxCatalogPages`); past that, return an error instead of looping. This mirrors the repo's existing pattern of bounding pagination/aggregation against untrusted external responses (see e.g. #5330, #5726, #5754).

**Regression test:** `mcp_test.go` spins up an `httptest.Server` that always returns a fresh `nextCursor`, simulating the stuck-endpoint case, and asserts `FetchCatalog` returns a page-limit error instead of hanging.

**To verify:** `cd packages/sandbox/daemon-go && go test ./internal/toolscatalog/...`

**Checks run locally:** `gofmt -l`, `go vet ./internal/toolscatalog/...`, `go build ./...`, and the targeted test above — all clean/passing. Full CI covers the rest of the daemon-go suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Capped `tools/list` pagination in the sandbox daemon’s MCP catalog client at 1000 pages to prevent hangs and unbounded memory when an endpoint never clears `nextCursor`. Returns an error instead of looping, keeping `/tools/sync` and the coalescer responsive.

- **Bug Fixes**
  - Added `maxCatalogPages = 1000` and a page counter in `FetchCatalog`; returns `tools/list: exceeded N pages` when hit.
  - Added a regression test in `packages/sandbox/daemon-go/internal/toolscatalog/mcp_test.go` using an `httptest.Server` that always returns `nextCursor`.
  - Matches existing pagination bounds used elsewhere in the repo.

<sup>Written for commit 66daea9b7d419e89fec92cf169086ff1edd73f35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

