### PR TITLE
fix(connections): reveal hover-only header actions on keyboard focus

### DIFF
--- a/apps/web/src/components/connections/connection-card.tsx
+++ b/apps/web/src/components/connections/connection-card.tsx
@@ -76,7 +76,7 @@ export function ConnectionCard({
                   className={cn(
                     "transition-opacity",
                     !headerActionsAlwaysVisible &&
-                      "sm:opacity-0 sm:group-hover:opacity-100",
+                      "sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100",
                   )}
                   onClick={(e) => e.stopPropagation()}
                 >


### PR DESCRIPTION
**Source:** hardening follow-up in the connection-card area (recent merges: #5927 made the card keyboard-reachable, #5937 fixed nested-action Enter bubbling). While auditing that keyboard-interaction path I found a related, still-unfixed gap in the same component.

**The bug:** `ConnectionCard`'s `headerActions` wrapper defaults (`headerActionsAlwaysVisible` unset/false) to `sm:opacity-0 sm:group-hover:opacity-100` — visible only on mouse hover. The header-action button(s) inside it are still real, tabbable elements (confirmed via the card's own `onKeyDown`, which already special-cases nested-control keydowns). A keyboard user tabbing through the card lands focus on a header action they cannot see, with no visual cue for what Enter/Space is about to activate. This repo already has the fix for the identical pattern in `apps/web/src/components/sandbox/content/item-row.tsx` (`opacity-0 group-hover:opacity-100 focus-within:opacity-100`) and a keyboard-only reveal variant in `sections-editor/section-list.tsx` — this file just never got it.

**Fix:** add `sm:group-focus-within:opacity-100` alongside the existing hover reveal, so focusing any descendant (a header-action button) reveals the same actions hover does.

**Note on current impact:** every current call site (`connection-dialog-content.tsx`, `catalog-item-card.tsx`, `connections.tsx`, `connection-selection-ui.tsx`) explicitly passes `headerActionsAlwaysVisible`, so this default branch isn't hit by any caller today — but it's the component's public default, and any future/omitted caller hits this exact gap. One-line CSS addition, no behavior change for existing callers.

**To verify:** render `ConnectionCard` without `headerActionsAlwaysVisible` and Tab to a header action — it now becomes visible instead of staying at `opacity-0`.

**Checks run locally:** `bun run fmt` (clean), `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint apps/web/src/components/connections/connection-card.tsx` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `ConnectionCard` header actions visible on keyboard focus when `headerActionsAlwaysVisible` is unset, so focused buttons aren’t hidden. Adds `sm:group-focus-within:opacity-100` alongside the hover reveal; no change for current callers that set `headerActionsAlwaysVisible`.

<sup>Written for commit 19e8df3ae109550ddec6d38621afde80ba7ddd13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

