### PR TITLE
fix(connections): don't fire card onClick on a nested action's Enter

### DIFF
--- a/apps/web/src/components/connections/connection-card.test.tsx
+++ b/apps/web/src/components/connections/connection-card.test.tsx
@@ -1,0 +1,47 @@
+import { setupComponentTest } from "../../../test/setup"; // happy-dom + jest-dom matchers
+setupComponentTest();
+import { describe, expect, it, mock } from "bun:test";
+import { fireEvent, render as renderBare } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { ConnectionCard } from "./connection-card";
+
+// useT() reads its language preference through TanStack Query.
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+const render = (ui: Parameters<typeof renderBare>[0]) =>
+  renderBare(ui, { wrapper });
+
+describe("ConnectionCard", () => {
+  it("activates onClick when Enter is pressed on the card itself", () => {
+    const onClick = mock();
+    const { getByRole } = render(
+      <ConnectionCard connection={{ title: "Foo" }} onClick={onClick} />,
+    );
+    fireEvent.keyDown(getByRole("button"), { key: "Enter" });
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not activate onClick when Enter is pressed on a nested header action", () => {
+    const onClick = mock();
+    const onAction = mock();
+    const { getByTestId } = render(
+      <ConnectionCard
+        connection={{ title: "Foo" }}
+        onClick={onClick}
+        headerActions={
+          <button type="button" data-testid="action" onClick={onAction}>
+            Manage
+          </button>
+        }
+      />,
+    );
+    fireEvent.keyDown(getByTestId("action"), { key: "Enter" });
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/connections/connection-card.tsx
+++ b/apps/web/src/components/connections/connection-card.tsx
@@ -47,6 +47,8 @@ export function ConnectionCard({
       onKeyDown={
         onClick
           ? (e) => {
+              // Skip keydowns bubbled from a nested control (header actions).
+              if (e.target !== e.currentTarget) return;
               if (e.key === "Enter" || e.key === " ") {
                 e.preventDefault();
                 onClick();


### PR DESCRIPTION
Follows #5927 ("make clickable connection cards keyboard-reachable"), which added `role="button"` + `tabIndex` + an `onKeyDown` Enter/Space handler to `ConnectionCard`.

The card's `onClick` was already guarded against nested header-action clicks via `e.stopPropagation()` inside the header-actions wrapper, but the new `onKeyDown` handler has no equivalent guard. `ConnectionCardHeaderActions` (used on the connections list page) renders a real dropdown-menu trigger button and a checkbox directly inside the card's DOM. Pressing Enter or Space while focused on one of those bubbles the keydown up to the card, which calls `preventDefault()` and fires the card's own `onClick` (navigating to the connection detail page) instead of the action's own activation — a real regression for keyboard-only users, introduced by the very PR meant to help them.

**Failure scenario:** tab to the "..." menu button (or the selection checkbox) on a connection card, press Enter — instead of opening the menu / toggling selection, the whole card navigates away.

**Fix:** guard the card's `onKeyDown` with `e.target !== e.currentTarget`, the same pattern already used for this exact problem in `section-variant-list.tsx`'s `SortableVariantRow`.

**Regression test:** `connection-card.test.tsx` renders the card with a header-action button and asserts Enter on that button does NOT call the card's `onClick`; reverting the guard makes this test fail (verified locally).

**To confirm:** `bun test apps/web/src/components/connections/connection-card.test.tsx`

Locally ran: `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, `bunx oxlint` on both changed files, and the targeted test above — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent `ConnectionCard` from navigating when Enter/Space is pressed on a nested header action. Adds a keydown guard to only handle keys on the card itself and a regression test ensuring nested actions don’t trigger the card’s `onClick`.

<sup>Written for commit 5d05b17ff6066af4dbb38fbcea92ef7ccf5524bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

