### PR TITLE
docs(selfhost): fix the monitoring table names, document auth and the serviceAccount key

### DIFF
--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/kubernetes.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/kubernetes.mdx
@@ -51,7 +51,7 @@ For production, schedule sandbox pods on a dedicated, tainted node pool. Sandbox
 The commands below pin chart versions explicitly. Pin them in your own deployment too, instead of tracking whatever is newest.
 
 ```bash
-export STUDIO_CHART_VERSION=0.13.0
+export STUDIO_CHART_VERSION=0.13.1
 export SANDBOX_OPERATOR_CHART_VERSION=0.1.4
 export SANDBOX_ENV_CHART_VERSION=0.15.3
 ```
@@ -237,6 +237,22 @@ A self-hosted deployment ships with no model access. Agents and Decopilot stay u
 
 Egress note: unless you run the models in your own network, Studio pods need outbound HTTPS to the provider's API.
 
+### 7. Configure authentication
+
+Studio uses Better Auth. For Kubernetes, configure it with environment variables in the same Secret or ConfigMap the chart already injects — there is nothing extra to mount:
+
+| Method | Variables |
+| --- | --- |
+| Social login | `AUTH_GOOGLE_CLIENT_ID` / `AUTH_GOOGLE_CLIENT_SECRET`, `AUTH_GITHUB_CLIENT_ID` / `AUTH_GITHUB_CLIENT_SECRET` |
+| Deployment-wide SSO | `AUTH_SSO_DOMAIN` plus the Microsoft Entra ID or Google Workspace variables |
+| Magic link, email OTP, email/password | `AUTH_MAGIC_LINK_ENABLED`, `AUTH_EMAIL_OTP_ENABLED`, `AUTH_EMAIL_PASSWORD_ENABLED`, plus a mail provider (`AUTH_RESEND_API_KEY` or `AUTH_SENDGRID_API_KEY`) |
+
+See [Authentication](/en/studio/self-hosting/authentication) for the full reference.
+
+<Callout type="note">
+  The `auth-config.json` file mentioned in the authentication reference is a Docker Compose convenience — the Kubernetes path does not need it. If you want it anyway (for SAML, or to keep one config artifact), mount it at `/app/apps/api/auth-config.json` from a ConfigMap using the chart's `volumes` and `volumeMounts` values, which apply to both the API and worker Deployments. Keep provider secrets in the Secret, not in that file.
+</Callout>
+
 ## Sandbox configuration
 
 ### Isolation and egress
@@ -305,6 +321,10 @@ housekeeper:
 `STUDIO_ENV` is required when the housekeeper is enabled because its default selectors are environment-scoped. Without the matching label, it intentionally selects no claims.
 
 ### Preview Gateway
+
+<Callout type="tip">
+  Treat public preview URLs as a later phase. They need Gateway API CRDs, a Gateway controller, wildcard DNS, and a wildcard certificate via DNS-01 — dependencies that usually belong to another team and another schedule. Studio, agents, and code execution all work without them; only shareable preview links are missing.
+</Callout>
 
 Without a preview Gateway, Studio can use its legacy in-process preview proxy when a preview URL pattern and the required external routing are provided. The current production design uses Gateway API and routes each preview directly to its sandbox daemon:
 

--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/monitoring.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/monitoring.mdx
@@ -41,9 +41,11 @@ aws s3 sync $DATA_DIR/traces s3://your-bucket/traces
 
 For production deployments, ClickHouse provides scalable, fast aggregations over monitoring data.
 
