### PR TITLE
fix(task-board): don't block manual re-delegation on the per-task run cap

### DIFF
--- a/apps/api/src/tools/task-board/enqueue-super-agent.ts
+++ b/apps/api/src/tools/task-board/enqueue-super-agent.ts
@@ -30,9 +30,10 @@ import {
 export async function reactToSuperAgentDelegation(
   ctx: StudioContext,
   item: TaskBoardItem,
+  opts?: Pick<SuperAgentPromptOpts, "userInitiated">,
 ): Promise<void> {
   if (item.assigneeId !== SUPER_AGENT_ASSIGNEE_ID) return;
-  await enqueueSuperAgentForTask(ctx, item).catch((err) => {
+  await enqueueSuperAgentForTask(ctx, item, opts).catch((err) => {
     // A paywall rejection is NOT best-effort: swallowing it would leave the
     // task delegated-but-never-running with only a log line. Callers decide
     // (the update tool surfaces it; the import route un-delegates).

--- a/apps/api/src/tools/task-board/reports-task-guards.integration.test.ts
+++ b/apps/api/src/tools/task-board/reports-task-guards.integration.test.ts
@@ -154,6 +154,29 @@ describe("reports-task guards", () => {
     expect((await taskBoard.getById(second.id, ORG))?.assigneeId).toBeNull();
   });
 
+  // Mirrors TASK_BOARD_ITEM_RERUN's userInitiatedTaskQuotaConfig() precheck.
+  it("a HUMAN re-delegating a runs-exhausted task is not blocked by the per-task cap", async () => {
+    const config = {
+      enforced: true,
+      freeTaskExecutions: 5,
+      monthlyTaskExecutions: 5,
+      maxRunsPerTask: 1,
+    };
+    const task = await taskBoard.create({
+      organizationId: ORG,
+      title: "finding-c",
+      by: "system",
+    });
+    await claimTaskExecution(ctx, task, config);
+    // The task already burned its one allowed run — the automatic config refuses it.
+    await expect(ensureTaskExecutionAllowed(ctx, task, config)).rejects.toThrow(
+      /execution limit/,
+    );
+    // Re-delegating it BY HAND must still be allowed.
+    const manual = { ...config, maxRunsPerTask: Number.POSITIVE_INFINITY };
+    await ensureTaskExecutionAllowed(ctx, task, manual);
+  });
+
   // Inverts the old assertion: delete used to be refused for a reports task.
   it("deletes a reports task and dismisses its finding", async () => {
     const reportsTask = await taskBoard.create({

--- a/apps/api/src/tools/task-board/update.ts
+++ b/apps/api/src/tools/task-board/update.ts
@@ -15,6 +15,7 @@ import { emitTaskBoardUpdated } from "./run-reactions";
 import {
   ensureTaskExecutionAllowed,
   isReportsTask,
+  userInitiatedTaskQuotaConfig,
 } from "../../billing/task-quota";
 
 /**
@@ -213,7 +214,12 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
       // delegated-but-never-running (the dispatch-side claim would throw
       // after the assignee already persisted).
       if (becameSuperAgent) {
-        await ensureTaskExecutionAllowed(ctx, previous);
+        // A human is delegating this card manually — the per-task run cap must not block it, only the period bucket.
+        await ensureTaskExecutionAllowed(
+          ctx,
+          previous,
+          userInitiatedTaskQuotaConfig(),
+        );
       }
     }
 
@@ -293,7 +299,9 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
     if (hasFieldUpdate || input.linkThreadId) {
       emitTaskBoardUpdated(organizationId, item);
     }
-    if (becameSuperAgent) await reactToSuperAgentDelegation(ctx, item);
+    if (becameSuperAgent) {
+      await reactToSuperAgentDelegation(ctx, item, { userInitiated: true });
+    }
 
     return { item };
   },


### PR DESCRIPTION
Follows #5932/#5935, which fixed the same bug for `TASK_BOARD_ITEM_RERUN` but missed the identical path in `TASK_BOARD_ITEM_UPDATE`'s manual drag-to-delegate flip.

**Failure scenario:** a reports-pushed task burns its `maxRunsPerTask` cap on automatic retries (a re-delegation loop, review bounces, the sweeper's infra retries). A human then drags the card onto the Super Agent by hand — `update.ts` called `ensureTaskExecutionAllowed(ctx, previous)` with the default (automatic) config, which still enforces the per-task cap, so the precheck throws `[SUBSCRIPTION_REQUIRED] ... execution limit`. Worse: since this precheck runs *before* the write, the user just sees the error, but if it had instead reached dispatch, the assignee would already be persisted with nothing running.

**Fix:** `update.ts` now calls `ensureTaskExecutionAllowed` with `userInitiatedTaskQuotaConfig()` (the same helper `TASK_BOARD_ITEM_RERUN` already uses) for the manual flip's precheck, and threads `{ userInitiated: true }` through `reactToSuperAgentDelegation` → `enqueueSuperAgentForTask` so the dispatch-side claim matches. Only the period bucket (trial/monthly) still gates a human's manual delegation — the per-task run cap, which exists to bound *automatic* re-dispatch, no longer does.

**Regression test:** added to `reports-task-guards.integration.test.ts` (real Postgres) — a runs-exhausted task is refused by the automatic config, but the same task with the manual (`userInitiated`-shaped) config is allowed, mirroring the existing `task-quota.integration.test.ts` coverage for the Re-run case.

**To confirm:** `bun test apps/api/src/tools/task-board/reports-task-guards.integration.test.ts` against a real Postgres (the `storage-integration` CI job runs this).

**Locally verified:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, and `bunx oxlint` on the three touched files all pass. The integration test itself needs the Postgres this sandbox doesn't have — full CI validates it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Manual drag-to-delegate to the Super Agent is no longer blocked by the per-task run cap; only the trial/monthly bucket applies. This matches the behavior already fixed for Re-run.

- **Bug Fixes**
  - Use userInitiatedTaskQuotaConfig() in the manual delegation precheck in update.ts.
  - Thread { userInitiated: true } through reactToSuperAgentDelegation → enqueueSuperAgentForTask so the dispatch claim aligns.
  - Add an integration test: automatic config rejects a runs-exhausted task, manual delegation passes.

<sup>Written for commit 50f776c3c073ab7358293539ffbd7428822a17d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

