### PR TITLE
fix(helm): reject studio chart HPA configs where minReplicas exceeds maxReplicas

### DIFF
--- a/deploy/helm/studio/templates/_helpers.tpl
+++ b/deploy/helm/studio/templates/_helpers.tpl
@@ -135,6 +135,12 @@ Global validations to ensure scaling requirements are met.
 {{- if and $usesPostgres (not .Values.database.url) (not .Values.secret.secretName) (not .Values.externalSecret.enabled) }}
 {{- fail "chart-deco-studio: set database.url when database.engine=postgresql, or use secret.secretName to provide DATABASE_URL via Secret" -}}
 {{- end }}
+{{- if and .Values.autoscaling.enabled (gt (int .Values.autoscaling.minReplicas) (int .Values.autoscaling.maxReplicas)) }}
+{{- fail (printf "chart-deco-studio: autoscaling.minReplicas (%d) must not exceed autoscaling.maxReplicas (%d)" (int .Values.autoscaling.minReplicas) (int .Values.autoscaling.maxReplicas)) -}}
+{{- end }}
+{{- if and .Values.worker.enabled .Values.worker.autoscaling.enabled (gt (int .Values.worker.autoscaling.minReplicas) (int .Values.worker.autoscaling.maxReplicas)) }}
+{{- fail (printf "chart-deco-studio: worker.autoscaling.minReplicas (%d) must not exceed worker.autoscaling.maxReplicas (%d)" (int .Values.worker.autoscaling.minReplicas) (int .Values.worker.autoscaling.maxReplicas)) -}}
+{{- end }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
The `deploy/helm/studio` chart already fails a render early with a clear message for several invalid autoscaling combinations (`chart-deco-studio.validate` in `_helpers.tpl`), but it never checked that `autoscaling.minReplicas <= autoscaling.maxReplicas` (nor the equivalent for `worker.autoscaling`). If an operator sets `minReplicas > maxReplicas`, the chart renders a `HorizontalPodAutoscaler` object that Kubernetes itself rejects at apply time with a much less actionable API-server error, well after `helm template`/`helm lint` succeeded.

Why it matters: this chart already validates every other cross-field invariant (postgres/distributed-storage requirements, reserved env names, OTEL config, etc.) at render time specifically so misconfigurations fail fast during `helm lint`/CI rather than surfacing as a confusing kubectl-apply error — this closes the one remaining gap in that same pattern for both the main and worker HPAs.

Fix: two new checks in `chart-deco-studio.validate` (`templates/_helpers.tpl`), each `fail`-ing with the exact offending values when `autoscaling.enabled`/`worker.autoscaling.enabled` is true and `minReplicas > maxReplicas`.

Verification:
- `helm lint deploy/helm/studio --set database.url=postgresql://ci:ci@postgres.example.com:5432/studio` — passes (unchanged, matches CI's `helm-test.yml` invocation).
- `helm template deco-studio deploy/helm/studio --set database.url=... --set autoscaling.enabled=true --set persistence.distributed=true --set autoscaling.minReplicas=10 --set autoscaling.maxReplicas=3` — now fails with `chart-deco-studio: autoscaling.minReplicas (10) must not exceed autoscaling.maxReplicas (3)` instead of rendering.
- Same check verified for `worker.autoscaling.minReplicas`/`maxReplicas`.
- Confirmed the default values render and the CI's in-cluster ClickHouse example (`examples/values-clickhouse.yaml`) both still render cleanly — no regression to existing valid configs.

A reviewer can reproduce with the `helm template ... --set autoscaling.minReplicas=10 --set autoscaling.maxReplicas=3` command above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add render-time validation to the `deploy/helm/studio` chart to reject HPA configs where `minReplicas` exceeds `maxReplicas` for both main and worker. This fails fast during `helm lint`/`template` with a clear error instead of at apply time.

- **Bug Fixes**
  - Added two checks in `templates/_helpers.tpl` to `fail` when `autoscaling.enabled` or `worker.autoscaling.enabled` and `minReplicas > maxReplicas`, including the offending values.
  - No changes to valid defaults or example values; existing renders remain unchanged.

<sup>Written for commit 760e994200f7dbb406d6d209adc2146c9717b59e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5948?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

