### PR TITLE
fix(task-board): read a failed run's OWN error text, not the table's newest

### DIFF
--- a/apps/api/src/storage/task-board-advance-review.integration.test.ts
+++ b/apps/api/src/storage/task-board-advance-review.integration.test.ts
@@ -297,6 +297,47 @@ describe("failed runs never reach In Review (real Postgres)", () => {
     expect(info?.errorText).toContain("did not become ready");
   });
 
+  /**
+   * The bug: the error-part subquery was uncorrelated, so its `LIMIT 1` took the
+   * newest error part in the whole TABLE. One failing thread hides it (that
+   * thread owns the newest one); a NEWER error part on another thread exposes it,
+   * which in prod is just another org failing in between.
+   */
+  it("reads its OWN error text, not the newest one in the table", async () => {
+    const { thread } = await cardWithRun("mine", "failed");
+    const { thread: other } = await cardWithRun("newer failure", "failed");
+    const errorPart = (id: string, text: string, at: Date) => ({
+      id: `${id}:m:1`,
+      seq: 1,
+      org_id: ORG2,
+      thread_id: id,
+      run_id: id,
+      message_id: `${id}:m`,
+      role: "assistant" as const,
+      kind: "error" as const,
+      payload: JSON.stringify({ type: "text", text }),
+      created_at: at.toISOString(),
+    });
+    await database.db
+      .insertInto("thread_message_parts")
+      .values([
+        errorPart(
+          thread.id,
+          "Error: Sandbox did not become ready within 180 seconds",
+          new Date(Date.now() - 60_000),
+        ),
+        errorPart(other.id, "Error: something else entirely", new Date()),
+      ])
+      .execute();
+
+    expect(
+      (await taskBoard.failedRunInfo(thread.id, ORG2))?.errorText,
+    ).toContain("did not become ready");
+    expect(
+      (await taskBoard.failedRunInfo(other.id, ORG2))?.errorText,
+    ).toContain("something else entirely");
+  });
+
   it("does not report a failure for a run that completed", async () => {
     const { thread } = await cardWithRun("completed run", "completed");
     expect(await taskBoard.failedRunInfo(thread.id, ORG2)).toBeNull();

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -625,16 +625,18 @@ export class TaskBoardStorage {
   ): Promise<{ kind: string | null; errorText: string | null } | null> {
     const row = await this.db
       .selectFrom("threads as t")
-      .leftJoin(
+      // LATERAL: uncorrelated, `LIMIT 1` took the newest error part in the TABLE.
+      .leftJoinLateral(
         (eb) =>
           eb
             .selectFrom("thread_message_parts as p")
-            .select(["p.thread_id", "p.payload"])
+            .select("p.payload")
+            .whereRef("p.thread_id", "=", "t.id")
             .where("p.kind", "=", "error")
             .orderBy("p.created_at", "desc")
             .limit(1)
             .as("err"),
-        (join) => join.onRef("err.thread_id", "=", "t.id"),
+        (join) => join.onTrue(),
       )
       .select(["t.status", "t.failure_kind as kind", "err.payload as payload"])
       .where("t.id", "=", threadId)


### PR DESCRIPTION
## Summary

`TaskBoardStorage.failedRunInfo` joined the run's error part with an **uncorrelated** subquery:

```ts
.leftJoin((eb) => eb.selectFrom("thread_message_parts as p")
  .where("p.kind", "=", "error").orderBy("p.created_at", "desc").limit(1)
  .as("err"), (join) => join.onRef("err.thread_id", "=", "t.id"))
```

The `LIMIT 1` applies to the **whole table**, so the join matches only when the thread being reacted to happens to own the newest error part in the entire deployment. Every other failure reads `errorText: null`.

Consequences, both on the failure hook (`reactToFailedTaskRun`):
- `retryBudgetFor` → `isTransientRunFailure` sees no text, so `TRANSIENT_ERROR_PATTERNS` never matches. Recognized infrastructure (`sandbox did not become ready`, `too many clients already`, `429/503`, `harness_crashed: unexpected eof`) gets the **1-attempt unknown budget instead of 3** and the card is parked in To Do.
- The card's timeline records a bare `"error"` with no reason, so nobody can tell why a run died.

It reads as working because the reaction usually runs right after the failure it reacts to — it breaks when another org fails in between, or when the sweeper reacts late.

Fixed by making it a LATERAL correlated on `p.thread_id = t.id`.

## Verified in prod

```sql
select t.id, t.failure_kind, err.payload is null as errortext_lost
from threads t left join (
  select p.thread_id, p.payload from thread_message_parts p
  where p.kind='error' order by p.created_at desc limit 1) err
  on err.thread_id = t.id
where t.id in (...);
-- errortext_lost = true for all three threads, each of which HAS an error part
```

## Testing

`apps/api/src/storage/task-board-advance-review.integration.test.ts` (real Postgres). The existing `reads the failure kind and the run's error text together` test passed on the broken query because its database had exactly one failing thread. The new test adds a **newer** error part on a sibling thread — what another org failing in between does in prod — and fails on the old query (`errorText` is `null`), passes with the fix. 17/17 pass; `bun run --cwd=apps/api check` and `bun run fmt` clean.

## Follow-ups (not in this PR)

Found while debugging a prod card (`board_pA_7SsIEhMmcStEcAidCs`) that a user could no longer re-run:
- a user-initiated re-run is blocked by the per-task run cap that automatic retries spend — separate PR;
- `enqueueSuperAgentForTask` rolls the quota tally back only for a `"claimed"` outcome, so a `"rerun"` claim whose dispatch throws spends a run that never started.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `failedRunInfo` to read the failing run’s own error part using a correlated LATERAL join. Restores correct error text, transient retry budgets, and accurate timeline entries.

- **Bug Fixes**
  - Use `leftJoinLateral` scoped by `thread_id` so `LIMIT 1` applies per thread.
  - Prevents `errorText: null` when another thread has a newer error.
  - Restores transient failure detection (e.g., sandbox not ready, 429/503).
  - Adds a regression test covering a sibling thread with a newer error part.

<sup>Written for commit 576763fe899d5617a34f48f9cefe42d09ee81989. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

