### PR TITLE
add SAST workflow with Gitleaks secret scanning

### DIFF
--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -1,0 +1,40 @@
+name: SAST
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: sast-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+# All third-party actions are pinned to a full commit SHA, not a tag.
+
+jobs:
+  gitleaks:
+    name: Gitleaks (secret history)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      # On pull_request the action calls GET /repos/{o}/{r}/pulls/{n}/commits
+      # to scan only the PR range. Without this it 403s with
+      # "Resource not accessible by integration".
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0 # full history so rotated-but-committed secrets are caught
+
+      # gitleaks-action requires a license key for ORGANIZATION-owned repos.
+      # Free for personal accounts and public repos, where the var is unused.
+      # Get a key at https://gitleaks.io and add it as a repo/org secret
+      # named GITLEAKS_LICENSE (Settings > Secrets and variables > Actions).
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}


### PR DESCRIPTION
## What

Adds `.github/workflows/sast.yml` — a new SAST workflow whose first job runs
[Gitleaks](https://github.com/gitleaks/gitleaks) to catch credentials committed
to the repo.

Triggers on every `pull_request` and on pushes to `main`, with
`cancel-in-progress` concurrency so superseded runs don't pile up.

## Why

Secrets that land in a commit stay in git history even after the offending line
is deleted, so review alone doesn't catch them. Scanning in CI blocks them at
the PR and flags anything already in history.

## Details

- **Full history checkout** (`fetch-depth: 0`) so secrets that were rotated but
  never scrubbed from history are still detected.
- **Actions pinned to full commit SHAs** rather than tags, so a retagged
  upstream release can't silently change what runs in CI.
- **Least-privilege permissions**: workflow-level `contents: read`, with
  `pull-requests: read` added only on the gitleaks job — the action calls
  `GET /repos/{owner}/{repo}/pulls/{n}/commits` to scan just the PR range and
  403s without it.
- Named `SAST` (not `gitleaks`) so future static-analysis jobs can be added as
  siblings without renaming the workflow or its required-check entry.

## Setup required before this is useful

`gitleaks-action@v2` **requires a paid license key for organization-owned
repos**. Since this repo is org-owned, the job will fail until a
`GITLEAKS_LICENSE` secret is added:

1. Get a key at https://gitleaks.io
2. Add it under Settings → Secrets and variables → Actions as `GITLEAKS_LICENSE`
   (repo- or org-level)

## Testing

CI on this PR is the test — the workflow runs against itself. Expect the job to
fail with a licensing error until the secret above is configured.

One thing worth deciding before merge: whether to add this as a required status check on main. Right now it reports but doesn't block.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `SAST` GitHub Actions workflow that runs `gitleaks/gitleaks-action` on pull requests and pushes to `main` to detect committed secrets. Previously there was no CI secret scanning; now Gitleaks scans the PR range and full history with minimal permissions and pinned action SHAs.

- Concurrency cancels in-progress runs per ref to avoid redundant scans.
- Full checkout (`fetch-depth: 0`) catches secrets left in history.
- Actions are pinned to commit SHAs; workflow uses `contents: read` and the job adds `pull-requests: read` to query PR commits.
- Named `SAST` to host future static-analysis jobs.

**Rollout**
- Add a `GITLEAKS_LICENSE` Actions secret at the repo or org level before relying on this workflow; otherwise the job fails with a licensing error on org-owned repos.
- Optionally set SAST as a required check on `main`.

<sup>Written for commit e95fb40a9606cd47833fc04242584f84eac2d259. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

