### PR TITLE
fix(sandbox): count dispatch continuations consecutively, not per run

### DIFF
--- a/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
@@ -290,6 +290,56 @@ describe("dispatchWithContinuation", () => {
     expect(attempts).toBe(2);
   });
 
+  // The budget is CONSECUTIVE no-progress failures. A run that streamed work
+  // between two unrelated apiserver hangups is the case this exists for: the
+  // old lifetime count failed it on the second break however long it had run.
+  test("a dispatch that made progress resets the continuation budget", async () => {
+    let attempts = 0;
+    const chunks = await collect(
+      dispatchWithContinuation({
+        runId: "run_1",
+        resume: null,
+        aborted: () => false,
+        maxAttempts: 2,
+        dispatchOnce: () => {
+          attempts++;
+          if (attempts === 3) return dispatch([chunk("finish")])();
+          return dispatch(
+            [chunk("start"), chunk("text-delta")],
+            new SandboxUnreachableError("pod gone"),
+          )();
+        },
+      }),
+    );
+    expect(attempts).toBe(3);
+    expect(chunks.map((c) => c.type)).toEqual([
+      "start",
+      "text-delta",
+      "text-delta",
+      "finish",
+    ]);
+  });
+
+  test("the total ceiling stops a pod that dies after every chunk", async () => {
+    let attempts = 0;
+    const run = dispatchWithContinuation({
+      runId: "run_1",
+      resume: null,
+      aborted: () => false,
+      maxAttempts: 2,
+      maxTotalAttempts: 3,
+      dispatchOnce: () => {
+        attempts++;
+        return dispatch(
+          [chunk("text-delta")],
+          new SandboxUnreachableError("pod gone yet again"),
+        )();
+      },
+    });
+    await expect(collect(run)).rejects.toThrow("pod gone yet again");
+    expect(attempts).toBe(3);
+  });
+
   // A displaced attempt must NOT continue: continuing re-dispatches the same
   // runId, which takes the run back off the successor that displaced us — the
   // two attempts would trade it back and forth until maxAttempts.

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -70,13 +70,28 @@ const SANDBOX_REPO_CWD = "/repo";
 const SANDBOX_HOSTED_HARNESSES = new Set<HarnessId>(["claude-code"]);
 
 /**
- * Dispatches per run: the first, plus ONE continuation after the sandbox goes
- * away. A second failure is the run's failure — repeated re-provisioning of a
- * sandbox that keeps dying burns model budget on a turn that never lands, and
- * the durable path already retries at a higher level (DBOS recovery re-enters
- * this client with the run's seq floor intact).
+ * Dispatches per run WITHOUT PROGRESS: the first, plus ONE continuation after
+ * the sandbox goes away. A second failure that streamed nothing is the run's
+ * failure — re-provisioning a sandbox that keeps dying on boot burns model
+ * budget on a turn that never lands, and the durable path already retries at a
+ * higher level (DBOS recovery re-enters this client with the run's seq floor
+ * intact).
+ *
+ * Counted CONSECUTIVELY, not per run: the break this bounds is the apiserver
+ * hanging up the daemon's port-forward, which is a routine blip, not a sick
+ * pod. A lifetime budget failed runs that had streamed thirty tool calls
+ * between two unrelated hangups minutes apart — which is exactly the run this
+ * is meant to save, and it also burns the org's task quota. Any chunk from the
+ * replacement pod proves the continuation worked, so it resets the count.
  */
 const MAX_DISPATCH_ATTEMPTS = 2;
+
+/**
+ * Hard ceiling on dispatches per run, however much progress each one makes.
+ * Guards the pathological shape the consecutive count alone would loop on: a
+ * pod that answers with one chunk and dies, forever.
+ */
+const MAX_TOTAL_DISPATCH_ATTEMPTS = 5;
 
 /**
  * How long Studio waits for ANY byte from the daemon before calling the pod
@@ -414,15 +429,23 @@ export async function* dispatchWithContinuation(args: {
   dispatchOnce: (
     resume: { reason: string } | null,
   ) => AsyncIterable<UIMessageChunk>;
+  /** Consecutive no-progress dispatches allowed. */
   maxAttempts?: number;
