### PR TITLE
fix(task-board): let a failed claude-code run be nudged, not only re-run

### DIFF
--- a/apps/api/src/harnesses/decopilot/hosted-runtime.ts
+++ b/apps/api/src/harnesses/decopilot/hosted-runtime.ts
@@ -18,6 +18,31 @@ export function isHostedDecopilotRuntime({
   );
 }
 
+/**
+ * Persisted runtime tuples a board-level nudge may re-prompt on the SAME
+ * thread: hosted Decopilot, plus the sandbox-hosted `claude-code` Super Agent.
+ *
+ * The second one is not an extension, it is the common case: every Super Agent
+ * run on an org with a repo imported is `claude-code` (`resolveTaskRepoChoice`),
+ * so gating stall recovery on Decopilot alone meant the only recovery those
+ * cards had was a full re-run — new thread, new sandbox, new branch, prompt from
+ * scratch. Re-prompting the failed thread keeps its branch (the dead run's
+ * commits are already pushed there) and its transcript.
+ *
+ * `user-desktop` stays Decopilot-only: the retired link runtime wrote that exact
+ * tuple, and it has no sandbox to dispatch into.
+ */
+export function isNudgeableRuntime(runtime: {
+  harnessId: string | null | undefined;
+  sandboxProviderKind: string | null | undefined;
+}): boolean {
+  return (
+    isHostedDecopilotRuntime(runtime) ||
+    (runtime.harnessId === "claude-code" &&
+      runtime.sandboxProviderKind === "agent-sandbox")
+  );
+}
+
 export function isRetiredLinkedDecopilotRuntime({
   harnessId,
   sandboxProviderKind,

--- a/apps/api/src/tools/task-board/stall-recovery.test.ts
+++ b/apps/api/src/tools/task-board/stall-recovery.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import { shouldAdvanceToReview } from "@/storage/task-board";
-import { decideStallAction, isNeverStartedRun } from "./stall-recovery";
+import {
+  decideStallAction,
+  isNeverStartedRun,
+  nudgePrompt,
+} from "./stall-recovery";
 
 /** A used thread — `shouldAdvanceToReview` filters out message-less ones. */
 const thread = (status: string | null, hasMessages = true) => ({
@@ -51,15 +55,28 @@ describe("decideStallAction", () => {
     }
   });
 
-  test("failed native, unknown, or unpinned threads are never nudged", () => {
-    for (const harnessId of [
-      "claude-code",
-      "codex",
-      "opencode",
-      "future",
-      null,
-    ]) {
+  test("failed unknown or unpinned harnesses are never nudged", () => {
+    for (const harnessId of ["codex", "opencode", "future", null]) {
       expect(decideStallAction(ran("failed", { harnessId }))).toBe("none");
+    }
+  });
+
+  // The common case, and the whole reason this widened: every Super Agent run
+  // on an org with a repo imported is claude-code, so gating on Decopilot left
+  // those cards with no recovery but a full re-run.
+  test("a failed sandbox-hosted claude-code run gets nudged", () => {
+    expect(decideStallAction(ran("failed", { harnessId: "claude-code" }))).toBe(
+      "nudge",
+    );
+  });
+
+  test("claude-code outside an agent-sandbox has no pod to re-prompt into", () => {
+    for (const sandboxProviderKind of [null, "user-desktop"]) {
+      expect(
+        decideStallAction(
+          ran("failed", { harnessId: "claude-code", sandboxProviderKind }),
+        ),
+      ).toBe("none");
     }
   });
 
@@ -73,6 +90,23 @@ describe("decideStallAction", () => {
     expect(
       decideStallAction(ran("failed", { sandboxProviderKind: "user-desktop" })),
     ).toBe("nudge");
+  });
+});
+
+describe("nudgePrompt", () => {
+  // `user_ask` is a Decopilot built-in; claude-code has no such tool, and
+  // naming it sends the run looking for something that isn't there.
+  test("only Decopilot is told about user_ask", () => {
+    expect(nudgePrompt("decopilot")).toContain("user_ask");
+    expect(nudgePrompt("claude-code")).not.toContain("user_ask");
+    expect(nudgePrompt(null)).not.toContain("user_ask");
+  });
+
+  test("both are told to continue on the same branch, not start over", () => {
+    for (const harness of ["decopilot", "claude-code"]) {
+      expect(nudgePrompt(harness)).toContain("Don't start over");
+      expect(nudgePrompt(harness)).toContain("same branch");
+    }
   });
 });
 

--- a/apps/api/src/tools/task-board/stall-recovery.ts
+++ b/apps/api/src/tools/task-board/stall-recovery.ts
@@ -37,13 +37,9 @@ import { PartEmitter } from "@/api/routes/decopilot/part-emitter";
 import { resolveTier } from "@/core/resolve-tier";
 import type { StudioContext } from "@/core/studio-context";
 import { enqueueThreadRun } from "@/dispatch-queue";
-import { isHostedDecopilotRuntime } from "@/harnesses/decopilot/hosted-runtime";
+import { isNudgeableRuntime } from "@/harnesses/decopilot/hosted-runtime";
 import { shouldAdvanceToReview } from "@/storage/task-board";
-import type {
-  TaskBoardItem,
-  TaskBoardItemThreadRef,
-  Thread,
-} from "@/storage/types";
+import type { TaskBoardItem, Thread } from "@/storage/types";
 import { getDecopilotId } from "@decocms/shared/sdk";
 import { advanceTasksToReviewOnThreadFinish } from "./run-reactions";
 import { isThreadRunStale } from "@/tools/thread/helpers";
@@ -69,23 +65,33 @@ export function decideStallAction(thread: {
   if (
     thread.status === "failed" &&
     thread.messageStorageVersion === 2 &&
-    isHostedDecopilotRuntime(thread)
+    isNudgeableRuntime(thread)
   ) {
     return "nudge";
   }
   return "none";
 }
 
-const NUDGE_PROMPT = [
-  "This task is still In Progress on the board and your last run ended without finishing it.",
-  "",
-  "Look at what you already did, then either:",
-  "- finish the remaining work (and open the PR, if it needed code changes),",
-  "- or, if it's actually done, say so in one line — the board moves the card for you,",
-  "- or, if you're blocked on something only a human knows, call the `user_ask` tool.",
-  "",
-  "Don't start over and don't redo work you already committed or pushed.",
-].join("\n");
+/**
+ * The nudge turn. Harness-aware in one line only: `user_ask` is a Decopilot
+ * built-in, so naming it at a sandbox-hosted run would send it hunting for a
+ * tool it doesn't have. Everything else holds for both — a re-prompted thread
+ * keeps its branch, so its previous run's commits are already in the checkout.
+ */
+export function nudgePrompt(harnessId: string | null): string {
+  return [
+    "This task is still In Progress on the board and your last run ended without finishing it.",
+    "",
+    "Look at what you already did (`git log`, `git status`, and the messages above), then either:",
+    "- finish the remaining work (and open the PR, if it needed code changes),",
+    "- or, if it's actually done, say so in one line — the board moves the card for you,",
+    harnessId === "decopilot"
+      ? "- or, if you're blocked on something only a human knows, call the `user_ask` tool."
+      : "- or, if you're blocked on something only a human knows, say what you need and stop.",
+    "",
+    "Don't start over and don't redo work you already committed or pushed. You are on the same branch as before — push to it and update your existing pull request rather than opening a second one.",
+  ].join("\n");
+}
 
 /**
  * Send one user turn onto a failed run's thread. Everything here is keyed off
@@ -97,16 +103,16 @@ const NUDGE_PROMPT = [
 async function nudgeThread(
   ctx: StudioContext,
   item: TaskBoardItem,
-  thread: TaskBoardItemThreadRef,
+  thread: Thread,
 ): Promise<void> {
   const organizationId = item.organizationId;
   const model = await resolveTier(ctx, "smart");
-  const agentId = thread.virtualMcpId ?? getDecopilotId(organizationId);
+  const agentId = thread.virtual_mcp_id ?? getDecopilotId(organizationId);
 
   const requestMessage = {
-    id: `stall-nudge-${item.id}-${thread.threadId}`,
+    id: `stall-nudge-${item.id}-${thread.id}`,
     role: "user" as const,
-    parts: [{ type: "text" as const, text: NUDGE_PROMPT }],
+    parts: [{ type: "text" as const, text: nudgePrompt(thread.harness_id) }],
   };
 
   // Persist the user turn before dispatch, for the same ordering reason as
@@ -115,13 +121,13 @@ async function nudgeThread(
   await new PartEmitter({
     storage: ctx.storage.threads.messageParts(),
     orgId: organizationId,
-    threadId: thread.threadId,
-    runId: thread.threadId,
+    threadId: thread.id,
+    runId: thread.id,
   }).emitRequestMessage(requestMessage);
 
   await enqueueThreadRun(
     {
-      threadId: thread.threadId,
+      threadId: thread.id,
       source: "background-tool",
       request: {
         messages: [requestMessage],
@@ -135,13 +141,24 @@ async function nudgeThread(
         mode: "default",
         organizationId,
         userId: item.assignedBy ?? item.createdBy,
-        harnessId: "decopilot",
+        // The thread's OWN runtime, not a hardcoded Decopilot: a Super Agent
+        // task on an org with a repo runs `claude-code`, and dispatching it as
+        // Decopilot would answer the nudge with a different agent than the one
+        // that did the work.
+        harnessId:
+          thread.harness_id === "claude-code" ? "claude-code" : "decopilot",
         sandboxProviderKind: "agent-sandbox",
-        taskId: thread.threadId,
+        // The branch the failed run was dispatched on, so the re-prompt lands
+        // in a sandbox on the SAME checkout (`resolveSandboxBranch` needs the
+        // explicit bare `thread:<id>` key for a run that started repo-less and
+        // bound one mid-run with `TASK_ADD_REPO`; every other case re-derives
+        // to the same value).
+        ...(thread.branch ? { branch: thread.branch } : {}),
+        taskId: thread.id,
         runMetadata: taskRunMetadata(item),
       },
     },
-    { workflowID: `stall-nudge:${item.id}:${thread.threadId}` },
+    { workflowID: `stall-nudge:${item.id}:${thread.id}` },
   );
 }
 
@@ -153,15 +170,18 @@ async function nudgeThread(
 async function resolveStallAction(
   ctx: StudioContext,
   threadId: string,
-): Promise<StallAction> {
+): Promise<{ action: StallAction; thread: Thread | null }> {
   const thread = await ctx.storage.threads.get(threadId);
-  if (!thread) return "none";
-  return decideStallAction({
-    status: thread.status,
-    messageStorageVersion: thread.message_storage_version,
-    harnessId: thread.harness_id,
-    sandboxProviderKind: thread.sandbox_provider_kind,
-  });
+  if (!thread) return { action: "none", thread: null };
+  return {
+    action: decideStallAction({
+      status: thread.status,
+      messageStorageVersion: thread.message_storage_version,
+      harnessId: thread.harness_id,
+      sandboxProviderKind: thread.sandbox_provider_kind,
+    }),
+    thread,
+  };
 }
 
 /** Recorded on a thread whose run never reported progress and can no longer be
@@ -265,8 +285,11 @@ export async function recoverStalledTasks(
     const thread = item.threads.find((t) => t.hasMessages);
     if (!thread) continue;
     try {
-      const action = await resolveStallAction(ctx, thread.threadId);
-      if (action === "none") continue;
+      const { action, thread: row } = await resolveStallAction(
+        ctx,
+        thread.threadId,
+      );
+      if (action === "none" || !row) continue;
       if (action === "advance") {
         await advanceTasksToReviewOnThreadFinish(
           ctx.storage.taskBoard,
@@ -275,7 +298,7 @@ export async function recoverStalledTasks(
           ctx.storage.organizationBilling,
         );
       } else {
-        await nudgeThread(ctx, item, thread);
+        await nudgeThread(ctx, item, row);
       }
     } catch (err) {
       console.error(`[task-board] stall recovery failed for ${item.id}`, err);


### PR DESCRIPTION
## Problem

Board stall recovery (`recoverStalledTasks`) can re-prompt a failed thread — one user turn asking the agent to finish what it started, on the **same** thread, so the same branch and the same transcript. It was gated on `isHostedDecopilotRuntime`.

**Every Super Agent run on an org with a repo imported is `claude-code`** (`resolveTaskRepoChoice` in `enqueue-super-agent.ts`). So `decideStallAction` returned `"none"` for every one of them, and the only recovery the product exposed was `TASK_BOARD_ITEM_RERUN` → new thread, new sandbox, new `sandbox/thread-<id>` branch, prompt from scratch.

Found while investigating a prod card that burned all five of its runs (`maxRunsPerTask`) restarting ~15 minutes of real work each, then answered "This task reached its limit" to the human who tried again.

## Change

- `isNudgeableRuntime` (new, next to `isHostedDecopilotRuntime`): hosted Decopilot **or** `claude-code` + `agent-sandbox`. `user-desktop` stays Decopilot-only — the retired link runtime wrote that tuple and has no sandbox to dispatch into. Still v2-threads-only.
- `nudgeThread` dispatches with the thread's **own** `harness_id` and its persisted `branch` instead of hardcoded `decopilot` / a re-derived branch. The branch matters: a run that started repo-less and bound one mid-run with `TASK_ADD_REPO` lives on the bare `thread:<id>` key, which `resolveSandboxBranch` only returns when the caller passes it explicitly.
- `nudgePrompt(harnessId)` — the one harness-dependent line is `user_ask` (a Decopilot built-in; claude-code has no such tool, and naming it sends the run hunting). Both harnesses now get an explicit "you are on the same branch, push to it, don't open a second PR".

Idempotency is unchanged: the message id and the DBOS `workflowID` are still keyed on (task, thread), so racing board opens still produce exactly one nudge run.

## Testing

`bun test apps/api/src/tools/task-board/stall-recovery.test.ts` — 23 pass. The test that asserted `claude-code` is never nudged is **inverted**, plus new cases for the non-sandbox provider kinds and for the prompt's harness split.

`bun run check`, `bun run lint`, `bun run fmt` clean.

Not covered here (follow-ups from the same investigation): making the *automatic* retry in `reactToFailedTaskRun` a continuation of the failed thread rather than a fresh dispatch, and real Agent-SDK session continuity.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let stalled task recovery nudge failed `claude-code` runs on the same thread and branch, not only force full re-runs. This preserves work already done and avoids restarting long runs.

- **Bug Fixes**
  - Added `isNudgeableRuntime` to allow nudging for hosted Decopilot and `claude-code` on `agent-sandbox` (v2 threads).
  - Nudge dispatch now uses the thread’s own `harness_id` and `branch` instead of hardcoded `decopilot`.
  - `nudgePrompt` is harness-aware: mentions `user_ask` only for Decopilot; both are told to continue on the same branch and update the existing PR.
  - Kept idempotency by keying on (task, thread); expanded tests to cover the new paths.

<sup>Written for commit 3178643d32155b64d7358b882a43e72379048e85. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

