### PR TITLE
refactor(connections): remove ConnectionCard's unused body/status props

### DIFF
--- a/apps/web/src/components/connections/connection-card.tsx
+++ b/apps/web/src/components/connections/connection-card.tsx
@@ -9,7 +9,6 @@ export interface ConnectionCardData {
   title: string;
   description?: string | null;
   icon?: string | null;
-  status?: "active" | "inactive" | "error";
 }
 
 export interface ConnectionCardProps {
@@ -17,7 +16,6 @@ export interface ConnectionCardProps {
   onClick?: () => void;
   headerActions?: React.ReactNode;
   headerActionsAlwaysVisible?: boolean;
-  body?: React.ReactNode;
   footer?: React.ReactNode;
   className?: string;
   fallbackIcon?: ReactNode;
@@ -28,7 +26,6 @@ export function ConnectionCard({
   onClick,
   headerActions,
   headerActionsAlwaysVisible = false,
-  body,
   footer,
   className,
   fallbackIcon,
@@ -96,9 +93,6 @@ export function ConnectionCard({
                 t("connections.connectionCard.noDescription")}
             </p>
           </div>
-
-          {/* Body: Additional content like status */}
-          {body && <div>{body}</div>}
         </div>
 
         {/* Footer: Custom footer with border-t spanning full width */}


### PR DESCRIPTION
**Source:** dead-code reduction (C1) found while auditing `apps/web/src/components/connections/connection-card.tsx`, the most-churned file in this tick's connections-UI focus area.

**Why:** `ConnectionCard`'s `body` prop and `ConnectionCardData.status` field are declared but have zero remaining references — no caller (`connections.tsx`, `connection-selection-ui.tsx`, `catalog-item-card.tsx`, `connection-dialog-content.tsx`) ever passes `body` or sets `status` on the object handed to `connection`, and the component itself never reads `connection.status`. Removing them shrinks the public surface of a component that's been through 5 hardening PRs recently, with no behavior change.

**Net delta:** -6 / +0. Confirmed zero references via `rg -n "ConnectionCard" apps/web/src -g '*.tsx' -A20 | grep 'body='` and `rg -n "ConnectionCardData"` (only declared/used inside this file). Callers pass full `ConnectionEntity` objects (which do have a `status` field) as `connection` — since TS allows excess properties on variables (only literals get excess-property checks), removing the optional `status`/`body` fields from the narrower `ConnectionCardData`/`ConnectionCardProps` types doesn't break any caller.

**To verify:** `cd apps/web && bunx tsc --noEmit` stays green; `bun test apps/web/src/components/connections/connection-card.test.tsx` still passes (2/2).

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/web), the targeted test file above, and `bunx oxlint apps/web/src/components/connections/connection-card.tsx` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove unused body prop from ConnectionCard and the status field from ConnectionCardData to reduce dead code and shrink the component’s API. No UI or behavior changes; callers never used these props.

<sup>Written for commit 1d826b236473dbc4bdc316b0a4d3d4f2c46a1a89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

