### PR TITLE
i18n(settings): translate AI provider connect-form validation errors

### DIFF
--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -198,8 +198,10 @@ export const settings = {
   "settings.buckets.temporarySessionOption":
     "Temporary session (STS, auto-refreshed)",
   "settings.connectForms.apiKeyField": "API Key",
+  "settings.connectForms.apiKeyRequired": "API key is required",
   "settings.connectForms.baseUrlField": "Base URL",
   "settings.connectForms.baseUrlPlaceholder": "http://localhost:4000/v1",
+  "settings.connectForms.baseUrlRequired": "Base URL is required",
   "settings.connectForms.cancel": "Cancel",
   "settings.connectForms.connectionSavedSuccess":
     "Connection saved successfully",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -209,8 +209,10 @@ export const settings = {
   "settings.buckets.temporarySessionOption":
     "Sess\u00e3o tempor\u00e1ria (STS, auto-atualizada)",
   "settings.connectForms.apiKeyField": "Chave API",
+  "settings.connectForms.apiKeyRequired": "A chave API é obrigatória",
   "settings.connectForms.baseUrlField": "URL Base",
   "settings.connectForms.baseUrlPlaceholder": "http://localhost:4000/v1",
+  "settings.connectForms.baseUrlRequired": "A URL base é obrigatória",
   "settings.connectForms.cancel": "Cancelar",
   "settings.connectForms.connectionSavedSuccess":
     "Conex\u00e3o salva com sucesso",

--- a/apps/web/src/views/settings/ai-providers/connect-forms.tsx
+++ b/apps/web/src/views/settings/ai-providers/connect-forms.tsx
@@ -15,12 +15,14 @@ import type { StudioToolInput as ToolInput } from "@decocms/shared/tools/tool-io
 import { KEYS } from "@/lib/query-keys";
 import type { OpenAICompatiblePreset } from "@/utils/openai-compatible-presets";
 
-const apiKeyFormSchema = z.object({
-  label: z.string().optional(),
-  apiKey: z.string().min(1, "API key is required"),
-});
+function apiKeyFormSchema(requiredMessage: string) {
+  return z.object({
+    label: z.string().optional(),
+    apiKey: z.string().min(1, requiredMessage),
+  });
+}
 
-type ApiKeyFormData = z.infer<typeof apiKeyFormSchema>;
+type ApiKeyFormData = z.infer<ReturnType<typeof apiKeyFormSchema>>;
 
 export function ConnectApiKeyForm({
   providerId,
@@ -42,7 +44,9 @@ export function ConnectApiKeyForm({
     handleSubmit,
     formState: { errors },
   } = useForm<ApiKeyFormData>({
-    resolver: zodResolver(apiKeyFormSchema),
+    resolver: zodResolver(
+      apiKeyFormSchema(t("settings.connectForms.apiKeyRequired")),
+    ),
     defaultValues: { label: "", apiKey: "" },
   });
 
@@ -138,13 +142,17 @@ export function ConnectApiKeyForm({
   );
 }
 
-const openaiCompatibleFormSchema = z.object({
-  label: z.string().optional(),
-  baseUrl: z.string().min(1, "Base URL is required"),
-  apiKey: z.string().optional(),
-});
+function openaiCompatibleFormSchema(requiredMessage: string) {
+  return z.object({
+    label: z.string().optional(),
+    baseUrl: z.string().min(1, requiredMessage),
+    apiKey: z.string().optional(),
+  });
+}
 
-type OpenAICompatibleFormData = z.infer<typeof openaiCompatibleFormSchema>;
+type OpenAICompatibleFormData = z.infer<
+  ReturnType<typeof openaiCompatibleFormSchema>
+>;
 
 export function ConnectOpenAICompatibleForm({
   preset,
@@ -166,7 +174,9 @@ export function ConnectOpenAICompatibleForm({
     handleSubmit,
     formState: { errors },
   } = useForm<OpenAICompatibleFormData>({
-    resolver: zodResolver(openaiCompatibleFormSchema),
+    resolver: zodResolver(
+      openaiCompatibleFormSchema(t("settings.connectForms.baseUrlRequired")),
+    ),
     defaultValues: {
       label: "",
       baseUrl: preset?.defaultBaseUrl ?? "",


### PR DESCRIPTION
The AI-provider "Connect API key" and "Connect OpenAI-compatible" forms had two Zod validation messages ("API key is required", "Base URL is required") hardcoded in English at module scope, even though every other string in these forms already goes through `t()`. A pt-br user filling the form with an empty required field sees an English error inline in an otherwise fully-localized UI.

Fix: move both Zod schemas into factory functions that take the translated required-message as a parameter, called inside the component with `t("settings.connectForms.apiKeyRequired")` / `t("settings.connectForms.baseUrlRequired")`. Added the two new keys to both `apps/web/src/i18n/en/settings.ts` and `apps/web/src/i18n/pt-br/settings.ts`.

To confirm: open Settings → AI Providers → Connect (API key or OpenAI-compatible), submit with the required field empty, with the app language set to Portuguese — the inline error now reads in Portuguese instead of English.

Locally verified: `bun run fmt`, `bunx tsc --noEmit` (apps/web, no new errors in touched files), `bunx oxlint` on the three changed files (0 warnings/errors). No dedicated test added — this is a locale-string fix with no new logic branch to regress-test; full CI covers typecheck/lint/build for the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes the required-field validation errors in the AI provider connect forms, removing hardcoded English. Users now see translated messages (e.g., pt-BR) when required fields are empty.

- **Bug Fixes**
  - Replaced hardcoded `zod` messages with `t("settings.connectForms.apiKeyRequired")` and `t("settings.connectForms.baseUrlRequired")`.
  - Refactored schemas into factory functions that accept the translated message; updated inferred types via `ReturnType`.
  - Added the two i18n keys in `apps/web/src/i18n/en/settings.ts` and `apps/web/src/i18n/pt-br/settings.ts`.

<sup>Written for commit b6908c2912073dd2a881306db58d93ea7d64a72b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5929?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

