### PR TITLE
fix(task-board): don't dispatch a retry on a dismissed card

### DIFF
--- a/apps/api/src/storage/task-board-due-retry.integration.test.ts
+++ b/apps/api/src/storage/task-board-due-retry.integration.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Real-Postgres coverage for `listItemsDueForRetry` excluding dismissed cards.
+ *
+ * The bug this encodes: a reports-pushed task's `delete()` only stamps
+ * `dismissed_at` (it keeps the row so the next diagnostic import doesn't
+ * recreate the card) — it never touches `status`/`retry_at`. Without a
+ * `dismissed_at IS NULL` filter here, a card whose retry was already armed
+ * when the user dismissed it stays visible to the review sweeper's retry
+ * pass, which dispatches a brand-new Super Agent run against a card the user
+ * already removed from the board.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { sql } from "kysely";
+import type { StudioDatabase } from "../database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../database/test-db-pg";
+import { TaskBoardStorage } from "./task-board";
+
+const ORG = "org_due_retry";
+const USER = "user_due_retry";
+
+describe("listItemsDueForRetry (real Postgres)", () => {
+  let database: StudioDatabase;
+  let taskBoard: TaskBoardStorage;
+
+  const dueRetryCard = async (title: string, by: string) => {
+    const task = await taskBoard.create({
+      organizationId: ORG,
+      title,
+      status: "in_progress",
+      by,
+    });
+    const claimed = await taskBoard.scheduleRunRetry(
+      task.id,
+      ORG,
+      1,
+      new Date(Date.now() - 1000),
+    );
+    expect(claimed).toBe(true);
+    return task;
+  };
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    await database.db
+      .insertInto("organization")
+      .values({
+        id: ORG,
+        name: ORG,
+        slug: "org-due-retry",
+        createdAt: new Date().toISOString(),
+      })
+      .execute();
+    const now = new Date().toISOString();
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES (${USER}, ${"due-retry@test"}, false, ${USER}, ${now}, ${now})
+    `.execute(database.db);
+    taskBoard = new TaskBoardStorage(database.db);
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  it("returns a due card created by a normal user", async () => {
+    const task = await dueRetryCard("normal retry", USER);
+
+    const due = await taskBoard.listItemsDueForRetry(50, new Date());
+
+    expect(due.map((r) => r.id)).toContain(task.id);
+  });
+
+  it("excludes a reports card dismissed while its retry was still armed", async () => {
+    const task = await dueRetryCard("dismissed while pending", "system");
+
+    // Mirrors TASK_BOARD_ITEM_DELETE on a reports task: stamps dismissed_at only.
+    await taskBoard.delete(task.id, ORG, USER);
+    const row = await database.db
+      .selectFrom("task_board_items")
+      .select("dismissed_at")
+      .where("id", "=", task.id)
+      .executeTakeFirst();
+    expect(row?.dismissed_at).toBeTruthy();
+
+    const due = await taskBoard.listItemsDueForRetry(50, new Date());
+
+    expect(due.map((r) => r.id)).not.toContain(task.id);
+  });
+});

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -824,6 +824,14 @@ export class TaskBoardStorage {
   /**
    * Cards whose retry is due, oldest first. Claimed one at a time by the caller
    * via `claimDueRetry`, so a batch read here is safe across replicas.
+   *
+   * `dismissed_at IS NULL` matters here specifically: a reports-pushed task's
+   * `delete()` only sets `dismissed_at` (it keeps the row so re-import doesn't
+   * recreate the card), leaving `status`/`retry_at` untouched. Without this
+   * filter a card dismissed while its retry was still pending gets a brand-new
+   * Super Agent run dispatched on it after the user already deleted it from the
+   * board — the same class of bug the other list queries here already guard
+   * against.
    */
   async listItemsDueForRetry(
     limit: number,
@@ -839,6 +847,7 @@ export class TaskBoardStorage {
       .where("retry_at", "is not", null)
       .where("retry_at", "<=", now)
       .where("status", "=", "in_progress")
+      .where("dismissed_at", "is", null)
       .orderBy("retry_at", "asc")
       .limit(limit)
       .execute();


### PR DESCRIPTION
The review sweeper's `dispatchDueRetries` pass calls `listItemsDueForRetry`, which had no `dismissed_at IS NULL` filter — unlike the sweeper's other two list queries (`listItemsPendingReview`, `listItemsStuckAfterFailure`), which both already guard on it.

Failure scenario: a reports-pushed task (`created_by = "system"`) is In Progress with a retry armed (a prior dispatch hit a transient failure and got re-armed via `scheduleRunRetry`). The user deletes the card from the board. `TASK_BOARD_ITEM_DELETE` → storage `delete()` only stamps `dismissed_at` on a reports task (it keeps the row so the next diagnostic import doesn't recreate it) — it never touches `status`/`retry_at`. On the next sweep tick, `listItemsDueForRetry` still returns the card, `claimDueRetry` claims it, and the sweeper dispatches a brand-new Super Agent run (spending quota and opening/updating a PR) against a card the user already removed from the board.

Fix: add the same `dismissed_at IS NULL` filter this table's other sweeper queries already carry.

Regression test: `apps/api/src/storage/task-board-due-retry.integration.test.ts` creates a reports-created card with an armed retry, dismisses it via `delete()`, and asserts `listItemsDueForRetry` no longer returns it (plus a control case proving a normal due card is still returned). This needs real Postgres (per TESTING.md) and will run in CI's `storage-integration` workflow — this sandbox has no Docker/Postgres to run it locally.

Reviewer check: `bun test apps/api/src/storage/task-board-due-retry.integration.test.ts` against a real Postgres (see the `test-db-pg.ts` header for the one-time local setup).

Locally verified: `bun run fmt`, `bunx tsc --noEmit` in `apps/api` (clean), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI (including the storage-integration job that actually runs this test) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops dispatching retries for dismissed task-board cards. Previously, `listItemsDueForRetry` returned dismissed items, so the sweeper could claim and run a retry after a user deleted a reports-pushed card; now dismissed items are excluded, preventing unwanted runs and quota spend.

- Adds a `dismissed_at IS NULL` filter to `listItemsDueForRetry` to match the other sweeper queries.
- Adds a Postgres integration test that verifies dismissed reports cards are not returned while normal due retries are.
- To verify locally: run `bun test apps/api/src/storage/task-board-due-retry.integration.test.ts` against a real Postgres (see `test-db-pg.ts`).

<sup>Written for commit e4a0143222a28297ee6b79d56d230ffd4e9413aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

