### PR TITLE
fix(cli): validate --port/--vite-port before they crash net.Server.listen()

### DIFF
--- a/apps/api/src/cli.ts
+++ b/apps/api/src/cli.ts
@@ -75,6 +75,15 @@ const { values, positionals } = parseArgs({
   allowPositionals: true,
 });
 
+// Fail fast with a usage error naming the flag, instead of a bad --port/--vite-port crashing net.Server.listen() with a confusing RangeError.
+try {
+  parsePositiveIntFlag("port", values.port, 65535);
+  parsePositiveIntFlag("vite-port", values["vite-port"], 65535);
+} catch (err) {
+  console.error((err as Error).message);
+  process.exit(1);
+}
+
 // ── Help ───────────────────────────────────────────────────────────────
 if (values.help) {
   console.log(`

--- a/apps/api/src/cli/parse-positive-int-flag.test.ts
+++ b/apps/api/src/cli/parse-positive-int-flag.test.ts
@@ -24,4 +24,14 @@ describe("parsePositiveIntFlag", () => {
   test("rejects a non-integer value", () => {
     expect(() => parsePositiveIntFlag("batch", "1.5")).toThrow();
   });
+
+  test("accepts a value within an optional max", () => {
+    expect(parsePositiveIntFlag("port", "3000", 65535)).toBe(3000);
+  });
+
+  test("rejects a value above an optional max", () => {
+    expect(() => parsePositiveIntFlag("port", "70000", 65535)).toThrow(
+      'Invalid --port "70000" — must be a positive integer up to 65535.',
+    );
+  });
 });

--- a/apps/api/src/cli/parse-positive-int-flag.ts
+++ b/apps/api/src/cli/parse-positive-int-flag.ts
@@ -7,11 +7,20 @@
 export function parsePositiveIntFlag(
   flag: string,
   raw: string | undefined,
+  max?: number,
 ): number | undefined {
   if (raw === undefined) return undefined;
   const value = Number(raw);
-  if (!Number.isSafeInteger(value) || value <= 0) {
-    throw new Error(`Invalid --${flag} "${raw}" — must be a positive integer.`);
+  if (
+    !Number.isSafeInteger(value) ||
+    value <= 0 ||
+    (max !== undefined && value > max)
+  ) {
+    throw new Error(
+      `Invalid --${flag} "${raw}" — must be a positive integer${
+        max !== undefined ? ` up to ${max}` : ""
+      }.`,
+    );
   }
   return value;
 }


### PR DESCRIPTION
**Source:** bug found while hardening `apps/api/src/cli/` — reachable from any user typing an invalid `--port`, not tied to an issue.

**Payoff:** today `deco --port abc` (or `--port 99999`) reaches `findAvailablePort()` -> `net.Server.listen()` and crashes with a raw internal `RangeError: options.port should be >= 0 and < 65536. Received type number (NaN).` instead of a clean usage message. `--batch`/`--limit` on `backfill-assets` already get this treatment via `parsePositiveIntFlag`; `--port`/`--vite-port` didn't.

**Failure scenario + fix:** `deco --port abc` or `deco dev --vite-port 70000` crashed with a confusing stack trace pointing into `node:net` instead of naming the bad flag. Extended `parsePositiveIntFlag` with an optional `max` bound (used for the 65535 port ceiling) and validate `--port`/`--vite-port` right after `parseArgs()` in `cli.ts`, before any command routing — printing `Invalid --port "abc" — must be a positive integer up to 65535.` and exiting 1. Added test cases for the new `max` param.

**Reviewer check:** `cd apps/api && bun run src/cli.ts --port abc` (prints the usage error, exits 1) and `bun test apps/api/src/cli/parse-positive-int-flag.test.ts`.

**Verified locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bun test apps/api/src/cli/parse-positive-int-flag.test.ts` (7 pass), `bunx oxlint` on the 3 touched files (0 errors/warnings). Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate `--port` and `--vite-port` before starting servers to avoid crashes in `net.Server.listen()`. Invalid values now show a clear usage error and exit with code 1.

- **Bug Fixes**
  - Added optional `max` to `parsePositiveIntFlag` and enforce `65535` for ports.
  - Validate flags right after `parseArgs()` in `cli.ts`.
  - Added tests for the `max` bound and error message.

<sup>Written for commit 62d45853c93d59a5109ab6d59efabc85122e4b1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

