### PR TITLE
fix(decopilot): report the raw body when inspect_page gets a non-JSON 200

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.test.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.test.ts
@@ -49,4 +49,24 @@ describe("createInspectPageTool", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  test("reports the raw body when browserless returns a 200 with non-JSON", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () =>
+      new Response("<html>not json</html>", { status: 200 })) as never;
+    try {
+      const tool = createInspectPageTool(writer, {
+        browserless: { baseUrl: "https://bl.example", token: "t" },
+        objectStorage: { put: async () => ({ key: "k" }) } as never,
+        toolOutputMap: new Map(),
+      });
+      const result = (await tool.execute!({ url: "https://example.com" }, {
+        toolCallId: "tc1",
+      } as never)) as { success: boolean; error: string };
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("<html>not json</html>");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.ts
@@ -164,18 +164,19 @@ export function createInspectPageTool(
           };
         }
 
+        // Read as text first so a failed parse can still report the raw body.
+        const rawText = await response.text();
         let result: {
           consoleLogs?: { type: string; text: string }[];
           errors?: string[];
           evaluateResult?: unknown;
         };
         try {
-          result = await response.json();
+          result = JSON.parse(rawText);
         } catch {
-          const text = await response.text().catch(() => "");
           return {
             success: false,
-            error: `Browserless returned non-JSON response: ${text.slice(0, 200)}`,
+            error: `Browserless returned non-JSON response: ${rawText.slice(0, 200)}`,
             url: input.url,
           };
         }


### PR DESCRIPTION
Bug found while reviewing the inspect_page tool's reliability (recently hardened by #5796/#5940/#5962) for edge-case response handling.

When Browserless returns a 200 with a non-JSON body, `createInspectPageTool`'s parse-failure branch tried to fall back to `response.text()` to show the raw body in the error message. But `Response.json()` already consumes the body stream before it throws on a bad parse, so that fallback `response.text()` call always throws `TypeError: Body already used` — silently swallowed by its own `.catch(() => "")` — meaning the error message shown to the agent was always `"Browserless returned non-JSON response: "` with an empty snippet, never the actual content that would help debug why Browserless misbehaved.

**Failure scenario:** Browserless returns HTTP 200 with an HTML error page or truncated response instead of JSON (e.g. a proxy/gateway hiccup upstream of Browserless). The tool reports an empty, useless error instead of the actual body, making the failure mode invisible to whoever's debugging it.

**Fix:** read the body as text once, then `JSON.parse` it — so a failed parse can still report the real raw content instead of an empty string, without changing behavior for the success path.

**Regression test:** added `"reports the raw body when browserless returns a 200 with non-JSON"` in inspect-page.test.ts, which fails against the old code (empty error string) and passes against the fix.

**Reviewer command:** `bun test apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.test.ts`

**Locally verified:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bunx oxlint` on both changed files, and the targeted test file above — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures `inspect_page` reports the raw body when Browserless returns a 200 with non‑JSON, improving failure diagnostics. Previously it attempted `response.json()` then `response.text()`, but the consumed body made the fallback empty; now it reads text once, then `JSON.parse`, so parse failures include a snippet.

- Error path now includes the first 200 chars of the raw body; success path is unchanged.
- Adds a regression test: “reports the raw body when browserless returns a 200 with non-JSON”.
- Run: bun test apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.test.ts

<sup>Written for commit 621aafddc0f5f6eed5af4b1ecec9ae80ca271361. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

