### PR TITLE
fix(billing): collect tax ID and billing address on Stripe Checkout

### DIFF
--- a/apps/api/src/billing/stripe-api.test.ts
+++ b/apps/api/src/billing/stripe-api.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
-import { computeTopUpChargeCents, toStripeForm } from "./stripe-api";
+import {
+  computeTopUpChargeCents,
+  taxAndAddressParams,
+  toStripeForm,
+} from "./stripe-api";
 import { toUsdCreditCents } from "./exchange-rate";
 
 describe("toStripeForm", () => {
@@ -34,6 +38,22 @@ describe("toStripeForm", () => {
       nested: { keep: "x", drop: undefined, gone: null },
     });
     expect([...form.keys()]).toEqual(["nested[keep]"]);
+  });
+});
+
+describe("taxAndAddressParams", () => {
+  test("collects address + tax ID, and writes back only for a saved customer", () => {
+    const guest = toStripeForm(taxAndAddressParams(null));
+    expect(guest.get("billing_address_collection")).toBe("required");
+    expect(guest.get("tax_id_collection[enabled]")).toBe("true");
+    // Stripe rejects customer_update without a `customer` on the session.
+    expect(guest.has("customer_update[address]")).toBe(false);
+
+    const saved = toStripeForm(taxAndAddressParams("cus_1"));
+    expect(saved.get("billing_address_collection")).toBe("required");
+    // Required by Stripe once a saved customer meets address collection.
+    expect(saved.get("customer_update[address]")).toBe("auto");
+    expect(saved.get("customer_update[name]")).toBe("auto");
   });
 });
 

--- a/apps/api/src/billing/stripe-api.ts
+++ b/apps/api/src/billing/stripe-api.ts
@@ -83,6 +83,26 @@ async function stripeRequest<T>(
   return parsed as T;
 }
 
+/**
+ * Collect the buyer's billing address + tax ID (CPF/CNPJ, VAT, …) on every
+ * Checkout — both are API-only params with no Dashboard fallback, so omitting
+ * them means we never see either.
+ *
+ * `customer_update` is mandatory, not cosmetic: with a saved `customer` and
+ * address collection on, Stripe 400s the session unless we explicitly allow
+ * Checkout to write back to the customer — and a customer whose address is
+ * still blank would otherwise render read-only prefill the buyer can't fill.
+ */
+export function taxAndAddressParams(
+  customerId: string | null,
+): Record<string, unknown> {
+  return {
+    billing_address_collection: "required",
+    tax_id_collection: { enabled: true },
+    ...(customerId && { customer_update: { address: "auto", name: "auto" } }),
+  };
+}
+
 /** First subscribe: Checkout collects + saves the card for the org's flat
  *  monthly subscription (quantity 1). */
 export async function createOrgCheckoutSession(input: {
@@ -97,6 +117,8 @@ export async function createOrgCheckoutSession(input: {
   const session = await stripeRequest<{ url?: string }>("/checkout/sessions", {
     params: {
       mode: "subscription",
+      // No `customer` is passed here — Checkout creates one, so no write-back.
+      ...taxAndAddressParams(null),
       line_items: [{ price: priceId, quantity: 1 }],
       success_url: input.successUrl,
       cancel_url: input.cancelUrl,
@@ -153,6 +175,7 @@ export async function createTopUpCheckoutSession(input: {
       // Reuse the org's saved customer when it exists (same card as the
       // subscription); otherwise Checkout creates a guest payment.
       ...(input.customerId && { customer: input.customerId }),
+      ...taxAndAddressParams(input.customerId),
       line_items: [
         {
           quantity: 1,


### PR DESCRIPTION
## Problem

We were not collecting tax IDs or billing addresses on any Stripe Checkout session — reported for Studio AI credits, and the org subscription session had the same gap.

Both `tax_id_collection` and `billing_address_collection` are **API-only** params with no Dashboard fallback, so their absence in `stripe-api.ts` meant:

- No CPF/CNPJ, VAT, or any tax ID was ever captured — including on the `currency: "brl"` top-up path.
- Address collection sat at Stripe's `auto` default, which for cards asks only for country + postal code.

## Change

One shared helper, spread into both session creators (`createOrgCheckoutSession`, `createTopUpCheckoutSession`):

```ts
billing_address_collection: "required",
tax_id_collection: { enabled: true },
...(customerId && { customer_update: { address: "auto", name: "auto" } }),
```

`customer_update` is load-bearing, not cosmetic — it's the top-up path's `customer: input.customerId` reuse that needs it. Stripe **rejects** a session that passes a saved customer with address collection on unless write-back is explicitly allowed, and a customer whose address is still blank would otherwise render read-only prefill the buyer can't fill in. The subscription session passes no `customer` (Checkout creates one), so it correctly omits the param.

## Deliberately not included

`automatic_tax: { enabled: true }`. It would start **charging** tax to live customers and needs Stripe Tax registrations configured for Brazil first — a finance call, not a code change. This PR only starts collecting the data that decision will depend on. Happy to follow up once someone confirms the registrations.

## Testing

- `bun test apps/api/src/billing/stripe-api.test.ts` — 7 pass. Added a case asserting both branches of the helper encode correctly, since getting the `customer_update` branch wrong breaks checkout for every existing customer.
- `bun run fmt` clean.
- Typecheck: no errors in the touched files. Full `bun run --cwd=apps/api check` is noisy in this worktree (no `node_modules` installed there), so I'm relying on CI for the whole-workspace pass.
- **Not verified against live Stripe** — the params are unexercised until a real Checkout session is created. Worth one test-mode top-up before this reaches production, specifically on the saved-customer path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collects tax IDs (CPF/CNPJ, VAT) and full billing addresses on all Stripe Checkout sessions to fix missing data and prevent saved-customer errors. Applies to org subscriptions and AI credit top-ups; no tax calculation behavior change.

- **Bug Fixes**
  - Always collect billing address and tax IDs via a shared helper used by both session creators.
  - When a saved customer is reused, enable write-back with `customer_update` to avoid Stripe 400s and allow editable address fields.
  - Added unit tests for both paths; does not enable `automatic_tax` (data collection only).

<sup>Written for commit 6dc011037d54de8ceeea85b58befa7264f31adc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

