### PR TITLE
fix(sandbox): close the check-then-spawn race for well-known dev-server scripts

### DIFF
--- a/packages/sandbox/daemon-go/internal/proc/taskmanager.go
+++ b/packages/sandbox/daemon-go/internal/proc/taskmanager.go
@@ -154,6 +154,22 @@ func (m *TaskManager) purgeStaleLogs() {
 }
 
 func (m *TaskManager) Spawn(spec TaskSpec) TaskSummary {
+	summary, _ := m.spawn(spec, false)
+	return summary
+}
+
+// SpawnUnlessLogNameRunning atomically checks for a running task with the
+// same LogName and spawns only if none exists, returning the existing task
+// (alreadyRunning=true) otherwise. RunningByLogName+Spawn as two separate
+// calls raced: two concurrent requests for the same well-known dev-server
+// script could both see "not running" and each start a process, doubling
+// memory use on the pod. Doing the check inside the same critical section
+// that registers the new task closes that window.
+func (m *TaskManager) SpawnUnlessLogNameRunning(spec TaskSpec) (summary TaskSummary, alreadyRunning bool) {
+	return m.spawn(spec, true)
+}
+
+func (m *TaskManager) spawn(spec TaskSpec, skipIfLogNameRunning bool) (TaskSummary, bool) {
 	if spec.ReplaceByLogName && spec.LogName != "" {
 		var waiters []chan struct{}
 		m.mu.Lock()
@@ -173,6 +189,15 @@ func (m *TaskManager) Spawn(spec TaskSpec) TaskSummary {
 	}
 
 	m.mu.Lock()
+	if skipIfLogNameRunning && spec.LogName != "" {
+		for _, t := range m.tasks {
+			if t.status == StatusRunning && t.spec.LogName == spec.LogName {
+				summary := m.summarizeLocked(t)
+				m.mu.Unlock()
+				return summary, true
+			}
+		}
+	}
 	m.counter++
 	id := fmt.Sprintf("%s%d", taskFilePrefix, m.counter)
 	logPath := filepath.Join(m.deps.LogsDir, id)
@@ -215,7 +240,7 @@ func (m *TaskManager) Spawn(spec TaskSpec) TaskSummary {
 	if m.deps.OnChange != nil {
 		m.deps.OnChange()
 	}
-	return m.summarize(task)
+	return m.summarize(task), false
 }
 
 func buildEnv(inherit bool, overrides map[string]string, extra map[string]string) []string {
@@ -462,22 +487,6 @@ func (m *TaskManager) fanOut(task *taskInternal, chunk OutputChunk) {
 	if task.spec.LogName != "" && m.deps.BroadcastChunk != nil {
 		m.deps.BroadcastChunk(task.spec.LogName, chunk.Data, false)
 	}
-}
-
-// RunningByLogName finds a live task by its log name. Used to answer "is the
-// dev server already up?" without guessing from ports.
-func (m *TaskManager) RunningByLogName(logName string) (TaskSummary, bool) {
-	if logName == "" {
-		return TaskSummary{}, false
-	}
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	for _, t := range m.tasks {
-		if t.status == StatusRunning && t.spec.LogName == logName {
-			return m.summarizeLocked(t), true
-		}
-	}
-	return TaskSummary{}, false
 }
 
 func (m *TaskManager) Get(id string) (TaskSummary, bool) {

--- a/packages/sandbox/daemon-go/internal/proc/taskmanager_test.go
+++ b/packages/sandbox/daemon-go/internal/proc/taskmanager_test.go
@@ -30,3 +30,36 @@ func TestConcurrentKillDuringSpawnDoesNotRace(t *testing.T) {
 	}()
 	wg.Wait()
 }
+
+// TestSpawnUnlessLogNameRunningIsAtomic exercises N concurrent requests for
+// the same LogName: a naive "check RunningByLogName, then Spawn" sequence
+// races and lets more than one through, which is exactly the double
+// dev-server-process bug this method exists to close.
+func TestSpawnUnlessLogNameRunningIsAtomic(t *testing.T) {
+	m := NewTaskManager(TaskManagerDeps{LogsDir: t.TempDir()})
+	defer m.Shutdown()
+
+	const n = 20
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+	started := 0
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			_, alreadyRunning := m.SpawnUnlessLogNameRunning(TaskSpec{
+				Command: "sleep 1", Mode: "pipe", LogName: "dev",
+			})
+			if !alreadyRunning {
+				mu.Lock()
+				started++
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	if started != 1 {
+		t.Fatalf("expected exactly 1 spawn to win the race, got %d", started)
+	}
+}

--- a/packages/sandbox/daemon-go/internal/routes/exec.go
+++ b/packages/sandbox/daemon-go/internal/routes/exec.go
@@ -83,30 +83,7 @@ func Exec(deps ExecDeps) http.HandlerFunc {
 		env := setup.BuildDevEnv(cfg, overrides)
 		rc := setup.PmRunCommand(cfg.RuntimePathPrefix, cwd, pmConf.RunPrefix, name)
 
-		if proc.IsWellKnownStarter(name) {
-			// The dev server is already up — hand back the task that is running
-			// it instead of starting a second one. An agent that runs `dev`
-			// without checking (the common case in a sandbox that was warmed
-			// for it) would otherwise put two Vite/Next builds on one pod's
-			// memory limit and OOM the pod out from under itself.
-			if existing, ok := deps.TaskManager.RunningByLogName(name); ok {
-				httpx.JSON(w, 200, map[string]any{
-					"taskId":         existing.ID,
-					"status":         existing.Status,
-					"alreadyRunning": true,
-				})
-				return
-			}
-			if deps.GetStatus().State == "error" {
-				deps.SetStatus(events.DaemonStatus{State: "running"})
-			}
-			phase := deps.Lifecycle.Current().Phase
-			if phase == events.PhaseIdle || phase == events.PhaseStartFailed || phase == events.PhaseCrashed {
-				deps.Lifecycle.Transition(events.LifecycleState{Phase: events.PhaseStarting})
-			}
-		}
-
-		task := deps.TaskManager.Spawn(proc.TaskSpec{
+		spec := proc.TaskSpec{
 			Command:   rc.Cmd,
 			Cwd:       cwd,
 			Env:       env,
@@ -114,7 +91,37 @@ func Exec(deps ExecDeps) http.HandlerFunc {
 			TimeoutMs: body.TimeoutMs,
 			Label:     rc.Label,
 			LogName:   name,
-		})
+		}
+
+		var task proc.TaskSummary
+		if proc.IsWellKnownStarter(name) {
+			// The dev server is already up — hand back the task that is running
+			// it instead of starting a second one. An agent that runs `dev`
+			// without checking (the common case in a sandbox that was warmed
+			// for it) would otherwise put two Vite/Next builds on one pod's
+			// memory limit and OOM the pod out from under itself. The
+			// check-and-spawn must be atomic: two concurrent requests both
+			// seeing "not running" and each spawning is exactly that race.
+			existing, alreadyRunning := deps.TaskManager.SpawnUnlessLogNameRunning(spec)
+			if alreadyRunning {
+				httpx.JSON(w, 200, map[string]any{
+					"taskId":         existing.ID,
+					"status":         existing.Status,
+					"alreadyRunning": true,
+				})
+				return
+			}
+			task = existing
+			if deps.GetStatus().State == "error" {
+				deps.SetStatus(events.DaemonStatus{State: "running"})
+			}
+			phase := deps.Lifecycle.Current().Phase
+			if phase == events.PhaseIdle || phase == events.PhaseStartFailed || phase == events.PhaseCrashed {
+				deps.Lifecycle.Transition(events.LifecycleState{Phase: events.PhaseStarting})
+			}
+		} else {
+			task = deps.TaskManager.Spawn(spec)
+		}
 
 		if mode == "background" {
 			httpx.JSON(w, 200, map[string]any{"taskId": task.ID, "status": task.Status})


### PR DESCRIPTION
Real race found while auditing the Go daemon's task-manager concurrency paths (the focus called out this tick, following #5945's task.pid sync fix).

**The bug**: `Exec()` in `packages/sandbox/daemon-go/internal/routes/exec.go` decided whether a well-known dev-server script (`dev`, etc.) was already running by calling `TaskManager.RunningByLogName(name)`, and only if that returned false did it call `TaskManager.Spawn(...)` — two separate, unlocked steps. Two concurrent `POST /exec/dev` requests (e.g. an agent double-clicking "run dev", or two tool calls racing) could both observe "not running" and each spawn a process, doubling memory use on the pod — exactly the OOM scenario the existing code comment warns about ("would otherwise put two Vite/Next builds on one pod's memory limit and OOM the pod").

**The fix**: added `TaskManager.SpawnUnlessLogNameRunning(spec)`, which performs the running-check and the task registration inside the *same* locked critical section (the same lock `Spawn` already takes to register the new task id), so only one concurrent caller can win; the loser gets back the winner's task instead of starting a second process. `exec.go` now calls this instead of the racy check-then-act pair. `RunningByLogName` had no other callers after this change, so it's removed as dead code rather than left orphaned.

**Regression test**: `TestSpawnUnlessLogNameRunningIsAtomic` in `taskmanager_test.go` fires 20 concurrent `SpawnUnlessLogNameRunning` calls with the same LogName and asserts exactly 1 wins — this fails under `-race`/without the fix if the check-then-spawn were done as two separate calls, and would show more than 1 winner with a naive (non-atomic) implementation.

**Reviewer command**: `cd packages/sandbox/daemon-go && go test -race ./internal/proc/...`

**Checks run locally**: `go build ./...`, `go vet ./...`, `go test -race ./internal/proc/...` (all pass), `gofmt -l .` (no output). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in the sandbox Go daemon where concurrent /exec/dev requests could start duplicate dev servers. The check-and-spawn is now atomic so only one process starts; others get the existing task, avoiding OOMs.

- **Bug Fixes**
  - Added `TaskManager.SpawnUnlessLogNameRunning` to atomically check and spawn under the same lock.
  - Updated `internal/routes/exec.go` to use the new method for well-known scripts (e.g., `dev`) and return `alreadyRunning` when applicable.
  - Removed `RunningByLogName` as dead code.
  - Added `TestSpawnUnlessLogNameRunningIsAtomic` to ensure only one spawn wins under concurrency.

<sup>Written for commit 995feac9b40ec751c3cd3232384c96286b6a4c15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

