### PR TITLE
feat(chart): optional Ingress for Studio, off by default

### DIFF
--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/kubernetes.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/kubernetes.mdx
@@ -51,7 +51,7 @@ For production, schedule sandbox pods on a dedicated, tainted node pool. Sandbox
 The commands below pin chart versions explicitly. Pin them in your own deployment too, instead of tracking whatever is newest.
 
 ```bash
-export STUDIO_CHART_VERSION=0.12.4
+export STUDIO_CHART_VERSION=0.13.0
 export SANDBOX_OPERATOR_CHART_VERSION=0.1.3
 export SANDBOX_ENV_CHART_VERSION=0.15.3
 ```
@@ -198,7 +198,40 @@ kubectl port-forward svc/deco-studio 8080:80 -n deco-studio
 
 Studio is then available at `http://localhost:8080`.
 
-### 5. Connect an AI provider
+### 5. Expose Studio
+
+The chart's Service is `ClusterIP` and the Ingress is optional and off by default, because the controller, class, TLS issuer, and annotations differ per cluster. Pick the option that matches what you already run.
+
+**Ingress (chart-managed).** Set `ingress.enabled` and the chart renders an Ingress backed by this release's Service — you don't hardcode the generated Service name, and the object joins the Helm release, so `helm rollback` and `helm uninstall` cover it:
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  hosts:
+    - host: studio.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+        - studio.example.com
+      secretName: studio-tls
+```
+
+Studio serves the whole app from the root, so one `/` `Prefix` rule per host is the normal shape. With `ingress.enabled=true`, the chart fails to render if `hosts` is empty or a host has no paths — an Ingress without rules is accepted by controllers and silently routes nothing.
+
+**LoadBalancer.** No controller in the cluster: set `service.type: LoadBalancer` and point DNS and TLS at the load balancer.
+
+**Gateway API.** Leave `ingress.enabled: false` and create a Gateway and HTTPRoute targeting the same Service. This is separate from the sandbox preview Gateway, which the `sandbox-env` chart configures.
+
+<Callout type="warning">
+  Whichever you choose, set `BASE_URL` and `BETTER_AUTH_URL` to the same public `https://` URL. Auth callbacks are built from those values, not from the incoming request host, so a mismatch produces sign-in redirects that fail.
+</Callout>
+
+### 6. Connect an AI provider
 
 A self-hosted deployment ships with no model access. Agents and Decopilot stay unusable until an organization owner connects a provider under **Settings → AI Providers** with a key you own — Anthropic, Google Gemini, OpenRouter, or any OpenAI-compatible endpoint, including a self-hosted vLLM server. The hosted deco AI Gateway and its starter credits are a feature of the managed offering; do not plan a self-hosted rollout around them. See [AI Providers](/en/studio/ai-providers).
 
