### PR TITLE
fix(sandbox): synchronize task.pid writes in the Go daemon's TaskManager

### DIFF
--- a/packages/sandbox/daemon-go/internal/proc/taskmanager.go
+++ b/packages/sandbox/daemon-go/internal/proc/taskmanager.go
@@ -259,7 +259,9 @@ func (m *TaskManager) startPipe(task *taskInternal) {
 		m.spawnError(task, err)
 		return
 	}
+	m.mu.Lock()
 	task.pid = cmd.Process.Pid
+	m.mu.Unlock()
 	m.armTimeout(task)
 
 	var wg sync.WaitGroup
@@ -300,7 +302,9 @@ func (m *TaskManager) startPty(task *taskInternal) {
 		m.spawnError(task, err)
 		return
 	}
+	m.mu.Lock()
 	task.pid = cmd.Process.Pid
+	m.mu.Unlock()
 	m.armTimeout(task)
 
 	go func() {

--- a/packages/sandbox/daemon-go/internal/proc/taskmanager_test.go
+++ b/packages/sandbox/daemon-go/internal/proc/taskmanager_test.go
@@ -1,0 +1,32 @@
+package proc
+
+import (
+	"sync"
+	"syscall"
+	"testing"
+)
+
+// TestConcurrentKillDuringSpawnDoesNotRace exercises the window between a
+// task becoming visible in the manager's map and its pid being recorded:
+// Spawn adds the task before cmd.Start() returns, so a concurrent Kill can
+// read task.pid while startPipe is still writing it. Run with -race.
+func TestConcurrentKillDuringSpawnDoesNotRace(t *testing.T) {
+	m := NewTaskManager(TaskManagerDeps{LogsDir: t.TempDir()})
+	defer m.Shutdown()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		m.Spawn(TaskSpec{Command: "sleep 1", Mode: "pipe"})
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			for _, s := range m.List(nil) {
+				m.Kill(s.ID, syscall.SIGTERM)
+			}
+		}
+	}()
+	wg.Wait()
+}


### PR DESCRIPTION
**Bug**, found while auditing `packages/sandbox/daemon-go` for race conditions (no linked issue).

`TaskManager.startPipe`/`startPty` write `task.pid = cmd.Process.Pid` after `cmd.Start()` succeeds, but without holding `TaskManager.mu`. The task is already inserted into `m.tasks`/`m.order` under the lock *before* `Spawn` calls `startPipe`/`startPty` (`taskmanager.go`, `Spawn`), so it's visible to any other daemon request (e.g. an HTTP `Kill` call) as soon as `Spawn` returns from the lock — which is before `cmd.Start()` has run. A concurrent `Kill`/`KillByLogName`/`escalate` call landing in that window reads `task.pid` (via `signalLocked`) under `m.mu`, but the write isn't synchronized, so it can observe the zero value and silently no-op instead of sending the signal — the caller believes the task was killed, but the process keeps running. It's also a real data race under `go test -race`/the Go race detector, i.e. undefined behavior, not just "maybe stale read".

**Fix**: move both `task.pid = cmd.Process.Pid` assignments inside `m.mu.Lock()/Unlock()`, matching every other mutation of `taskInternal` fields in this file.

**Regression test**: `internal/proc/taskmanager_test.go::TestConcurrentKillDuringSpawnDoesNotRace` spawns a task on one goroutine while another goroutine repeatedly lists+kills it — reproduces the exact race window. Confirmed it fails under `go test -race` on the pre-fix code (`WARNING: DATA RACE` between `startPipe` write and `signalLocked` read) and passes cleanly after the fix.

**To verify**: `cd packages/sandbox/daemon-go && go test ./internal/proc/... -race -count=1`

**Locally ran**: `gofmt -l`, `go vet ./internal/proc/...`, `go build ./...`, and the targeted `-race` test above — all clean. Full CI (daemon-e2e, etc.) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Synchronizes `task.pid` writes in `packages/sandbox/daemon-go` TaskManager to remove a race that let `Kill`/`KillByLogName` see `pid==0` and no-op. PID is now set under `m.mu` in `startPipe` and `startPty`, with a regression test (`TestConcurrentKillDuringSpawnDoesNotRace`) that fails under `-race` pre-fix and passes after.

<sup>Written for commit 385f0684cd4eaeb2d224430d1d6bd5f6962e19c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

