### PR TITLE
fix(connections): don't show pointer cursor on non-clickable connection cards

### DIFF
--- a/apps/web/src/components/connections/connection-card.tsx
+++ b/apps/web/src/components/connections/connection-card.tsx
@@ -37,8 +37,8 @@ export function ConnectionCard({
   return (
     <Card
       className={cn(
-        "cursor-pointer transition-colors group overflow-hidden flex flex-col h-full",
-        onClick && "hover:bg-muted/50",
+        "transition-colors group overflow-hidden flex flex-col h-full",
+        onClick && "cursor-pointer hover:bg-muted/50",
         className,
       )}
       onClick={onClick}


### PR DESCRIPTION
**Source:** bug found while auditing `ConnectionCard` for visual regressions in click handling.

**What's wrong:** `ConnectionCard`'s root `Card` always applied `cursor-pointer`, regardless of whether an `onClick` handler was passed. The adjacent `hover:bg-muted/50` class on the same line is already correctly gated on `onClick`, and the `role`/`tabIndex` attributes lower in the file are gated on it too — the cursor class was the one spot that fell through the cracks.

**Failure scenario:** `virtual-mcp/connection-dialog-content.tsx` renders a `ConnectionCard` for an already-added/existing connection (the "attached" card, around line 294) with no `onClick` at all — only its header "Add" button is interactive. Hovering that card shows a pointer cursor and no hover background, misleadingly signaling the whole card is clickable when clicking it does nothing.

**Fix:** move `cursor-pointer` into the same `onClick &&` branch as `hover:bg-muted/50`, so the cursor only changes when the card is actually clickable. Purely a class-list change — no click/keyboard logic touched.

**Reviewer check:** open the virtual-mcp connection dialog, look at an already-connected/instance card that has no card-level `onClick` (only its header action button), and confirm the cursor is now the default arrow over the card body.

**Verified locally:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, `bun test apps/web/src/components/connections/connection-card.test.tsx` (2 pass), `bunx oxlint apps/web/src/components/connections/connection-card.tsx` (0 errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop showing a pointer on `ConnectionCard` components that aren’t clickable. `cursor-pointer` is now applied only when an `onClick` is provided (alongside `hover:bg-muted/50`), so non-clickable cards use the default cursor.

<sup>Written for commit fb59499244c1f58b2e8353c180a2d612c0a60b7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

