### PR TITLE
fix(sandbox): reject out-of-range dev ports detected from a repo's scripts

### DIFF
--- a/apps/api/src/shared/github-runtime-detect.test.ts
+++ b/apps/api/src/shared/github-runtime-detect.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "bun:test";
+import { extractDevPort } from "./github-runtime-detect";
+
+describe("extractDevPort", () => {
+  it("extracts a valid port from a dev script", () => {
+    expect(
+      extractDevPort(
+        JSON.stringify({ scripts: { dev: "PORT=3000 next dev" } }),
+      ),
+    ).toBe("3000");
+  });
+
+  it("extracts a valid port from a deno task", () => {
+    expect(
+      extractDevPort(JSON.stringify({ tasks: { dev: "deno run --port8000" } })),
+    ).toBe("8000");
+  });
+
+  it("drops an out-of-range 5-digit match instead of returning it", () => {
+    expect(
+      extractDevPort(
+        JSON.stringify({ scripts: { dev: "PORT=99999 next dev" } }),
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null when the script has no port", () => {
+    expect(
+      extractDevPort(JSON.stringify({ scripts: { dev: "next dev" } })),
+    ).toBeNull();
+  });
+
+  it("returns null on malformed JSON", () => {
+    expect(extractDevPort("not json")).toBeNull();
+  });
+
+  it("returns null for null content", () => {
+    expect(extractDevPort(null)).toBeNull();
+  });
+});

--- a/apps/api/src/shared/github-runtime-detect.ts
+++ b/apps/api/src/shared/github-runtime-detect.ts
@@ -142,7 +142,15 @@ async function fetchGithubFile(
   }
 }
 
-function extractDevPort(content: string | null): string | null {
+/**
+ * `PORT_RE` allows 4-5 digits, but a 5-digit match can exceed the valid TCP
+ * port range (e.g. a script's `--port 99999`, or a version-looking number the
+ * regex happens to catch). The repo's `dev`/`start` script is untrusted
+ * content from GitHub — bound the match to 1-65535 before it reaches
+ * `start.ts`'s `Number(port)` as `devPort`, same rationale as `helpers.ts`'s
+ * `parseValidPort` for the user-pinned port.
+ */
+export function extractDevPort(content: string | null): string | null {
   if (!content) return null;
   try {
     const parsed = JSON.parse(content) as {
@@ -151,8 +159,10 @@ function extractDevPort(content: string | null): string | null {
     };
     const cmds = parsed.tasks ?? parsed.scripts ?? {};
     const cmd = cmds.dev ?? cmds.start ?? "";
-    const match = cmd.match(PORT_RE);
-    return match?.[1] ?? null;
+    const port = cmd.match(PORT_RE)?.[1] ?? null;
+    if (!port) return null;
+    const n = Number(port);
+    return n >= 1 && n <= 65535 ? port : null;
   } catch {
     return null;
   }


### PR DESCRIPTION
**Source:** bug found while auditing `apps/api/src/tools/sandbox/helpers.ts`/`start.ts` for sandbox-provisioning reliability (this tick's focus area).

**Payoff:** `detectRepoRuntime`'s lockfile probe extracts a dev-server port straight from a repo's own `package.json`/`deno.json` `dev`/`start` script (`extractDevPort` in `github-runtime-detect.ts`). Its regex (`PORT_RE`) matches 4-5 digit numbers, but never checked the match was actually a valid TCP port — a repo whose script contains e.g. `PORT=99999` (or any other 5-digit number the regex happens to catch) had that value flow unchecked into `start.ts`'s `port = detected.devPort ?? port` and then into `workload.devPort = Number(port)`, sent straight to the sandbox provider. `helpers.ts` already guards the exact same class of value — the *user-pinned* `metadata.runtime.port` — down to 1-65535 via `parseValidPort` (added in #5597, with the explicit rationale "keeps... `Number(port)` from ever producing `0`/`NaN`... as `devPort`"), but the auto-detected path added later never got that same guard.

**Fix:** `extractDevPort` now numeric-range-checks its regex match (1-65535) before returning it, so an out-of-range match is dropped exactly like "no port found" — the caller falls back to the runner picking its own port, same as today's no-lockfile-match path.

**Verify:** `cd apps/api && bun test src/shared/github-runtime-detect.test.ts` — new tests cover a valid `PORT=`/`--port` match, an out-of-range 5-digit match (now dropped), no-port, malformed JSON, and null content.

**Local checks run:** `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), the targeted test file above (6/6 pass), `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject invalid dev-server ports parsed from repo scripts so out-of-range values (e.g., 99999) don’t reach the sandbox. If detection is invalid, we now fall back to the runner’s auto port selection.

- **Bug Fixes**
  - Range-check `extractDevPort` results to 1–65535; drop anything else.
  - Align auto-detected port validation with the existing `parseValidPort` guard used for user-pinned ports.
  - Add tests for valid `PORT=`/`--port`, out-of-range, no port, malformed JSON, and null content.

<sup>Written for commit 41a33a9c164746f8cfc63f5566bab74700b1e681. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

