### PR TITLE
fix(sandbox): validate metadata.runtime.env before SANDBOX_START pushes it

### DIFF
--- a/apps/api/src/tools/sandbox/helpers.test.ts
+++ b/apps/api/src/tools/sandbox/helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "bun:test";
 import {
+  readValidatedRuntimeEnv,
   readValidatedSubmoduleCredentials,
   resolveRuntimeConfig,
 } from "./helpers";
@@ -101,6 +102,46 @@ describe("resolveRuntimeConfig", () => {
       runtime: { selected: "npm", port: "65535" },
     };
     expect(resolveRuntimeConfig(metadata).port).toBe("65535");
+  });
+});
+
+describe("readValidatedRuntimeEnv", () => {
+  it("returns null when metadata / runtime / array is absent", () => {
+    expect(readValidatedRuntimeEnv(null)).toBeNull();
+    expect(readValidatedRuntimeEnv({})).toBeNull();
+    expect(readValidatedRuntimeEnv({ runtime: {} })).toBeNull();
+    expect(readValidatedRuntimeEnv({ runtime: { env: "nope" } })).toBeNull();
+  });
+
+  // Feeds SANDBOX_START's secret-resolving loop; a malformed row must be dropped here, not thrown there.
+  it("drops malformed entries instead of letting them through", () => {
+    const result = readValidatedRuntimeEnv({
+      runtime: {
+        env: [
+          { key: "FOO", kind: "literal", value: "bar" },
+          { key: "bad key", kind: "literal", value: "x" }, // invalid key
+          { key: "NO_VALUE", kind: "literal" }, // missing value
+          { key: "NO_SECRET", kind: "secret" }, // missing secretId
+          { key: "EMPTY_SECRET", kind: "secret", secretId: "" },
+          { kind: "literal", value: "no-key" }, // missing key
+          "garbage",
+          null,
+          { key: "SECRET_KEY", kind: "secret", secretId: "sec_1" },
+        ],
+      },
+    });
+    expect(result).toEqual([
+      { key: "FOO", kind: "literal", value: "bar" },
+      { key: "SECRET_KEY", kind: "secret", secretId: "sec_1" },
+    ]);
+  });
+
+  it("returns null when every entry is invalid", () => {
+    expect(
+      readValidatedRuntimeEnv({
+        runtime: { env: [{ key: "bad key", kind: "literal", value: "x" }] },
+      }),
+    ).toBeNull();
   });
 });
 

--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -31,6 +31,7 @@ import {
   type StudioContext,
 } from "../../core/studio-context";
 import {
+  readValidatedRuntimeEnv,
   readValidatedSubmoduleCredentials,
   resolveRuntimeConfig,
   type RuntimeConfigMeta,
@@ -646,7 +647,7 @@ async function provisionSandbox(
   // Resolve declared env (literals + secret refs) and push to the daemon
   // *before* it can start install/dev. Daemon deep-merges, so resuming an
   // already-claimed sandbox stays idempotent.
-  const envEntries = (metadata as RuntimeConfigMeta).runtime?.env ?? null;
+  const envEntries = readValidatedRuntimeEnv(metadata);
   await resolveAndPushEnv({
     ctx,
     runner,


### PR DESCRIPTION
**Bug, not an issue follow-up.** `virtualMcp.metadata` is an untrusted JSON column — that's exactly why `readValidatedRuntimeEnv`/`readValidatedSubmoduleCredentials` exist in `helpers.ts`. `sandbox-proxy.ts`'s setup/start step already reads `metadata.runtime.env` through `readValidatedRuntimeEnv` before calling `resolveAndPushEnv`. `SANDBOX_START` (`start.ts`) does the identical operation three lines below where it correctly validates `submoduleCredentials`, but for `env` it used a raw `(metadata as RuntimeConfigMeta).runtime?.env ?? null` cast instead — skipping the validator entirely.

**Failure scenario:** a virtual MCP row with a malformed `runtime.env` (hand-edited metadata, a stale/older schema, `env` not even an array) reaches `resolveAndPushEnv`'s `for (const entry of entries)` unfiltered. A non-object entry throws on `entry.kind` access, a non-array `env` isn't iterable — either way `SANDBOX_START` throws instead of the entry being silently dropped, which is the exact crash class `readValidatedRuntimeEnv`'s docstring says it exists to prevent ("a bad row can't crash `resolveAndPushEnv`'s `for...of`").

**Fix:** switch `start.ts` to `readValidatedRuntimeEnv(metadata)`, same reader `sandbox-proxy.ts` already uses. Also added unit coverage for `readValidatedRuntimeEnv` itself — it had zero tests despite its sibling `readValidatedSubmoduleCredentials` (identical shape, same untrusted-metadata rationale) already being covered in this file.

**Verify:** `cd apps/api && bunx tsc --noEmit`; `bun test apps/api/src/tools/sandbox/helpers.test.ts` and `bun test apps/api/src/tools/sandbox/start.test.ts` (both green, 18 and 22 tests respectively); `bunx oxlint apps/api/src/tools/sandbox/helpers.test.ts apps/api/src/tools/sandbox/start.ts` (0 warnings/errors).

Locally ran: format, targeted typecheck, the two targeted test files, per-file oxlint — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `metadata.runtime.env` in `SANDBOX_START` using `readValidatedRuntimeEnv` before pushing to the daemon, preventing crashes from malformed env data and aligning with `sandbox-proxy`.
Adds unit tests for `readValidatedRuntimeEnv` to ensure invalid entries are dropped and non-array envs return null.

<sup>Written for commit 9f601c4f49e9dd25f2b83bcc8ecf3a216d281f98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