+  /** Dispatches allowed in total, progress or not. */
+  maxTotalAttempts?: number;
 }): AsyncIterable<UIMessageChunk> {
   const maxAttempts = args.maxAttempts ?? MAX_DISPATCH_ATTEMPTS;
+  const maxTotalAttempts = args.maxTotalAttempts ?? MAX_TOTAL_DISPATCH_ATTEMPTS;
   let resume = args.resume;
   let forwardedStart = resume !== null;
+  /** Consecutive failures whose dispatch streamed nothing. */
+  let stalled = 0;
 
   for (let attempt = 1; ; attempt++) {
+    let progressed = false;
     try {
       for await (const chunk of args.dispatchOnce(resume)) {
+        progressed = true;
         if ((chunk as { type?: string }).type === "start") {
           if (forwardedStart) continue;
           forwardedStart = true;
@@ -432,12 +455,18 @@ export async function* dispatchWithContinuation(args: {
       return;
     } catch (err) {
       if (args.aborted()) throw err;
-      if (!(err instanceof SandboxUnreachableError) || attempt >= maxAttempts) {
+      stalled = progressed ? 1 : stalled + 1;
+      if (
+        !(err instanceof SandboxUnreachableError) ||
+        stalled >= maxAttempts ||
+        attempt >= maxTotalAttempts
+      ) {
         throw err;
       }
       console.warn("[sandbox-dispatch] sandbox lost mid-run; continuing", {
         runId: args.runId,
         attempt,
+        progressed,
         reason: err.message,
       });
       resume = {


### PR DESCRIPTION
## Summary

`MAX_DISPATCH_ATTEMPTS = 2` in `sandbox-dispatch-client.ts` was a **lifetime** budget. Two unrelated `SANDBOX_UNREACHABLE` breaks failed a run no matter how much work it had landed in between — and the break it bounds is the kube-apiserver hanging up the daemon's port-forward WebSocket, which is a routine blip rather than a sick pod (the code comment at the throw site already says so).

It is now a **consecutive** no-progress budget: any chunk from the replacement pod proves the continuation worked and resets the count. `MAX_TOTAL_DISPATCH_ATTEMPTS = 5` is the hard ceiling, guarding the one shape the consecutive count alone would loop on (a pod that answers with one chunk and dies, forever). The no-progress path is unchanged — two dispatches that stream nothing still fail the run.

## Why

Prod, 2026-08-12, `thrd_m-wriPiuerCcfxcTpekAj` (7th failed attempt on `board_pA_7SsIEhMmcStEcAidCs`):

```
13:47:11  claim adopts sandbox …-nslnf, run starts
13:49:30  sandbox lost mid-run; continuing  attempt: 1
          SANDBOX_UNREACHABLE — socket connection closed unexpectedly
13:49:31  claim re-adopts …-vsppf, run continues, ~30 more tool calls
13:56:12  same break → attempt >= maxAttempts → run failed
13:58:12  claim deleted (releaseAfter's 120s grace — a consequence, not the cause)
```

The sandbox pod never died: the Sandbox CR and pod were alive and reconciling until the claim's own post-run release, with no karpenter disruption, no eviction and no container recreate. Three other threads hit the identical break in the same 25-minute window (`thrd_au6rvS4eLfry7pQylv18q`, `thrd_EznWggbSf1uEQl7v6Nhpt`, `thrd_B5QpF4RjXue3ydu7_CrPW`) and survived only because each spent one attempt.

Cost of the old behaviour is a burned org task-quota run plus a wedged card, since a failed autonomous thread is `read_only` and cannot be continued by any path a user can reach.

## Testing

`bun test apps/api/src/harnesses/sandbox-dispatch-client.test.ts` — 28 pass. Two new cases:
- progress resets the budget (die → stream → die → succeed = 3 dispatches, message extended not re-opened)
- the total ceiling stops a pod that dies after every chunk

The existing "a sandbox that keeps dying fails the run instead of looping" test is untouched and still passes — that path streams nothing, which is exactly what the consecutive count is for.

`bun run fmt` and `bun run --cwd=apps/api check` pass.

## Not in scope

Why the apiserver hangs up the port-forward at all. This makes runs survive it; it does not stop it. Streaming the daemon over the preview ingress instead of a port-forward is the real fix and is a much bigger change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Count sandbox dispatch continuations consecutively, not per run, so routine port-forward hangups no longer fail long-running runs. Previously any two `SANDBOX_UNREACHABLE` breaks failed the run; now only two consecutive no-progress dispatches fail, with a hard ceiling to prevent infinite retries.

- Introduces `MAX_TOTAL_DISPATCH_ATTEMPTS = 5` and optional `maxTotalAttempts`; `maxAttempts` now counts consecutive no-progress only.
- Resets the stall counter on any streamed chunk; keeps the existing failure on two dispatches that stream nothing.
- Adds tests covering budget reset and the total-attempts ceiling.

<sup>Written for commit f97bd53c77b712b863b4dc5c5158ede02190c993. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

