### PR TITLE
i18n(registry): translate hardcoded tool-discovery error strings

### DIFF
--- a/apps/web/src/hooks/registry/use-discover-tools.ts
+++ b/apps/web/src/hooks/registry/use-discover-tools.ts
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useStudioTools } from "@/lib/studio-tools";
 import type { RegistryToolMeta } from "@/lib/registry/types";
+import { useT } from "@/i18n/use-t.ts";
 
 export type DiscoverStatus =
   | "idle"
@@ -10,6 +11,7 @@ export type DiscoverStatus =
   | "auth_required";
 
 export function useDiscoverTools() {
+  const t = useT();
   const [discoverStatus, setDiscoverStatus] = useState<DiscoverStatus>("idle");
   const [discoverError, setDiscoverError] = useState<string | null>(null);
 
@@ -42,7 +44,7 @@ export function useDiscoverTools() {
       }
 
       if (!data.tools || data.tools.length === 0) {
-        setDiscoverError("No tools found on this MCP server.");
+        setDiscoverError(t("registry.discoverTools.noToolsFound"));
         setDiscoverStatus("error");
         return null;
       }
@@ -51,7 +53,9 @@ export function useDiscoverTools() {
       return data.tools;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      setDiscoverError(message || "Could not discover tools.");
+      setDiscoverError(
+        message || t("registry.discoverTools.couldNotDiscoverTools"),
+      );
       setDiscoverStatus("error");
       return null;
     }

--- a/apps/web/src/i18n/en/registry.ts
+++ b/apps/web/src/i18n/en/registry.ts
@@ -46,6 +46,8 @@ export const registry = {
   "registry.deleteConfirmDialog.description":
     "This action cannot be undone. Item {title} will be permanently removed from this private registry.",
   "registry.deleteConfirmDialog.title": "Delete registry item?",
+  "registry.discoverTools.couldNotDiscoverTools": "Could not discover tools.",
+  "registry.discoverTools.noToolsFound": "No tools found on this MCP server.",
   "registry.imageUpload.change": "Change",
   "registry.imageUpload.clickOrDragToUpload": "Click or drag to upload",
   "registry.imageUpload.dropImageHere": "Drop image here",

--- a/apps/web/src/i18n/pt-br/registry.ts
+++ b/apps/web/src/i18n/pt-br/registry.ts
@@ -48,6 +48,10 @@ export const registry = {
   "registry.deleteConfirmDialog.description":
     "Esta ação não pode ser desfeita. O item {title} será removido permanentemente deste registro privado.",
   "registry.deleteConfirmDialog.title": "Deletar item do registro?",
+  "registry.discoverTools.couldNotDiscoverTools":
+    "Não foi possível descobrir as ferramentas.",
+  "registry.discoverTools.noToolsFound":
+    "Nenhuma ferramenta encontrada neste servidor MCP.",
   "registry.imageUpload.change": "Alterar",
   "registry.imageUpload.clickOrDragToUpload": "Clique ou arraste para enviar",
   "registry.imageUpload.dropImageHere": "Solte a imagem aqui",


### PR DESCRIPTION
**Source**: bug found while auditing i18n coverage in `apps/web/src/hooks/registry/` (my assigned focus area this tick).

**Payoff**: `useDiscoverTools()` is used by the registry item dialog and tools editor to render the "discover tools" error message directly in the UI (`tools-editor.tsx:140`, `registry-item-dialog.tsx:1013`), but it built two of its error strings (`"No tools found on this MCP server."` and `"Could not discover tools."`) as raw hardcoded English literals instead of going through `useT()` — unlike every other user-facing string in the registry views. A pt-BR user hitting a tool-discovery failure would see English text mixed into an otherwise-translated dialog.

**Fix**: added `registry.discoverTools.noToolsFound` / `registry.discoverTools.couldNotDiscoverTools` keys to both `apps/web/src/i18n/en/registry.ts` and `apps/web/src/i18n/pt-br/registry.ts`, and swapped the hook to call `t(...)` instead of the literal strings. No behavior change beyond the rendered locale.

**Verify**: open the "Add MCP Server" dialog, enter an unreachable/empty-tools URL and click "Auto-discover" — the error banner now reads from the dictionary (in pt-BR: "Nenhuma ferramenta encontrada neste servidor MCP.").

**Checks run locally**: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint` on the three touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localized tool discovery error messages in the registry by replacing hardcoded English with `useT()` and adding `registry.discoverTools.*` keys to `en` and `pt-br`. This fixes mixed-language errors in the tools editor and registry item dialog; no behavior change besides proper translation.

<sup>Written for commit b4f680cc166283cd7699bc55c86851b80aef1244. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

