### PR TITLE
refactor(sections-editor): drop redundant sortableId prop from SortablePageVariantRow

### DIFF
--- a/apps/web/src/components/sections-editor/page-variant-tabs.tsx
+++ b/apps/web/src/components/sections-editor/page-variant-tabs.tsx
@@ -209,7 +209,6 @@ function PageVariantRowContent({
 
 function SortablePageVariantRow({
   entry,
-  sortableId,
   isActive,
   canDelete,
   decofile,
@@ -221,7 +220,6 @@ function SortablePageVariantRow({
   onDelete,
 }: {
   entry: VariantTabEntry;
-  sortableId: string;
   isActive: boolean;
   canDelete: boolean;
   decofile: Record<string, unknown>;
@@ -234,7 +232,7 @@ function SortablePageVariantRow({
 }) {
   const { attributes, listeners, setNodeRef, transform, isDragging } =
     useSortable({
-      id: sortableId,
+      id: entry.id,
       animateLayoutChanges: () => false,
     });
 
@@ -463,7 +461,6 @@ export function PageVariantTabs({
             {entries.map((entry) => (
               <SortablePageVariantRow
                 key={entry.id}
-                sortableId={entry.id}
                 entry={entry}
                 isActive={entry.index === activeIndex}
                 canDelete={canDelete}


### PR DESCRIPTION
**Source**: reduction found while auditing `sections-editor` variant components for prop cleanup.

**Why**: `SortablePageVariantRow` in `page-variant-tabs.tsx` took both a full `entry: VariantTabEntry` prop *and* a separate `sortableId: string` prop, even though the call site always passed `sortableId={entry.id}` — the two were never independent. This is inconsistent with the sibling `section-variant-list.tsx`'s `SortableVariantRow`, which receives only `entry` and calls `useSortable({ id: entry.id, ... })` directly. The extra prop was pure duplication of data already on `entry`.

**Change**: removed the `sortableId` prop from `SortablePageVariantRow` and its call site; `useSortable` now reads `entry.id` directly, matching the sibling component's pattern. Net: -4/+1 lines. Behavior is unchanged — `sortableId` was always `entry.id`, so the sortable identity passed to dnd-kit is identical.

**Verify**: `cd apps/web && bunx tsc --noEmit` (clean) and `bun test apps/web/src/components/sections-editor/page-variant-tabs.test.ts` (3 pass) — this test file covers `reuseVariantEntryIds`, whose stable-id behavior this change doesn't touch.

**Checks run locally**: `bun run fmt`, targeted `tsc --noEmit` in `apps/web`, the one targeted test file above, and `bunx oxlint apps/web/src/components/sections-editor/page-variant-tabs.tsx` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the redundant sortableId prop from SortablePageVariantRow and now use entry.id directly in useSortable. This aligns with the sibling component’s pattern, removes duplicate data, and keeps behavior unchanged.

<sup>Written for commit c6aa3dc7faafbd604088767ffeeca911f46fdb14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

