### PR TITLE
fix(i18n): correct plural handling in registry import dialogs

### DIFF
--- a/apps/web/src/i18n/en/registry.ts
+++ b/apps/web/src/i18n/en/registry.ts
@@ -23,9 +23,9 @@ export const registry = {
   "registry.csvImportDialog.downloadTemplate": "Download template",
   "registry.csvImportDialog.emptyStateHint":
     "Choose a CSV file or download the template to get started.",
-  "registry.csvImportDialog.importButton": "Import {count} item(s)",
+  "registry.csvImportDialog.importButton": "Import {count} items",
   "registry.csvImportDialog.importedCount":
-    "Imported {count} item(s) successfully",
+    "Imported {count} items successfully",
   "registry.csvImportDialog.importingButton": "Importing...",
   "registry.csvImportDialog.itemsCount": "{count} items",
   "registry.csvImportDialog.linePrefix": "Line {line}:",
@@ -444,7 +444,7 @@ export const registry = {
   "registry.registryItemsPage.icon": "Icon",
   "registry.registryItemsPage.id": "ID",
   "registry.registryItemsPage.importCsv": "Import CSV",
-  "registry.registryItemsPage.importedItems": "Imported {count} item(s)",
+  "registry.registryItemsPage.importedItems": "Imported {count} items",
   "registry.registryItemsPage.items": "Items",
   "registry.registryItemsPage.loadingItems": "Loading items...",
   "registry.registryItemsPage.loadingMoreItems": "Loading more items...",

--- a/apps/web/src/i18n/pt-br/registry.ts
+++ b/apps/web/src/i18n/pt-br/registry.ts
@@ -25,9 +25,9 @@ export const registry = {
   "registry.csvImportDialog.downloadTemplate": "Baixar modelo",
   "registry.csvImportDialog.emptyStateHint":
     "Escolha um arquivo CSV ou baixe o modelo para começar.",
-  "registry.csvImportDialog.importButton": "Importar {count} item(ns)",
+  "registry.csvImportDialog.importButton": "Importar {count} itens",
   "registry.csvImportDialog.importedCount":
-    "Importados {count} item(ns) com sucesso",
+    "Importados {count} itens com sucesso",
   "registry.csvImportDialog.importingButton": "Importando...",
   "registry.csvImportDialog.itemsCount": "{count} itens",
   "registry.csvImportDialog.linePrefix": "Linha {line}:",
@@ -473,7 +473,7 @@ export const registry = {
   "registry.registryItemsPage.icon": "Ícone",
   "registry.registryItemsPage.id": "ID",
   "registry.registryItemsPage.importCsv": "Importar CSV",
-  "registry.registryItemsPage.importedItems": "Importado(s) {count} item(ns)",
+  "registry.registryItemsPage.importedItems": "Importados {count} itens",
   "registry.registryItemsPage.items": "Itens",
   "registry.registryItemsPage.loadingItems": "Carregando itens...",
   "registry.registryItemsPage.loadingMoreItems": "Carregando mais itens...",


### PR DESCRIPTION
## Summary

Fixed mechanical translation gap in the registry i18n files where Portuguese directly copied English `item(s)` pattern as `item(ns)`, which is grammatically incorrect. The correct Portuguese plural form is `itens`.

## Changes

**English (`apps/web/src/i18n/en/registry.ts`):**
- Line 26: `item(s)` → `items` (csvImportDialog.importButton)
- Line 28: `item(s)` → `items` (csvImportDialog.importedCount)
- Line 447: `item(s)` → `items` (registryItemsPage.importedItems)

**Portuguese (`apps/web/src/i18n/pt-br/registry.ts`):**
- Line 28: `item(ns)` → `itens` (csvImportDialog.importButton)
- Line 30: `item(ns)` → `itens` (csvImportDialog.importedCount)
- Line 476: `item(ns)` → `itens` (registryItemsPage.importedItems)

## Motivation

The English file had an inconsistent placeholder pattern `item(s)` that doesn't make grammatical sense when interpolated with a count (e.g., "Import 5 item(s)"). The Portuguese translation mechanically copied this as `item(ns)` without proper Portuguese pluralization. All three entries now use the correct plural form consistently.

## Verification

- ✅ `bun run fmt` - no changes needed
- ✅ `bunx tsc --noEmit` in apps/web - passes
- ✅ `bunx oxlint` on modified files - 0 errors, 0 warnings
- Changes verified with grep to ensure all instances replaced correctly

## Impact

This fixes grammatical correctness in the registry UI import dialog and items page for both English and Portuguese locales. The change is purely cosmetic (text strings) with no functional impact.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix incorrect pluralization in the registry CSV import dialog and items page by replacing "item(s)" with "items" in English and "item(ns)" with "itens" in pt-BR across three i18n keys. Text-only change; improves grammar for counts like "Imported {count} items" with no functional impact.

<sup>Written for commit 9ebffec0efe14f7b001a10b8996116d0882bcf07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

