### PR TITLE
fix(reports): Google sign-in is rejected on every shared deck link

### DIFF
--- a/apps/web/src/routes/reports/auth-gate.tsx
+++ b/apps/web/src/routes/reports/auth-gate.tsx
@@ -8,6 +8,7 @@ import type {
 import { faviconForDomain } from "@decocms/shared/report-seo";
 import { isPostHogInitialized } from "@/lib/posthog-client";
 import { KEYS } from "@/lib/query-keys";
+import { callbackUrl } from "./callback-url";
 import { useT } from "@/i18n/use-t.ts";
 import { ReportSocialProof } from "./report-social-proof";
 import {
@@ -71,12 +72,6 @@ function getReportAuthCopy(
     verify: t("reports.authGate.verify"),
     useDifferentEmail: t("reports.authGate.useDifferentEmail"),
   };
-}
-
-function callbackUrl(domain: string): string {
-  const path = `/report/${encodeURIComponent(domain)}`;
-  if (typeof window === "undefined") return path;
-  return `${path}${window.location.search}${window.location.hash}`;
 }
 
 // Mock findings mirroring the deck cover's clickable TOC.

--- a/apps/web/src/routes/reports/callback-url.test.ts
+++ b/apps/web/src/routes/reports/callback-url.test.ts
@@ -10,7 +10,9 @@ const BETTER_AUTH_RELATIVE =
 
 // The module reads `window.location` and falls back to a bare path when there
 // is no window (SSR), so the test provides one.
-const g = globalThis as { window?: { location: { search: string; hash: string } } };
+const g = globalThis as {
+  window?: { location: { search: string; hash: string } };
+};
 const setLocation = (search: string, hash: string) => {
   g.window = { location: { search, hash } };
 };

--- a/apps/web/src/routes/reports/callback-url.test.ts
+++ b/apps/web/src/routes/reports/callback-url.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { callbackUrl } from "./callback-url";
+
+// The pattern Better Auth 1.4.22 applies to a relative `callbackURL`
+// (matchesOriginPattern, allowRelativePaths branch). Copied verbatim so this
+// test fails loudly if an upgrade widens or narrows it — that is the contract
+// callbackUrl() has to satisfy, and every value below is checked against it.
+const BETTER_AUTH_RELATIVE =
+  /^\/(?!\/|\\|%2f|%5c)[\w\-.\+/@]*(?:\?[\w\-.\+/=&%@]*)?$/;
+
+// The module reads `window.location` and falls back to a bare path when there
+// is no window (SSR), so the test provides one.
+const g = globalThis as { window?: { location: { search: string; hash: string } } };
+const setLocation = (search: string, hash: string) => {
+  g.window = { location: { search, hash } };
+};
+
+afterEach(() => {
+  g.window = undefined;
+});
+
+describe("callbackUrl", () => {
+  test("a shared deck link survives — and Better Auth accepts it", () => {
+    // The link people actually click: the raw ':' in share_id is what made
+    // signIn.social throw "Invalid callbackURL" and the button look dead.
+    setLocation(
+      "?share_id=store.example:cta:7jvq0tag&utm_source=share&utm_medium=deck",
+      "#cta",
+    );
+    const url = callbackUrl("store.example");
+    expect(url).toMatch(BETTER_AUTH_RELATIVE);
+    // attribution is preserved (track.ts reads share_id/utm_* back)
+    const query = new URLSearchParams(url.split("?")[1]);
+    expect(query.get("share_id")).toBe("store.example:cta:7jvq0tag");
+    expect(query.get("utm_medium")).toBe("deck");
+    // the anchor is gone: no encoding of '#' can satisfy an anchored pattern
+    expect(url).not.toContain("#");
+  });
+
+  test("a bare anchor no longer breaks sign-in", () => {
+    // Reported failing with no query string at all — the '#' alone was enough.
+    setLocation("", "#cover");
+    expect(callbackUrl("store.example")).toBe("/report/store.example");
+  });
+
+  test("an already-encoded share link stays valid", () => {
+    setLocation("?share_id=store.example%3Acta%3Aabc", "");
+    const url = callbackUrl("store.example");
+    expect(url).toMatch(BETTER_AUTH_RELATIVE);
+    expect(new URLSearchParams(url.split("?")[1]).get("share_id")).toBe(
+      "store.example:cta:abc",
+    );
+  });
+
+  test("no query and no hash is unchanged", () => {
+    setLocation("", "");
+    expect(callbackUrl("store.example")).toBe("/report/store.example");
+  });
+
+  test("a domain that survives no encoding falls back to the home path", () => {
+    setLocation("", "");
+    // encodeURIComponent leaves a '%', which the pattern's PATH class excludes;
+    // landing on home beats handing Better Auth a URL it rejects.
+    const url = callbackUrl("stör e.example");
+    expect(url).toMatch(BETTER_AUTH_RELATIVE);
+    expect(url).toBe("/");
+  });
+});

--- a/apps/web/src/routes/reports/callback-url.ts
+++ b/apps/web/src/routes/reports/callback-url.ts
@@ -1,0 +1,33 @@
+/** Better Auth (1.4.22) validates a RELATIVE `callbackURL` against this exact
+ *  pattern — `matchesOriginPattern`'s `allowRelativePaths` branch in
+ *  `packages/better-auth/src/auth/trusted-origins.ts`:
+ *
+ *    /^\/(?!\/|\\|%2f|%5c)[\w\-.\+/@]*(?:\?[\w\-.\+/=&%@]*)?$/
+ *
+ *  Neither `:` nor `#` appears in either character class, and the pattern is
+ *  anchored. So a shared deck link — `?share_id=<domain>:<slide>:<id>` — and
+ *  ANY `#anchor` were rejected before the provider redirect even started:
+ *  `signIn.social` threw "Invalid callbackURL", the button looked dead, and
+ *  people clicked it again (98 events across 19 people in 30 days).
+ *
+ *  Kept relative on purpose: an absolute URL would pass only while
+ *  `getOrigin(url)` string-equals the server's `baseUrl`, which silently
+ *  breaks on a trailing slash or a preview host. */
+const RELATIVE_CALLBACK_RE =
+  /^\/(?!\/|\\|%2f|%5c)[\w\-.\+/@]*(?:\?[\w\-.\+/=&%@]*)?$/;
+
+export function callbackUrl(domain: string): string {
+  const path = `/report/${encodeURIComponent(domain)}`;
+  // A path we cannot vouch for (an encoded domain leaves a `%`, which the
+  // pattern's path class excludes) is worse than losing the destination.
+  const safePath = RELATIVE_CALLBACK_RE.test(path) ? path : "/";
+  if (typeof window === "undefined") return safePath;
+  // Re-serializing through URLSearchParams percent-encodes the raw `:` a share
+  // link carries, and share_id/utm_* survive — `track.ts` reads them to
+  // attribute the signup to the deck that drove it.
+  const query = new URLSearchParams(window.location.search).toString();
+  // The hash is dropped: nothing reads it back (it is a share-link anchor), and
+  // no encoding of it can satisfy an anchored pattern with no `#` in it.
+  const candidate = query ? `${safePath}?${query}` : safePath;
+  return RELATIVE_CALLBACK_RE.test(candidate) ? candidate : safePath;
+}


### PR DESCRIPTION
## Problem

`callbackUrl()` (`apps/web/src/routes/reports/auth-gate.tsx`) appended `window.location.search` and `window.location.hash` **raw** onto the report path. Better Auth 1.4.22 validates a *relative* `callbackURL` against `matchesOriginPattern`'s `allowRelativePaths` branch (`packages/better-auth/src/auth/trusted-origins.ts`):

```
/^\/(?!\/|\\|%2f|%5c)[\w\-.\+/@]*(?:\?[\w\-.\+/=&%@]*)?$/
```

Neither `:` nor `#` appears in either character class, and the pattern is anchored. Both halves of a shared deck link are therefore rejected **before the provider redirect starts**:

| in the URL | why it fails |
|---|---|
| `?share_id=<domain>:<slide>:<id>` | raw colons — not in the query class |
| any `#anchor` | no `#` in either class **and** the pattern is anchored, so even `/report/<domain>#cover` fails with no query string at all |

`signIn.social` throws "Invalid callbackURL" (FORBIDDEN), the page does nothing, and people click again. Last 30 days: **19 people / 98 events** of `social_signin_failed{error:"Invalid callbackURL"}`, ≈5 clicks each — plus the same failure counted from the other call site as `report_auth_failed{stage:"redirect"}` (20 people / 106 events). A replay shows ~50s of repeated clicking, then the visitor leaves.

Note this hits **exactly the highest-intent traffic**: someone who followed a shared deck link to the CTA.

## Fix

- The query is re-serialized through `URLSearchParams`, which percent-encodes the colons (`:` → `%3A`) while keeping `share_id` and `utm_*` intact — `track.ts` reads those back to attribute the signup to the deck that drove it, so attribution is not lost.
- The hash is **dropped**: nothing reads it back (it is a share-link anchor), and no encoding of `#` can satisfy an anchored pattern that excludes it.
- The result is tested against the pattern *before* it is handed over, so a value we cannot vouch for (an encoded domain leaves a `%`, which the **path** class excludes) degrades to the report path — or `/` — instead of a dead button.

Kept **relative** on purpose: an absolute URL would pass only while `getOrigin(url)` string-equals the server's `baseUrl` (`getTrustedOrigins()` is just `[baseUrl]`), which breaks silently on a trailing slash or a preview host.

Moved into `callback-url.ts` so the pure function is testable without the React tree — the test asserts every case against a **verbatim copy** of Better Auth's pattern, so an upgrade that widens or narrows it fails here instead of in production.

## Tests

`bun test apps/web/src/routes/reports/callback-url.test.ts` — 5 pass: shared link (colons + anchor) now matches the pattern and keeps `share_id`/`utm_*`; bare anchor; already-encoded share link; no query/hash unchanged; un-encodable domain falls back safely.

(`track.test.ts` fails in a bare checkout for an unrelated reason — `posthog-js` isn't installed; the new module is dependency-free.)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Google sign-in on shared report links by generating a relative callback URL that `better-auth` accepts. Previously we appended the raw query and hash to `/report/<domain>`, which `better-auth` rejected (`:` in `share_id`, any `#`), so the provider redirect never started.

- Re-serializes the query via `URLSearchParams` (encodes `:`), drops the hash, and validates against the allowed relative-path pattern; falls back to `/report/<domain>` or `/` if invalid.
- Preserves `share_id` and `utm_*` for attribution; keeps URLs relative to avoid origin mismatches on previews/trailing slashes; SSR returns a bare path.
- Extracts `callbackUrl()` to `apps/web/src/routes/reports/callback-url.ts` and adds `callback-url.test.ts` covering shared-link, anchor-only, already-encoded, SSR, and invalid-domain cases.

<sup>Written for commit 10e1ec917bb0f3256de395e6d11d27849c7aa133. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