-1. Set the `CLICKHOUSE_URL` environment variable to your ClickHouse HTTP endpoint.
-2. Create tables named `monitoring_logs` and `monitoring_metrics` in your ClickHouse instance.
-3. When configured, the monitoring UI queries ClickHouse directly via HTTP.
+1. Point an OTLP collector at ClickHouse. Studio emits monitoring telemetry as standard OpenTelemetry **log records** with `studio.monitoring.*` attributes, which the exporter writes into its `otel_logs` table — the exporter creates that table on first write.
+2. Create the `studio_monitoring_logs` **view** over `otel_logs`. The dashboard reads that view, not a table, and it is a one-time provisioning step the app never performs itself. The DDL and the column-name caveats are in [`apps/api/src/monitoring/clickhouse-setup.md`](https://github.com/decocms/studio/blob/main/apps/api/src/monitoring/clickhouse-setup.md).
+3. Set `CLICKHOUSE_URL` to your ClickHouse HTTP endpoint. Read access is enough — Studio only queries.
+
+Deploy before provisioning the view, not the other way round: the view is defined over a table the collector creates on its first write. Until it exists the dashboard errors on every query, which is expected and clears the moment you create it. There is no separate metrics table — counts, averages, and percentiles are derived from the same log rows.
 
 ```bash
 CLICKHOUSE_URL=https://your-clickhouse-instance:8123

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/kubernetes.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/kubernetes.mdx
@@ -51,7 +51,7 @@ Em produção, agende pods de sandbox em um node pool dedicado e com taint. Esse
 Os comandos abaixo fixam versões de chart explicitamente. Fixe também no seu deployment, em vez de acompanhar a versão mais recente.
 
 ```bash
-export STUDIO_CHART_VERSION=0.13.0
+export STUDIO_CHART_VERSION=0.13.1
 export SANDBOX_OPERATOR_CHART_VERSION=0.1.4
 export SANDBOX_ENV_CHART_VERSION=0.15.3
 ```
@@ -237,6 +237,22 @@ Um deployment self-hosted não vem com acesso a modelos. Agentes e Decopilot fic
 
 Nota de egress: a menos que os modelos rodem na sua própria rede, os pods do Studio precisam de HTTPS de saída para a API do provedor.
 
+### 7. Configure a autenticação
+
+O Studio usa o Better Auth. No Kubernetes, configure por variáveis de ambiente no mesmo Secret ou ConfigMap que o chart já injeta — não há nada extra para montar:
+
+| Método | Variáveis |
+| --- | --- |
+| Login social | `AUTH_GOOGLE_CLIENT_ID` / `AUTH_GOOGLE_CLIENT_SECRET`, `AUTH_GITHUB_CLIENT_ID` / `AUTH_GITHUB_CLIENT_SECRET` |
+| SSO para todo o deployment | `AUTH_SSO_DOMAIN` mais as variáveis do Microsoft Entra ID ou do Google Workspace |
+| Magic link, OTP por e-mail, e-mail/senha | `AUTH_MAGIC_LINK_ENABLED`, `AUTH_EMAIL_OTP_ENABLED`, `AUTH_EMAIL_PASSWORD_ENABLED`, mais um provedor de e-mail (`AUTH_RESEND_API_KEY` ou `AUTH_SENDGRID_API_KEY`) |
+
+Veja [Autenticação](/pt-br/studio/self-hosting/authentication) para a referência completa.
+
+<Callout type="note">
+  O arquivo `auth-config.json` citado na referência de autenticação é uma conveniência do Docker Compose — o caminho de Kubernetes não precisa dele. Se você quiser usá-lo mesmo assim (para SAML, ou para manter um único artefato de configuração), monte-o em `/app/apps/api/auth-config.json` a partir de um ConfigMap usando os values `volumes` e `volumeMounts` do chart, que valem para os Deployments de API e worker. Mantenha os secrets dos provedores no Secret, não nesse arquivo.
+</Callout>
+
 ## Configuração de sandbox
 
 ### Isolamento e egress
@@ -305,6 +321,10 @@ housekeeper:
 `STUDIO_ENV` é obrigatório quando o housekeeper está habilitado, pois seus seletores padrão são limitados ao ambiente. Sem o label correspondente, ele intencionalmente não seleciona nenhum claim.
 
 ### Gateway de preview
+
+<Callout type="tip">
+  Trate URLs públicas de preview como uma fase posterior. Elas exigem CRDs de Gateway API, um Gateway controller, DNS wildcard e certificado wildcard via DNS-01 — dependências que normalmente pertencem a outro time e a outro cronograma. Studio, agentes e execução de código funcionam sem isso; só os links compartilháveis de preview ficam de fora.
+</Callout>
 
 Sem um Gateway de preview, o Studio pode usar seu proxy de preview legado em processo quando um padrão de URL e o roteamento externo necessário são fornecidos. O design atual de produção usa Gateway API e encaminha cada preview diretamente para seu daemon de sandbox:
 

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/monitoring.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/monitoring.mdx
@@ -41,9 +41,11 @@ aws s3 sync $DATA_DIR/traces s3://your-bucket/traces
 
 Para deployments em produção, o ClickHouse fornece agregações rápidas e escaláveis sobre os dados de monitoramento.
 
-1. Defina a variável de ambiente `CLICKHOUSE_URL` para o endpoint HTTP do seu ClickHouse.
-2. Crie tabelas chamadas `monitoring_logs` e `monitoring_metrics` na sua instância do ClickHouse.
-3. Quando configurado, a UI de monitoramento consulta o ClickHouse diretamente via HTTP.
+1. Aponte um collector OTLP para o ClickHouse. O Studio emite a telemetria de monitoramento como **log records** OpenTelemetry padrão com atributos `studio.monitoring.*`, que o exporter grava na tabela `otel_logs` — criada por ele na primeira escrita.
+2. Crie a **view** `studio_monitoring_logs` sobre `otel_logs`. O dashboard lê essa view, não uma tabela, e provisioná-la é uma etapa única que a aplicação nunca executa sozinha. O DDL e as ressalvas de nomes de coluna estão em [`apps/api/src/monitoring/clickhouse-setup.md`](https://github.com/decocms/studio/blob/main/apps/api/src/monitoring/clickhouse-setup.md).
+3. Defina `CLICKHOUSE_URL` com o endpoint HTTP do seu ClickHouse. Acesso de leitura basta — o Studio apenas consulta.
+
+Faça o deploy antes de provisionar a view, não o contrário: ela é definida sobre uma tabela que o collector cria na primeira escrita. Até a view existir, o dashboard falha em toda consulta — esperado, e resolve assim que você a cria. Não existe tabela separada de métricas: contagens, médias e percentis derivam das mesmas linhas de log.
 
 ```bash
 CLICKHOUSE_URL=https://your-clickhouse-instance:8123

--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,11 +2,15 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
+# 0.13.1: documents the pre-existing `serviceAccount` values block. The
+# templates already honoured it; it was simply absent from values.yaml, so
+# `helm show values` hid a key the sandbox layer depends on. The render is
+# byte-identical with default values.
 # 0.13.0: optional Ingress (ingress.enabled, default false). Renders nothing
 # when disabled, so existing releases are unaffected.
 # 0.12.4: chart-managed API/worker dispatch roles now use
 # STUDIO_DISPATCH_ROLE; legacy overrides are rejected.
-version: 0.13.0
+version: 0.13.1
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -52,6 +52,19 @@ ingress:
   #      - studio.example.com
   #    secretName: studio-tls
 
+# ServiceAccount for the API and worker pods. Undocumented until now, though the
+# templates have always honoured it — and the sandbox layer depends on it: the
+# sandbox-env chart grants claim/port-forward RBAC to a NAMED service account,
+# so leaving Studio on `default` yields 403 "cannot create sandboxclaims".
+# Set create: true with a name matching sandbox-env's mesh.serviceAccountName.
+serviceAccount:
+  # Renders the ServiceAccount and runs the pods as it.
+  create: false
+  # Empty + create: true → the release fullname. Empty + create: false → `default`.
+  name: ""
+  annotations: {}
+  automount: true
+
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
Four follow-ups found while walking the self-hosting path the way a customer will.

## 1. `monitoring.mdx` pointed at tables that do not exist

The page said to create `monitoring_logs` and `monitoring_metrics`. The dashboard queries a **view** named `studio_monitoring_logs` (12 references in `apps/api/src`), and there is no metrics table at all — counts, averages and percentiles derive from the same log rows:

```
monitoring.mdx:45  → "Create tables named `monitoring_logs` and `monitoring_metrics`"
apps/api/src       → 12 × studio_monitoring_logs, 0 × monitoring_metrics
```

Anyone who enabled monitoring and followed the page got `UNKNOWN_TABLE` on every query — deterministically, not occasionally. The page now describes the real shape: a collector writes OTel log records into `otel_logs`, then you provision the view over it, in that order, with the DDL linked from the setup doc that lives beside the code.

## 2. The Kubernetes guide never mentioned authentication

`authentication.mdx` says to mount an `auth-config.json` and to "see your deployment guides for mounting details". The Compose guide documents the mount; the Kubernetes guide had zero mentions of the file, so a Kubernetes reader followed a dangling pointer.

Adds a step covering the environment variables that actually configure auth on this path — social login, deployment-wide SSO, magic link, OTP, email/password — and notes that the JSON file is a Compose convenience, mountable through the chart's existing `volumes`/`volumeMounts` for anyone who wants it anyway (SAML, single config artifact).

## 3. `serviceAccount` was missing from `values.yaml`

The templates have always honoured it, and the guide's example sets it, but `helm show values` never revealed it. That matters because the sandbox layer depends on it: `sandbox-env` grants claim and port-forward RBAC to a *named* service account, so a Studio release left on `default` fails with `403 ... cannot create sandboxclaims`.

Documented with `create: false`. Chart `0.13.0` → `0.13.1`.

## 4. Preview URLs now carry sequencing advice

The prerequisites were listed but not their implication: Gateway API CRDs, a Gateway controller, wildcard DNS and a DNS-01 wildcard certificate usually belong to another team and another schedule, and everything except shareable preview links works without them.

## Verification

- `helm template` with default values is **byte-identical** before and after the `serviceAccount` addition (`diff` on the full render); `--set serviceAccount.create=true --set serviceAccount.name=deco-studio` still produces the ServiceAccount and binds the pods to it.
- `helm lint` clean.
- Callout tags balanced across all four touched pages; en and pt-br kept in step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns self-hosting docs with actual monitoring schema, documents Kubernetes auth setup, and surfaces the chart’s `serviceAccount` values so sandbox RBAC works. Previously the monitoring guide told users to create non-existent tables, causing `UNKNOWN_TABLE`; it now directs traffic through OTLP logs and the `studio_monitoring_logs` view. Bumps `chart-deco-studio` to 0.13.1 without changing the default render.

**Review and rollout**
- Monitoring: Use an OTLP collector writing to ClickHouse `otel_logs`, then create the `studio_monitoring_logs` view from the linked DDL; set `CLICKHOUSE_URL`. If you created `monitoring_logs`/`monitoring_metrics` from the old guide, provision the view instead; metrics derive from logs.
- Kubernetes auth: Configure Better Auth via env vars (social, SSO, magic link, OTP, email/password). Mounting `auth-config.json` is optional and only via `volumes`/`volumeMounts` if needed (keep secrets in a Secret).
- Helm chart: Adds documented `serviceAccount` values (default `create: false`, `name: ""`) to `deploy/helm/studio/values.yaml`; upgrade to 0.13.1. Required when using sandbox: set `serviceAccount.create=true` and `serviceAccount.name` to match your `sandbox-env` mesh service account to avoid 403s.
- Preview URLs: Notes to defer public preview setup; Studio works without Gateway API, wildcard DNS, or DNS-01 certs; only shareable preview links depend on them.
- Docs updated in `en` and `pt-br`.

<sup>Written for commit 891f4808f6ad58f2ce304bf6965996eb4f217d6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

