### PR TITLE
fix(task-board): stop spending the run budget on dispatches that never ran

### DIFF
--- a/apps/api/src/billing/task-quota.integration.test.ts
+++ b/apps/api/src/billing/task-quota.integration.test.ts
@@ -418,8 +418,8 @@ describe("task quota (integration)", () => {
     const task = await makeTask("system", org);
 
     await claimTaskExecution(ctxRb, task, CONFIG);
-    await rollbackTaskExecution(billing, org, task.id);
-    await rollbackTaskExecution(billing, org, task.id); // idempotent
+    await rollbackTaskExecution(billing, org, task.id, "claimed");
+    await rollbackTaskExecution(billing, org, task.id, "claimed"); // idempotent
 
     expect(await billing.countTaskClaims(org, "trial")).toBe(0);
     // Unlike a refund (the run happened, produced nothing): nothing ran here,
@@ -437,9 +437,53 @@ describe("task quota (integration)", () => {
     const task = await makeTask("system", org);
     await claimTaskExecution(ctxFor(org), task, CONFIG);
 
-    await rollbackTaskExecution(billing, "org_rollback_other", task.id);
+    await rollbackTaskExecution(
+      billing,
+      "org_rollback_other",
+      task.id,
+      "claimed",
+    );
     expect(await stateOf(task.id)).toBe("held");
     expect(await runCountOf(task.id)).toBe(1);
+  });
+
+  // The re-dispatch paths (review bounce, conflict re-run, the sweeper's own
+  // retry) all claim "rerun", which increments the SAME per-task tally the cap
+  // reads. A dispatch that then throws must give that tally back, or a card
+  // whose re-dispatch keeps failing walks itself to `runs_exhausted` without
+  // ever starting a run — and the human's Re-run button answers "this task
+  // reached its limit". The period slot is NOT given back: an earlier run
+  // really did ride it.
+  it("rolling back a rerun spends no run but keeps the slot charged", async () => {
+    const org = "org_rollback_rerun";
+    await seedOrg(org, true);
+    const ctxRr = ctxFor(org);
+    const task = await makeTask("system", org);
+
+    expect(await claimTaskExecution(ctxRr, task, CONFIG)).toBe("claimed");
+    expect(await claimTaskExecution(ctxRr, task, CONFIG)).toBe("rerun");
+    expect(await runCountOf(task.id)).toBe(2);
+
+    await rollbackTaskExecution(billing, org, task.id, "rerun");
+
+    expect(await runCountOf(task.id)).toBe(1);
+    expect(await stateOf(task.id)).toBe("held");
+    expect(await billing.countTaskClaims(org, "trial")).toBe(1);
+    // The freed run is really usable again — the cap is not walked down by
+    // dispatches that never happened.
+    expect(await claimTaskExecution(ctxRr, task, CONFIG)).toBe("rerun");
+  });
+
+  it("a rollback never drives the run tally below zero", async () => {
+    const org = "org_rollback_floor";
+    await seedOrg(org, true);
+    const task = await makeTask("system", org);
+
+    await claimTaskExecution(ctxFor(org), task, CONFIG);
+    await rollbackTaskExecution(billing, org, task.id, "rerun");
+    await rollbackTaskExecution(billing, org, task.id, "rerun");
+
+    expect(await runCountOf(task.id)).toBe(0);
   });
 
   it("a refund is org-scoped — another org's id can't touch the claim", async () => {

--- a/apps/api/src/billing/task-quota.ts
+++ b/apps/api/src/billing/task-quota.ts
@@ -249,9 +249,11 @@ export async function ensureTaskExecutionAllowed(
  * so a burst of concurrent dispatches consumes exactly the remaining slots.
  *
  * Returns what it did, because only the caller knows whether the dispatch it
- * charged for actually started: `"claimed"` took a slot and is the ONLY
- * outcome a failed dispatch may roll back. `"rerun"` rode an earlier run's
- * slot — rolling that back would refund a run that really happened.
+ * charged for actually started, and the two charged outcomes unwind
+ * differently: `"claimed"` took a period slot AND a run, `"rerun"` only a run
+ * (it rode an earlier run's slot, so releasing that would refund a run that
+ * really happened). Both spend the per-task tally, so both must roll it back
+ * when nothing dispatched — see `rollbackTaskExecution`.
  */
 export async function claimTaskExecution(
   ctx: StudioContext,
@@ -298,7 +300,10 @@ export async function claimTaskExecution(
 
 /**
  * Undo a charge whose dispatch never started — see `rollbackTaskClaim` for why
- * this differs from a refund. Only valid for a `"claimed"` outcome.
+ * this differs from a refund. Takes the claim outcome it is undoing: a
+ * `"claimed"` gives its period slot back, a `"rerun"` only its run tally (the
+ * slot belongs to an earlier run that really happened). A `"skipped"` claimed
+ * nothing and is a no-op.
  *
  * Errors are swallowed: the caller is already unwinding a dispatch failure and
  * must re-throw THAT error, not this one.
@@ -307,9 +312,13 @@ export async function rollbackTaskExecution(
   billing: OrganizationBillingStorage,
   organizationId: string,
   taskBoardItemId: string,
+  claim: "claimed" | "rerun" | "skipped",
 ): Promise<void> {
+  if (claim === "skipped") return;
   await billing
-    .rollbackTaskClaim(organizationId, taskBoardItemId)
+    .rollbackTaskClaim(organizationId, taskBoardItemId, {
+      releaseSlot: claim === "claimed",
+    })
     .catch((err) =>
       console.error("[task-quota] rollback failed (stays charged)", err),
     );

--- a/apps/api/src/storage/organization-billing.ts
+++ b/apps/api/src/storage/organization-billing.ts
@@ -3,6 +3,7 @@
  * status, period end. Platform-written only (the webhook is the writer).
  */
 
+import { sql } from "kysely";
 import type { Kysely, Selectable } from "kysely";
 import type { Database } from "./types";
 
@@ -259,22 +260,31 @@ export class OrganizationBillingStorage {
   }
 
   /**
-   * Undo a claim whose dispatch never started. Frees the slot AND rolls the run
-   * tally back — unlike a refund, where the run DID happen and only produced
-   * nothing, so its tally has to stand. Nothing ran here, so nothing may be
-   * spent: a task whose dispatch keeps failing (no model configured) would
-   * otherwise burn its per-task cap and die with a quota error for runs that
-   * never existed.
+   * Undo a claim whose dispatch never started. Always rolls the run tally back —
+   * unlike a refund, where the run DID happen and only produced nothing, so its
+   * tally has to stand. Nothing ran here, so nothing may be spent: a task whose
+   * dispatch keeps failing (no model configured) would otherwise burn its
+   * per-task cap and die with a quota error for runs that never existed.
+   *
+   * `releaseSlot` is the difference between the two claim outcomes this undoes.
+   * A `"claimed"` dispatch TOOK a period slot, so it gives that back too. A
+   * `"rerun"` rode a slot an earlier run already paid for (and may have shipped
+   * a PR from) — releasing it would refund a run that really happened, so only
+   * the tally is rolled back.
+   *
+   * `greatest(…, 0)` because a claim can only be undone as many times as it was
+   * charged; a double call must not drive the cap negative.
    */
   async rollbackTaskClaim(
     organizationId: string,
     taskBoardItemId: string,
+    { releaseSlot }: { releaseSlot: boolean },
   ): Promise<void> {
     await this.db
       .updateTable("task_quota_claims")
-      .set((eb) => ({
-        state: "released",
-        run_count: eb("run_count", "-", 1),
+      .set(() => ({
+        ...(releaseSlot ? { state: "released" as const } : {}),
+        run_count: sql<number>`greatest(run_count - 1, 0)`,
       }))
       .where("organization_id", "=", organizationId)
       .where("task_board_item_id", "=", taskBoardItemId)

--- a/apps/api/src/tools/task-board/enqueue-super-agent.ts
+++ b/apps/api/src/tools/task-board/enqueue-super-agent.ts
@@ -239,18 +239,18 @@ export async function enqueueSuperAgentForTask(
     //
     // ROLLBACK, not refund: no run happened, so the per-task tally must not be
     // spent either — otherwise a task whose dispatch keeps failing dies at the
-    // run cap with a quota error for runs that never existed.
-    //
-    // Only a FRESH claim is ours to undo. A `"rerun"` rides a slot an earlier
-    // run already paid for (and may well have shipped a PR from) — undoing it
-    // here would refund a run that really happened.
-    if (claim === "claimed") {
-      await rollbackTaskExecution(
-        ctx.storage.organizationBilling,
-        task.organizationId,
-        task.id,
-      );
-    }
+    // run cap with a quota error for runs that never existed. That holds for a
+    // `"rerun"` too: it incremented the same tally, and the sweeper's automatic
+    // retries spend it, so a card whose re-dispatch keeps throwing used to walk
+    // itself to the cap without ever starting a run. Its period SLOT is not
+    // ours to give back (an earlier run really did ride it) — that distinction
+    // lives in `rollbackTaskExecution`.
+    await rollbackTaskExecution(
+      ctx.storage.organizationBilling,
+      task.organizationId,
+      task.id,
+      claim,
+    );
     throw err;
   }
 

--- a/apps/api/src/tools/task-board/review-sweeper.test.ts
+++ b/apps/api/src/tools/task-board/review-sweeper.test.ts
@@ -7,7 +7,9 @@
  */
 
 import { describe, expect, it } from "bun:test";
+import { TaskQuotaError } from "@/billing/task-quota";
 import { prReadyForReview } from "./prs-get";
+import { isPermanentDispatchFailure } from "./review-sweeper";
 
 const pr = (over: Partial<Parameters<typeof prReadyForReview>[0][number]>) => ({
   state: "open",
@@ -66,5 +68,27 @@ describe("prReadyForReview", () => {
     expect(prReadyForReview([pr({ state: null, checksStatus: null })])).toBe(
       true,
     );
+  });
+});
+
+/**
+ * The retry re-arm keeps `attempts` untouched, on purpose: a dispatch that
+ * failed on infrastructure deserves the same recovery as the run it was going
+ * to start. That makes the classification load-bearing — a failure that can
+ * never clear would be re-armed forever, which is what a quota rejection did.
+ */
+describe("isPermanentDispatchFailure", () => {
+  it("a quota rejection can never clear on a later tick", () => {
+    for (const reason of ["runs_exhausted", "trial_exhausted"] as const) {
+      expect(isPermanentDispatchFailure(new TaskQuotaError(reason))).toBe(true);
+    }
+  });
+
+  it("anything else is a blip worth re-arming for", () => {
+    expect(isPermanentDispatchFailure(new Error("connection reset"))).toBe(
+      false,
+    );
+    expect(isPermanentDispatchFailure("no model configured")).toBe(false);
+    expect(isPermanentDispatchFailure(undefined)).toBe(false);
   });
 });

--- a/apps/api/src/tools/task-board/review-sweeper.ts
+++ b/apps/api/src/tools/task-board/review-sweeper.ts
@@ -66,7 +66,8 @@ import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
 import { enqueueEnabledReviewers } from "./enqueue-reviewer";
 import { enqueueSuperAgentForTask } from "./enqueue-super-agent";
 import { retryAutoMergeIfApproved } from "./merge-pr";
-import { reactToFailedTaskRun } from "./run-reactions";
+import { emitTaskBoardUpdated, reactToFailedTaskRun } from "./run-reactions";
+import { TaskQuotaError } from "@/billing/task-quota";
 import { ABANDONED_FAILURE_REASON } from "./stall-recovery";
 import { THREAD_EXPIRY_MS } from "@/tools/thread/helpers";
 import { fetchPrLiveState, prReadyForReview } from "./prs-get";
@@ -100,6 +101,20 @@ const REARM_DELAY_MS = 60 * 1000;
  *  failure) always wins the normal case, short enough that a card whose pod died
  *  mid-reaction recovers on its own. */
 const UNHANDLED_FAILURE_GRACE_MS = 2 * 60 * 1000;
+
+/**
+ * True for a retry dispatch failure that a later tick cannot fix.
+ *
+ * Everything else the dispatch can throw (the context factory, a quota READ, a
+ * DB blip) is a blip worth re-arming for. A quota REJECTION is not: the
+ * per-task cap and an exhausted period bucket both stay exhausted, and the
+ * re-arm deliberately leaves `attempts` untouched — so that one failure mode
+ * would re-throw every minute forever with a budget that never terminates.
+ * Pure — unit-tested.
+ */
+export function isPermanentDispatchFailure(err: unknown): boolean {
+  return err instanceof TaskQuotaError;
+}
 
 export interface TaskBoardReviewSweeperOptions {
   intervalMs?: number;
@@ -291,6 +306,19 @@ export class TaskBoardReviewSweeper {
           `[task-board-review-sweeper] retry dispatch for ${id} failed`,
           err,
         );
+        // A failure no later tick can fix must not be re-armed (see
+        // `isPermanentDispatchFailure`) — the card would sit In Progress with
+        // no run behind it and the same rejection every minute. Send it back
+        // to To Do with the reason, the same terminal the retry budget itself
+        // has when it runs out.
+        if (isPermanentDispatchFailure(err)) {
+          await this.returnToTodo(
+            id,
+            organizationId,
+            err instanceof Error ? err.message : String(err),
+          );
+          continue;
+        }
         // The claim already cleared `retry_at`, so leaving it here would spend
         // the attempt on a run that never started — the exact silent strand this
         // whole path exists to remove. Re-arm it instead: the dispatch itself can
@@ -313,6 +341,43 @@ export class TaskBoardReviewSweeper {
       }
     }
     return count;
+  }
+
+  /**
+   * Park a card a retry can no longer help back on To Do, with the reason on
+   * its timeline — the same landing `reactToFailedTaskRun` gives a card that
+   * runs out of retry budget, so a human sees one shape for "the agent stopped
+   * and it needs you" rather than a card frozen In Progress.
+   */
+  private async returnToTodo(
+    id: string,
+    organizationId: string,
+    reason: string,
+  ): Promise<void> {
+    try {
+      const item = await this.taskBoard.getById(id, organizationId);
+      if (!item || item.status !== "in_progress") return;
+      const returned = await this.taskBoard.returnToTodoAfterFailure(
+        id,
+        organizationId,
+        item.updatedBy,
+      );
+      if (!returned) return;
+      await this.taskBoard
+        .recordActivity({
+          taskBoardItemId: id,
+          action: "status_changed",
+          actorId: null,
+          data: { from: "in_progress", to: "todo", reason },
+        })
+        .catch(() => {});
+      emitTaskBoardUpdated(organizationId, returned);
+    } catch (err) {
+      console.error(
+        `[task-board-review-sweeper] returning ${id} to todo failed`,
+        err,
+      );
+    }
   }
 
   /** Hand a card with a linked, ready PR off to the enabled reviewers. Returns


### PR DESCRIPTION
Two quota/retry bookkeeping bugs found while investigating a prod card that answered **"This task reached its limit"** to a human after burning all five of its runs on ~15 minutes of real work each. Neither is the cause of that card, but both make the same failure mode worse and terminate budgets that shouldn't terminate (or fail to terminate ones that should).

## 1. A `"rerun"` claim whose dispatch throws spends a run that never started

`enqueueSuperAgentForTask` rolls its claim back only for a `"claimed"` outcome. But `claimTaskUnderLimit` increments the **same** `task_quota_claims.run_count` for a `"rerun"`, and that tally is what `maxRunsPerTask` reads. Every automatic re-dispatch path — review bounce, conflict re-run, the sweeper's infrastructure retry — claims `"rerun"`, so a card whose dispatch keeps throwing walks itself to `runs_exhausted` with nothing to show for it.

The original comment was half right: a rerun's period **slot** is genuinely not ours to give back (an earlier run rode it and may have shipped a PR). Its **run** is.

- `rollbackTaskExecution(billing, org, task, claim)` now takes the outcome it undoes: both charged outcomes roll the tally back, only `"claimed"` releases the slot. `"skipped"` is a no-op.
- `rollbackTaskClaim` takes `{ releaseSlot }` and floors the decrement at 0, so a double call can't drive the cap negative.

## 2. `dispatchDueRetries` re-arms a quota rejection forever

The re-arm on a thrown dispatch deliberately leaves `attempts` untouched — correct for a blip in the context factory or a DB read. A `TaskQuotaError` is not a blip: the per-task cap and an exhausted period bucket both stay exhausted, so the card re-throws every minute with a budget that can never terminate, sitting In Progress with no run behind it. (This card's timeline shows two such loops.)

`isPermanentDispatchFailure` splits the two. A permanent failure returns the card to To Do with the reason on its timeline — the same landing `reactToFailedTaskRun` gives a card that runs out of retry budget.

## Testing

- `bun test apps/api/src/billing apps/api/src/tools/task-board` — 292 pass (needs `DATABASE_URL` for the real-PG integration files).
- New real-PG cases in `task-quota.integration.test.ts`: a rolled-back rerun frees the run but keeps the slot charged and the freed run is usable again; the tally never goes below zero. The three existing `rollbackTaskExecution` call sites are updated to the new signature.
- New unit cases for `isPermanentDispatchFailure`.
- **Not covered:** the sweeper's wiring itself (`dispatchDueRetries` → `returnToTodo`). It needs a real `StudioContextFactory` plus `STUDIO_TASK_QUOTA_ENFORCED` frozen at boot, which is neither tier — the extracted predicate is what's unit-tested.

`bun run check`, `bun run lint`, `bun run fmt` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops spending a task’s run budget on dispatches that never start and prevents the sweeper from re‑arming quota rejections forever, reducing false “This task reached its limit” outcomes.

- **Bug Fixes**
  - Roll back the run tally when a dispatch fails for both `"claimed"` and `"rerun"` outcomes; only `"claimed"` also releases the period slot. Updated `rollbackTaskExecution(billing, orgId, taskId, claim)` and `OrganizationBillingStorage.rollbackTaskClaim(..., { releaseSlot })` with a non-negative floor.
  - In `dispatchDueRetries`, classify permanent failures via `isPermanentDispatchFailure` (treat `TaskQuotaError` as permanent) and return the card to To Do with the reason, instead of re‑arming retries; other errors still re‑arm.

<sup>Written for commit 2538a377c40e3880cbf712fa9a4911b0cd356ed7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

