### PR TITLE
fix(reports): let anonymous visitors generate a report, not just read one

### DIFF
--- a/apps/api/src/api/routes/reports.ts
+++ b/apps/api/src/api/routes/reports.ts
@@ -1,17 +1,4 @@
-/**
- * Report Routes — `/api/_reports/*`
- *
- * Proxy between the report page (`/report/:domain`) and the reports engine
- * (reports.decocms.com, `/api/v2`). The engine's master API key stays
- * server-side; the caller's session email is the only delivery address
- * accepted when a scan starts.
- *
- * `GET /site/:domain` is the one route that also serves unauthenticated
- * callers — it returns only the cover slide of an already-completed scan, so
- * the first card of a report is visible before login. Everything else
- * (starting a scan, polling it, resolving email links) still requires a
- * session.
- */
+/** Report Routes — `/api/_reports/*`: proxy to the reports engine (`/api/v2`), master key server-side. Login gates reading the deck, not producing it — see each route below. */
 
 import { Hono, type MiddlewareHandler } from "hono";
 import { auth } from "@/auth";
@@ -93,8 +80,6 @@ const requireReportUser: MiddlewareHandler<ReportsEnv> = async (c, next) => {
   return undefined;
 };
 
-app.use("/run", requireReportUser);
-app.use("/status", requireReportUser);
 app.use("/link-token/*", requireReportUser);
 app.use("/suggest", requireReportUser);
 
@@ -125,14 +110,16 @@ app.get("/site/:domain", async (c) => {
   }
 });
 
