### PR TITLE
fix(mcp-oauth): bound the connection-check probe with a timeout

### DIFF
--- a/apps/web/src/sdk/lib/mcp-oauth.test.ts
+++ b/apps/web/src/sdk/lib/mcp-oauth.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test, afterEach } from "bun:test";
+import { isConnectionAuthenticated } from "./mcp-oauth";
+
+describe("isConnectionAuthenticated", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  test("surfaces a clear message when the probe times out", async () => {
+    global.fetch = (() =>
+      Promise.reject(
+        new DOMException("The operation timed out.", "TimeoutError"),
+      )) as unknown as typeof fetch;
+
+    const result = await isConnectionAuthenticated({
+      url: "https://example.com/api/my-org/mcp/conn-1",
+      token: null,
+    });
+
+    expect(result.isAuthenticated).toBe(false);
+    expect(result.error).toBe("Connection check timed out after 15s");
+  });
+});

--- a/apps/web/src/sdk/lib/mcp-oauth.ts
+++ b/apps/web/src/sdk/lib/mcp-oauth.ts
@@ -125,6 +125,14 @@ export function setMcpOAuthBrowserAdapter(
 const ADAPTER_POLL_INTERVAL_MS = 600;
 
 /**
+ * Ceiling for the `initialize` probe in `isConnectionAuthenticated`. Without
+ * it, a hung MCP server left the caller waiting on the browser's own fetch
+ * timeout (which can be minutes), showing a stuck "checking connection" UI
+ * instead of a clear error.
+ */
+const CONNECTION_CHECK_TIMEOUT_MS = 15_000;
+
+/**
  * Options for the MCP OAuth provider
  */
 export interface McpOAuthProviderOptions {
@@ -887,6 +895,7 @@ export async function isConnectionAuthenticated({
           },
         },
       }),
+      signal: AbortSignal.timeout(CONNECTION_CHECK_TIMEOUT_MS),
     });
 
     // Extract connection ID for OAuth token status check
@@ -948,11 +957,14 @@ export async function isConnectionAuthenticated({
     };
   } catch (error) {
     console.error("[isConnectionAuthenticated] Error:", error);
+    const isTimeout = error instanceof Error && error.name === "TimeoutError";
     return {
       isAuthenticated: false,
       supportsOAuth: false,
       hasOAuthToken: false,
-      error: (error as Error).message,
+      error: isTimeout
+        ? `Connection check timed out after ${CONNECTION_CHECK_TIMEOUT_MS / 1000}s`
+        : (error as Error).message,
     };
   }
 }


### PR DESCRIPTION
**Source:** bug found while hunting the `mcp-oauth-callback` focus area — the timeout/retry hardening on the actual OAuth *popup* flow in `authenticateMcp` is already covered by open PR #5897, but `isConnectionAuthenticated`'s network probe (used to check whether an MCP connection is authenticated / needs OAuth) had no timeout at all.

**Payoff:** without a timeout, a hung or slow-to-respond MCP server left the caller waiting on the browser's own fetch timeout (which can run for minutes), so the connections UI got stuck on "checking connection" instead of surfacing a clear, actionable error quickly.

**Fix:** added a 15s `AbortSignal.timeout()` to the `initialize` probe fetch in `isConnectionAuthenticated`, and a dedicated timeout error message (`Connection check timed out after 15s`) instead of whatever raw `DOMException` text the browser happens to produce. Added `mcp-oauth.test.ts` with a regression test that mocks `fetch` to reject with a `TimeoutError` and asserts the clear message is returned (inverts the old behavior, where a timeout fell through to the generic catch-all and produced an inconsistent/unclear message across browsers).

**To verify:** `bun test apps/web/src/sdk/lib/mcp-oauth.test.ts`

**Checked locally:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, `bunx oxlint apps/web/src/sdk/lib/mcp-oauth.ts apps/web/src/sdk/lib/mcp-oauth.test.ts` (all clean), and the targeted test above (passes). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 15s timeout to the connection check in `isConnectionAuthenticated` so hung MCP servers don’t freeze the UI. Returns a clear timeout error instead of waiting on the browser’s long fetch timeout.

- **Bug Fixes**
  - Bound the probe fetch with `AbortSignal.timeout(15_000)`.
  - Standardized timeout handling and message ("Connection check timed out after 15s"); added a regression test in `mcp-oauth.test.ts`.

<sup>Written for commit 8685d83b79736509eb885da9857ed753cab6feca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5964?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

