### PR TITLE
fix(sections-editor): reveal variant row's actions menu on keyboard focus

### DIFF
--- a/apps/web/src/components/sections-editor/section-variant-list.tsx
+++ b/apps/web/src/components/sections-editor/section-variant-list.tsx
@@ -157,7 +157,7 @@ function VariantRowContent({
                 "sectionsEditor.sectionVariantList.openActionsFor",
                 { label },
               )}
-              className="size-6 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 data-[state=open]:opacity-100"
+              className="size-6 shrink-0 opacity-0 transition-opacity group-hover:opacity-100 group-has-[:focus-visible]:opacity-100 data-[state=open]:opacity-100"
               onClick={(e) => e.stopPropagation()}
               onPointerDown={(e) => e.stopPropagation()}
             >


### PR DESCRIPTION
**Source:** a bug found while auditing `section-variant-list.tsx` for the sections-editor UI polish pass — the same hover-only-reveal gap already fixed in this repo for `connection-card.tsx` (#5939) and documented as the established convention in this file's sibling `section-list.tsx` (see its `ACTION_BUTTON_HIDDEN` comment: `group-has-[:focus-visible]` is used over `group-focus-within` specifically so a mouse click doesn't stick the button open, only real keyboard focus does).

**The bug:** each `SectionVariantList` row's "..." actions-menu trigger is `opacity-0` and only reveals via `group-hover:opacity-100` (plus `data-[state=open]:opacity-100` once already open). A keyboard user tabbing through the variant list lands focus on that button — it's a real, tabbable `<button>` — but it stays invisible until they blindly press Enter/Space, with no visual cue of what they're about to activate.

**Fix:** add `group-has-[:focus-visible]:opacity-100` alongside the existing hover/open reveal, matching the exact convention already used in `section-list.tsx` for the same row-group pattern.

**To verify:** render `SectionVariantList` with 2+ variants and Tab to a row's "..." button — it now becomes visible instead of staying at `opacity-0` (previously invisible until clicked or activated blind).

**Checks run locally:** `bun run fmt` (clean), `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint apps/web/src/components/sections-editor/section-variant-list.tsx` (0 warnings/errors). Pure CSS class addition, no test needed. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix accessibility in the sections editor: the "…" actions button in `SectionVariantList` rows now shows on keyboard focus, not only on hover/open. Uses `group-has-[:focus-visible]` to match `section-list.tsx` behavior and avoid the button staying hidden when tabbed to.

<sup>Written for commit e86276c0413fb85f8d55cbf8cefd94709cdef41a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

