### PR TITLE
fix(decopilot): reject non-http(s) URLs before scrape_url forwards them to Browserless

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/scrape-url.test.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/scrape-url.test.ts
@@ -84,6 +84,31 @@ describe("createScrapeUrlTool", () => {
     }
   });
 
+  test("rejects a non-http(s) URL before it reaches browserless", async () => {
+    const originalFetch = globalThis.fetch;
+    let fetchCalled = false;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response("<html>ok</html>", { status: 200 });
+    }) as never;
+    try {
+      const tool = createScrapeUrlTool(writer, {
+        browserless: { baseUrl: "https://bl.example", token: "t" },
+        objectStorage: { put: async () => ({ key: "k" }) } as never,
+        toolOutputMap: new Map(),
+      });
+      const parsed = await (
+        tool.inputSchema as unknown as {
+          validate: (v: unknown) => Promise<{ success: boolean }>;
+        }
+      ).validate({ url: "file:///etc/passwd" });
+      expect(parsed.success).toBe(false);
+      expect(fetchCalled).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("caps an oversized browserless error body instead of embedding it whole", async () => {
     const originalFetch = globalThis.fetch;
     const hugeBody = "x".repeat(50_000);

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/scrape-url.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/scrape-url.ts
@@ -26,8 +26,15 @@ const BROWSERLESS_FETCH_TIMEOUT_MS = 45_000;
 // Upstream error bodies are unbounded — cap what lands in the tool error.
 const ERROR_BODY_MAX_CHARS = 500;
 
+// Reject non-http(s) schemes (file:, javascript:, ...) before forwarding to Browserless.
 const ScrapeUrlInputSchema = z.object({
-  url: z.string().url().describe("The URL of the web page to scrape."),
+  url: z
+    .string()
+    .url()
+    .refine((url) => /^https?:\/\//i.test(url), {
+      message: "URL must use http or https",
+    })
+    .describe("The URL of the web page to scrape."),
 });
 
 export type ScrapeUrlInput = z.infer<typeof ScrapeUrlInputSchema>;


### PR DESCRIPTION
The `scrape_url` built-in tool validated its `url` input with only `z.string().url()`, which accepts any scheme `new URL()` parses — `file:`, `javascript:`, `ftp:`, etc. — and forwards it unchecked as the JSON body of a POST to the Browserless `/content` API.

A maintainer wants this because `url` crosses a trust boundary (model/agent-controlled input feeding an outbound network call to an external service) and a non-http(s) scheme is unlikely to be an intentional scrape target — it's either a mistake or an attempt to get Browserless to fetch a local file / execute a `javascript:` payload in the page context.

Fix: add a `.refine()` on the existing zod schema requiring the URL to start with `http://` or `https://`. Invalid schemes are now rejected by the AI SDK's tool input validation before `execute` ever runs, so no malformed/dangerous URL reaches Browserless.

Added a regression test (`rejects a non-http(s) URL before it reaches browserless`) asserting `file:///etc/passwd` fails schema validation and `fetch` is never called.

Reviewer check: `bun test ./apps/api/src/harnesses/lib/decopilot/built-in-tools/scrape-url.test.ts` (from `apps/api/`) — all 5 tests pass.

Locally verified: `bun run fmt`, `bunx tsc --noEmit` (apps/api workspace), the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Block non-http(s) URLs in `scrape_url` so only http/https are allowed, preventing unsafe schemes from reaching Browserless. This hardens the tool against accidental or malicious inputs.

- **Bug Fixes**
  - Added input schema refine to require `http://` or `https://`; invalid schemes are rejected before execution.
  - Added regression test to ensure `file:///etc/passwd` fails validation and `fetch` is never called.

<sup>Written for commit e3d8d7e9a1dcb25f6bae6f61ac922687a8035521. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

