### PR TITLE
fix(connections): don't expose a no-op click target on the catalog card

### DIFF
--- a/apps/web/src/routes/orgs/catalog-item-card.test.tsx
+++ b/apps/web/src/routes/orgs/catalog-item-card.test.tsx
@@ -1,0 +1,61 @@
+import { setupComponentTest } from "../../../test/setup"; // happy-dom + jest-dom matchers
+setupComponentTest();
+import { describe, expect, it, mock } from "bun:test";
+import { fireEvent, render as renderBare } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { CatalogItemCard } from "./catalog-item-card";
+import type { RegistryItem } from "@/components/store/types";
+
+// useT() reads its language preference through TanStack Query.
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+const render = (ui: Parameters<typeof renderBare>[0]) =>
+  renderBare(ui, { wrapper });
+
+const item: RegistryItem = {
+  id: "provider/app",
+  title: "App",
+  server: { name: "app" },
+};
+
+describe("CatalogItemCard", () => {
+  it("is not exposed as a button when the viewer can't connect or navigate", () => {
+    const { container } = render(
+      <CatalogItemCard
+        item={item}
+        canManage={false}
+        allConnections={[]}
+        connectedAppNames={new Set()}
+        connectingItemId={null}
+        onNavigateConnected={mock()}
+        onConnect={mock()}
+      />,
+    );
+    expect(container.querySelector('[role="button"]')).toBeNull();
+  });
+
+  it("is clickable to connect when the viewer can manage connections", () => {
+    const onConnect = mock();
+    const { container } = render(
+      <CatalogItemCard
+        item={item}
+        canManage
+        allConnections={[]}
+        connectedAppNames={new Set()}
+        connectingItemId={null}
+        onNavigateConnected={mock()}
+        onConnect={onConnect}
+      />,
+    );
+    const card = container.querySelector('[role="button"]');
+    expect(card).not.toBeNull();
+    fireEvent.keyDown(card as Element, { key: "Enter" });
+    expect(onConnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/routes/orgs/catalog-item-card.tsx
+++ b/apps/web/src/routes/orgs/catalog-item-card.tsx
@@ -67,6 +67,8 @@ export function CatalogItemCard({
   );
 
   const isCommunity = isCommunityItem(item);
+  // Members without connections:manage can browse but not connect.
+  const isClickable = isConnected || canManage;
 
   const handleClick = () => {
     if (isConnected) {
@@ -76,11 +78,7 @@ export function CatalogItemCard({
       }
       return;
     }
-    // Connecting installs a connection (connections:manage). Members without it
-    // can browse the catalog but not connect.
-    if (canManage) {
-      handleConnect();
-    }
+    handleConnect();
   };
 
   const handleConnect = () => {
@@ -108,7 +106,7 @@ export function CatalogItemCard({
       <ConnectionCard
         connection={{ title, description, icon }}
         fallbackIcon={<Container />}
-        onClick={handleClick}
+        onClick={isClickable ? handleClick : undefined}
         headerActionsAlwaysVisible
         headerActions={
           <div className="flex items-center gap-2">


### PR DESCRIPTION
**Source:** bug found while auditing `ConnectionCard` usage in the "Connection Card polish" focus area.

**Bug:** `CatalogItemCard` always passed `handleClick` to `ConnectionCard`'s `onClick`, even for a viewer who is neither `isConnected` nor `canManage`. `ConnectionCard` treats any truthy `onClick` as an actual action: it adds `cursor-pointer`, `role="button"`, `tabIndex={0}`, and wires Enter/Space to fire the click handler. So a non-manager browsing an unconnected catalog item saw a keyboard-focusable, clickable-looking card that silently called `handleConnect()` → `onConnect(item)` on click/Enter — a real permission-boundary leak (an action that should be gated by `canManage` fired anyway) and an a11y correctness gap (an inert card exposed as an interactive button).

**Fix:** only pass `onClick` when the card has a real action (`isConnected || canManage`); otherwise pass `undefined` so `ConnectionCard` renders it as a plain, non-interactive card.

**Regression test:** `apps/web/src/routes/orgs/catalog-item-card.test.tsx` — asserts no `role="button"` element exists when `canManage=false` and the item isn't connected, and that Enter still triggers `onConnect` when `canManage=true`.

**Reviewer check:** `bun test apps/web/src/routes/orgs/catalog-item-card.test.tsx`

**Locally verified:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, `bunx oxlint apps/web/src/routes/orgs/catalog-item-card.tsx apps/web/src/routes/orgs/catalog-item-card.test.tsx`, and the targeted test above all pass. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `CatalogItemCard` from rendering as an interactive button when the viewer has no action. Previously it always passed `onClick` to `ConnectionCard`, exposing `role="button"` and sometimes calling `onConnect` for non-managers; now it only passes `onClick` when `isConnected || canManage`, restoring a11y and permission gates.

- Gates clickability via `isClickable = isConnected || canManage` and `onClick={isClickable ? handleClick : undefined}`; removes the inner `canManage` check from `handleClick`.
- Adds `apps/web/src/routes/orgs/catalog-item-card.test.tsx` to verify no `role="button"` for non-managers on unconnected items and that Enter triggers `onConnect` when `canManage` is true.

<sup>Written for commit 1161c1eca5f7111d4f1a287786e49303963f5454. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5972?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

