### PR TITLE
fix(connections): expose selection state on connection cards to AT

### DIFF
--- a/apps/web/src/components/connections/connection-card.tsx
+++ b/apps/web/src/components/connections/connection-card.tsx
@@ -19,6 +19,8 @@ export interface ConnectionCardProps {
   footer?: React.ReactNode;
   className?: string;
   fallbackIcon?: ReactNode;
+  /** When the card acts as a selection toggle, its current pressed state. */
+  selected?: boolean | "mixed";
 }
 
 export function ConnectionCard({
@@ -29,6 +31,7 @@ export function ConnectionCard({
   footer,
   className,
   fallbackIcon,
+  selected,
 }: ConnectionCardProps) {
   const t = useT();
   return (
@@ -41,6 +44,7 @@ export function ConnectionCard({
       onClick={onClick}
       role={onClick ? "button" : undefined}
       tabIndex={onClick ? 0 : undefined}
+      aria-pressed={onClick && selected !== undefined ? selected : undefined}
       onKeyDown={
         onClick
           ? (e) => {

--- a/apps/web/src/routes/orgs/connection-selection-ui.tsx
+++ b/apps/web/src/routes/orgs/connection-selection-ui.tsx
@@ -124,6 +124,13 @@ export function ConnectionGroupCard({
             !allSelected &&
             "ring-1 ring-primary/50",
         )}
+        selected={
+          selectionMode
+            ? allSelected
+              ? true
+              : someSelected && "mixed"
+            : undefined
+        }
         fallbackIcon={<Container />}
         headerActionsAlwaysVisible
         headerActions={

--- a/apps/web/src/routes/orgs/connections.tsx
+++ b/apps/web/src/routes/orgs/connections.tsx
@@ -577,6 +577,7 @@ function ConnectionResults({
                     className={cn(
                       isSelected && "ring-2 ring-primary bg-primary/5",
                     )}
+                    selected={selectionMode ? isSelected : undefined}
                     headerActionsAlwaysVisible
                     headerActions={
                       <ConnectionCardHeaderActions


### PR DESCRIPTION
**Source:** a11y gap found auditing `connection-card.tsx` (recently churned, flagged as this tick's connections-UI focus area).

**Why:** In the connections list and the grouped-connection view, entering selection mode and clicking a card toggles its selected state, but the only feedback is a visual ring/background class (`ring-2 ring-primary`, etc.) on the card's wrapping div. The card already renders `role="button"`/`tabIndex` for keyboard activation, but never communicates its pressed/selected state to assistive tech, so a screen-reader or switch-access user gets no confirmation a card is selected.

**Fix:** Added an optional `selected?: boolean | "mixed"` prop to `ConnectionCard` that sets `aria-pressed` on the card's button role element. Wired it from both call sites that already track selection: `connections.tsx` (flat list, `isSelected`) and `connection-selection-ui.tsx`'s `ConnectionGroupCard` (group toggle, using `"mixed"` for a partially-selected group — matching the existing indeterminate-checkbox visual). No behavior change outside selection mode (`selected` stays `undefined`, so `aria-pressed` is omitted, matching prior markup).

**Reviewer check:** `bun test apps/web/src/components/connections/connection-card.test.tsx` (existing keyboard-activation tests still pass); `cd apps/web && bunx tsc --noEmit` is clean; `bunx oxlint` on the three touched files reports 0 warnings/errors.

**Verified locally:** the targeted test file, a scoped `tsc --noEmit`, and per-file `oxlint` as above. Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Announces connection card selection state to assistive tech via aria-pressed. Previously selection mode relied on visuals only; now `ConnectionCard` sets `aria-pressed` from an optional `selected` prop, including "mixed" for partially selected groups. Outside selection mode the markup is unchanged.

- Adds `selected?: boolean | "mixed"` to `ConnectionCard`; applies `aria-pressed` only when `onClick` is present and `selected` is defined.
- Wires `selected` in `connections.tsx` for per-card selection and in `connection-selection-ui.tsx` for group selection (`true`/`"mixed"` in selection mode).

<sup>Written for commit f44ee1e8ea7bf1f47cfc2a6b07edd292d3f1c762. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5981?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

