### PR TITLE
i18n(settings): translate the org connect-to-clients page

### DIFF
--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -197,6 +197,38 @@ export const settings = {
     "Stores only a refresh endpoint + API key; short-lived credentials are fetched on demand and refreshed automatically.",
   "settings.buckets.temporarySessionOption":
     "Temporary session (STS, auto-refreshed)",
+  "settings.connectClients.activeKeys": "Active keys",
+  "settings.connectClients.activeKeysDescription":
+    "Keys you've generated for headless clients. Revoke any time.",
+  "settings.connectClients.apiKeyTab": "API key",
+  "settings.connectClients.copy": "Copy",
+  "settings.connectClients.createdAt": "Created {date}",
+  "settings.connectClients.customClientHint": "Wiring a custom client?",
+  "settings.connectClients.doneHideKey": "Done, hide key",
+  "settings.connectClients.failedToLoadKeys": "Failed to load keys: {error}",
+  "settings.connectClients.generateKeyFor": "Generate key for {client}",
+  "settings.connectClients.generatingKey": "Generating…",
+  "settings.connectClients.headlessKeyHint":
+    "For CI, Conductor, or headless agents that can't open a browser.",
+  "settings.connectClients.keyCreated": "Key created",
+  "settings.connectClients.keyRevoked": "Key revoked",
+  "settings.connectClients.loadingActiveKeys": "Loading active keys…",
+  "settings.connectClients.noConnectKeysYet":
+    "No connect keys minted yet. Generate one from a client tab above for headless setups.",
+  "settings.connectClients.oauthKeyHint":
+    "Recommended for your laptop. Browser will open on first use to sign in — no token to manage.",
+  "settings.connectClients.oauthMetadataHint":
+    "OAuth 2.1 Protected Resource Metadata is advertised on 401:",
+  "settings.connectClients.oauthTab": "OAuth",
+  "settings.connectClients.orgUnifiedMcp": "Your org's unified MCP",
+  "settings.connectClients.orgUnifiedMcpDescription":
+    "Plug this URL into any MCP client to give that runtime every connection enabled in this org, governed by your Decopilot rules.",
+  "settings.connectClients.pageTitle": "Connect to clients",
+  "settings.connectClients.revoke": "Revoke",
+  "settings.connectClients.revokeConfirm":
+    'Revoke "{name}"? Any client still using this key will lose access.',
+  "settings.connectClients.snippetOneTimeWarning":
+    "Copy this snippet now — the key won't be shown again. You can revoke it later from the list below.",
   "settings.connectForms.apiKeyField": "API Key",
   "settings.connectForms.apiKeyRequired": "API key is required",
   "settings.connectForms.baseUrlField": "Base URL",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -208,6 +208,40 @@ export const settings = {
     "Armazena apenas um endpoint de atualiza\u00e7\u00e3o + chave API; credenciais de curta dura\u00e7\u00e3o s\u00e3o buscadas sob demanda e atualizadas automaticamente.",
   "settings.buckets.temporarySessionOption":
     "Sess\u00e3o tempor\u00e1ria (STS, auto-atualizada)",
+  "settings.connectClients.activeKeys": "Chaves ativas",
+  "settings.connectClients.activeKeysDescription":
+    "Chaves que você gerou para clientes headless. Revogue quando quiser.",
+  "settings.connectClients.apiKeyTab": "Chave API",
+  "settings.connectClients.copy": "Copiar",
+  "settings.connectClients.createdAt": "Criada em {date}",
+  "settings.connectClients.customClientHint":
+    "Conectando um cliente personalizado?",
+  "settings.connectClients.doneHideKey": "Concluído, ocultar chave",
+  "settings.connectClients.failedToLoadKeys":
+    "Falha ao carregar chaves: {error}",
+  "settings.connectClients.generateKeyFor": "Gerar chave para {client}",
+  "settings.connectClients.generatingKey": "Gerando…",
+  "settings.connectClients.headlessKeyHint":
+    "Para CI, Conductor, ou agentes headless que não conseguem abrir um navegador.",
+  "settings.connectClients.keyCreated": "Chave criada",
+  "settings.connectClients.keyRevoked": "Chave revogada",
+  "settings.connectClients.loadingActiveKeys": "Carregando chaves ativas…",
+  "settings.connectClients.noConnectKeysYet":
+    "Nenhuma chave de conexão criada ainda. Gere uma na aba de um cliente acima para configurações headless.",
+  "settings.connectClients.oauthKeyHint":
+    "Recomendado para seu laptop. O navegador abrirá no primeiro uso para você entrar — sem token para gerenciar.",
+  "settings.connectClients.oauthMetadataHint":
+    "Os metadados do OAuth 2.1 Protected Resource são anunciados no 401:",
+  "settings.connectClients.oauthTab": "OAuth",
+  "settings.connectClients.orgUnifiedMcp": "O MCP unificado da sua org",
+  "settings.connectClients.orgUnifiedMcpDescription":
+    "Insira esta URL em qualquer cliente MCP para dar a esse runtime toda conexão habilitada nesta org, governada pelas suas regras do Decopilot.",
+  "settings.connectClients.pageTitle": "Conectar a clientes",
+  "settings.connectClients.revoke": "Revogar",
+  "settings.connectClients.revokeConfirm":
+    'Revogar "{name}"? Qualquer cliente que ainda use esta chave perderá o acesso.',
+  "settings.connectClients.snippetOneTimeWarning":
+    "Copie este snippet agora — a chave não será exibida novamente. Você pode revogá-la mais tarde na lista abaixo.",
   "settings.connectForms.apiKeyField": "Chave API",
   "settings.connectForms.apiKeyRequired": "A chave API é obrigatória",
   "settings.connectForms.baseUrlField": "URL Base",

--- a/apps/web/src/views/settings/org-connect.tsx
+++ b/apps/web/src/views/settings/org-connect.tsx
@@ -31,6 +31,7 @@ import {
   useCreateApiKey,
   useDeleteApiKey,
 } from "@/hooks/use-api-keys";
+import { useT } from "@/i18n/use-t.ts";
 
 const KEY_NAME_PREFIX = "Connect: ";
 
@@ -52,6 +53,7 @@ function hostnameLabel(): string {
 }
 
 function CopyInline({ text }: { text: string }) {
+  const t = useT();
   const { handleCopy, copied } = useCopy();
   return (
     <Button
@@ -59,7 +61,7 @@ function CopyInline({ text }: { text: string }) {
       size="icon"
       className="size-7 shrink-0"
       onClick={() => handleCopy(text)}
-      aria-label="Copy"
+      aria-label={t("settings.connectClients.copy")}
     >
       {copied ? <Check size={14} /> : <Copy01 size={14} />}
     </Button>
@@ -81,32 +83,35 @@ function ClientPanel({
   isGenerating: boolean;
   onClearNewKey: () => void;
 }) {
+  const t = useT();
   return (
     <Tabs defaultValue="oauth" className="mt-4">
       <TabsList>
-        <TabsTrigger value="oauth">OAuth</TabsTrigger>
-        <TabsTrigger value="api-key">API key</TabsTrigger>
+        <TabsTrigger value="oauth">
+          {t("settings.connectClients.oauthTab")}
+        </TabsTrigger>
+        <TabsTrigger value="api-key">
+          {t("settings.connectClients.apiKeyTab")}
+        </TabsTrigger>
       </TabsList>
 
       <TabsContent value="oauth" className="mt-3 space-y-3">
         <p className="text-xs text-muted-foreground">
-          Recommended for your laptop. Browser will open on first use to sign in
-          — no token to manage.
+          {t("settings.connectClients.oauthKeyHint")}
         </p>
         <InstallSnippet client={client} mode="oauth" url={url} />
       </TabsContent>
 
       <TabsContent value="api-key" className="mt-3 space-y-3">
         <p className="text-xs text-muted-foreground">
-          For CI, Conductor, or headless agents that can't open a browser.
+          {t("settings.connectClients.headlessKeyHint")}
         </p>
         {newKey ? (
           <>
             <Alert variant="warning" className="text-xs">
               <AlertTriangle />
               <AlertDescription>
-                Copy this snippet now — the key won't be shown again. You can
-                revoke it later from the list below.
+                {t("settings.connectClients.snippetOneTimeWarning")}
               </AlertDescription>
             </Alert>
             <InstallSnippet
@@ -121,7 +126,7 @@ function ClientPanel({
               onClick={onClearNewKey}
               className="text-xs"
             >
-              Done, hide key
+              {t("settings.connectClients.doneHideKey")}
             </Button>
           </>
         ) : (
@@ -135,8 +140,10 @@ function ClientPanel({
             >
               <Key01 size={14} />
               {isGenerating
-                ? "Generating…"
-                : `Generate key for ${clientLabel(client)}`}
+                ? t("settings.connectClients.generatingKey")
+                : t("settings.connectClients.generateKeyFor", {
+                    client: clientLabel(client),
+                  })}
             </Button>
           </>
         )}
@@ -146,6 +153,7 @@ function ClientPanel({
 }
 
 function ConnectKeysList() {
+  const t = useT();
   const { data, isLoading, error } = useApiKeysList();
   const deleteKey = useDeleteApiKey();
 
@@ -154,14 +162,18 @@ function ConnectKeysList() {
 
   if (isLoading) {
     return (
-      <p className="text-xs text-muted-foreground">Loading active keys…</p>
+      <p className="text-xs text-muted-foreground">
+        {t("settings.connectClients.loadingActiveKeys")}
+      </p>
     );
   }
 
   if (error) {
     return (
       <p className="text-xs text-destructive">
-        Failed to load keys: {error.message}
+        {t("settings.connectClients.failedToLoadKeys", {
+          error: error.message,
+        })}
       </p>
     );
   }
@@ -169,8 +181,7 @@ function ConnectKeysList() {
   if (connectKeys.length === 0) {
     return (
       <p className="text-xs text-muted-foreground">
-        No connect keys minted yet. Generate one from a client tab above for
-        headless setups.
+        {t("settings.connectClients.noConnectKeysYet")}
       </p>
     );
   }
@@ -187,7 +198,9 @@ function ConnectKeysList() {
               {key.name.replace(KEY_NAME_PREFIX, "")}
             </div>
             <div className="text-muted-foreground">
-              Created {new Date(key.createdAt).toLocaleDateString()}
+              {t("settings.connectClients.createdAt", {
+                date: new Date(key.createdAt).toLocaleDateString(),
+              })}
             </div>
           </div>
           <Button
@@ -196,11 +209,14 @@ function ConnectKeysList() {
             onClick={() => {
               if (
                 confirm(
-                  `Revoke "${key.name}"? Any client still using this key will lose access.`,
+                  t("settings.connectClients.revokeConfirm", {
+                    name: key.name,
+                  }),
                 )
               ) {
                 deleteKey.mutate(key.id, {
-                  onSuccess: () => toast.success("Key revoked"),
+                  onSuccess: () =>
+                    toast.success(t("settings.connectClients.keyRevoked")),
                   onError: (e) => toast.error(e.message),
                 });
               }
@@ -209,7 +225,7 @@ function ConnectKeysList() {
             className="gap-1 text-destructive hover:text-destructive"
           >
             <Trash01 size={14} />
-            Revoke
+            {t("settings.connectClients.revoke")}
           </Button>
         </li>
       ))}
@@ -218,6 +234,7 @@ function ConnectKeysList() {
 }
 
 export function OrgConnectPage() {
+  const t = useT();
   const { org } = useProjectContext();
   const url = mcpUrl(org.slug);
   const createKey = useCreateApiKey();
@@ -232,7 +249,7 @@ export function OrgConnectPage() {
       {
         onSuccess: (key) => {
           setNewKeys((prev) => ({ ...prev, [client]: key.key }));
-          toast.success("Key created");
+          toast.success(t("settings.connectClients.keyCreated"));
         },
         onError: (err) => toast.error(err.message),
       },
@@ -249,7 +266,7 @@ export function OrgConnectPage() {
       <Page.Content>
         <Page.Body>
           <SettingsPage>
-            <Page.Title>Connect to clients</Page.Title>
+            <Page.Title>{t("settings.connectClients.pageTitle")}</Page.Title>
 
             <Card className="p-5 gap-3">
               <div className="flex items-start gap-3">
@@ -258,12 +275,10 @@ export function OrgConnectPage() {
                 </div>
                 <div className="min-w-0 flex-1">
                   <h2 className="text-[15px] font-medium leading-tight">
-                    Your org's unified MCP
+                    {t("settings.connectClients.orgUnifiedMcp")}
                   </h2>
                   <p className="text-sm text-muted-foreground mt-1 leading-snug">
-                    Plug this URL into any MCP client to give that runtime every
-                    connection enabled in this org, governed by your Decopilot
-                    rules.
+                    {t("settings.connectClients.orgUnifiedMcpDescription")}
                   </p>
                 </div>
               </div>
@@ -273,12 +288,10 @@ export function OrgConnectPage() {
               </div>
               <details className="text-xs text-muted-foreground">
                 <summary className="cursor-pointer hover:text-foreground">
-                  Wiring a custom client?
+                  {t("settings.connectClients.customClientHint")}
                 </summary>
                 <div className="mt-2 space-y-1">
-                  <p>
-                    OAuth 2.1 Protected Resource Metadata is advertised on 401:
-                  </p>
+                  <p>{t("settings.connectClients.oauthMetadataHint")}</p>
                   <div className="flex items-center gap-2 rounded-md border border-border bg-background px-2 py-1">
                     <code className="text-[11px] flex-1 truncate">
                       {oauthMetadataUrl}
@@ -326,10 +339,10 @@ export function OrgConnectPage() {
             <section className="flex flex-col gap-3">
               <div className="px-4">
                 <h2 className="text-[15px] font-medium leading-tight">
-                  Active keys
+                  {t("settings.connectClients.activeKeys")}
                 </h2>
                 <p className="text-sm text-muted-foreground leading-snug mt-1">
-                  Keys you've generated for headless clients. Revoke any time.
+                  {t("settings.connectClients.activeKeysDescription")}
                 </p>
               </div>
               <ConnectKeysList />


### PR DESCRIPTION
**Source:** i18n debt hunt in the registry/settings area. `apps/web/src/views/settings/org-connect.tsx` (the "Connect to clients" settings page — MCP URL, OAuth/API-key tabs, active-keys list) had zero `useT` usage; every user-facing string, toast, and `aria-label` was hardcoded English, so pt-BR users saw English throughout this whole page.

**Payoff:** brings this settings page in line with the rest of the app's i18n coverage — pt-BR users get a fully translated connect-to-clients flow instead of a page that silently reverts to English.

**Change:** added a new `settings.connectClients.*` key namespace (pageTitle, tab labels, hints, toasts, the revoke-confirm and generate-key interpolated strings) to both `apps/web/src/i18n/en/settings.ts` and `apps/web/src/i18n/pt-br/settings.ts`, and wired `useT()` through `org-connect.tsx` in place of every hardcoded string. Product/client names ("Claude Code", "Cursor", etc.) are left as-is per the i18n convention (proper nouns aren't translated).

**Verify:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (green, `pt-br/settings.ts`'s `satisfies Record<keyof typeof en, string>` check proves key parity), `bunx oxlint apps/web/src/views/settings/org-connect.tsx apps/web/src/i18n/en/settings.ts apps/web/src/i18n/pt-br/settings.ts` (0 warnings/errors). No test file needed — this is pure string extraction, no logic branches.

A reviewer can confirm by loading the org settings "Connect" page with the pt-BR locale selected and checking every string renders in Portuguese.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localized the org settings “Connect to clients” page. pt-BR users now see Portuguese across the flow, including toasts and aria labels.

- **Refactors**
  - Added `settings.connectClients.*` keys in `apps/web/src/i18n/en/settings.ts` and `apps/web/src/i18n/pt-br/settings.ts`.
  - Wired `useT()` through `apps/web/src/views/settings/org-connect.tsx` for all UI strings, including interpolations (date, client, key name).
  - Kept product/client proper nouns as-is per convention.

<sup>Written for commit 9ba78fc262c3535274c98a1d86eee00875fa3014. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

