### PR TITLE
fix(decopilot): reject non-http(s) URLs in the inspect_page tool

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.test.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.test.ts
@@ -4,6 +4,31 @@ import { createInspectPageTool } from "./inspect-page";
 const writer = { write: () => {} } as never;
 
 describe("createInspectPageTool", () => {
+  test("rejects a non-http(s) URL before it reaches browserless", async () => {
+    const originalFetch = globalThis.fetch;
+    let fetchCalled = false;
+    globalThis.fetch = (async () => {
+      fetchCalled = true;
+      return new Response("{}", { status: 200 });
+    }) as never;
+    try {
+      const tool = createInspectPageTool(writer, {
+        browserless: { baseUrl: "https://bl.example", token: "t" },
+        objectStorage: { put: async () => ({ key: "k" }) } as never,
+        toolOutputMap: new Map(),
+      });
+      const parsed = await (
+        tool.inputSchema as unknown as {
+          validate: (v: unknown) => Promise<{ success: boolean }>;
+        }
+      ).validate({ url: "file:///etc/passwd" });
+      expect(parsed.success).toBe(false);
+      expect(fetchCalled).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("caps an oversized browserless error body instead of embedding it whole", async () => {
     const originalFetch = globalThis.fetch;
     const hugeBody = "x".repeat(50_000);

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.ts
@@ -28,8 +28,15 @@ const BROWSERLESS_FETCH_TIMEOUT_MS = 45_000;
 // Upstream error bodies are unbounded — cap what lands in the tool error.
 const ERROR_BODY_MAX_CHARS = 500;
 
+// Reject non-http(s) schemes (file:, javascript:, ...) before forwarding to Browserless.
 const InspectPageInputSchema = z.object({
-  url: z.string().url().describe("The URL of the web page to inspect."),
+  url: z
+    .string()
+    .url()
+    .refine((url) => /^https?:\/\//i.test(url), {
+      message: "URL must use http or https",
+    })
+    .describe("The URL of the web page to inspect."),
   evaluate: z
     .string()
     .optional()


### PR DESCRIPTION
**Source:** hardening follow-up found while hunting this tick's new-commits area — the sibling `scrape_url` built-in tool (touched by PR #5894, merged) already guards against this exact class of input.

**Payoff:** `scrape_url`'s `ScrapeUrlInputSchema` rejects any non-http(s) URL (`file:`, `javascript:`, etc.) before forwarding it to Browserless's REST API — a `.refine()` added specifically because the url is untrusted model input. `inspect_page`'s `InspectPageInputSchema` only had zod's generic `.url()` check, which accepts any URL-shaped string including `file://` and other non-http(s) schemes, and hands it to the same Browserless `/function` endpoint. `inspect_page` had the identical validation gap its sibling was already fixed against.

**Fix:** mirror `scrape_url`'s scheme guard on `inspect_page`'s input schema — behavior-preserving for every http(s) URL, and now rejects anything else at the schema layer before any network call.

**Failure scenario:** a model calls `inspect_page` with `url: "file:///etc/passwd"` (or any other non-http(s) scheme) — it used to pass validation and get forwarded to Browserless; now zod rejects it before any request is made. New regression test asserts the schema rejects a `file://` URL and that `fetch` is never called.

**Verify:** `cd apps/api && bun test src/harnesses/lib/decopilot/built-in-tools/inspect-page.test.ts`

**Local checks run:** `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), the targeted test file above (2/2 pass), `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject non-http(s) URLs in `inspect_page` so unsafe schemes never reach Browserless. Mirrors `scrape_url` validation to block inputs like `file://` and `javascript:` up front.

- **Bug Fixes**
  - Added a `.refine()` to `InspectPageInputSchema` to allow only http/https.
  - New test ensures `file://` URLs fail validation and `fetch` is not called.

<sup>Written for commit de2a0ff9993e3c5ca5b818869d338634a2d0fec2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

