### PR TITLE
fix(task-board): refund quota when the review sweeper unsticks a failed task

### DIFF
--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -1567,6 +1567,9 @@ export async function createApp(options: CreateAppOptions = {}) {
   // automations/thread-gate: it only sets a module-level pointer.
   const projectorThreadStorage = new SqlThreadStorage(database.db);
   const projectorTaskBoard = new TaskBoardStorage(database.db);
+  // Quota bookkeeping for the projector's thread-finish reaction: a run that
+  // ended without a PR releases its held slot (billing/task-quota.ts).
+  const projectorBilling = new OrganizationBillingStorage(database.db);
   // Reconciles Super Agent tasks parked In Review: links the PR a sandboxed
   // `claude-code` run opened (nothing else does — see review-sweeper.ts) and
   // hands off to the enabled reviewers. It has to be a timer rather than part of
@@ -1578,6 +1581,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   const taskBoardReviewSweeper = new TaskBoardReviewSweeper(
     projectorTaskBoard,
     automationContextFactory,
+    projectorBilling,
   );
   if (getSettings().taskBoardReviewSweeperEnabled) {
     taskBoardReviewSweeper.start();
@@ -1589,9 +1593,6 @@ export async function createApp(options: CreateAppOptions = {}) {
       taskBoardReviewSweeper.dispose();
     };
   }
-  // Quota bookkeeping for the projector's thread-finish reaction: a run that
-  // ended without a PR releases its held slot (billing/task-quota.ts).
-  const projectorBilling = new OrganizationBillingStorage(database.db);
   setProjectorWorkflowRuntime({
     getJetStream: () => natsProvider?.getJetStream() ?? null,
     getJetStreamManager: async () => {

--- a/apps/api/src/tools/task-board/review-sweeper.ts
+++ b/apps/api/src/tools/task-board/review-sweeper.ts
@@ -61,12 +61,17 @@
  */
 
 import type { StudioContextFactory } from "@/automations/fire";
+import type { OrganizationBillingStorage } from "@/storage/organization-billing";
 import type { TaskBoardStorage } from "@/storage/task-board";
 import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
 import { enqueueEnabledReviewers } from "./enqueue-reviewer";
 import { enqueueSuperAgentForTask } from "./enqueue-super-agent";
 import { retryAutoMergeIfApproved } from "./merge-pr";
-import { emitTaskBoardUpdated, reactToFailedTaskRun } from "./run-reactions";
+import {
+  emitTaskBoardUpdated,
+  reactToFailedTaskRun,
+  refundUnproductiveTaskClaims,
+} from "./run-reactions";
 import { TaskQuotaError } from "@/billing/task-quota";
 import { ABANDONED_FAILURE_REASON } from "./stall-recovery";
 import { THREAD_EXPIRY_MS } from "@/tools/thread/helpers";
@@ -135,6 +140,7 @@ export class TaskBoardReviewSweeper {
   constructor(
     private readonly taskBoard: TaskBoardStorage,
     private readonly contextFactory: StudioContextFactory,
+    private readonly billing: OrganizationBillingStorage,
     private readonly options: TaskBoardReviewSweeperOptions = {},
   ) {}
 
@@ -233,7 +239,7 @@ export class TaskBoardReviewSweeper {
    * no longer advances to In Review, that would be a permanent strand. This is
    * the floor: the reaction is idempotent (it re-reads the card and both writes
    * are conditional on In Progress), so re-running it costs a query and fixes the
-   * gap with no bookkeeping of its own.
+   * gap and refunds the claim.
    */
   private async reactToUnhandledFailures(limit: number): Promise<void> {
     const stuck = await this.taskBoard.listItemsStuckAfterFailure(
@@ -246,6 +252,12 @@ export class TaskBoardReviewSweeper {
           `[task-board-review-sweeper] reacting to an unhandled failure on ${id}`,
         );
         await reactToFailedTaskRun(this.taskBoard, threadId, organizationId);
+        await refundUnproductiveTaskClaims(
+          this.taskBoard,
+          this.billing,
+          threadId,
+          organizationId,
+        );
       } catch (err) {
         console.error(
           `[task-board-review-sweeper] unhandled-failure reaction for ${id} failed`,

--- a/apps/api/src/tools/task-board/run-reactions.ts
+++ b/apps/api/src/tools/task-board/run-reactions.ts
@@ -391,7 +391,7 @@ export async function reactToFailedTaskRun(
  * stall recovery) costs the customer their execution rather than costing us an
  * unbilled one.
  */
-async function refundUnproductiveTaskClaims(
+export async function refundUnproductiveTaskClaims(
   taskBoard: TaskBoardStorage,
   billing: OrganizationBillingStorage,
   threadId: string,


### PR DESCRIPTION
Bug found while auditing the task-board quota/enqueue-super-agent flow for stale-state gaps after the recent billing tweaks (#5935/#5934/#5932).

**The gap:** `refundUnproductiveTaskClaims` (billing/task-quota.ts) is documented as "the ONE place a task-quota charge is refunded", and the normal in-band path (`advanceTasksToReviewOnThreadFinish`, wired from the projector in app.ts) always runs it right after `reactToFailedTaskRun`. But `TaskBoardReviewSweeper`'s unhandled-failure floor (`reactToUnhandledFailures` in review-sweeper.ts) exists specifically for the case where the in-band reaction never ran — "a pod that dies between `markRunFailed` and that reaction" — and it only called `reactToFailedTaskRun` directly, skipping the refund entirely.

**Failure scenario:** a gated (reports-pushed) task whose Super Agent run fails, and whose in-band reaction never fires (the pod dies first). The review sweeper's floor picks it up ~2 minutes later, exhausts retries, and returns the card to Todo with no PR and nothing else running — which is exactly `refundUnproductiveTaskClaims`'s own refund criteria. But because that function was never called on this path, the org's quota claim for that task stayed charged forever, unlike the identical outcome reached through the live projector path.

**Fix:** exported `refundUnproductiveTaskClaims` from run-reactions.ts and call it right after `reactToFailedTaskRun` in the sweeper, passing the same `OrganizationBillingStorage` already constructed for the projector's own reaction (moved its construction earlier in app.ts so it's available before the sweeper is built).

**Verify:** `bunx tsc --noEmit` in apps/api (clean), `bunx oxlint` on the 3 touched files (0 warnings/errors), and the existing targeted suites both pass: `bun test apps/api/src/tools/task-board/review-sweeper.test.ts` (10 pass) and `bun test apps/api/src/tools/task-board/run-reactions.test.ts` (16 pass). Full CI validates the rest.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refunds task quota when the review sweeper unsticks a failed task, so orgs aren’t charged if the in‑band reaction never ran.

- **Bug Fixes**
  - Call `refundUnproductiveTaskClaims` right after `reactToFailedTaskRun` in the sweeper’s unhandled-failure path.
  - Export `refundUnproductiveTaskClaims` and inject `OrganizationBillingStorage` into the sweeper (constructed earlier in `app.ts`).

<sup>Written for commit 1e86d9ef60277a3493b7d5b988e8e7936b6ee708. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