@@ -319,6 +352,7 @@ These defaults come from `deploy/helm/studio/values.yaml`:
 | `image.repository` / `image.tag` | Studio API/worker image ([tags](https://github.com/orgs/decocms/packages/container/package/studio%2Fstudio)) | `ghcr.io/decocms/studio/studio` / unset |
 | `nginx.image.repository` / `nginx.image.tag` | Front-door image ([tags](https://github.com/orgs/decocms/packages/container/package/studio%2Fstudio-nginx)) | `ghcr.io/decocms/studio/studio-nginx` / unset |
 | `service.type` / `service.port` | Service exposure | `ClusterIP` / `80` |
+| `ingress.enabled` / `ingress.className` / `ingress.hosts` | Optional chart-managed Ingress | `false` / `""` / `[]` |
 | `database.engine` | Database engine | `postgresql` |
 | `worker.enabled` / `worker.replicaCount` | Queue worker Deployment | `true` / `2` |
 | `worker.autoscaling.enabled` | Worker HPA | `true` |

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/kubernetes.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/kubernetes.mdx
@@ -51,7 +51,7 @@ Em produção, agende pods de sandbox em um node pool dedicado e com taint. Esse
 Os comandos abaixo fixam versões de chart explicitamente. Fixe também no seu deployment, em vez de acompanhar a versão mais recente.
 
 ```bash
-export STUDIO_CHART_VERSION=0.12.4
+export STUDIO_CHART_VERSION=0.13.0
 export SANDBOX_OPERATOR_CHART_VERSION=0.1.3
 export SANDBOX_ENV_CHART_VERSION=0.15.3
 ```
@@ -198,7 +198,40 @@ kubectl port-forward svc/deco-studio 8080:80 -n deco-studio
 
 O Studio estará disponível em `http://localhost:8080`.
 
-### 5. Conecte um provedor de IA
+### 5. Exponha o Studio
+
+O Service do chart é `ClusterIP` e o Ingress é opcional e desligado por padrão, porque controller, class, emissor de TLS e annotations variam por cluster. Escolha a opção que corresponde ao que você já roda.
+
+**Ingress (gerenciado pelo chart).** Defina `ingress.enabled` e o chart renderiza um Ingress apontando para o Service desta release — você não hardcoda o nome gerado do Service, e o objeto passa a fazer parte da release Helm, então `helm rollback` e `helm uninstall` cobrem ele:
+
+```yaml
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  hosts:
+    - host: studio.example.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls:
+    - hosts:
+        - studio.example.com
+      secretName: studio-tls
+```
+
+O Studio serve a aplicação inteira a partir da raiz, então uma única regra `/` com `Prefix` por host é o formato normal. Com `ingress.enabled=true`, o chart falha ao renderizar se `hosts` estiver vazio ou se um host não tiver paths — um Ingress sem regras é aceito pelos controllers e simplesmente não roteia nada.
+
+**LoadBalancer.** Sem controller no cluster: defina `service.type: LoadBalancer` e aponte DNS e TLS para o load balancer.
+
+**Gateway API.** Deixe `ingress.enabled: false` e crie um Gateway e um HTTPRoute apontando para o mesmo Service. Isso é separado do Gateway de preview do sandbox, que é configurado pelo chart `sandbox-env`.
+
+<Callout type="warning">
+  Qualquer que seja a escolha, defina `BASE_URL` e `BETTER_AUTH_URL` com a mesma URL pública `https://`. Os callbacks de autenticação são montados a partir desses valores, não do host da requisição, então uma divergência gera redirects de login que falham.
+</Callout>
+
+### 6. Conecte um provedor de IA
 
 Um deployment self-hosted não vem com acesso a modelos. Agentes e Decopilot ficam inutilizáveis até que um owner da organização conecte um provedor em **Settings → AI Providers** com uma chave sua — Anthropic, Google Gemini, OpenRouter ou qualquer endpoint compatível com OpenAI, incluindo um servidor vLLM self-hosted. O deco AI Gateway hospedado e seus créditos iniciais são um recurso da oferta gerenciada; não planeje um rollout self-hosted em cima deles. Veja [Provedores de IA](/pt-br/studio/ai-providers).
 
@@ -319,6 +352,7 @@ Estes padrões vêm de `deploy/helm/studio/values.yaml`:
 | `image.repository` / `image.tag` | Imagem de API/worker do Studio ([tags](https://github.com/orgs/decocms/packages/container/package/studio%2Fstudio)) | `ghcr.io/decocms/studio/studio` / não definido |
 | `nginx.image.repository` / `nginx.image.tag` | Imagem do front door ([tags](https://github.com/orgs/decocms/packages/container/package/studio%2Fstudio-nginx)) | `ghcr.io/decocms/studio/studio-nginx` / não definido |
 | `service.type` / `service.port` | Exposição do Service | `ClusterIP` / `80` |
+| `ingress.enabled` / `ingress.className` / `ingress.hosts` | Ingress opcional gerenciado pelo chart | `false` / `""` / `[]` |
 | `database.engine` | Engine do banco | `postgresql` |
 | `worker.enabled` / `worker.replicaCount` | Deployment de workers de fila | `true` / `2` |
 | `worker.autoscaling.enabled` | HPA dos workers | `true` |

--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,9 +2,11 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
+# 0.13.0: optional Ingress (ingress.enabled, default false). Renders nothing
+# when disabled, so existing releases are unaffected.
 # 0.12.4: chart-managed API/worker dispatch roles now use
 # STUDIO_DISPATCH_ROLE; legacy overrides are rejected.
-version: 0.12.4
+version: 0.13.0
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/templates/NOTES.txt
+++ b/deploy/helm/studio/templates/NOTES.txt
@@ -1,6 +1,18 @@
 1. Get the application URL by running these commands:
 
-{{- if contains "ClusterIP" .Values.service.type }}
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+{{- $host := .host }}
+{{- $scheme := "http" }}
+{{- range $.Values.ingress.tls }}
+{{- if has $host .hosts }}{{ $scheme = "https" }}{{ end }}
+{{- end }}
+  Visit {{ $scheme }}://{{ $host }}
+{{- end }}
+
+  Set BASE_URL and BETTER_AUTH_URL to that same URL — auth callbacks are
+  built from them, not from the request host.
+{{- else if contains "ClusterIP" .Values.service.type }}
   export SERVICE_NAME={{ include "chart-deco-studio.fullname" . }}
   echo "To access the application, run:"
   echo "  kubectl --namespace {{ .Release.Namespace }} port-forward svc/$SERVICE_NAME 8080:{{ .Values.service.port }}"

--- a/deploy/helm/studio/templates/_helpers.tpl
+++ b/deploy/helm/studio/templates/_helpers.tpl
@@ -272,6 +272,27 @@ Validates ExternalSecret configuration.
 {{- end }}
 
 {{/*
+Validates the optional Ingress. An enabled Ingress with no host renders a
+rules-less object the controller accepts and silently routes nothing, so fail
+at render time instead.
+*/}}
+{{- define "chart-deco-studio.validateIngress" -}}
+{{- if .Values.ingress.enabled }}
+{{- if not .Values.ingress.hosts }}
+{{- fail "chart-deco-studio: ingress.hosts is required when ingress.enabled=true" -}}
+{{- end }}
+{{- range .Values.ingress.hosts }}
+{{- if not .host }}
+{{- fail "chart-deco-studio: every entry in ingress.hosts needs a host" -}}
+{{- end }}
+{{- if not .paths }}
+{{- fail (printf "chart-deco-studio: ingress host %s has no paths — add at least { path: /, pathType: Prefix }" .host) -}}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 Validates public NATS tunnel cluster-creds mount configuration.
 */}}
 {{- define "chart-deco-studio.validateNatsTunnel" -}}

--- a/deploy/helm/studio/templates/ingress.yaml
+++ b/deploy/helm/studio/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "chart-deco-studio.fullname" . }}
+  labels:
+    {{- include "chart-deco-studio.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . | quote }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "Prefix" }}
+            backend:
+              service:
+                name: {{ include "chart-deco-studio.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/studio/templates/validations.yaml
+++ b/deploy/helm/studio/templates/validations.yaml
@@ -7,3 +7,4 @@ This file only runs chart-level validations and renders no resources.
 {{- include "chart-deco-studio.validateNatsTunnel" . -}}
 {{- include "chart-deco-studio.validateDispatchRole" . -}}
 {{- include "chart-deco-studio.validateClickhouse" . -}}
+{{- include "chart-deco-studio.validateIngress" . -}}

--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -19,6 +19,39 @@ image:
     - deco
     - --no-local-mode
 
+# Optional Ingress in front of the Service. OFF by default: clusters differ in
+# controller, class, TLS issuer, and annotations, and deployments that front
+# Studio with a LoadBalancer or Gateway API want no Ingress at all.
+#
+# When enabled, the backend is this release's Service on service.port — you
+# don't hardcode the generated name. Set BASE_URL and BETTER_AUTH_URL to the
+# same public https:// URL you put in hosts[].host, or auth callbacks break.
+#
+# Gateway API users: leave this off and create a Gateway + HTTPRoute pointing
+# at the same Service (the sandbox preview Gateway is configured separately,
+# in the sandbox-env chart).
+ingress:
+  enabled: false
+  # Ingress controller class, e.g. "nginx", "traefik", "alb". Empty → the
+  # cluster's default IngressClass.
+  className: ""
+  # Controller-specific config, e.g. cert-manager's
+  # cert-manager.io/cluster-issuer, or nginx body-size/timeout tuning.
+  annotations: {}
+  # Required when enabled. Studio serves the whole app from the root path,
+  # so a single "/" Prefix rule per host is the normal shape.
+  hosts: []
+  #  - host: studio.example.com
+  #    paths:
+  #      - path: /
+  #        pathType: Prefix
+  # TLS is the controller's job. With cert-manager, name a secret that does
+  # not exist yet and the issuer annotation above will populate it.
+  tls: []
+  #  - hosts:
+  #      - studio.example.com
+  #    secretName: studio-tls
+
 service:
   type: ClusterIP
   port: 80

--- a/selfhost/production/README.md
+++ b/selfhost/production/README.md
@@ -88,19 +88,37 @@ Two supported paths (never inline secret material in git):
 `BETTER_AUTH_SECRET` + `ENCRYPTION_KEY` MUST be stable across restarts; the
 sentinel token MUST equal `sandbox-env.sentinel.token`.
 
-### Ingress — the chart renders none; expose with what you have
+### Ingress — optional, off by default
 
 Studio's Service is `ClusterIP:80`. Pick the least-effort option for your cluster:
 
-1. **You already run an ingress controller** (nginx/Traefik/ALB) → create an
-   Ingress routing your host to Service `studio`:80 with your `ingressClassName`
-   + TLS (cert-manager or the controller's).
+1. **You already run an ingress controller** (nginx/Traefik/ALB) → turn on the
+   chart's Ingress (0.13.0+). It backs onto this release's Service, so you don't
+   hardcode the generated name, and `helm rollback`/`uninstall` cover it:
+
+   ```yaml
+   ingress:
+     enabled: true
+     className: nginx
+     annotations:
+       cert-manager.io/cluster-issuer: letsencrypt
+     hosts:
+       - host: studio.example.com
+         paths:
+           - path: /
+             pathType: Prefix
+     tls:
+       - hosts: [studio.example.com]
+         secretName: studio-tls
+   ```
+
 2. **Cloud, no controller** → `service.type=LoadBalancer`, then point DNS + TLS
    at the LB.
-3. **Istio / Gateway API** → a Gateway + HTTPRoute to the Service (same shape as
-   the sandbox preview gateway).
+3. **Istio / Gateway API** → leave `ingress.enabled: false` and add a Gateway +
+   HTTPRoute to the Service (same shape as the sandbox preview gateway).
 
-Set `BASE_URL` / `BETTER_AUTH_URL` to the public `https://` URL either way.
+Set `BASE_URL` / `BETTER_AUTH_URL` to the public `https://` URL either way —
+auth callbacks come from those, not from the request host.
 
 ## Sandbox (code-execution + previews)
 

--- a/selfhost/production/values-studio-prod.yaml
+++ b/selfhost/production/values-studio-prod.yaml
@@ -135,15 +135,32 @@ persistence:
   storageClass: "<your-storage-class>"   # e.g. gp3
   size: 10Gi                             # deco prod
 
-# ── Exposing Studio (ingress) — the chart renders NO Ingress; pick what fits ──
+# ── Exposing Studio — the Ingress is optional and OFF by default ──────────────
 # Studio's Service is ClusterIP:80 by default. Expose it with whatever your
 # cluster already has (best → least effort):
-#   1. Ingress controller you already run (nginx/Traefik/ALB): create an Ingress
-#      routing host → Service `<release>`:80, with your ingressClassName + TLS.
+#   1. Ingress controller you already run (nginx/Traefik/ALB): turn on the
+#      chart's Ingress below (chart 0.13.0+). It backs onto this release's
+#      Service, so the generated name is never hardcoded, and the object lives
+#      in the Helm release (rollback/uninstall cover it).
 #   2. Cloud without an ingress controller: set the Service to LoadBalancer:
 #        service: { type: LoadBalancer }
 #      then point DNS/TLS at the LB (cert via cert-manager or the cloud LB).
-#   3. Istio/Gateway API: a Gateway + HTTPRoute to the Service (same as previews).
-# Set BASE_URL / BETTER_AUTH_URL (above) to the public https URL either way.
+#   3. Istio/Gateway API: leave ingress.enabled=false and add a Gateway +
+#      HTTPRoute to the Service (same shape as the sandbox previews).
+# Set BASE_URL / BETTER_AUTH_URL (above) to the public https URL either way —
+# auth callbacks are built from those, not from the request host.
+# ingress:
+#   enabled: true
+#   className: nginx                       # or traefik / alb / your class
+#   annotations:
+#     cert-manager.io/cluster-issuer: <your-issuer>
+#   hosts:
+#     - host: studio.<your-domain>
+#       paths:
+#         - path: /
+#           pathType: Prefix
+#   tls:
+#     - hosts: [studio.<your-domain>]
+#       secretName: studio-tls
 # service:
 #   type: LoadBalancer

--- a/selfhost/skills/self-host-studio/SKILL.md
+++ b/selfhost/skills/self-host-studio/SKILL.md
@@ -63,13 +63,17 @@ detected environment, then walk these. Record answers into a values file you'll
    - **NATS**: bundled (default) OR their own (`nats.enabled=false` + `NATS_URL`).
 
 3. **Reachability / ingress** — the public URL → `BASE_URL` + `BETTER_AUTH_URL`
-   (`http://studio.localhost` locally; `https://studio.<domain>` real). The chart
-   renders NO Ingress, so ask what they have and expose accordingly:
-   - **have an ingress controller** (nginx/Traefik/ALB)? → they create an Ingress
-     to Service `<release>`:80 with their ingressClassName + TLS.
+   (`http://studio.localhost` locally; `https://studio.<domain>` real). The
+   chart's Ingress is optional and OFF by default, so ask what they have:
+   - **have an ingress controller** (nginx/Traefik/ALB)? → set `ingress.enabled=true`
+     + `className` + `hosts[].host` with a `/` `Prefix` path, and `tls` (chart
+     0.13.0+; it backs onto the release's own Service). Render fails if `hosts`
+     is empty or a host has no paths.
    - **cloud, no controller?** → `service.type=LoadBalancer` + DNS/TLS at the LB.
-   - **Istio/Gateway API?** → Gateway + HTTPRoute.
+   - **Istio/Gateway API?** → leave `ingress.enabled=false`, add Gateway + HTTPRoute.
    Locally it's just the `LoadBalancer:80` servicelb.
+   Whatever they pick, `BASE_URL`/`BETTER_AUTH_URL` must equal the public URL —
+   auth callbacks come from those, not from the request host.
 
 4. **Secrets** — how do they manage secrets? (ask; never inline in git)
    - **External Secrets Operator?** → `externalSecret.enabled=true` + `secretPath`


### PR DESCRIPTION
Stacked on #5959 (base is that branch, so the diff here is just the Ingress work). GitHub retargets this to `main` when #5959 merges.

## Why

The Studio chart renders no Ingress, so every self-hoster authors a raw Ingress outside the release. That is not the Helm convention — `helm create`'s own scaffold ships `ingress.yaml` (and `httproute.yaml`) with `enabled: false`, and mainstream app charts follow it. Omitting the template is normal for operator/CRD charts, not for a user-facing web app.

It costs the operator three concrete things:

- the Ingress is outside the release — no `helm rollback`, no cleanup on `helm uninstall`, absent from `helm get manifest`;
- they must hardcode the Service name, which is `{{ include "chart-deco-studio.fullname" . }}` — coupling their manifest to a chart-internal helper that can move on upgrade;
- our own production guide works around it by telling people to wrap the chart in an umbrella just to have somewhere to put the Ingress.

The `sandbox-env` chart already renders a Gateway for previews, so the main app was the only thing in the repo with no chart-managed routing.

## What changed

- `templates/ingress.yaml` + an `ingress:` values block, default `enabled: false`.
- Backend resolves from the release, so the generated Service name is never hardcoded by the user.
- `validateIngress`: render fails when enabled with no `hosts`, or a host with no `paths`. A rules-less Ingress is accepted by controllers and then silently routes nothing — better to fail at `helm template` than to debug a 404 later.
- `NOTES.txt` prints the resulting URL, choosing `https` when the host is listed in `ingress.tls`.
- Chart `0.12.4` → `0.13.0`. `publish-chart.yml` republishes on merge since `Chart.yaml` changed.
- Docs: new "Expose Studio" step in the Kubernetes guide (en + pt-br) covering Ingress / LoadBalancer / Gateway API, a values-table row, the production values example, `selfhost/production/README.md`, and the install skill. Each states that `BASE_URL` / `BETTER_AUTH_URL` must equal the public URL — auth callbacks are built from those, not from the request host, and that mismatch is a common self-host failure.

## Compatibility

Default-off, so it renders nothing for existing releases. The internal CD pins an older chart and fronts Studio with a load balancer; it is unaffected either way.

## Verification

- `helm lint` clean.
- Disabled (default): zero `kind: Ingress` in the rendered output, both for the chart directly and via the local umbrella.
- Enabled with class + cert-manager annotation + TLS: renders one Ingress whose backend is the release Service on `service.port`.
- `ingress.enabled=true` with no hosts → `ingress.hosts is required when ingress.enabled=true`.
- A host with no paths → `ingress host studio.example.com has no paths — add at least { path: /, pathType: Prefix }`.
- `NOTES.txt` renders `Visit https://studio.example.com` when the host is under `tls`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional chart-managed Ingress for the Studio Helm chart to simplify routing for self-hosters. It’s off by default and backwards compatible; chart bumped to 0.13.0.

- **New Features**
  - Optional Ingress via `ingress.enabled` (default `false`); renders nothing when disabled.
  - Ingress backend targets this release’s Service (no hardcoded Service name).
  - Render-time validation when enabled without `hosts` or when a host has no `paths`.
  - `NOTES.txt` prints the visit URL, preferring https if the host appears in `ingress.tls`.
  - Chart version: 0.12.4 → 0.13.0; no changes required for existing installs.

- **Docs**
  - Added “Expose Studio” step to the Kubernetes guide (en + pt-br) with Ingress, LoadBalancer, and Gateway API examples, plus a values-table row.
  - Updated self-host production README, production values example, and install skill to use the new Ingress and note that `BASE_URL` and `BETTER_AUTH_URL` must match the public URL.

<sup>Written for commit 7b8f2eb2d0899a3982bcc01dd55c54f18dec56a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

