### PR TITLE
fix(thread): cap trigger_ids array size on COLLECTION_THREADS_LIST

### DIFF
--- a/apps/api/src/tools/thread/list.test.ts
+++ b/apps/api/src/tools/thread/list.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test";
+import { COLLECTION_THREADS_LIST } from "./list";
+
+describe("COLLECTION_THREADS_LIST input schema", () => {
+  it("accepts a reasonably sized trigger_ids filter", () => {
+    const result = COLLECTION_THREADS_LIST.inputSchema.safeParse({
+      where: { trigger_ids: ["a", "b"] },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an oversized trigger_ids filter", () => {
+    const trigger_ids = Array.from({ length: 1001 }, (_, i) => `t${i}`);
+    const result = COLLECTION_THREADS_LIST.inputSchema.safeParse({
+      where: { trigger_ids },
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/apps/api/src/tools/thread/list.ts
+++ b/apps/api/src/tools/thread/list.ts
@@ -19,7 +19,7 @@ const ThreadListInputSchema = CollectionListInputSchema.extend({
   where: z
     .object({
       created_by: z.string().optional(),
-      trigger_ids: z.array(z.string()).optional(),
+      trigger_ids: z.array(z.string()).max(1000).optional(),
       virtual_mcp_id: z.string().optional(),
       /** Show archived (hidden=true) threads instead of open ones */
       hidden: z.boolean().optional(),


### PR DESCRIPTION
COLLECTION_THREADS_LIST's `where.trigger_ids` filter (used by `listByTriggerIds` in `apps/api/src/storage/threads.ts`) accepted an unbounded array, which is forwarded straight into a SQL `IN (...)` clause. Every other pagination knob on this tool (`limit`, and the shared `CollectionListInputSchema.limit`) is capped at 1000 — `trigger_ids` was the one filter with no ceiling, letting any authenticated caller of this MCP tool build an arbitrarily large `IN` clause.

Fix: cap `trigger_ids` at 1000 entries, matching the existing `limit` cap used elsewhere in the same schema. Legitimate callers are unaffected — the only current caller (`apps/web/src/views/automations/automation-runs.tsx`) passes one automation's trigger ids, always far under the cap.

Reviewer check: `bun test apps/api/src/tools/thread/list.test.ts` — asserts the schema accepts a normal-sized array and rejects one with 1001 entries.

Locally verified: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bunx oxlint apps/api/src/tools/thread/list.ts apps/api/src/tools/thread/list.test.ts`, and the targeted test above all pass. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cap the `where.trigger_ids` array in `COLLECTION_THREADS_LIST` to 1000 to prevent oversized SQL IN clauses and align with existing pagination limits. Added tests to verify the cap; current callers remain unaffected.

<sup>Written for commit d197829288c645cfce606d808fec1d99ff4d48d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5946?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

