### PR TITLE
refactor(storage): remove dead TagStoragePort interface

### DIFF
--- a/apps/api/src/storage/ports.ts
+++ b/apps/api/src/storage/ports.ts
@@ -28,7 +28,6 @@ import type {
   OrganizationJoinRequest,
   OrgSite,
   OrganizationSettings,
-  OrganizationTag,
   Thread,
   ThreadMessage,
 } from "./types";
@@ -691,38 +690,6 @@ export interface VirtualMcpPluginConfigStoragePort {
   getBoundConnectionsForVirtualMcps(
     virtualMcpIds: string[],
   ): Promise<Map<string, BoundConnectionSummary[]>>;
-}
-
-// ============================================================================
-// Tag Storage Port
-// ============================================================================
-
-export interface TagStoragePort {
-  // Organization tags
-  listOrgTags(organizationId: string): Promise<OrganizationTag[]>;
-  getTag(tagId: string): Promise<OrganizationTag | null>;
-  getTagByName(
-    organizationId: string,
-    name: string,
-  ): Promise<OrganizationTag | null>;
-  createTag(organizationId: string, name: string): Promise<OrganizationTag>;
-  deleteTag(tagId: string): Promise<void>;
-
-  // Member tags
-  getMemberTags(memberId: string): Promise<OrganizationTag[]>;
-  setMemberTags(memberId: string, tagIds: string[]): Promise<void>;
-  addMemberTag(memberId: string, tagId: string): Promise<void>;
-  removeMemberTag(memberId: string, tagId: string): Promise<void>;
-
-  // Member verification
-  verifyMemberOrg(memberId: string, organizationId: string): Promise<boolean>;
-
-  // Bulk operations for monitoring
-  getUserTagsInOrg(
-    userId: string,
-    organizationId: string,
-  ): Promise<OrganizationTag[]>;
-  getMembersWithTags(organizationId: string): Promise<Map<string, string[]>>;
 }
 
 // ============================================================================


### PR DESCRIPTION
**Source:** C1 dead-code reduction — hunted in `apps/api/src/storage/ports.ts` per my focus area (storage ports cleanup).

**Why:** `TagStoragePort` is an exported interface with zero references anywhere in the repo outside its own declaration. The real wiring never used it: `apps/api/src/core/context-factory.ts` instantiates the concrete `TagStorage` class directly, and `apps/api/src/core/studio-context.ts` types the `tags` field as `TagStorage`, not `TagStoragePort`. It's a port abstraction that was defined but never adopted — pure dead code.

**Verified behavior-preserving:** `rg -w TagStoragePort` across `apps/api`, `apps/web`, and `packages` shows only the declaration itself (now removed). Its sibling import `OrganizationTag` became unused as a result and was removed from the same import block. No runtime behavior changes — this is a type-only deletion.

**Net line delta:** -30 / +0.

**Reviewer check:** `cd apps/api && bunx tsc --noEmit` (green) and `bunx oxlint apps/api/src/storage/ports.ts` (0 warnings/errors).

**Locally verified:** `bun run fmt`, `bunx tsc --noEmit` (apps/api workspace), `bunx oxlint` on the changed file. No test file needed — this is a pure dead-code deletion proven by grep, not a behavior change. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the dead `TagStoragePort` interface from `apps/api/src/storage/ports.ts` and the now-unused `OrganizationTag` import. This is a type-only cleanup with no behavior changes; the codebase uses the concrete `TagStorage` class directly.

<sup>Written for commit 312600ca45e2f81a4bacc0722b1adcf6e762d7f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

