### PR TITLE
fix(sandbox): stop daemon-e2e from orphaning spawned dev servers

### DIFF
--- a/packages/sandbox/daemon-e2e/daemon.e2e.helpers.ts
+++ b/packages/sandbox/daemon-e2e/daemon.e2e.helpers.ts
@@ -182,7 +182,11 @@ export async function stopDaemon(d: Daemon | null): Promise<void> {
     // ChildProcess.kill() terminates only the Bun parent; an in-flight npm.cmd
     // child can survive and keep appDir locked. taskkill /T closes that tree.
     await new Promise<void>((resolve) => {
-      proc.once("exit", () => resolve());
+      let killTimer: ReturnType<typeof setTimeout> | undefined;
+      proc.once("exit", () => {
+        if (killTimer) clearTimeout(killTimer);
+        resolve();
+      });
       if (process.platform === "win32" && proc.pid !== undefined) {
         const killer = spawn(
           "taskkill",
@@ -195,7 +199,13 @@ export async function stopDaemon(d: Daemon | null): Promise<void> {
         killer.once("error", fallBackToParentKill);
         killer.once("exit", fallBackToParentKill);
       } else {
-        proc.kill("SIGKILL");
+        // SIGTERM (not SIGKILL) so the daemon reaps any dev server it spawned.
+        proc.kill("SIGTERM");
+        killTimer = setTimeout(() => {
+          if (proc.exitCode === null && proc.signalCode === null) {
+            proc.kill("SIGKILL");
+          }
+        }, 5000);
       }
     });
   }


### PR DESCRIPTION
A subprocess-lifecycle bug in the sandbox daemon e2e harness: `stopDaemon()` sends `SIGKILL` straight to the daemon's own process. The Go daemon's production shutdown path (`d.shutdown()`, wired to SIGTERM/SIGINT in `main.go`) is what calls `TaskManager.Shutdown()`, which kills the process *groups* of anything the daemon spawned (e.g. a `npm run dev` dev server, itself in its own pgroup via `Setpgid: true`). SIGKILL bypasses that handler entirely, so the daemon dies but its dev-server child does not — it gets reparented to init and keeps running forever.

**Payoff**: every e2e test that boots a dev server (warmpool, proxy, ws-proxy, etc.) currently leaks a live `node`/`npm` process per test run, on CI runners and on every contributor's machine that runs this suite locally. I confirmed this empirically: running `daemon.warmpool.e2e.test.ts` once left 15 orphaned `npm run dev` processes (verified `ppid=1`, still running) even though all 8 tests passed. After the fix, the same run leaves zero.

**Fix**: send `SIGTERM` instead, so the daemon's own graceful-shutdown path reaps its process groups before exiting, falling back to `SIGKILL` only if it doesn't exit within 5s (matching the same escalation pattern the daemon itself uses for tasks, `killEscalationDelay = 3s`).

**How to verify**: 
```
cd packages/sandbox/daemon-go && go build -o bin/daemon .
cd ../../..
pkill -f 'npm run dev' # clear any pre-existing leaks
bun test packages/sandbox/daemon-e2e/daemon.warmpool.e2e.test.ts
pgrep -fl 'npm run dev' # should print nothing
```
On `main` (before this fix) the last command lists orphaned processes; after the fix it's empty.

**Locally verified**: `bun run fmt` (clean), `bunx oxlint packages/sandbox/daemon-e2e/daemon.e2e.helpers.ts` (0 warnings/errors), and the full targeted run above plus `daemon.ws-proxy.e2e.test.ts`, `daemon.proxy.e2e.test.ts`, `daemon.e2e.helpers.test.ts`, and `daemon.git.e2e.test.ts` (28 tests) — all pass, no behavior change, no regressions, teardown latency unaffected in the common case (SIGTERM exits promptly when there's no lingering child). No type changes, so no targeted `tsc` run. Full CI validates the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sandbox e2e teardown so spawned dev servers don’t get orphaned. `stopDaemon()` now sends `SIGTERM` to the Go daemon and escalates to `SIGKILL` after 5s, preventing leaked `npm run dev` processes.

- **Bug Fixes**
  - Use `SIGTERM` instead of `SIGKILL` so the daemon reaps its children; escalate to `SIGKILL` after 5s.
  - Keep Windows path using `taskkill /T`; stops lingering `node`/`npm` processes in e2e runs.

<sup>Written for commit 9399d5c7909c68f8ec4ee7bbcd18394576f807b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5961?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

