### PR TITLE
refactor(i18n): align pt-br import order with en for consistency

### DIFF
--- a/apps/web/src/i18n/pt-br/index.ts
+++ b/apps/web/src/i18n/pt-br/index.ts
@@ -33,9 +33,9 @@ import { automations } from "./automations.ts";
 import { agentShellLayout } from "./agent-shell-layout.ts";
 import { admin } from "./admin.ts";
 import { sandbox } from "./sandbox.ts";
-import type { TranslationKey } from "../en/index.ts";
-import { announcements } from "./announcements.ts";
 import { settings } from "./settings.ts";
+import { announcements } from "./announcements.ts";
+import type { TranslationKey } from "../en/index.ts";
 
 export const ptBR = {
   ...virtualMcp,


### PR DESCRIPTION
**Source:** i18n registry sanity audit — found import order inconsistency between language files

**The issue:** The PT-BR i18n index file imported `announcements` and `settings` in a different order than the EN file, and had a type import awkwardly placed in the middle of the regular imports. While this didn't cause functional problems (verified no overlapping keys between modules and TypeScript validation passes), it violates consistency and readability principles.

**The fix:** Reordered imports in `apps/web/src/i18n/pt-br/index.ts` to match EN:
- Moved type import to the end (after regular imports)
- Reordered `settings` and `announcements` imports to match EN's order

**Verification:** 
- ✓ `bun run fmt` passes
- ✓ TypeScript type check passes in `apps/web`
- ✓ `bunx oxlint` has 0 warnings/errors
- ✓ i18n interpolation tests pass (6/6)
- ✓ No overlapping keys between modules

**Changes:** `-2/+2` lines; pure import reordering, no behavioral changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reordered imports in `apps/web/src/i18n/pt-br/index.ts` to match the EN file for consistency and readability. Moved the `TranslationKey` type import to the end and aligned `settings` and `announcements` order; no behavior changes.

<sup>Written for commit 675d1fd0b00e24af13e53c846878bbe0086ffa0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

