### PR TITLE
fix(decopilot): return 400 for malformed JSON on the chat dispatch route

### DIFF
--- a/apps/api/src/api/routes/decopilot/routes.ts
+++ b/apps/api/src/api/routes/decopilot/routes.ts
@@ -133,7 +133,9 @@ async function validateRequest(
   c: Context<{ Variables: { studioContext: StudioContext } }>,
 ) {
   const organization = ensureOrganization(c);
-  const rawPayload = await c.req.json();
+  const rawPayload = await c.req.json().catch(() => {
+    throw new HTTPException(400, { message: "Invalid JSON body" });
+  });
 
   const parseResult = StreamRequestSchema.safeParse(rawPayload);
   if (!parseResult.success) {


### PR DESCRIPTION
Bug found while hardening the decopilot API routes (dispatch-run/routes/schemas — the files heavily touched by the recent refactor chain #5638-5657).

`validateRequest()` in `apps/api/src/api/routes/decopilot/routes.ts` calls `await c.req.json()` with no error handling before running it through `StreamRequestSchema.safeParse`. This is the request-validation entry point for `/:org/decopilot/messages` (and the thread-scoped variant) — the primary trust boundary for hosted chat, parsing a client-supplied body. When the body isn't valid JSON, Hono's `c.req.json()` rejects, the rejection propagates uncaught to the global `app.onError` handler (`error-handler.ts`), which flattens it to a generic `500 Internal Server Error` instead of a `4xx` client error.

Every other decopilot route that reads an optional JSON body already guards this — e.g. the flip route two hundred lines down: `c.req.json().catch(() => null)`. This was the one entry point still missing that guard, and it's the highest-traffic one.

**Failure scenario:** any malformed/truncated JSON body sent to the chat dispatch endpoint (a flaky client, a proxy that mangles the payload, or a buggy caller) surfaces as a 500, which client-side retry/error-handling logic typically doesn't treat the same way as a 400 — and it pollutes server error logs/alerting with a class of "error" that is really a client input problem.

**Fix:** wrap the `c.req.json()` call so a parse failure throws `HTTPException(400, { message: "Invalid JSON body" })` instead, matching the existing safeParse-failure path two lines below it.

**To verify:** `curl -X POST localhost:PORT/api/<org>/decopilot/messages -H 'content-type: application/json' -d '{not json'` now returns 400 instead of 500. I confirmed the pre-fix 500 behavior with a minimal reproduction using the same Hono version's `onError` + raw `c.req.json()` before applying the fix.

Checks run locally:
- `bun run fmt` — clean
- `bunx tsc --noEmit` (root) — clean
- `bun test apps/api/src/api/routes/decopilot/routes.test.ts` — 37 pass
- `bunx oxlint apps/api/src/api/routes/decopilot/routes.ts` — 0 warnings/errors

Full CI validates the rest (integration/e2e coverage for this route lives in `packages/e2e/tests/decopilot-messages.spec.ts` per this file's own test-tier comment).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 400 Bad Request for malformed JSON on decopilot chat dispatch routes by guarding `c.req.json()` in `validateRequest()`; previously this bubbled to a 500 via the global error handler. This hardens the hosted-chat trust boundary and matches behavior on other decopilot routes.

<sup>Written for commit 7b8a300c2effed96cccfaa559129ffc962de084b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

