### PR TITLE
test(sandbox): assert a DELETE still terminates as `cancelled`

### DIFF
--- a/packages/sandbox/daemon-e2e/daemon.dispatch.e2e.test.ts
+++ b/packages/sandbox/daemon-e2e/daemon.dispatch.e2e.test.ts
@@ -399,10 +399,20 @@ describe("daemon e2e: dispatch runs a harness", () => {
   );
 
   it(
-    "cancelling a run kills the harness instead of waiting for it",
+    "cancelling a run kills the harness and reports `cancelled`, not `sandbox_gone`",
     async () => {
       const started = Date.now();
-      const run = dispatch("hang", "run-hang");
+      const res = await dispatch("hang", "run-hang");
+      expect(res.status).toBe(200);
+
+      // Read the body in the background so the terminal the cancel produces is
+      // observed rather than discarded.
+      const ended = (async () => {
+        const frames: DispatchFrame[] = [];
+        for await (const { frame } of readFrames(res)) frames.push(frame);
+        return frames;
+      })();
+
       // Let the daemon exec the harness before cancelling it.
       await new Promise((r) => setTimeout(r, 500));
       const cancel = await fetch(url(d, "/_sandbox/runs/run-hang"), {
@@ -410,12 +420,17 @@ describe("daemon e2e: dispatch runs a harness", () => {
         headers: authHeaders(),
       });
       expect(cancel.status).toBe(204);
-      // The dispatch ends with the run — either a dropped connection or an
-      // answered request, but never by outliving the cancel.
-      await run.then(
-        (res) => res.body?.cancel(),
-        () => undefined,
-      );
+
+      const frames = await ended;
+      // A DELETE is the ONE cancel a human asked for, and the tombstone it
+      // leaves is the only proof of that. Everything else that cancels the run's
+      // ctx — this daemon shutting down, the client hanging up — now reports
+      // `sandbox_gone`, which Studio CONTINUES on a replacement pod. Reporting
+      // that here would make a deliberate stop restart itself.
+      const terminal = frames.at(-1);
+      expect(terminal?.done).toBe(true);
+      expect(terminal?.error?.code).toBe("cancelled");
+      // The run ended with the cancel, never by outliving it.
       expect(Date.now() - started).toBeLessThan(20_000);
     },
     HOOK_TIMEOUT_MS,


### PR DESCRIPTION
Follow-up to #5966 (merged) — the test missed the merge by about a minute.

#5966 split the daemon's single cancel branch in two:

- tombstoned run (a DELETE someone actually sent) → `cancelled`, never retried
- everything else (daemon shutdown, dropped client) → `sandbox_gone`, which Studio maps to `SandboxUnreachableError` and **continues on a replacement pod**

The dangerous direction of that split is a real cancel leaking into `sandbox_gone`: a run a human stopped would quietly restart itself. Nothing guarded it. The existing cancel test threw the body away (`res.body?.cancel()`), so it proved the harness died but never read the terminal frame that says *why* — the exact field the split changed.

It now reads the frames and asserts `error.code === "cancelled"`. Black-box over HTTP, same as the rest of the suite.

`bun test daemon-e2e/daemon.dispatch.e2e.test.ts` against the Go daemon: 16/16 pass. Test-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the e2e cancel test to read terminal frames and assert a DELETE ends with error code "cancelled", not "sandbox_gone". Prevents regressions where a user-stopped run could restart on a replacement pod.

<sup>Written for commit a857643375964fc6ee2ac210adf77e5c9e5b560a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