-/** POST /api/_reports/run — trigger a scan (master-key, server-only). The
- *  engine is idempotent + single-flight, so spamming this for a domain never
- *  starts parallel runs. The engine receives the authenticated session email
- *  to notify the requester; it never accepts a caller-supplied address. The
- *  optional `distinctId` is the visitor's PostHog id, so the engine's
- *  server-side funnel events attribute to the same person. */
+/** POST /api/_reports/run — trigger a scan (master-key, server-only). Open to
+ *  anonymous callers: producing a report needs no account, only reading the
+ *  full deck does. The engine is idempotent + single-flight, so spamming this
+ *  for a domain never starts parallel runs. When there IS a session, its email
+ *  is sent as the requester's notification address — never a caller-supplied
+ *  one; anonymous runs send none and are followed in-tab instead. The optional
+ *  `distinctId` is the visitor's PostHog id, so the engine's server-side funnel
+ *  events attribute to the same person. */
 app.post("/run", async (c) => {
-  const user = c.get("reportUser")!;
+  const user = c.get("reportUser");
   let body: { domain?: unknown; distinctId?: unknown };
   try {
     body = await c.req.json();
@@ -141,7 +128,7 @@ app.post("/run", async (c) => {
   }
   const domain = typeof body.domain === "string" ? body.domain.trim() : "";
   if (!domain) return c.json({ error: "domain is required" }, 400);
-  const email = user.email;
+  const email = user?.email;
   const distinctId =
     typeof body.distinctId === "string" &&
     body.distinctId.trim() &&
@@ -156,7 +143,11 @@ app.post("/run", async (c) => {
         "Content-Type": "application/json",
         Authorization: `Bearer ${resolveApiKey({})}`,
       },
-      body: JSON.stringify({ url: domain, email, distinct_id: distinctId }),
+      body: JSON.stringify({
+        url: domain,
+        ...(email ? { email } : {}),
+        distinct_id: distinctId,
+      }),
     });
     if (!res.ok) return c.json({ error: `run HTTP ${res.status}` }, 502);
     const j = (await res.json()) as {

--- a/apps/web/src/i18n/en/reports.ts
+++ b/apps/web/src/i18n/en/reports.ts
@@ -110,6 +110,10 @@ export const reports = {
   "reports.listTemplate.moreSignals": "more signals in the full diagnostic",
   "reports.listTemplate.unlockRevenue": "Unlock my revenue",
   "reports.paginasVariant.found": "found",
+  "reports.scanGate.anonymousHelp":
+    "Signing in also unlocks the full report when it's done.",
+  "reports.scanGate.anonymousLabel": "Want it in your inbox when it's ready?",
+  "reports.scanGate.anonymousSignIn": "Sign in to get notified",
   "reports.scanGate.errorBlocked": "This report is not publicly available.",
   "reports.scanGate.errorEmpty":
     "We scanned your store, but the report is still being assembled. Check back soon.",
@@ -126,7 +130,7 @@ export const reports = {
   "reports.scanGate.stageNow": "now",
   "reports.scanGate.stageReady": "Report ready",
   "reports.scanGate.subtitle":
-    "You can follow along here. We'll also let you know when it's ready.",
+    "You can follow along here — it takes a few minutes.",
   "reports.scanGate.tryAnother": "Try another store",
   "reports.scorecardTemplate.noComparison": "No comparison",
   "reports.scorecardTemplate.rivalLeads": "{rival} leads",

--- a/apps/web/src/i18n/pt-br/reports.ts
+++ b/apps/web/src/i18n/pt-br/reports.ts
@@ -113,6 +113,11 @@ export const reports = {
   "reports.listTemplate.moreSignals": "outros sinais no diagnóstico completo",
   "reports.listTemplate.unlockRevenue": "Destravar minha receita",
   "reports.paginasVariant.found": "achados",
+  "reports.scanGate.anonymousHelp":
+    "Entrar também libera o relatório completo quando ficar pronto.",
+  "reports.scanGate.anonymousLabel":
+    "Quer receber por e-mail quando ficar pronto?",
+  "reports.scanGate.anonymousSignIn": "Entrar para ser avisado",
   "reports.scanGate.errorBlocked":
     "Este relatório não está disponível publicamente.",
   "reports.scanGate.errorEmpty":
@@ -129,7 +134,7 @@ export const reports = {
   "reports.scanGate.stageNow": "agora",
   "reports.scanGate.stageReady": "Relatório pronto",
   "reports.scanGate.subtitle":
-    "Você pode acompanhar por aqui. Também avisaremos quando estiver pronto.",
+    "Você pode acompanhar por aqui — leva alguns minutos.",
   "reports.scanGate.tryAnother": "Tentar outra loja",
   "reports.scorecardTemplate.noComparison": "Sem comparação",
   "reports.scorecardTemplate.rivalLeads": "{rival} lidera",

--- a/apps/web/src/routes/reports.tsx
+++ b/apps/web/src/routes/reports.tsx
@@ -245,10 +245,8 @@ export default function ReportPage() {
     />
   ) : session.isPending ? (
     <ReportAuthGate domain={domain} loading />
-  ) : !authenticated ? (
-    // No completed scan yet, and anonymous visitors can't start one.
-    <ReportAuthGate domain={domain} />
   ) : (
+    // No completed scan yet — anonymous visitors start one too.
     <ScanGate
       domain={domain}
       initial={initial.data}

--- a/apps/web/src/routes/reports/scan-gate.tsx
+++ b/apps/web/src/routes/reports/scan-gate.tsx
@@ -11,7 +11,7 @@ import {
   reportDrops,
   type ScanPhase,
 } from "./orchestrate-scan";
-import { ReportAuthGate, ReportBackdrop } from "./auth-gate";
+import { ReportAuthGate, ReportAuthOverlay, ReportBackdrop } from "./auth-gate";
 import { ReportSocialProof } from "./report-social-proof";
 import SignalDeck from "./signal-deck";
 import { DECK } from "./templates/tokens";
@@ -201,7 +201,7 @@ function ScanScreen({
               {t("reports.scanGate.subtitle")}
             </p>
 
-            {/* Authenticated delivery address */}
+            {/* Delivery address, or the sign-in that becomes one */}
             <div
               className="mt-4 sm:mt-5 rounded-xl sm:rounded-2xl px-4 sm:px-5 py-4 sm:py-5"
               style={{ background: "#F2F1EF" }}
@@ -210,9 +210,17 @@ function ScanScreen({
                 className="mb-2.5 sm:mb-3 text-[15px] sm:text-[16px]"
                 style={{ color: DECK.ink }}
               >
-                {t("reports.scanGate.notificationLabel")}
+                {t(
+                  email
+                    ? "reports.scanGate.notificationLabel"
+                    : "reports.scanGate.anonymousLabel",
+                )}
               </p>
-              <NotificationEmail email={email} />
+              {email ? (
+                <NotificationEmail email={email} />
+              ) : (
+                <SignInToBeNotified domain={domain} />
+              )}
             </div>
 
             {/* Tracker */}
@@ -403,6 +411,35 @@ function StepDot({ state }: { state: StageState }) {
       className="h-[18px] w-[18px] shrink-0 rounded-full"
       style={{ border: `1.5px solid ${DECK.border}` }}
     />
+  );
+}
+
+// ── anonymous: sign in to get the finished report ────────────────────────────
+
+/** The scan runs without an account, so there's no address to deliver it to.
+ *  Signing in from here (same in-place card the deck uses — no navigation, so
+ *  the poll keeps running behind it) both registers the requester's email with
+ *  the engine's notification list and unlocks the deck past the cover. */
+function SignInToBeNotified({ domain }: { domain: string }) {
+  const t = useT();
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="flex h-11 w-full items-center justify-center rounded-xl px-5 text-[14px] font-medium transition-transform active:scale-[0.98]"
+        style={{ background: DECK.primary, color: DECK.primaryFg }}
+      >
+        {t("reports.scanGate.anonymousSignIn")}
+      </button>
+      <p className="mt-2.5 text-[12px] leading-4" style={{ color: DECK.muted }}>
+        {t("reports.scanGate.anonymousHelp")}
+      </p>
+      {open && (
+        <ReportAuthOverlay domain={domain} onClose={() => setOpen(false)} />
+      )}
+    </>
   );
 }
 

--- a/packages/e2e/tests/report-auth-gate.spec.ts
+++ b/packages/e2e/tests/report-auth-gate.spec.ts
@@ -6,34 +6,57 @@ import { expect, newApiContext, test } from "../fixtures/test";
 // locale. Pin it rather than inherit the runner's.
 test.use({ locale: "en-US" });
 
-test("anonymous shared report shows login over a blurred preview", async ({
+test("an anonymous visitor's scan starts without a login wall", async ({
   page,
 }) => {
+  const domain = `anon-visitor-${crypto.randomUUID()}.example`;
   await page.goto(
-    "/report/example.com?share_id=example%3Aslide%3Atest&utm_source=share#overview",
+    `/report/${domain}?share_id=example%3Aslide%3Atest&utm_source=share#overview`,
   );
 
-  const dialog = page.getByRole("dialog", { name: "Access your report" });
-  await expect(dialog).toBeVisible();
-  await expect(dialog.getByText("Already received by")).toBeVisible();
+  // No completed scan and no session ⇒ the scan screen, not the login gate.
+  await expect(page.getByText("Analysis started")).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Sign in to get notified" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("dialog", { name: "Access your report" }),
+  ).toHaveCount(0);
 
-  const preview = page.locator('div[aria-hidden="true"]').filter({
-    hasText: "A complete view of your store and where to grow first.",
-  });
-  await expect(preview).toHaveCSS("filter", "blur(9px)");
   await expect(page).toHaveURL(/share_id=example%3Aslide%3Atest/);
   await expect(page).toHaveURL(/#overview$/);
 });
 
-test("scan operations reject anonymous callers, but reading a report doesn't", async ({
+test("anonymous callers can start and follow a scan, with no delivery address", async ({
   playwright,
 }) => {
   const anonymous = await newApiContext(playwright);
+  const domain = `anon-run-${crypto.randomUUID()}.example`;
+
+  const run = await anonymous.post("/api/_reports/run", {
+    data: { domain, email: "attacker-controlled@example.com" },
+  });
+  expect(run.status()).toBe(200);
+
+  const commerceMock = await playwright.request.newContext({
+    baseURL: `http://localhost:${process.env.COMMERCE_MOCK_PORT ?? "4100"}`,
+  });
+  const captured = (await (
+    await commerceMock.get(
+      `/__e2e/report-run?domain=${encodeURIComponent(domain)}`,
+    )
+  ).json()) as { url?: string; email?: string };
+  expect(captured.url).toBe(domain);
+  // Sessionless run ⇒ no notification address, least of all the caller's.
+  expect(captured.email).toBeUndefined();
+  await commerceMock.dispose();
+
+  // Polling is open too — 400 (missing id) proves the 401 gate is gone.
+  const status = await anonymous.get("/api/_reports/status");
+  expect(status.status()).toBe(400);
+
+  // Still session-only: anything tied to a person.
   const gated = await Promise.all([
-    anonymous.post("/api/_reports/run", {
-      data: { domain: "example.com", email: "other@example.com" },
-    }),
-    anonymous.get("/api/_reports/status?id=run-id"),
     anonymous.get("/api/_reports/link-token/token-id"),
     anonymous.get("/api/_reports/suggest?q=e"),
   ]);
@@ -42,10 +65,10 @@ test("scan operations reject anonymous callers, but reading a report doesn't", a
     expect(response.headers()["cache-control"]).toContain("no-store");
   }
 
-  // GET /site is the one route anonymous callers can reach — it's how the
-  // cover slide of an already-completed scan shows before login. There's no
-  // completed scan for this domain, so it comes back "not_found", not a 401.
-  const site = await anonymous.get("/api/_reports/site/example.com");
+  // Reading is open, but a never-scanned domain has nothing to read.
+  const site = await anonymous.get(
+    `/api/_reports/site/${encodeURIComponent(domain)}`,
+  );
   expect(site.status()).toBe(200);
   expect(site.headers()["cache-control"]).toContain("no-store");
   expect((await site.json()).status).toBe("not_found");
@@ -81,9 +104,14 @@ test("an expired report session returns to the inline login", async ({
 
   await page.goto("/report/session-expired.example");
 
-  await expect(
-    page.getByRole("dialog", { name: "Access your report" }),
-  ).toBeVisible();
+  const dialog = page.getByRole("dialog", { name: "Access your report" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText("Already received by")).toBeVisible();
+
+  const preview = page.locator('div[aria-hidden="true"]').filter({
+    hasText: "A complete view of your store and where to grow first.",
+  });
+  await expect(preview).toHaveCSS("filter", "blur(9px)");
 });
 
 test("a failed initial read never triggers a scan", async ({ page }) => {


### PR DESCRIPTION
## Problem

`POST /api/_reports/run` required a session. An anonymous visitor landing on `/report/:domain` with no completed scan got a login wall **before** anything was produced — nothing to show, and the sign-in bought them a scan they hadn't started yet. Login should gate *reading* the deck, not producing it.

## Change

**API** (`apps/api/src/api/routes/reports.ts`)
- Removed the session requirement from `POST /run` and `GET /status`. Status matters too: the scan poll calls it, so a 401 there flipped a running scan to the auth gate mid-flight.
- The engine's requester email is optional (`api/v2/diagnostics/run`). With a session we still send that address and never a caller-supplied one; anonymous runs send none.
- Unchanged: `/link-token/*` and `/suggest` are session-only, and `GET /site/:domain` still truncates to the cover slide (+ chapter titles) for anonymous callers — the findings never cross the wire without a session, and `signal-deck.tsx` still funnels every navigation past slide 0 into the auth overlay.

**Web**
- `routes/reports.tsx`: dropped the `!authenticated` branch, so anonymous visitors fall through to the same `ScanGate`. It's the same element in both states, so signing in mid-scan only changes props — the poll doesn't remount.
- `scan-gate.tsx`: in place of the "we'll notify you at &lt;email&gt;" block, anonymous visitors get an inline sign-in that opens the existing `ReportAuthOverlay`. That both registers their email with the engine's notification list and unlocks the deck when it's done; the scan keeps running behind the card.
- The scan subtitle no longer promises an email to a visitor who hasn't given one.
- New `reports.scanGate.anonymous*` keys in `en` + `pt-br`.

## Testing

- `bun run check` and `bun run lint` clean; report unit tests pass (68/68).
- `packages/e2e/tests/report-auth-gate.spec.ts`: inverted the assertions that encoded the old behavior — anonymous visitor on an unscanned domain now sees the scan screen (not the gate), an anonymous `POST /run` reaches the engine mock with **no** `email`, `GET /status` without an id answers 400 (proving the 401 gate is gone), and `link-token`/`suggest` still 401. The blurred-preview + login-card coverage moved to the expired-session test, which renders the same card.
- The e2e suite was **not** run locally (local Postgres wouldn't boot in this worktree); CI covers it.

## Notes

No rate limit added on the now-open `POST /run`: a public run only records a pending request and notifies admins — the engine's approval gate is what stands between a request and any compute. If it gets abused, the limit belongs there, per IP.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow anonymous visitors to start a scan from /report/:domain and follow progress. Previously `POST /api/_reports/run` and `GET /api/_reports/status` required a session, blocking scans behind a login wall; now producing a report is open, while reading the full deck still requires login. When logged in we send the session email as the notification address; anonymous runs send none.

**API**
- Open `POST /run` and `GET /status`; keep `/link-token/*` and `/suggest` session-only; `/site/:domain` still returns only the cover slide for anonymous callers.
- Treat the engine’s `email` as optional; forward the session email when present and never a caller-supplied one; anonymous runs omit `email`.
- `GET /status` without `id` returns 400 (was 401).
- No rate limit added here; the engine approval gate continues to protect compute.

**Web + Tests**
- Route anonymous users to `ScanGate`; show an inline sign-in (`ReportAuthOverlay`) to get notified and unlock the deck; the scan continues polling without remount.
- Updated copy and i18n keys for the anonymous flow; removed promise of email for users without an address.
- E2E: assert anonymous run reaches the engine without `email`, `status` ungated (400 on missing id), and `/link-token/*`/`/suggest` remain gated.

<sup>Written for commit 230cb1d186ae957716c983e261099a70be8d621b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

