### PR TITLE
fix(sandbox): a pod that dies mid-run is infrastructure, not a cancel

### DIFF
--- a/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
@@ -3,6 +3,7 @@ import type { UIMessageChunk } from "ai";
 import { harnessRunResultSchema } from "@decocms/sandbox/dispatch/schemas";
 import {
   dispatchWithContinuation,
+  errorForTerminal,
   harnessRunsInSandbox,
   isRunSuperseded,
   isUnreachableStatus,
@@ -308,6 +309,35 @@ describe("dispatchWithContinuation", () => {
     });
     await expect(collect(run)).rejects.toThrow("a newer dispatch took over");
     expect(attempts).toBe(1);
+  });
+});
+
+// Which terminal code continues the turn, which drops it quietly, and which
+// fails it. `sandbox_gone` is the one that changed: the daemon reported an
+// evicted pod as `cancelled`, so a turn nobody stopped was settled as a
+// deliberate cancel and never retried.
+describe("errorForTerminal", () => {
+  test("a sandbox that could not finish is continuable, not a failure", () => {
+    const err = errorForTerminal("sandbox_gone", "the sandbox stopped mid-run");
+    expect(err).toBeInstanceOf(SandboxUnreachableError);
+    expect(isRunSuperseded(err)).toBe(false);
+  });
+
+  test("a takeover stops this attempt quietly", () => {
+    const err = errorForTerminal("superseded", "a newer dispatch took over");
+    expect(isRunSuperseded(err)).toBe(true);
+    expect(err).not.toBeInstanceOf(SandboxUnreachableError);
+  });
+
+  // A cancel a human asked for, and a harness that really crashed, are the
+  // run's own outcome — continuing either would re-run work that already ended.
+  test("a real terminal fails the run", () => {
+    for (const code of ["cancelled", "harness_crashed", "bad_input"]) {
+      const err = errorForTerminal(code, "why");
+      expect(err).not.toBeInstanceOf(SandboxUnreachableError);
+      expect(isRunSuperseded(err)).toBe(false);
+      expect(err.message).toBe(`${code}: why`);
+    }
   });
 });
 

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -485,6 +485,42 @@ function toWireInput(input: HarnessStreamInput): unknown {
   return wire;
 }
 
