### PR TITLE
fix(task-board): don't resurrect a dismissed card into In Review

### DIFF
--- a/apps/api/src/storage/task-board-advance-dismissed.integration.test.ts
+++ b/apps/api/src/storage/task-board-advance-dismissed.integration.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Real-Postgres coverage for `advanceToReviewIfInProgress` excluding
+ * dismissed cards.
+ *
+ * Same bug class as `task-board-due-retry.integration.test.ts`: a
+ * reports-pushed task's `delete()` only stamps `dismissed_at` (it keeps the
+ * row so the next diagnostic import doesn't recreate the card) — it never
+ * touches `status`. Without a `dismissed_at IS NULL` guard here, a dismissed
+ * card whose linked thread finishes afterward gets resurrected straight into
+ * the reviewers' lane via `advanceLinkedTasksToReviewOnThreadFinish`.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { sql } from "kysely";
+import type { StudioDatabase } from "../database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../database/test-db-pg";
+import { TaskBoardStorage } from "./task-board";
+
+const ORG = "org_advance_dismissed";
+const USER = "user_advance_dismissed";
+
+describe("advanceToReviewIfInProgress (real Postgres)", () => {
+  let database: StudioDatabase;
+  let taskBoard: TaskBoardStorage;
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    await database.db
+      .insertInto("organization")
+      .values({
+        id: ORG,
+        name: ORG,
+        slug: "org-advance-dismissed",
+        createdAt: new Date().toISOString(),
+      })
+      .execute();
+    const now = new Date().toISOString();
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES (${USER}, ${"advance-dismissed@test"}, false, ${USER}, ${now}, ${now})
+    `.execute(database.db);
+    taskBoard = new TaskBoardStorage(database.db);
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  it("advances a normal in-progress card to in_review", async () => {
+    const task = await taskBoard.create({
+      organizationId: ORG,
+      title: "normal advance",
+      status: "in_progress",
+      by: USER,
+    });
+
+    const advanced = await taskBoard.advanceToReviewIfInProgress(
+      task.id,
+      ORG,
+      USER,
+    );
+
+    expect(advanced?.status).toBe("in_review");
+  });
+
+  it("does not advance a reports card dismissed while still in_progress", async () => {
+    const task = await taskBoard.create({
+      organizationId: ORG,
+      title: "dismissed while in progress",
+      status: "in_progress",
+      by: "system",
+    });
+
+    // Mirrors TASK_BOARD_ITEM_DELETE on a reports task: dismissed_at only.
+    await taskBoard.delete(task.id, ORG, USER);
+    const row = await database.db
+      .selectFrom("task_board_items")
+      .select("dismissed_at")
+      .where("id", "=", task.id)
+      .executeTakeFirst();
+    expect(row?.dismissed_at).toBeTruthy();
+
+    const advanced = await taskBoard.advanceToReviewIfInProgress(
+      task.id,
+      ORG,
+      USER,
+    );
+
+    expect(advanced).toBeNull();
+  });
+});

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -1040,6 +1040,11 @@ export class TaskBoardStorage {
    * The `where status = 'in_progress'` predicate is the whole point: it makes
    * the advance idempotent under concurrency, which the plain `update()` is not.
    * See the caller above for what the duplicates cost.
+   *
+   * `dismissed_at IS NULL` matters for the same reason as `listItemsDueForRetry`:
+   * a reports-pushed task's `delete()` only stamps `dismissed_at` and leaves
+   * `status` at `in_progress`, so a dismissed card whose linked thread finishes
+   * afterward would otherwise get resurrected straight into the reviewers' lane.
    */
   async advanceToReviewIfInProgress(
     id: string,
@@ -1056,6 +1061,7 @@ export class TaskBoardStorage {
       .where("id", "=", id)
       .where("organization_id", "=", organizationId)
       .where("status", "=", "in_progress")
+      .where("dismissed_at", "is", null)
       .returningAll()
       .executeTakeFirst();
 


### PR DESCRIPTION
Follows #5973's fix (merged today) for the same bug class: `advanceToReviewIfInProgress` in `apps/api/src/storage/task-board.ts` flips a card `in_progress` -> `in_review` gated only on id/org/status, with no `dismissed_at IS NULL` guard.

A reports-pushed card's `delete()` (see the comment above `delete()`) only stamps `dismissed_at` and deliberately leaves `status` untouched, so the row keeps its threads/comments/quota claim for a possible restore. That means a dismissed card sitting `in_progress` is still a live target for `advanceLinkedTasksToReviewOnThreadFinish`: if its linked thread finishes after the user dismisses it, the card gets resurrected straight into the reviewers' lane, exactly the resurrection bug #5973 just fixed on the retry-sweep path.

Failure scenario: user dismisses a reports card whose Super Agent thread is still running; the thread later completes; `advanceLinkedTasksToReviewOnThreadFinish` -> `advanceToReviewIfInProgress` matches the still-`in_progress` row and flips it to `in_review`, un-dismissing it without the user's action.

Fix: add `.where("dismissed_at", "is", null)` to the conditional update, mirroring the guard `listItemsDueForRetry` already got in #5973.

Regression test: `apps/api/src/storage/task-board-advance-dismissed.integration.test.ts` (real-Postgres, same pattern as `task-board-due-retry.integration.test.ts`) — asserts a normal in-progress card still advances, and a dismissed-while-in-progress reports card does not.

To confirm: run the new integration test file under the `storage-integration` CI workflow (needs real Postgres, not available on this laptop).

Locally verified: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint` on both touched files (0 warnings/errors). Full CI (including the Postgres-backed integration test) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents dismissed task-board cards from being advanced into In Review when a linked thread completes. Previously, the server advanced cards from In Progress to In Review without checking `dismissed_at`, which could resurrect user-dismissed cards; now dismissed cards are ignored.

**Review notes**
- Add `dismissed_at IS NULL` guard to `advanceToReviewIfInProgress`; the conditional update remains idempotent.
- Add Postgres-backed integration test validating normal advance and no advance for a dismissed, in-progress card.
- No API or schema changes. Deploy normally; no migration required.

<sup>Written for commit 5663fa3d3f11c0257584565fd8f70f940c85617c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

