### PR TITLE
fix(sandbox): stop dropping cloneOnly: false from the daemon config payload

### DIFF
--- a/packages/sandbox/server/provider/shared/build-config-payload.test.ts
+++ b/packages/sandbox/server/provider/shared/build-config-payload.test.ts
@@ -109,6 +109,17 @@ describe("buildConfigPayload", () => {
     ]);
   });
 
+  it("sends cloneOnly: false even with no repo/application/tenant, so a warm-pool pod's stale cloneOnly clears", () => {
+    const payload = buildConfigPayload({
+      runtime: "node",
+      packageManager: null,
+      repo: null,
+      cloneOnly: false,
+    });
+
+    expect(payload).toEqual({ cloneOnly: false });
+  });
+
   // Inverted deliberately: this used to omit the key, which the daemon reads as
   // "keep current" — so deleting your last credential row never revoked the PAT
   // on a live pod, and a re-bootstrapped pod kept the previous config's tokens.

--- a/packages/sandbox/server/provider/shared/build-config-payload.ts
+++ b/packages/sandbox/server/provider/shared/build-config-payload.ts
@@ -72,7 +72,14 @@ export function buildConfigPayload(args: {
 
   const orgId = tenant?.orgId;
 
-  if (!git && !application && !operator && !args.cloneOnly && !orgId) {
+  // `cloneOnly: false` must still reach the daemon; only an absent one is "nothing to say".
+  if (
+    !git &&
+    !application &&
+    !operator &&
+    args.cloneOnly === undefined &&
+    !orgId
+  ) {
     return null;
   }
   return {


### PR DESCRIPTION
**Source:** bug found while auditing sandbox state-store contracts (`packages/sandbox/server/provider/`) for stale/mismatched persisted state.

**Why a maintainer wants this:** `buildConfigPayload`'s early-return guard treated `cloneOnly: false` the same as an absent `cloneOnly`, so any ensure() with no repo/workload/tenant/orgId (a plain image-only sandbox reused from the warm pool) produced a `null` payload instead of `{ cloneOnly: false }`. In the sentinel/warm-pool provisioning path (`runner.ts`'s `postConfig(daemonUrl, this.sentinelToken, configPayload ?? {}, ...)`), that `null` becomes an empty `{}` POST body — so a pod that was previously claimed with `cloneOnly: true` never gets told to turn it off, and silently skips dependency install + dev server start for the new tenant it's recycled into.

**Failure scenario:** warm-pool pod P is claimed for a `cloneOnly: true` (checkout-only) task, config posted `{cloneOnly: true, ...}`. P is released back to the pool, then claimed again for a normal dev-server task with just an `image` override (no repo/workload/tenant this time) — `workloadConfigPayload` returns `null`, `postConfig` fires with `{}`, and the daemon keeps its stale `cloneOnly: true`, so the new tenant's dev server never starts.

**Fix:** the early-return check now only short-circuits when `cloneOnly` is `undefined`, matching the intent already documented at the payload's build site ("Always sent when true, never as an absent-means-false"). Added `build-config-payload.test.ts` case asserting `{cloneOnly: false}` is returned (not `null`) when no other field is set — this is the exact shape that used to collapse to `null`.

**Verify:** `bun test packages/sandbox/server/provider/shared/build-config-payload.test.ts`

**Local checks run:** `bun run fmt`, `cd packages/sandbox && bunx tsc --noEmit`, `bunx oxlint` on both touched files, and the targeted test file above — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops dropping cloneOnly: false from the daemon config payload on image-only ensures, so recycled warm‑pool pods clear stale cloneOnly:true and install deps/start the dev server.

- Old behavior: buildConfigPayload returned null when no repo/application/operator/orgId and cloneOnly:false; postConfig sent {}, so the daemon kept cloneOnly:true.
- New behavior: return { cloneOnly: false } unless cloneOnly is undefined; only return null when the payload is truly empty. Adds a test to lock this in.

<sup>Written for commit 25f9c47f4ecbe00c69f6f5d6769f35ec3ec5c352. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