+/**
+ * How often a streaming dispatch pushes its sandbox's shutdown deadline out.
+ * Same cadence as the preview SSE handler's `TTL_RENEW_MS`, and for the same
+ * reason: comfortably inside the 15-minute claim TTL, so a missed renewal (or a
+ * slow apiserver) still leaves two more chances before the pod is reaped.
+ */
+const TTL_RENEW_MS = 5 * 60_000;
+
+/**
+ * Keep the claim alive on an interval, returning the stop. Best-effort by
+ * construction — a failed renewal costs the run its pod at the deadline, which
+ * is exactly today's behavior, so it must never break the stream it is
+ * protecting.
+ */
+function renewWhileStreaming(
+  provider: SandboxProvider,
+  handle: string,
+): () => void {
+  if (!provider.renewTtl) return () => {};
+  const renew = () =>
+    void provider
+      .renewTtl?.(handle)
+      .catch((err) =>
+        console.warn(
+          `[sandbox-dispatch] TTL renew failed for ${handle}: ${err instanceof Error ? err.message : String(err)}`,
+        ),
+      );
+  // Immediately as well as on the interval: a run dispatched onto a reused
+  // sandbox is adopting a TTL that is already part-spent — that is how a run
+  // could die four minutes in.
+  renew();
+  const timer = setInterval(renew, TTL_RENEW_MS);
+  timer.unref?.();
+  return () => clearInterval(timer);
+}
+
 async function* dispatchToDaemon(args: {
   provider: SandboxProvider;
   handle: string;
@@ -535,6 +571,23 @@ async function* dispatchToDaemon(args: {
     throw new Error(summary);
   }
   if (!res.body) throw new SandboxUnreachableError("dispatch returned no body");
+  // Hold the pod open for as long as this run streams.
+  //
+  // A claim is created with `spec.lifecycle.shutdownTime = now + 15min`
+  // (`DEFAULT_IDLE_TTL_MS`) and the operator deletes the pod at that instant.
+  // `renewTtl` pushes it forward — and until now its ONLY caller was the
+  // preview SSE handler, i.e. a browser being attached. A Super Agent run has
+  // no browser, so nothing renewed it and every headless run had a hard
+  // 15-minute wall clock: at the deadline the operator SIGTERMs the daemon,
+  // `CancelAll` fires, and the turn dies mid-edit. That is the sandbox_gone
+  // case above, and it is why one prod card burned six runs without ever
+  // opening a PR.
+  //
+  // Deliberately NOT the daemon's `/idle` activity — that feeds the
+  // housekeeper's idle sweep, which can only end a claim early, never extend
+  // it. The claim's own deadline is a separate clock and this is the only thing
+  // that moves it.
+  const stopTtlRenew = renewWhileStreaming(args.provider, args.handle);
   let total = 0;
   // Sticky, and only acted on after every frame's chunks are yielded: partial
   // work first, THEN the throw, because the consumer's error path is what
@@ -543,17 +596,24 @@ async function* dispatchToDaemon(args: {
   // the FIRST reason is the real one.
   let error: { code: string; message: string } | null = null;
   let done = false;
-  for await (const line of ndjsonLines(res.body, args.signal)) {
-    const parsed = harnessRunResultSchema.safeParse(line);
-    if (!parsed.success) {
-      throw new Error(
-        `sandbox dispatch returned a malformed frame: ${parsed.error.message}`,
-      );
+  try {
+    for await (const line of ndjsonLines(res.body, args.signal)) {
+      const parsed = harnessRunResultSchema.safeParse(line);
+      if (!parsed.success) {
+        throw new Error(
+          `sandbox dispatch returned a malformed frame: ${parsed.error.message}`,
+        );
+      }
+      total += parsed.data.chunks.length;
+      yield* parsed.data.chunks as UIMessageChunk[];
+      error ??= parsed.data.error;
+      if (parsed.data.done) done = true;
     }
-    total += parsed.data.chunks.length;
-    yield* parsed.data.chunks as UIMessageChunk[];
-    error ??= parsed.data.error;
-    if (parsed.data.done) done = true;
+  } finally {
+    // Every exit path, including the consumer abandoning this generator: a
+    // leaked interval would keep a dead sandbox's claim alive for the rest of
+    // the process's life.
+    stopTtlRenew();
   }
   console.log("[sandbox-dispatch] run ended", {
     runId: args.runId,

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -33,6 +33,10 @@ import type { UIMessageChunk } from "ai";
 import { sleep } from "@decocms/shared/std";
 import type { SandboxClient } from "@decocms/sandbox/dispatch/sandbox-client";
 import { harnessRunResultSchema } from "@decocms/sandbox/dispatch/schemas";
+import {
+  SANDBOX_GONE_TERMINAL_CODE,
+  SANDBOX_UNREACHABLE_PREFIX,
+} from "@decocms/sandbox/dispatch/error-codes";
 import type { SandboxProvider } from "@decocms/sandbox/provider";
 import { isTransientStreamError } from "@/harnesses/decopilot/built-in-tools/subtask";
 import type { HarnessId, HarnessStreamInput } from "@/harnesses/lib/types";
@@ -93,7 +97,10 @@ const DAEMON_SILENCE_TIMEOUT_MS = 90_000;
  */
 export class SandboxUnreachableError extends Error {
   constructor(reason: string) {
-    super(reason);
+    // Prefixed in the CONSTRUCTOR, so the marker `isTransientRunFailure` reads
+    // downstream cannot be forgotten by a new throw site. See
+    // SANDBOX_UNREACHABLE_PREFIX.
+    super(`${SANDBOX_UNREACHABLE_PREFIX} ${reason}`);
     this.name = "SandboxUnreachableError";
   }
 }
@@ -565,12 +572,31 @@ async function* dispatchToDaemon(args: {
       `the sandbox stopped streaming after ${total} chunks without finishing the run`,
     );
   }
-  if (error?.code === SUPERSEDED_TERMINAL_CODE) {
-    // Another dispatch owns this run now. Whatever this attempt streamed above
-    // is already yielded; the successor publishes the terminal.
-    throw new RunSupersededError(error.message);
+  if (error) throw errorForTerminal(error.code, error.message);
+}
+
+/**
+ * What a daemon terminal frame means to this side. Three outcomes, and which
+ * one a code gets decides whether the turn is continued, dropped quietly, or
+ * failed — so it is pure and unit-tested rather than buried in the stream loop.
+ *
+ * - `superseded`: another dispatch owns this run now. Whatever this attempt
+ *   streamed is already yielded; the successor publishes the terminal.
+ * - `sandbox_gone`: the pod could not finish — it was shutting down (eviction,
+ *   scale-in) or our connection to it dropped. Nobody cancelled anything, so it
+ *   continues on a replacement pod exactly like a broken stream does. The
+ *   daemon used to report this case as `cancelled`, which reached the thread as
+ *   `Error: cancelled: run cancelled` and was never retried, on a turn whose
+ *   work was already committed to the branch by the shutdown publish.
+ * - anything else (`harness_crashed`, `cancelled`, `bad_input`, …): a real
+ *   terminal the run reported. Failing is the answer.
+ */
+export function errorForTerminal(code: string, message: string): Error {
+  if (code === SUPERSEDED_TERMINAL_CODE) return new RunSupersededError(message);
+  if (code === SANDBOX_GONE_TERMINAL_CODE) {
+    return new SandboxUnreachableError(message);
   }
-  if (error) throw new Error(`${error.code}: ${error.message}`);
+  return new Error(`${code}: ${message}`);
 }
 
 /**

--- a/apps/api/src/tools/task-board/transient-failure.test.ts
+++ b/apps/api/src/tools/task-board/transient-failure.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { SandboxUnreachableError } from "@/harnesses/sandbox-dispatch-client";
 import {
   isTransientRunFailure,
   retryBudgetFor,
@@ -82,6 +83,41 @@ describe("isTransientRunFailure", () => {
       false,
     );
     expect(isTransientRunFailure({ kind: null })).toBe(false);
+  });
+});
+
+// Every message this class carries is infrastructure by construction, and the
+// board matched NONE of them by wording — so the failure it sees most often got
+// one attempt instead of three. These are the real messages, built through the
+// real constructor, so a reworded one still passes and a DROPPED marker fails.
+describe("SandboxUnreachableError is always infrastructure", () => {
+  const reasons = [
+    "the sandbox stream broke mid-run: The socket connection was closed unexpectedly",
+    "the sandbox stopped mid-run (pod shutting down or connection dropped)",
+    "the sandbox stopped streaming after 94 chunks without finishing the run",
+    "no output from the sandbox for 90s (its keepalive is every 15s, so the pod is gone)",
+    "could not reach the sandbox daemon: fetch failed",
+  ];
+
+  for (const reason of reasons) {
+    test(reason.slice(0, 48), () => {
+      const errorText = `Error: ${new SandboxUnreachableError(reason).message}`;
+      expect(isTransientRunFailure({ kind: "error", errorText })).toBe(true);
+      expect(retryBudgetFor({ kind: "error", errorText })).toBe(
+        TRANSIENT_RETRY_BUDGET,
+      );
+    });
+  }
+
+  // The prefix is what is matched, so a plain error that merely mentions a
+  // sandbox must NOT be promoted to the infrastructure budget.
+  test("prose about a sandbox is not the marker", () => {
+    expect(
+      isTransientRunFailure({
+        kind: "error",
+        errorText: "TypeError: sandbox.stream is not a function",
+      }),
+    ).toBe(false);
   });
 });
 

--- a/apps/api/src/tools/task-board/transient-failure.ts
+++ b/apps/api/src/tools/task-board/transient-failure.ts
@@ -24,6 +24,8 @@
  * entry must be a message a healthy cluster does not produce.
  */
 
+import { SANDBOX_UNREACHABLE_PREFIX } from "@decocms/sandbox/dispatch/error-codes";
+
 /** Failure kinds that are infrastructure whatever the message says. */
 const TRANSIENT_KINDS = new Set([
   "stall",
@@ -103,5 +105,13 @@ export function isTransientRunFailure(failure: {
   if (TRANSIENT_KINDS.has(kind)) return true;
   const text = failure.errorText ?? "";
   if (!text) return false;
+  // Every `SandboxUnreachableError` — the pod stopped mid-turn, its stream
+  // broke, it went silent, or it reported `sandbox_gone`. Checked by MARKER
+  // rather than by wording: the class's constructor stamps it, so unlike the
+  // patterns below this cannot drift and a new throw site is covered the day it
+  // is written. This is the most common infrastructure failure the board sees
+  // and it matched none of the patterns, so every one of them got the
+  // unknown-error budget of a single attempt.
+  if (text.includes(SANDBOX_UNREACHABLE_PREFIX)) return true;
   return TRANSIENT_ERROR_PATTERNS.some((re) => re.test(text));
 }

--- a/packages/sandbox/daemon-go/internal/dispatch/dispatch.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/dispatch.go
@@ -18,6 +18,13 @@ import (
 
 const tombstoneTTL = 60 * time.Second
 
+// Terminal code for a run this pod could not finish (shutdown / dropped
+// connection) as opposed to one that was cancelled on purpose. Studio maps it
+// to `SandboxUnreachableError` and continues the turn elsewhere — the literal
+// is the contract, and its TypeScript half is
+// `SANDBOX_GONE_TERMINAL_CODE` in packages/sandbox/dispatch/error-codes.ts.
+const sandboxGoneCode = "sandbox_gone"
+
 // How long a takeover waits for the run it displaced to actually exit before
 // starting the new one. The displaced harness holds `claude` processes writing
 // into the checkout the new run is about to read, so overlapping them is how
@@ -452,11 +459,26 @@ func (reg *Registry) runHarness(
 				"a newer dispatch took over this run"))
 			return
 		}
-		// Genuinely cancelled: the client hung up, or a DELETE stopped the run
-		// and nothing replaced it. Terminal, so the reader is never left
-		// guessing.
-		slog.Info("dispatch cancelled", "harness", harnessId, "run_id", runId, "elapsed_s", elapsed)
-		body.write(terminalFrame("cancelled", "run cancelled"))
+		// A DELETE stopped this run and nothing replaced it — the tombstone is
+		// that request's own marker, so it is the only proof the cancel was
+		// ASKED FOR. Studio spends no retry on it, which is right: a human said
+		// stop.
+		if reg.tombstoned(runId) {
+			slog.Info("dispatch cancelled", "harness", harnessId, "run_id", runId, "elapsed_s", elapsed)
+			body.write(terminalFrame("cancelled", "run cancelled"))
+			return
+		}
+		// Nobody asked. The ctx died because this daemon is going away
+		// (SIGTERM → `CancelAll`, i.e. the pod was evicted or scaled in) or the
+		// client's connection dropped. Reporting `cancelled` here is how a
+		// pod eviction settled a live thread as `Error: cancelled: run
+		// cancelled` — a verdict Studio never retries, on a turn that was
+		// mid-edit. `sandbox_gone` says the pod could not finish, not that the
+		// run should not: the checkout is intact, the shutdown publish pushes it
+		// to the branch, and a replacement pod can pick the turn up.
+		slog.Info("dispatch sandbox gone", "harness", harnessId, "run_id", runId, "elapsed_s", elapsed)
+		body.write(terminalFrame(sandboxGoneCode,
+			"the sandbox stopped mid-run (pod shutting down or connection dropped)"))
 		return
 	}
 	if err != nil {

--- a/packages/sandbox/daemon-go/internal/dispatch/dispatch_test.go
+++ b/packages/sandbox/daemon-go/internal/dispatch/dispatch_test.go
@@ -259,6 +259,7 @@ func TestTerminalFrameAlwaysMarksDone(t *testing.T) {
 		{"clean", ""},
 		{"crash", "harness_crashed"},
 		{"cancelled", "cancelled"},
+		{"sandbox gone", sandboxGoneCode},
 	} {
 		var frame struct {
 			Chunks []json.RawMessage `json:"chunks"`
@@ -297,5 +298,59 @@ func TestKeepaliveCountsAsActivity(t *testing.T) {
 
 	if idle := activity.Idle().IdleMs; idle > 100 {
 		t.Fatalf("a keepalive tick must count as activity; idle reported %dms", idle)
+	}
+}
+
+// The discriminator between "a human said stop" and "this pod could not
+// finish". Both cancel the run's ctx, and for a long time both reported
+// `cancelled` — which Studio reads as a deliberate act and never retries. A pod
+// evicted mid-turn therefore killed the turn permanently, with the work sitting
+// committed on the branch.
+func TestTombstoneMarksOnlyAskedForCancels(t *testing.T) {
+	const token = "tkn"
+	reg := NewRegistry()
+	entry, _ := reg.claim("run-1", func() {})
+
+	// Shutdown (`CancelAll`) and a dropped connection leave no tombstone: the
+	// run is continuable, so it must NOT be reported as cancelled.
+	reg.CancelAll()
+	if reg.tombstoned("run-1") {
+		t.Fatal("a shutdown cancel must not look like an asked-for cancel")
+	}
+	if reg.displaced("run-1", entry) {
+		t.Fatal("nothing took the run over, so it is not superseded either")
+	}
+
+	// A DELETE is the asked-for one, and it says so on the registry.
+	req := httptest.NewRequest("DELETE", "/runs/run-1", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+	reg.HandleCancel(rec, req, func() string { return token })
+	if rec.Code != 204 {
+		t.Fatalf("cancel returned %d", rec.Code)
+	}
+	if !reg.tombstoned("run-1") {
+		t.Fatal("a DELETE must mark the run as deliberately cancelled")
+	}
+
+	// Scoped to the run it named — a sibling run on the same pod is untouched.
+	if reg.tombstoned("run-2") {
+		t.Fatal("a cancel must not tombstone another run")
+	}
+}
+
+// An unauthorized DELETE must not be able to turn a continuable failure into a
+// permanent one.
+func TestUnauthorizedCancelLeavesNoTombstone(t *testing.T) {
+	reg := NewRegistry()
+	reg.claim("run-1", func() {})
+	rec := httptest.NewRecorder()
+	reg.HandleCancel(rec, httptest.NewRequest("DELETE", "/runs/run-1", nil),
+		func() string { return "tkn" })
+	if rec.Code != 401 {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+	if reg.tombstoned("run-1") {
+		t.Fatal("a rejected cancel must not tombstone the run")
 	}
 }

--- a/packages/sandbox/dispatch/error-codes.ts
+++ b/packages/sandbox/dispatch/error-codes.ts
@@ -12,3 +12,31 @@ export const LINK_ERROR_CODES = [
 ] as const;
 
 export type LinkErrorCode = (typeof LINK_ERROR_CODES)[number];
+
+/**
+ * The daemon's terminal code for a run its pod could not finish: the daemon is
+ * shutting down (SIGTERM → `CancelAll`, i.e. the pod was evicted or scaled in)
+ * or the client's connection dropped. NOT `cancelled` — nobody asked for this
+ * to stop, the work is in the checkout (and, on shutdown, pushed to the branch
+ * by the publish that runs right after), and the turn is continuable on a
+ * replacement pod.
+ *
+ * Kept here rather than next to the daemon because both ends must agree on the
+ * literal: the daemon writes it, `sandbox-dispatch-client` maps it to
+ * `SandboxUnreachableError`.
+ */
+export const SANDBOX_GONE_TERMINAL_CODE = "sandbox_gone";
+
+/**
+ * Stable marker on every `SandboxUnreachableError` message — same convention as
+ * `[SUBSCRIPTION_REQUIRED]` and `[CREDITS]`: a prefix that survives the trip
+ * through an error part's text, so a reader downstream can recognize the class
+ * without matching prose.
+ *
+ * The reader is `isTransientRunFailure` (tools/task-board/transient-failure.ts),
+ * which decides whether a failed task run is worth re-dispatching. It used to
+ * match each of these messages by wording and matched none of them, so the most
+ * common infrastructure failure there is got the unknown-error budget of one
+ * attempt instead of the full three.
+ */
+export const SANDBOX_UNREACHABLE_PREFIX = "[SANDBOX_UNREACHABLE]";

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -243,7 +243,9 @@ const PORT_WALK_LIMIT = 256;
 // one type isn't worth it.
 interface ForwardWebSocket {
   close: () => void;
-  on: (event: "close" | "error", handler: () => void) => void;
+  /** `error` carries the cause; `close` does not. Optional so a `close`
+   *  handler that ignores it still satisfies the type. */
+  on: (event: "close" | "error", handler: (err?: unknown) => void) => void;
 }
 
 interface PortForwarder {
@@ -2557,7 +2559,17 @@ export class AgentSandboxProvider implements SandboxProvider {
         }
         ws = opened as ForwardWebSocket;
         ws.on("close", cleanup);
-        ws.on("error", () => {
+        ws.on("error", (err?: unknown) => {
+          // Logged for the same reason as the `.catch` below, and it matters
+          // MORE here: this branch fires when an ESTABLISHED forward dies
+          // mid-run, which is what a dispatch sees as "the socket connection
+          // was closed unexpectedly". It was silent, so the one question that
+          // failure raises — apiserver recycling the connection, the pod going
+          // away, a TLS error — had no answer anywhere in the logs.
+          console.warn(
+            `[${LOG_LABEL}] port-forward to ${podName}:${containerPort} dropped mid-connection: ${errMsg(err)}`,
+            JSON.stringify(describeErrorChain(err)),
+          );
           this.invalidateRecord(handle);
           cleanup();
         });


### PR DESCRIPTION
Found debugging `board_46FLuBSK-bxaqPQ3_t4E1` (deco-studio): 6 runs, all failed, no PR, `run_count` past the cap.

## 1. `cancelled: run cancelled` is still happening — #5859 only fixed half

Three of that card's six runs died with it, on 08-11, four days after #5859. That PR handled the **displaced** case (takeover → `superseded`). The other branch is unchanged:

```go
// Genuinely cancelled: the client hung up, or a DELETE stopped the run…
body.write(terminalFrame("cancelled", "run cancelled"))
```

Those two causes are not the same thing. On SIGTERM the daemon calls `dispatchReg.CancelAll()`, every in-flight dispatch lands here, and Studio reads `cancelled` as the run's verdict — `DELIBERATE_KINDS`, zero retries. So **a sandbox pod being evicted or scaled in permanently kills the turn**, and it does it on the most recoverable failure there is: `shutdown()` runs `gitx.Publish` immediately after, so the work is already committed and pushed to the branch.

The discriminator was already there and unused — `HandleCancel` writes `reg.tombstones[runId]`, which is the only proof a stop was *asked for*. Now:

| | terminal | Studio |
|---|---|---|
| displaced by a takeover | `superseded` | stop quietly, successor owns it |
| tombstoned (a DELETE) | `cancelled` | fail, no retry — a human said stop |
| **neither** | **`sandbox_gone`** | **`SandboxUnreachableError` → continue on a fresh pod** |

## 2. No `SandboxUnreachableError` message was recognized as infrastructure

There are five of them (`the sandbox stream broke mid-run: …`, `no output from the sandbox for 90s`, `the sandbox stopped streaming after N chunks`, …). `TRANSIENT_ERROR_PATTERNS` matched **none**, so the failure the board sees most often got `UNKNOWN_RETRY_BUDGET = 1` instead of `TRANSIENT_RETRY_BUDGET = 3`. Every "retry 1 of 1" on that card's timeline is this.

Fixed by marker, not by wording: the constructor stamps `[SANDBOX_UNREACHABLE]` (same convention as `[SUBSCRIPTION_REQUIRED]` / `[CREDITS]`) and `isTransientRunFailure` checks for it. A reworded message stays covered; so does a throw site written next year.

## 3. The forwarder's error branch was silent

`ws.on("error")` invalidated the record and cleaned up without logging. That is the branch that fires when an *established* port-forward dies mid-run — i.e. the source of "The socket connection was closed unexpectedly" — so **why** it keeps happening has no answer anywhere in the logs. It now logs the cause chain like the sibling `.catch` already does. I still can't tell you the root cause of the drops; this is what makes the next one answerable.

## Testing

- Go: `TestTombstoneMarksOnlyAskedForCancels` (shutdown/dropped ≠ DELETE, and the tombstone is per-run), `TestUnauthorizedCancelLeavesNoTombstone` (a rejected DELETE must not turn a continuable failure into a permanent one), `sandbox_gone` added to the terminal-frame table. `go test ./internal/dispatch/` ok.
- TS: `errorForTerminal` extracted pure from the stream loop (it replaces three inline branches) and unit-tested for all three outcomes; the five real `SandboxUnreachableError` messages asserted transient **through the real constructor**, so dropping the marker fails the test; a plain error mentioning "sandbox" asserted *not* transient.
- `bun test` on both touched files: 43 pass. `bun run check`, `lint`, `fmt` clean.

## Rollout

The daemon ships in the sandbox image, Studio in the API — they roll separately, and either order is safe: an old Studio sees `sandbox_gone` and fails the run exactly as it fails `cancelled` today (no worse), and an old daemon keeps sending `cancelled`, which a new Studio still treats as deliberate. The improvement lands when both are out.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat sandbox pods that die mid-run as infrastructure, not user cancels. Adds `sandbox_gone` → `SandboxUnreachableError`, renews the sandbox claim TTL while streaming to prevent 15‑minute evictions, continues runs on a fresh pod with the correct retry budget, and logs dropped port-forward connections.

- **Bug Fixes**
  - Daemon: emit `sandbox_gone` when a run ends without a tombstone (pod shutdown/connection drop). Keep `cancelled` only for real DELETEs. Studio maps `sandbox_gone` to `SandboxUnreachableError` and continues the turn.
  - Dispatch client: renew claim TTL during streaming (immediately and every 5 minutes) and stop on exit, so headless runs don’t hit the 15‑minute shutdown.
  - Task board: mark all `SandboxUnreachableError` messages with `SANDBOX_UNREACHABLE_PREFIX` and treat them as transient (full retry budget).
  - Agent sandbox: log cause chain on `ws.on("error")` for established port-forward drops.

- **Migration**
  - Backward compatible. Old Studio treats `sandbox_gone` like `cancelled`; new Studio still handles old `cancelled`. Improvement appears when both daemon and Studio are deployed.

<sup>Written for commit 7bf1713ffc028a57ce467a90e390e9ba75132304. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

