### PR TITLE
fix(task-board): reject a reviewToken from an earlier review cycle

### DIFF
--- a/apps/api/src/tools/task-board/review-decision.test.ts
+++ b/apps/api/src/tools/task-board/review-decision.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import { reviewTokenVerified } from "./review-decision";
+
+describe("reviewTokenVerified", () => {
+  const cycleA = new Date("2026-01-01T00:00:00Z").getTime();
+  const cycleB = new Date("2026-01-02T00:00:00Z").getTime();
+
+  it("verifies a claim for the right reviewer on the current cycle", () => {
+    const claim = { reviewer: "qa", cycleAt: new Date(cycleA) };
+    expect(reviewTokenVerified(claim, "qa", cycleA)).toBe(true);
+  });
+
+  it("rejects a claim whose reviewer doesn't match", () => {
+    const claim = { reviewer: "qa", cycleAt: new Date(cycleA) };
+    expect(reviewTokenVerified(claim, "code_review", cycleA)).toBe(false);
+  });
+
+  it("rejects a stale token from an earlier review cycle", () => {
+    const claim = { reviewer: "qa", cycleAt: new Date(cycleA) };
+    expect(reviewTokenVerified(claim, "qa", cycleB)).toBe(false);
+  });
+
+  it("rejects a missing claim", () => {
+    expect(reviewTokenVerified(null, "qa", cycleA)).toBe(false);
+  });
+});

--- a/apps/api/src/tools/task-board/review-decision.ts
+++ b/apps/api/src/tools/task-board/review-decision.ts
@@ -5,6 +5,7 @@ import {
   MAX_REVIEW_BOUNCES,
   REVIEWER_LABEL,
   reviewBounceLimitReached,
+  reviewCycleStart,
 } from "@decocms/shared/task-board";
 import { TaskBoardItemStatusSchema } from "./schema";
 import { recordTaskActivity } from "./activity";
@@ -14,6 +15,32 @@ import { allEnabledReviewersVerifiedApproved, mergeLinkedPr } from "./merge-pr";
 import { fetchPrConflict } from "./prs-get";
 import { reactToApprovedPrConflict } from "./conflict-reaction";
 import { TaskQuotaError } from "@/billing/task-quota";
+
+/**
+ * True when a resolved reviewToken claim actually belongs to THIS reviewer's
+ * claim on the CURRENT review cycle.
+ *
+ * `claimReviewer` mints a fresh row (and token) for every review cycle but
+ * never deletes the old one, so comparing only the reviewer field — as this
+ * used to — let a token minted for an EARLIER cycle still verify: a reviewer
+ * that kept its token from a prior bounce (visible in that run's own prompt,
+ * see `enqueueReviewerForTask`) could replay it after being bounced back and
+ * re-approving with no real review this cycle, counting toward the
+ * two-reviewer auto-merge gate the token exists to protect. Comparing
+ * `cycleAt` closes that: a claim from any cycle but the current one no longer
+ * verifies. Pure — unit-tested.
+ */
+export function reviewTokenVerified(
+  claim: { reviewer: string; cycleAt: Date } | null,
+  reviewer: string,
+  currentCycleAt: number,
+): boolean {
+  return (
+    claim !== null &&
+    claim.reviewer === reviewer &&
+    claim.cycleAt.getTime() === currentCycleAt
+  );
+}
 
 export const TASK_BOARD_REVIEW_DECISION = defineTool({
   name: "TASK_BOARD_REVIEW_DECISION",
@@ -86,17 +113,22 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
       throw new Error(`Task board item not found: ${taskBoardItemId}`);
     }
 
-    // Verify the caller is the reviewer it claims to be: the reviewToken must
-    // resolve to a claim for THIS task whose reviewer matches. An unverified
-    // decision is still recorded (so a dropped token never stalls the flow) but
-    // won't count toward an automatic merge (see the verified gate below).
+    // Verify the caller's reviewToken against THIS task's CURRENT cycle.
     const claim = reviewToken
       ? await ctx.storage.taskBoard.resolveReviewClaimByToken(
           taskBoardItemId,
           reviewToken,
         )
       : null;
-    const verified = claim?.reviewer === reviewer;
+    const currentCycleAt = claim
+      ? reviewCycleStart(
+          await ctx.storage.taskBoard.listActivity(
+            taskBoardItemId,
+            organizationId,
+          ),
+        )
+      : 0;
+    const verified = reviewTokenVerified(claim, reviewer, currentCycleAt);
 
     if (decision === "request_changes") {
       // Break a runaway review loop BEFORE bouncing. A reviewer that keeps


### PR DESCRIPTION
A trust-boundary bug in the reviewer-token verification `TASK_BOARD_REVIEW_DECISION` uses to gate automatic PR merges.

**The bug:** `resolveReviewClaimByToken` resolves a `reviewToken` to its claim row (which reviewer, which cycle), but `review-decision.ts` only checked `claim.reviewer === reviewer` before marking a decision `verified: true`. `claimReviewer` mints a fresh claim row (and token) for every review cycle but never deletes the previous one, so a token minted for an EARLIER cycle still resolves successfully and still passes that check today. A reviewer agent that kept its token from a prior bounce (the token is echoed back to it in its own run prompt, so it's sitting right there in that thread's history) could replay it on a later cycle and have the decision recorded as verified with no real review having happened this cycle — `allEnabledReviewersVerifiedApproved` then counts it toward the two-reviewer gate that `auto_merge` relies on to ship a PR untouched by a human. This is exactly the forgery the token exists to prevent (see the comment on `allEnabledReviewersVerifiedApproved` in `merge-pr.ts`).

**The fix:** `reviewTokenVerified` (new, pure, unit-tested) additionally compares `claim.cycleAt` against the task's current review cycle (`reviewCycleStart` off the activity log, the same source of truth the merge gate itself uses) — a claim from any cycle but the current one no longer verifies.

**Regression test:** `apps/api/src/tools/task-board/review-decision.test.ts` — a pure unit test on `reviewTokenVerified` covering: matching reviewer+cycle (verified), wrong reviewer (rejected), matching reviewer but stale cycle (rejected — the bug case), and a missing claim (rejected).

**To confirm:** `bun test apps/api/src/tools/task-board/review-decision.test.ts`

**Locally verified:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files — all green. Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects stale `reviewToken`s from earlier review cycles to prevent forged verified reviews from counting toward auto‑merge. Adds a pure check so only the current cycle and correct reviewer can verify.

- **Bug Fixes**
  - Added `reviewTokenVerified` to require both reviewer match and `cycleAt === reviewCycleStart(...)`.
  - Updated `TASK_BOARD_REVIEW_DECISION` to resolve the claim, derive the current cycle from activity, and use `reviewTokenVerified`.
  - Added unit tests for: valid match, wrong reviewer, stale cycle, and missing claim.

<sup>Written for commit 9024ba9125b54df5d94a205a63b90bb8356dd6b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

