### PR TITLE
fix(task-board): don't retry or resurrect a dismissed card's failed run

### DIFF
--- a/apps/api/src/storage/task-board-retry-dismissed.integration.test.ts
+++ b/apps/api/src/storage/task-board-retry-dismissed.integration.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Real-Postgres coverage for `scheduleRunRetry`/`returnToTodoAfterFailure`
+ * excluding dismissed cards.
+ *
+ * Same bug class as `task-board-advance-dismissed.integration.test.ts`: a
+ * reports-pushed task's `delete()` only stamps `dismissed_at` and leaves
+ * `status` at `in_progress`. `reactToFailedTaskRun`/the review sweeper decide
+ * whether to react off that stale `status` (read via `getById`, which doesn't
+ * expose `dismissedAt`) — without a `dismissed_at IS NULL` guard here, a card
+ * dismissed while its run was still in flight gets a fresh retry armed, or
+ * gets resurrected back onto To Do, once that run finally fails.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { sql } from "kysely";
+import type { StudioDatabase } from "../database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../database/test-db-pg";
+import { TaskBoardStorage } from "./task-board";
+
+const ORG = "org_retry_dismissed";
+const USER = "user_retry_dismissed";
+
+describe("scheduleRunRetry / returnToTodoAfterFailure (real Postgres)", () => {
+  let database: StudioDatabase;
+  let taskBoard: TaskBoardStorage;
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    await database.db
+      .insertInto("organization")
+      .values({
+        id: ORG,
+        name: ORG,
+        slug: "org-retry-dismissed",
+        createdAt: new Date().toISOString(),
+      })
+      .execute();
+    const now = new Date().toISOString();
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES (${USER}, ${"retry-dismissed@test"}, false, ${USER}, ${now}, ${now})
+    `.execute(database.db);
+    taskBoard = new TaskBoardStorage(database.db);
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  it("arms a retry on a normal in-progress card", async () => {
+    const task = await taskBoard.create({
+      organizationId: ORG,
+      title: "normal retry",
+      status: "in_progress",
+      by: USER,
+    });
+
+    const scheduled = await taskBoard.scheduleRunRetry(
+      task.id,
+      ORG,
+      1,
+      new Date(Date.now() + 1000),
+    );
+
+    expect(scheduled).toBe(true);
+  });
+
+  it("does not arm a retry on a card dismissed while still in_progress", async () => {
+    const task = await taskBoard.create({
+      organizationId: ORG,
+      title: "dismissed before retry",
+      status: "in_progress",
+      by: "system",
+    });
+
+    // Mirrors TASK_BOARD_ITEM_DELETE on a reports task: dismissed_at only.
+    await taskBoard.delete(task.id, ORG, USER);
+
+    const scheduled = await taskBoard.scheduleRunRetry(
+      task.id,
+      ORG,
+      1,
+      new Date(Date.now() + 1000),
+    );
+
+    expect(scheduled).toBe(false);
+  });
+
+  it("returns a normal in-progress card to todo after failure", async () => {
+    const task = await taskBoard.create({
+      organizationId: ORG,
+      title: "normal return to todo",
+      status: "in_progress",
+      by: USER,
+    });
+
+    const returned = await taskBoard.returnToTodoAfterFailure(
+      task.id,
+      ORG,
+      USER,
+    );
+
+    expect(returned?.status).toBe("todo");
+  });
+
+  it("does not resurrect a card dismissed while still in_progress onto todo", async () => {
+    const task = await taskBoard.create({
+      organizationId: ORG,
+      title: "dismissed before return to todo",
+      status: "in_progress",
+      by: "system",
+    });
+
+    await taskBoard.delete(task.id, ORG, USER);
+
+    const returned = await taskBoard.returnToTodoAfterFailure(
+      task.id,
+      ORG,
+      USER,
+    );
+
+    expect(returned).toBeNull();
+  });
+});

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -650,6 +650,13 @@ export class TaskBoardStorage {
    * Park a card on a retry: it stays In Progress (the work is still ours) and
    * becomes due for re-dispatch at `retryAt`. Conditional on the card still
    * being In Progress so a human who moved it meanwhile keeps their move.
+   *
+   * `dismissed_at IS NULL` matters for the same reason as `listItemsDueForRetry`:
+   * a reports-pushed task's `delete()` only stamps `dismissed_at` and leaves
+   * `status` at `in_progress`. `reactToFailedTaskRun`/the review sweeper read
+   * that stale `status` off `getById` (which doesn't expose `dismissedAt`), so
+   * without this guard a dismissed card whose run then fails gets a fresh retry
+   * armed on it.
    */
   async scheduleRunRetry(
     id: string,
@@ -663,6 +670,7 @@ export class TaskBoardStorage {
       .where("id", "=", id)
       .where("organization_id", "=", organizationId)
       .where("status", "=", "in_progress")
+      .where("dismissed_at", "is", null)
       .returning("id")
       .execute();
     return rows.length > 0;
@@ -671,7 +679,9 @@ export class TaskBoardStorage {
   /**
    * Send a card back to To Do after a run failed for good (not infrastructure,
    * or out of retries). Clears the retry state so a later re-run starts with a
-   * full budget. Conditional on In Progress for the same reason as above.
+   * full budget. Conditional on In Progress and `dismissed_at IS NULL` for the
+   * same reason as `scheduleRunRetry` above — otherwise a dismissed card gets
+   * resurrected straight back onto the board.
    */
   async returnToTodoAfterFailure(
     id: string,
@@ -690,6 +700,7 @@ export class TaskBoardStorage {
       .where("id", "=", id)
       .where("organization_id", "=", organizationId)
       .where("status", "=", "in_progress")
+      .where("dismissed_at", "is", null)
       .returning("id")
       .execute();
     if (rows.length === 0) return null;


### PR DESCRIPTION
Follows #5978's `advanceToReviewIfInProgress` fix (dismissed-card resurrection bug class) — same gap, two other call sites.

`scheduleRunRetry` and `returnToTodoAfterFailure` in `apps/api/src/storage/task-board.ts` were gated only on `status = 'in_progress'`, missing the `dismissed_at IS NULL` guard that `advanceToReviewIfInProgress`/`listItemsDueForRetry` already carry. A reports-pushed task's `delete()` only stamps `dismissed_at` (it keeps the row so the next diagnostic import doesn't recreate the card) — it never touches `status`.

**Failure scenario:** a user dismisses a reports-pushed card while its linked run is still in flight. `reactToFailedTaskRun` (called from the run-finish hook) and the review sweeper's failure path both decide whether to react by checking `item.status !== "in_progress"` off `taskBoard.getById()` — but `TaskBoardItem` doesn't expose `dismissedAt` at all, so that check can't see the dismissal. When the run then fails: `scheduleRunRetry` arms a fresh retry on a card the user already deleted from the board, or (once the retry budget is spent) `returnToTodoAfterFailure` resurrects it straight back into the To Do lane.

**Fix:** add `.where("dismissed_at", "is", null)` to both storage-layer updates — the same one-line guard already proven in `advanceToReviewIfInProgress` and `listItemsDueForRetry`. Fixing it at the storage layer covers both call sites (`run-reactions.ts` and `review-sweeper.ts`) without touching either caller.

Regression test: `apps/api/src/storage/task-board-retry-dismissed.integration.test.ts` — dismisses a card via `taskBoard.delete()` (which only sets `dismissed_at`), then asserts `scheduleRunRetry` returns `false` and `returnToTodoAfterFailure` returns `null` for it, alongside the normal (non-dismissed) case still working.

**To verify:** `bun test apps/api/src/storage/task-board-retry-dismissed.integration.test.ts` (needs a real Postgres — this laptop has none, so I could only verify via `tsc --noEmit` + `oxlint` locally; CI's Postgres-backed integration-test job runs the rest).

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint` on both touched files (0 warnings/errors).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop scheduling retries or returning to To Do for dismissed task-board cards when their linked runs fail. Previously, both paths only checked status='in_progress' and could arm a retry or resurrect a card dismissed while its run was in flight; now they also require dismissed_at IS NULL.

**Details**
- Add `dismissed_at IS NULL` guard to `scheduleRunRetry` and `returnToTodoAfterFailure` in `apps/api/src/storage/task-board.ts`.
- Behavior change: dismissed cards now yield `false` from `scheduleRunRetry` and `null` from `returnToTodoAfterFailure`; non-dismissed behavior is unchanged.
- Storage-layer fix covers both `run-reactions` and the review sweeper without caller changes; real-Postgres integration test added at `apps/api/src/storage/task-board-retry-dismissed.integration.test.ts`.

<sup>Written for commit 4473b2204baf6d9326452db7e63ff462e17f4563. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

