### PR TITLE
fix(decopilot): cap inspect_page's browserless error body

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.test.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { createInspectPageTool } from "./inspect-page";
+
+const writer = { write: () => {} } as never;
+
+describe("createInspectPageTool", () => {
+  test("caps an oversized browserless error body instead of embedding it whole", async () => {
+    const originalFetch = globalThis.fetch;
+    const hugeBody = "x".repeat(50_000);
+    globalThis.fetch = (async () =>
+      new Response(hugeBody, { status: 502 })) as never;
+    try {
+      const tool = createInspectPageTool(writer, {
+        browserless: { baseUrl: "https://bl.example", token: "t" },
+        objectStorage: { put: async () => ({ key: "k" }) } as never,
+        toolOutputMap: new Map(),
+      });
+      const result = (await tool.execute!({ url: "https://example.com" }, {
+        toolCallId: "tc1",
+      } as never)) as { success: boolean; error: string };
+      expect(result.success).toBe(false);
+      expect(result.error.length).toBeLessThan(600);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.ts
@@ -25,6 +25,9 @@ import { LARGE_RESULT_TOKEN_THRESHOLD } from "./constants";
 // Give it headroom over the inner timeout instead of leaving it unbounded.
 const BROWSERLESS_FETCH_TIMEOUT_MS = 45_000;
 
+// Upstream error bodies are unbounded — cap what lands in the tool error.
+const ERROR_BODY_MAX_CHARS = 500;
+
 const InspectPageInputSchema = z.object({
   url: z.string().url().describe("The URL of the web page to inspect."),
   evaluate: z
@@ -149,7 +152,7 @@ export function createInspectPageTool(
           const errorText = await response.text().catch(() => "Unknown error");
           return {
             success: false,
-            error: `Browserless function call failed (${response.status}): ${errorText}`,
+            error: `Browserless function call failed (${response.status}): ${errorText.slice(0, ERROR_BODY_MAX_CHARS)}`,
             url: input.url,
           };
         }


### PR DESCRIPTION
**Source:** a small hardening gap found while auditing the decopilot built-in-tools directory — `inspect-page.ts`'s sibling `scrape-url.ts` (see PR #5894) already caps a Browserless error response body at `ERROR_BODY_MAX_CHARS` (500), but `inspect-page.ts`'s function-call error path interpolated `errorText` unbounded straight into the tool error.

**Payoff:** Browserless is an untrusted upstream call — a 5xx or malformed response can return an arbitrarily large body (e.g. an HTML error page or stack trace). That unbounded string was flowing straight into the tool result and back into the model's context on every inspect_page failure, bloating context/cost exactly the failure mode #5894 fixed for `scrape_url`.

**Fix:** slice `errorText` to `ERROR_BODY_MAX_CHARS` (500) before embedding it in the error message, mirroring `scrape-url.ts` exactly.

**Regression test:** `inspect-page.test.ts` (new) — mocks `fetch` to return a 50,000-char error body and asserts the resulting error string stays under 600 chars. Mirrors the equivalent test already in `scrape-url.test.ts`.

**Reviewer command:** `cd apps/api && bun test src/harnesses/lib/decopilot/built-in-tools/inspect-page.test.ts`

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/api workspace, clean), `bunx oxlint` on both changed files (0 warnings/errors), and the new targeted test (1 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap Browserless error bodies in `inspect_page` to 500 chars to prevent large upstream errors from bloating tool output and context. Mirrors `scrape_url` and adds a regression test to ensure the cap.

<sup>Written for commit cc1932992d2252ad36d200188290a6c61fc428ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

