### PR TITLE
fix(task-board): don't block a user's Re-run on the per-task run cap

### DIFF
--- a/apps/api/src/billing/task-quota.integration.test.ts
+++ b/apps/api/src/billing/task-quota.integration.test.ts
@@ -133,6 +133,38 @@ describe("task quota (integration)", () => {
     expect(await runCountOf(task.id)).toBe(2);
   });
 
+  /**
+   * The per-task cap bounds automatic re-dispatch (re-delegation loops, review
+   * bounces, the sweeper's infrastructure retries) — and those spend the same
+   * tally. A prod card burned all 5 on transport failures plus the machine's own
+   * retry, so the human's Re-run answered "This task reached its limit" with no
+   * way left to run the task at all.
+   */
+  it("a HUMAN re-run is not blocked by the per-task cap", async () => {
+    const [claimed] = await database.db
+      .selectFrom("task_quota_claims")
+      .select(["task_board_item_id", "run_count"])
+      .where("organization_id", "=", ORG)
+      .where("run_count", ">=", CONFIG.maxRunsPerTask)
+      .limit(1)
+      .execute();
+    const task = {
+      id: claimed!.task_board_item_id,
+      createdBy: "system",
+      organizationId: ORG,
+    };
+    const manual = { ...CONFIG, maxRunsPerTask: Number.POSITIVE_INFINITY };
+
+    expect(await claimTaskExecution(ctx, task, manual)).toBe("rerun");
+    expect(await runCountOf(task.id)).toBe(CONFIG.maxRunsPerTask + 1);
+    await ensureTaskExecutionAllowed(ctx, task, manual);
+
+    // Automatic dispatch is still capped.
+    await expect(claimTaskExecution(ctx, task, CONFIG)).rejects.toThrow(
+      /execution limit/,
+    );
+  });
+
   it("user-created tasks are never gated or counted", async () => {
     const userTask = await makeTask("user_1");
     await claimTaskExecution(ctx, userTask, CONFIG); // no throw, no claim

--- a/apps/api/src/billing/task-quota.ts
+++ b/apps/api/src/billing/task-quota.ts
@@ -173,6 +173,23 @@ export function taskQuotaConfig(): TaskQuotaConfig {
   };
 }
 
+/**
+ * The config for a re-run a HUMAN asked for (`TASK_BOARD_ITEM_RERUN`).
+ *
+ * `maxRunsPerTask` bounds AUTOMATIC re-dispatch — a re-delegation loop, a review
+ * bounce, the sweeper's infrastructure retries — and those spend the same tally.
+ * A prod card burned all 5 on transport failures and the machine's own retry, so
+ * Re-run answered "This task reached its limit" and the human had no way to run
+ * the task at all. Being unable to retry is worse than an extra subsidized run:
+ * the period bucket still gates a released claim, and nothing here is automatic.
+ *
+ * ponytail: known ceiling — a still-`held` claim now funds unlimited MANUAL
+ * re-runs. Add a per-task manual cap if anyone ever sits on the button.
+ */
+export function userInitiatedTaskQuotaConfig(): TaskQuotaConfig {
+  return { ...taskQuotaConfig(), maxRunsPerTask: Number.POSITIVE_INFINITY };
+}
+
 /** The org a task's quota belongs to is the TASK's org, never the ambient
  *  context's — a ctx/task mismatch must not claim under the wrong org. */
 interface GatedTask {

--- a/apps/api/src/tools/task-board/enqueue-super-agent.ts
+++ b/apps/api/src/tools/task-board/enqueue-super-agent.ts
@@ -5,6 +5,7 @@ import {
   claimTaskExecution,
   rollbackTaskExecution,
   TaskQuotaError,
+  userInitiatedTaskQuotaConfig,
 } from "../../billing/task-quota";
 import { isReportsTask } from "@decocms/shared/task-board";
 import { captureOrgEvent } from "@/posthog";
@@ -65,6 +66,9 @@ export type SuperAgentPromptOpts = {
    *  work that already failed, so it outranks a brand-new task for the next
    *  slot. Defaults to a new task. See `dispatch-queue/run-priority.ts`. */
   runClass?: RunClass;
+  /** A human asked for this run (`TASK_BOARD_ITEM_RERUN`), so the per-task run
+   *  cap — which bounds automatic re-dispatch — does not apply to it. */
+  userInitiated?: boolean;
 };
 
 /**
@@ -169,7 +173,11 @@ export async function enqueueSuperAgentForTask(
   // throws [SUBSCRIPTION_REQUIRED] and nothing enqueues. The interactive
   // flip pre-checks in TASK_BOARD_ITEM_UPDATE so the user sees the paywall
   // BEFORE the write; here the claim is the enforcement.
-  const claim = await claimTaskExecution(ctx, task);
+  const claim = await claimTaskExecution(
+    ctx,
+    task,
+    opts?.userInitiated ? userInitiatedTaskQuotaConfig() : undefined,
+  );
 
   let harness: "claude-code" | "decopilot" = "decopilot";
   try {

--- a/apps/api/src/tools/task-board/rerun.ts
+++ b/apps/api/src/tools/task-board/rerun.ts
@@ -45,6 +45,10 @@ import { cancelThreadGateHead } from "@/dispatch-queue/thread-gate-queue";
 import { recordTaskActivity } from "./activity";
 import { emitTaskBoardUpdated } from "./run-reactions";
 import { enqueueSuperAgentForTask } from "./enqueue-super-agent";
+import {
+  ensureTaskExecutionAllowed,
+  userInitiatedTaskQuotaConfig,
+} from "@/billing/task-quota";
 
 /** Recorded on a thread this re-run took over. */
 const SUPERSEDED_FAILURE_REASON = "Superseded by a manual re-run of this task";
@@ -183,6 +187,9 @@ export const TASK_BOARD_ITEM_RERUN = defineTool({
       );
     }
 
+    // Paywall before any write: a refused re-run must leave the card untouched.
+    await ensureTaskExecutionAllowed(ctx, item, userInitiatedTaskQuotaConfig());
+
     // Take over: fail every thread still holding the task open. `failIfNotTerminal`
     // rather than `markRunFailed` because a `requires_action` thread has to be
     // closed out too — it is non-terminal to `shouldAdvanceToReview`, so leaving
@@ -208,8 +215,8 @@ export const TASK_BOARD_ITEM_RERUN = defineTool({
     // In Progress before dispatch, so the card reads as running the moment the
     // board refreshes rather than sitting in its old lane until the run's first
     // chunk lands. `enqueueSuperAgentForTask` claims quota itself (idempotent
-    // per task, capped per task by `maxRunsPerTask`) and throws
-    // `TaskQuotaError` when the cap is hit — which must surface, so this is NOT
+    // per task, and exempt from `maxRunsPerTask`) and throws
+    // `TaskQuotaError` on an empty period bucket — which must surface, so NOT
     // best-effort: a swallowed failure here is exactly the silent no-op this
     // tool exists to remove.
     const updated = await ctx.storage.taskBoard.update(
@@ -227,7 +234,7 @@ export const TASK_BOARD_ITEM_RERUN = defineTool({
     });
     emitTaskBoardUpdated(organizationId, updated);
 
-    await enqueueSuperAgentForTask(ctx, updated);
+    await enqueueSuperAgentForTask(ctx, updated, { userInitiated: true });
 
     return { status: updated.status, supersededThreadIds };
   },


### PR DESCRIPTION
## The bug

`maxRunsPerTask` (default 5) exists to bound **automatic** re-dispatch: a re-delegation loop, a review bounce, an approved-PR conflict, the sweeper's infrastructure retries. Every one of those goes through `enqueueSuperAgentForTask` → `claimTaskExecution` and spends the same per-task tally a human's **Re-run** spends. So a card whose runs keep dying to infrastructure runs out of the *human's* retries.

Prod, `board_pA_7SsIEhMmcStEcAidCs` (task_quota_claims.run_count = 5/5):

| # | when | what |
|---|---|---|
| 1 | 08-05 21:10 | `The socket connection was closed unexpectedly` (fixed since by #5780) |
| 2 | 08-05 21:10 | same |
| 3 | 08-06 13:14 | daemon terminal `cancelled: run cancelled`, 78s in |
| 4 | 08-11 16:31 | the user's own Re-run superseded it |
| 5 | 08-11 16:47 | 13 min / 94 tool calls, then `failed` with no error text |

Re-run then answered **"This task reached its limit"** — while the org has `free_task_executions = 999999`. The cap was the *only* thing blocking, and nothing about it was the user's doing.

## The fix

A user-initiated re-run (`TASK_BOARD_ITEM_RERUN` → `userInitiated: true`) claims with `maxRunsPerTask` disabled. The org's **period bucket still gates it** (a real trial user still hits the paywall), and every automatic dispatch path keeps the cap unchanged.

Second, smaller fix in the same handler: the quota is now pre-checked **before** the status write. A refused re-run had already flipped the card to In Progress, so it sat In Progress with nothing running — which the sweeper reads as a stalled run and re-dispatches into the same rejection. Two of those loops are on that card's timeline (20:26→20:39, 21:43).

Known ceiling, marked `ponytail:`: a still-`held` claim now funds unlimited *manual* re-runs. Add a per-task manual cap if anyone sits on the button.

## Testing

`apps/api/src/billing/task-quota.integration.test.ts` (real Postgres): a task at the cap accepts a human re-run (`"rerun"`, tally 3) and its pre-check passes, while an automatic claim on the same task still throws `execution limit`. 288 tests across `tools/task-board` + `billing` pass; `check`, `lint`, `fmt` clean.

Not covered by a test: the one-line `userInitiated: true` wiring in the rerun tool — a unit test would need a stubbed `StudioContext` (banned per TESTING.md) and there is no e2e for this tool yet.

## Related

#5931 fixes the other half of that card's story: `failedRunInfo` lost the run's error text, which downgraded recognized infrastructure failures from the 3-attempt transient budget to the 1-attempt unknown one.

Still open, not fixed here: `enqueueSuperAgentForTask` rolls the tally back only for a `"claimed"` outcome, so a `"rerun"` claim whose dispatch throws spends a run that never started; and the sweeper re-arms `retry_at` indefinitely when a retry dispatch is rejected by quota.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let users Re-run a task even after it hits the per‑task run cap. Automatic retries remain capped, and we now pre-check the org quota before any status change to avoid “In Progress” with no run.

- **Bug Fixes**
  - Exempt human-initiated re-runs from `maxRunsPerTask` via `userInitiatedTaskQuotaConfig` and `userInitiated: true` through `rerun` → `enqueueSuperAgentForTask` → `claimTaskExecution`; period bucket still applies.
  - Pre-check quota in `TASK_BOARD_ITEM_RERUN` with `ensureTaskExecutionAllowed` before updating status to prevent idle “In Progress” cards.
  - Added integration test: manual re-run bypasses the per-task cap; automatic dispatch remains capped.

<sup>Written for commit e6b5168bd097d2d04646f26062bba94c0d25fd02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

