### PR TITLE
fix(task-board): stop cards dead-ending In Review with no signal

### DIFF
--- a/apps/api/src/tools/task-board/enqueue-reviewer.test.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.test.ts
@@ -10,6 +10,7 @@ import {
   hasFailedAttemptThisCycle,
   MAX_REVIEWER_ATTEMPTS,
   REVIEWER_DISALLOWED_TOOLS,
+  reviewerAttemptsExhausted,
   reviewerHandledThisCycle,
 } from "./enqueue-reviewer";
 import { REVIEW_RUN_TOOL_NAMES } from "./task-run-context";
@@ -112,6 +113,8 @@ describe("reviewerHandledThisCycle", () => {
       ),
     );
     expect(reviewerHandledThisCycle(task, "qa", CYCLE_START)).toBe(true);
+    // …and says WHY: no verdict is coming, so the card needs a human.
+    expect(reviewerAttemptsExhausted(task, "qa", CYCLE_START)).toBe(true);
   });
 
   it("a completed review alongside a failed attempt is still handled", () => {
@@ -174,6 +177,61 @@ describe("reviewerHandledThisCycle", () => {
     expect(reviewerHandledThisCycle(task, "qa", CYCLE_START)).toBe(false);
     expect(reviewerHandledThisCycle(task, "code_review", CYCLE_START)).toBe(
       true,
+    );
+  });
+});
+
+describe("reviewerAttemptsExhausted", () => {
+  const failed = (createdAt: string) =>
+    thread({ title: "QA Agent: fix", status: "failed", createdAt });
+
+  it("is false below the attempt budget", () => {
+    const task = taskWith([failed("2026-01-01T10:01:00Z")]);
+    expect(reviewerAttemptsExhausted(task, "qa", CYCLE_START)).toBe(false);
+  });
+
+  // The distinction that matters: `reviewerHandledThisCycle` is also true for a
+  // reviewer that ran fine, and that card must NOT be handed to a human.
+  it("is false when a review actually completed", () => {
+    const task = taskWith([
+      failed("2026-01-01T10:01:00Z"),
+      thread({
+        title: "QA Agent: fix",
+        status: "completed",
+        createdAt: "2026-01-01T10:02:00Z",
+      }),
+    ]);
+    expect(reviewerHandledThisCycle(task, "qa", CYCLE_START)).toBe(true);
+    expect(reviewerAttemptsExhausted(task, "qa", CYCLE_START)).toBe(false);
+  });
+
+  it("is false while an attempt is still live", () => {
+    const task = taskWith([
+      failed("2026-01-01T10:01:00Z"),
+      thread({
+        title: "QA Agent: fix",
+        status: "in_progress",
+        createdAt: "2026-01-01T10:02:00Z",
+      }),
+    ]);
+    expect(reviewerAttemptsExhausted(task, "qa", CYCLE_START)).toBe(false);
+  });
+
+  it("ignores failures from a prior cycle", () => {
+    const task = taskWith([
+      failed("2026-01-01T09:00:00Z"),
+      failed("2026-01-01T09:30:00Z"),
+    ]);
+    expect(reviewerAttemptsExhausted(task, "qa", CYCLE_START)).toBe(false);
+  });
+
+  it("scopes to the given reviewer", () => {
+    const task = taskWith([
+      failed("2026-01-01T10:01:00Z"),
+      failed("2026-01-01T10:02:00Z"),
+    ]);
+    expect(reviewerAttemptsExhausted(task, "code_review", CYCLE_START)).toBe(
+      false,
     );
   });
 });

--- a/apps/api/src/tools/task-board/enqueue-reviewer.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.ts
@@ -9,7 +9,7 @@ import {
   type ReviewerKind,
 } from "@decocms/shared/task-board";
 import { recordTaskActivity } from "./activity";
-import { emitTaskBoardUpdated } from "./run-reactions";
+import { emitTaskBoardUpdated, handTaskToHuman } from "./run-reactions";
 import { enqueueAgentRunForTask } from "./enqueue-task-run";
 import { resolveTaskRepoChoice } from "./claude-code-task-run";
 
@@ -89,6 +89,16 @@ export async function enqueueEnabledReviewers(
   // and Code Reviewer are enabled.
   await Promise.all(
     enabled.map(async (kind) => {
+      // A dead end, not a wait — see `reviewerAttemptsExhausted`.
+      if (reviewerAttemptsExhausted(task, kind, lastInReviewAt)) {
+        await handTaskToHuman(
+          ctx,
+          task,
+          `${REVIEWER_LABEL[kind]} failed ${MAX_REVIEWER_ATTEMPTS} times on ` +
+            `this review — it will not be retried`,
+        );
+        return;
+      }
       if (reviewerHandledThisCycle(task, kind, lastInReviewAt)) return;
       // Getting here with a dead reviewer thread from THIS cycle means the last
       // attempt failed (see `reviewerHandledThisCycle`). Its claim row is still
@@ -166,6 +176,48 @@ export function hasFailedAttemptThisCycle(
   );
 }
 
+/** The reviewer's threads belonging to the current cycle: created since the
+ *  cycle started, plus any still-live one (which owns the cycle wherever it
+ *  started). Pure. */
+function reviewerThreadsThisCycle(
+  task: TaskBoardItem,
+  kind: ReviewerKind,
+  lastInReviewAt: number,
+): TaskBoardItem["threads"] {
+  return task.threads.filter((thr) => {
+    if (!isReviewerThreadTitle(thr.title, kind)) return false;
+    const live =
+      thr.status !== null && !TERMINAL_THREAD_STATUSES.has(thr.status);
+    return live || new Date(thr.createdAt).getTime() >= lastInReviewAt;
+  });
+}
+
+/**
+ * True when this reviewer has spent every attempt of the cycle on a FAILED run.
+ *
+ * This is a dead end, not a wait: the claim key is (task, reviewer, cycle), so
+ * `claimReviewer` refuses every further dispatch until the card leaves and
+ * re-enters In Review — which only a reviewer verdict or a human can cause. The
+ * verdict is therefore never coming and the all-approved gate can never close,
+ * so the caller hands the card to a person instead of letting the sweeper visit
+ * it forever. Two cards sat In Review for six days on exactly this: one
+ * approval each, and a QA Agent that had died twice.
+ *
+ * Pure — unit-tested.
+ */
+export function reviewerAttemptsExhausted(
+  task: TaskBoardItem,
+  kind: ReviewerKind,
+  lastInReviewAt: number,
+): boolean {
+  const thisCycle = reviewerThreadsThisCycle(task, kind, lastInReviewAt);
+  return (
+    thisCycle.length > 0 &&
+    thisCycle.every((thr) => thr.status === "failed") &&
+    thisCycle.length >= MAX_REVIEWER_ATTEMPTS
+  );
+}
+
 /**
  * True when a reviewer of `kind` needs no further dispatch this cycle — the
  * guard that stops a duplicate reviewer run on every poll / re-trigger.
@@ -194,12 +246,7 @@ export function reviewerHandledThisCycle(
   kind: ReviewerKind,
   lastInReviewAt: number,
 ): boolean {
-  const thisCycle = task.threads.filter((thr) => {
-    if (!isReviewerThreadTitle(thr.title, kind)) return false;
-    const live =
-      thr.status !== null && !TERMINAL_THREAD_STATUSES.has(thr.status);
-    return live || new Date(thr.createdAt).getTime() >= lastInReviewAt;
-  });
+  const thisCycle = reviewerThreadsThisCycle(task, kind, lastInReviewAt);
   if (thisCycle.length === 0) return false;
   // A live run owns the cycle; never dispatch alongside it.
   if (

--- a/apps/api/src/tools/task-board/merge-pr.test.ts
+++ b/apps/api/src/tools/task-board/merge-pr.test.ts
@@ -1,0 +1,92 @@
+/**
+ * The two decisions a failed auto-merge has to get right. Both were silent
+ * `return false`s, and both stranded real cards In Review: an approved PR that
+ * had drifted into a conflict was retried every five minutes forever with
+ * nobody dispatched to rebase it, and a full set of approvals that didn't
+ * verify sat there for a week looking ready to ship. Pure; the merge round-trip
+ * itself is e2e.
+ */
+import { describe, expect, it } from "bun:test";
+import type { ReviewCycleActivity } from "@decocms/shared/task-board";
+import { approvedButUnverified } from "@decocms/shared/task-board";
+import { mayBeConflict } from "./merge-pr";
+
+const BOTH = ["qa", "code_review"] as const;
+const at = "2026-08-12T00:00:00.000Z";
+const approved = (
+  reviewer: string,
+  verified: boolean,
+): ReviewCycleActivity => ({
+  action: "review_approved",
+  data: { reviewer, verified },
+  occurredAt: at,
+});
+
+describe("mayBeConflict", () => {
+  it("is true for a plain refusal — the one outcome a conflict looks like", () => {
+    expect(mayBeConflict({ merged: false, reason: "refused" })).toBe(true);
+    expect(
+      mayBeConflict({
+        merged: false,
+        reason: "refused",
+        detail: "405 Pull Request has merge conflicts",
+      }),
+    ).toBe(true);
+  });
+
+  // A 429 says nothing about mergeability, and re-asking IS the burst.
+  it("is false for a rate-limited refusal", () => {
+    expect(
+      mayBeConflict({
+        merged: false,
+        reason: "refused",
+        detail: "Streamable HTTP error: too many requests",
+      }),
+    ).toBe(false);
+  });
+
+  it("is false for every non-refusal outcome", () => {
+    expect(mayBeConflict({ merged: true })).toBe(false);
+    for (const reason of [
+      "no_pr",
+      "checks_pending",
+      "checks_failing",
+      "no_connection",
+      "error",
+    ] as const) {
+      expect(mayBeConflict({ merged: false, reason })).toBe(false);
+    }
+  });
+});
+
+describe("approvedButUnverified", () => {
+  it("is true when a full set of approvals includes an unverified one", () => {
+    const activity = [approved("qa", true), approved("code_review", false)];
+    expect(approvedButUnverified(activity, [...BOTH])).toBe(true);
+  });
+
+  // The happy path must not be handed to a human — it is about to merge.
+  it("is false when every approval verified", () => {
+    const activity = [approved("qa", true), approved("code_review", true)];
+    expect(approvedButUnverified(activity, [...BOTH])).toBe(false);
+  });
+
+  // Still waiting on the other reviewer is not a dead end.
+  it("is false while a reviewer has not voted yet", () => {
+    expect(approvedButUnverified([approved("qa", false)], [...BOTH])).toBe(
+      false,
+    );
+  });
+
+  it("is false when a reviewer requested changes", () => {
+    const activity: ReviewCycleActivity[] = [
+      approved("qa", false),
+      {
+        action: "review_changes_requested",
+        data: { reviewer: "code_review", verified: true },
+        occurredAt: at,
+      },
+    ];
+    expect(approvedButUnverified(activity, [...BOTH])).toBe(false);
+  });
+});

--- a/apps/api/src/tools/task-board/merge-pr.ts
+++ b/apps/api/src/tools/task-board/merge-pr.ts
@@ -3,16 +3,20 @@ import type { TaskBoardItem } from "@/storage/types";
 import { clientFromConnection } from "@/mcp-clients";
 import {
   allReviewersApproved,
+  approvedButUnverified,
   REVIEWER_FLAG,
   REVIEWER_KINDS,
 } from "@decocms/shared/task-board";
 import { recordTaskActivity } from "./activity";
+import { reactToApprovedPrConflict } from "./conflict-reaction";
 import {
   fetchPrChecksStatus,
+  fetchPrConflict,
   invalidatePrReads,
+  isRateLimitError,
   resolveGithubConnection,
 } from "./prs-get";
-import { emitTaskBoardUpdated } from "./run-reactions";
+import { emitTaskBoardUpdated, handTaskToHuman } from "./run-reactions";
 
 /** Cap the merge round-trip so a slow GitHub can't hang the caller. */
 const MERGE_TIMEOUT_MS = 15000;
@@ -199,6 +203,88 @@ export async function allEnabledReviewersVerifiedApproved(
 }
 
 /**
+ * True when every enabled reviewer approved but at least one approval did NOT
+ * verify — the auto-merge gate is unsatisfiable for the rest of this cycle.
+ *
+ * A reviewer's token binds its decision to its dispatch, so an approval that
+ * fails to verify (the model dropped the token from its prompt, or replayed one
+ * minted for an earlier cycle) is recorded but doesn't count. Nothing then
+ * re-dispatches that reviewer — its claim for the cycle is spent — so the card
+ * shows two green approvals on the board and can never merge. One sat like that
+ * for seven days. There is no automatic way out, which is exactly what makes it
+ * a person's: hand it over rather than sweeping it forever.
+ */
+async function handUnverifiedApprovalToHuman(
+  ctx: StudioContext,
+  item: TaskBoardItem,
+): Promise<void> {
+  const settings = await ctx.storage.organizationSettings.get(
+    item.organizationId,
+  );
+  const flags = settings?.flags ?? {};
+  const enabled = REVIEWER_KINDS.filter(
+    (k) => flags[REVIEWER_FLAG[k]] === true,
+  );
+  const activity = await ctx.storage.taskBoard.listActivity(
+    item.id,
+    item.organizationId,
+  );
+  if (!approvedButUnverified(activity, enabled)) return;
+  await handTaskToHuman(
+    ctx,
+    item,
+    "every reviewer approved, but an approval could not be verified — " +
+      "auto-merge is blocked and no reviewer can be re-dispatched this cycle",
+  );
+}
+
+/**
+ * True when a merge outcome is worth a `pull_request_read` to ask GitHub
+ * whether the PR conflicts. Pure — unit-tested.
+ *
+ * Only a refusal can be a conflict; every other reason (no PR, no connection,
+ * red or pending checks) is definitely not one. A rate-limited refusal is
+ * excluded too: it says nothing about mergeability, and paying another GitHub
+ * call into a 429 is the burst that keeps the limit shut.
+ */
+export function mayBeConflict(outcome: MergeOutcome): boolean {
+  if (outcome.merged || outcome.reason !== "refused") return false;
+  return !isRateLimitError(outcome.detail ?? "");
+}
+
+/**
+ * Hand an approved-but-conflicting PR back to the Super Agent to rebase.
+ *
+ * The inline approval path does this (`review-decision.ts`), but the SWEEP's
+ * retry didn't — so a conflict that appeared after the approval (the base
+ * branch moved on, which is the common case for a card that waited) left the
+ * card retrying the same 405 every five minutes, forever, with no run ever
+ * dispatched to fix it. Two cards in one org, `merge_conflict_resolution` count
+ * zero across the whole board.
+ *
+ * `mayBeConflict` decides which outcomes are worth the extra GitHub read; the
+ * reaction itself re-checks approval, the org flag and its own dispatch cap.
+ */
+async function resolveConflictAfterRefusedMerge(
+  ctx: StudioContext,
+  item: TaskBoardItem,
+  outcome: MergeOutcome,
+): Promise<void> {
+  if (!mayBeConflict(outcome)) return;
+  const orgId = item.organizationId;
+  const prs = await ctx.storage.taskBoard.listPrs(item.id, orgId);
+  // The newest linked PR — the one `mergeLinkedPr` just tried to merge.
+  const pr = prs[0];
+  if (!pr) return;
+  await reactToApprovedPrConflict(ctx, orgId, item, {
+    pr: { number: pr.number, url: pr.url },
+    conflict: await fetchPrConflict(ctx, orgId, pr),
+  }).catch((err) => {
+    console.error("[task-board] sweep conflict auto-resolve failed", err);
+  });
+}
+
+/**
  * Retry the auto-merge for a card that finished its review but never shipped.
  *
  * The reviewer decision merges inline, and when that merge fails the card is
@@ -221,11 +307,15 @@ export async function retryAutoMergeIfApproved(
   const settings = await ctx.storage.organizationSettings.get(orgId);
   if (settings?.flags?.auto_merge !== true) return false;
   if (!(await allEnabledReviewersVerifiedApproved(ctx, orgId, item.id))) {
+    await handUnverifiedApprovalToHuman(ctx, item);
     return false;
   }
 
   const outcome = await mergeLinkedPr(ctx, orgId, item.id);
-  if (!outcome.merged) return false;
+  if (!outcome.merged) {
+    await resolveConflictAfterRefusedMerge(ctx, item, outcome);
+    return false;
+  }
 
   const done = await ctx.storage.taskBoard.update(
     item.id,

--- a/apps/api/src/tools/task-board/review-decision.ts
+++ b/apps/api/src/tools/task-board/review-decision.ts
@@ -9,7 +9,7 @@ import {
 } from "@decocms/shared/task-board";
 import { TaskBoardItemStatusSchema } from "./schema";
 import { recordTaskActivity } from "./activity";
-import { emitTaskBoardUpdated } from "./run-reactions";
+import { emitTaskBoardUpdated, handTaskToHuman } from "./run-reactions";
 import { enqueueSuperAgentForTask } from "./enqueue-super-agent";
 import { allEnabledReviewersVerifiedApproved, mergeLinkedPr } from "./merge-pr";
 import { fetchPrConflict } from "./prs-get";
@@ -153,28 +153,18 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
           actorId: null,
           data: { reviewer, notes, verified, bounceLimitReached: true },
         });
-        console.warn(
-          `[task-board] ${taskBoardItemId}: ${MAX_REVIEW_BOUNCES} review ` +
-            `bounces reached — unassigning the Super Agent, needs a human`,
+        // Stays In Review with the reviewer's notes, where a human picks it up.
+        await handTaskToHuman(
+          ctx,
+          item,
+          `${MAX_REVIEW_BOUNCES} review bounces reached — the reviewer and the ` +
+            `Super Agent are not converging`,
         );
-        // Unassign so the card reads as a person's problem rather than an
-        // agent's, and so nothing downstream re-dispatches it. It stays In
-        // Review with the reviewer's notes: that is where a human wants to
-        // pick it up, and the ship button stays hidden because nothing is
-        // approved.
-        const handed = await ctx.storage.taskBoard.update(
-          taskBoardItemId,
-          organizationId,
-          { assigneeId: null },
-          item.updatedBy,
-        );
-        await recordTaskActivity(ctx, {
-          taskBoardItemId,
-          action: "assignee_changed",
-          actorId: null,
-          data: { from: item.assigneeId, to: null },
-        });
-        emitTaskBoardUpdated(organizationId, handed);
+        const handed =
+          (await ctx.storage.taskBoard.getById(
+            taskBoardItemId,
+            organizationId,
+          )) ?? item;
         return { status: handed.status, merged: false };
       }
 

--- a/apps/api/src/tools/task-board/review-sweeper.test.ts
+++ b/apps/api/src/tools/task-board/review-sweeper.test.ts
@@ -9,7 +9,7 @@
 import { describe, expect, it } from "bun:test";
 import { TaskQuotaError } from "@/billing/task-quota";
 import { prReadyForReview } from "./prs-get";
-import { isPermanentDispatchFailure } from "./review-sweeper";
+import { isPermanentDispatchFailure, noPrHandoffDue } from "./review-sweeper";
 
 const pr = (over: Partial<Parameters<typeof prReadyForReview>[0][number]>) => ({
   state: "open",
@@ -90,5 +90,31 @@ describe("isPermanentDispatchFailure", () => {
     );
     expect(isPermanentDispatchFailure("no model configured")).toBe(false);
     expect(isPermanentDispatchFailure(undefined)).toBe(false);
+  });
+});
+
+/**
+ * The other terminal the sweeper owns: a card parked In Review with no PR. No
+ * reviewer is ever dispatched at it, so without a handover it is swept forever
+ * and reads like a card whose reviewers are still thinking.
+ */
+describe("noPrHandoffDue", () => {
+  const CYCLE = new Date("2026-01-01T10:00:00Z").getTime();
+  const at = (mins: number) => CYCLE + mins * 60_000;
+
+  it("waits out the grace — the PR link and the status move are two calls", () => {
+    expect(noPrHandoffDue(CYCLE, at(1))).toBe(false);
+    expect(noPrHandoffDue(CYCLE, at(14))).toBe(false);
+  });
+
+  it("hands over once the card has sat there past the grace", () => {
+    expect(noPrHandoffDue(CYCLE, at(15))).toBe(true);
+    expect(noPrHandoffDue(CYCLE, at(60 * 24))).toBe(true);
+  });
+
+  // No `→ in_review` entry on the timeline reads as infinitely old, which is
+  // right: those are the oldest strands and no PR is coming for them either.
+  it("hands over a card with no recorded review cycle at all", () => {
+    expect(noPrHandoffDue(0, at(0))).toBe(true);
   });
 });

--- a/apps/api/src/tools/task-board/review-sweeper.ts
+++ b/apps/api/src/tools/task-board/review-sweeper.ts
@@ -61,14 +61,20 @@
  */
 
 import type { StudioContextFactory } from "@/automations/fire";
+import type { StudioContext } from "@/core/studio-context";
 import type { OrganizationBillingStorage } from "@/storage/organization-billing";
 import type { TaskBoardStorage } from "@/storage/task-board";
-import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
+import type { TaskBoardItem } from "@/storage/types";
+import {
+  reviewCycleStart,
+  SUPER_AGENT_ASSIGNEE_ID,
+} from "@decocms/shared/task-board";
 import { enqueueEnabledReviewers } from "./enqueue-reviewer";
 import { enqueueSuperAgentForTask } from "./enqueue-super-agent";
 import { retryAutoMergeIfApproved } from "./merge-pr";
 import {
   emitTaskBoardUpdated,
+  handTaskToHuman,
   reactToFailedTaskRun,
   refundUnproductiveTaskClaims,
 } from "./run-reactions";
@@ -101,6 +107,12 @@ const DEFAULT_BATCH_SIZE = 50;
  *  blip in the context factory or the quota read. */
 const REARM_DELAY_MS = 60 * 1000;
 
+/** How long a card may sit In Review with no linked PR before it is handed to a
+ *  person. A run links its PR and moves the card in two separate calls, so a
+ *  sweep can land between them — this is the margin that stops a card being
+ *  handed over a second before its PR arrives. */
+const NO_PR_HANDOFF_GRACE_MS = 15 * 60 * 1000;
+
 /** How long a failed run may sit unreacted-to before the sweeper steps in. Long
  *  enough that the in-band reaction (which runs within milliseconds of the
  *  failure) always wins the normal case, short enough that a card whose pod died
@@ -119,6 +131,19 @@ const UNHANDLED_FAILURE_GRACE_MS = 2 * 60 * 1000;
  */
 export function isPermanentDispatchFailure(err: unknown): boolean {
   return err instanceof TaskQuotaError;
+}
+
+/**
+ * True when a PR-less card has been In Review long enough to hand over.
+ *
+ * A cycle start of 0 means the card has no `→ in_review` entry on its timeline
+ * at all — a card moved there before the activity log recorded the transition,
+ * or by a path that doesn't. That reads as "infinitely old", which is the right
+ * answer: those are the oldest strands, and there is no PR coming for them
+ * either. Pure — unit-tested.
+ */
+export function noPrHandoffDue(cycleStartMs: number, nowMs: number): boolean {
+  return nowMs - cycleStartMs >= NO_PR_HANDOFF_GRACE_MS;
 }
 
 export interface TaskBoardReviewSweeperOptions {
@@ -392,6 +417,36 @@ export class TaskBoardReviewSweeper {
     }
   }
 
+  /**
+   * Hand a card parked In Review with no pull request to a person.
+   *
+   * There is nothing for a reviewer to review, so no reviewer is ever
+   * dispatched — the run either finished without opening a PR or opened one and
+   * never called `TASK_BOARD_ITEM_PR_LINK`. Until now that was a silent
+   * `return`: the card was swept every five minutes forever and read on the
+   * board exactly like one waiting on its reviewers. Four sat that way in one
+   * org, the oldest for a week.
+   *
+   * Waits out `NO_PR_HANDOFF_GRACE_MS` first, because the run links its PR and
+   * moves the card in two separate calls and the sweep can land between them.
+   */
+  private async handOffReviewWithoutPr(
+    ctx: StudioContext,
+    item: TaskBoardItem,
+  ): Promise<void> {
+    const activity = await this.taskBoard.listActivity(
+      item.id,
+      item.organizationId,
+    );
+    if (!noPrHandoffDue(reviewCycleStart(activity), Date.now())) return;
+    await handTaskToHuman(
+      ctx,
+      item,
+      "no pull request is linked to this task — there is nothing for a " +
+        "reviewer to review",
+    );
+  }
+
   /** Hand a card with a linked, ready PR off to the enabled reviewers. Returns
    *  true when reviewers were considered (i.e. the card had a PR to review). */
   private async reconcileItem(
@@ -419,10 +474,7 @@ export class TaskBoardReviewSweeper {
     // mid-sweep costs one interval of delay — the right trade for a slow floor.
     await this.taskBoard.markSwept(id, organizationId);
 
-    // Nothing to review without a PR — a research/answer task reaches In Review
-    // too, and dispatching a reviewer at it would burn a run on nothing.
     const prs = await this.taskBoard.listPrs(id, organizationId);
-    if (prs.length === 0) return false;
 
     // Built as the task's owner, like the run-finish trigger does — the sweeper
     // has storage only, and the reviewer dispatch needs a full context.
@@ -431,6 +483,11 @@ export class TaskBoardReviewSweeper {
       item.assignedBy ?? item.createdBy,
     );
     if (!ctx) return false;
+
+    if (prs.length === 0) {
+      await this.handOffReviewWithoutPr(ctx, item);
+      return false;
+    }
 
     // A card whose review already COMPLETED but whose merge failed is stranded:
     // the cycle's reviewer claims are spent, so the dispatch below is a no-op

--- a/apps/api/src/tools/task-board/run-reactions.ts
+++ b/apps/api/src/tools/task-board/run-reactions.ts
@@ -30,9 +30,11 @@ import { exponentialBackoffWithJitter } from "@decocms/shared/std";
 import { sseHub } from "@/event-bus/sse-hub";
 import {
   isReportsTask,
+  SUPER_AGENT_ASSIGNEE_ID,
   TASK_BOARD_ITEM_DELETED_EVENT,
   TASK_BOARD_ITEM_UPDATED_EVENT,
 } from "@decocms/shared/task-board";
+import { recordTaskActivity } from "./activity";
 import type { TaskBoardStorage } from "@/storage/task-board";
 import type { TaskBoardItem, TaskBoardItemStatus } from "@/storage/types";
 
@@ -415,6 +417,53 @@ export async function refundUnproductiveTaskClaims(
     }
   } catch (err) {
     console.error("[task-board] quota refund pass failed", err);
+  }
+}
+
+/**
+ * Stop automating a card and hand it to a person, with the reason on its
+ * timeline.
+ *
+ * Every automatic lane out of In Review can dead-end: the reviewer's approval
+ * didn't verify, its runs burned their attempts, the run parked a card there
+ * with no PR to review. Each of those used to `return` silently — the card kept
+ * being swept, kept costing GitHub calls, and read on the board exactly like a
+ * card whose reviewers were still thinking. Twelve of them accumulated in one
+ * org, the oldest for a week.
+ *
+ * Unassigning is what makes it terminal AND idempotent: every automatic path
+ * (the sweeper's `reconcileItem`, the reviewer dispatch, the conflict reaction)
+ * requires the Super Agent as assignee, so a handed-over card is visited once
+ * and then left alone. Deliberately leaves the STATUS untouched — In Review is
+ * where a human wants to pick a reviewed card up, and moving it would lose the
+ * reviewers' notes' context. Returns true when this call did the handover.
+ */
+export async function handTaskToHuman(
+  ctx: StudioContext,
+  item: TaskBoardItem,
+  reason: string,
+): Promise<boolean> {
+  const orgId = item.organizationId;
+  if (item.assigneeId !== SUPER_AGENT_ASSIGNEE_ID) return false;
+  try {
+    const handed = await ctx.storage.taskBoard.update(
+      item.id,
+      orgId,
+      { assigneeId: null },
+      item.updatedBy,
+    );
+    await recordTaskActivity(ctx, {
+      taskBoardItemId: item.id,
+      action: "assignee_changed",
+      actorId: null,
+      data: { from: item.assigneeId, to: null, reason },
+    });
+    console.warn(`[task-board] ${item.id} handed to a human: ${reason}`);
+    emitTaskBoardUpdated(orgId, handed);
+    return true;
+  } catch (err) {
+    console.error(`[task-board] handing ${item.id} to a human failed`, err);
+    return false;
   }
 }
 

--- a/packages/shared/src/task-board.ts
+++ b/packages/shared/src/task-board.ts
@@ -149,6 +149,26 @@ export function allReviewersApproved(
 }
 
 /**
+ * True when every enabled reviewer approved, but the approvals do NOT satisfy
+ * the verified gate the auto-merge requires.
+ *
+ * The card then shows a full set of green approvals and can never merge: the
+ * reviewer whose token didn't verify has already spent its claim for the cycle,
+ * so nothing re-dispatches it and no later event can change the verdict. It is
+ * a dead end that looks like progress, which is why it gets its own predicate
+ * rather than living as an `!allReviewersApproved(…, verifiedOnly)` fall-through.
+ */
+export function approvedButUnverified(
+  activity: ReviewCycleActivity[],
+  enabled: ReviewerKind[],
+): boolean {
+  return (
+    allReviewersApproved(activity, enabled) &&
+    !allReviewersApproved(activity, enabled, { verifiedOnly: true })
+  );
+}
+
+/**
  * How many times a task may be bounced back to the Super Agent by a reviewer
  * before the loop is broken and a human takes over.
  *


### PR DESCRIPTION
## Why

Debugging the `deco-studio` board turned up **12 cards parked In Review**, the oldest for a week. None of them were waiting on a reviewer — each was sitting on a dead end that no code path could get out of, and every one of them was a silent `return` on a path the sweeper kept revisiting every five minutes.

| Cause | Cards | What actually happened |
|---|---|---|
| Approved PR drifted into a merge conflict | 2 | The sweeper's merge retry re-attempted the same `405 Pull Request has merge conflicts` forever. `merge_conflict_resolution` count across the entire board: **0**. |
| Full set of approvals, one didn't verify | 1 | `verified: false` on a `review_approved`. The reviewer's cycle claim is spent, so nothing re-dispatches it and the auto-merge gate can never close — while the board shows two green approvals. |
| Reviewer burned both attempts on failed runs | 2 | `claimReviewer` refuses every retry for the rest of the cycle, so the verdict is never coming. |
| No linked PR at all | 4 | No reviewer is ever dispatched at a PR-less card, by design. |

*(The remaining 3: two blocked on a live GitHub MCP `429` — infra, not code — and one correctly handed over at the review-bounce limit.)*

## What this changes

**The conflict one is a real gap, and gets the reaction it was missing.** `review-decision.ts` already hands an approved-but-conflicting PR back to the Super Agent to rebase; `retryAutoMergeIfApproved` didn't, which is exactly the case where a conflict is *likeliest* (the base branch moved while the card waited). Now it does.

**The other three are genuinely terminal, so they hand the card to a person** — unassign, with the reason on the timeline. Unassigning is also what makes it idempotent and cheap: every automatic path requires the Super Agent as assignee and `listItemsPendingReview` filters on it, so a handed-over card is visited once and then drops out of the sweep. Status stays In Review, where a human wants to pick a reviewed card up.

`handTaskToHuman` (`run-reactions.ts`) is that handover, shared with the review-bounce limit which was already doing it inline — that call site shrinks by 12 lines.

### Deliberate non-changes

- **A rate-limited merge refusal does NOT trigger the conflict read.** A 429 says nothing about mergeability, and another `pull_request_read` into it is the burst that keeps the limit shut. `mayBeConflict` encodes that.
- **The PR-less handover waits out a 15 min grace.** A run links its PR and moves the card in two separate calls; a sweep can land between them.
- **Nothing auto-merges that wasn't already mergeable.** The conflict reaction re-checks approval, the org flag, and its own all-time dispatch cap internally.

## Testing

Four new pure predicates, all unit-tested (`bun test apps/api/src/tools/task-board/` — 44 pass across the touched files, remaining failures in that dir are the pre-existing `*.integration.test.ts` needing a real Postgres, identical on `main`):

- `mayBeConflict` — refusal vs. rate-limited refusal vs. every other outcome
- `approvedButUnverified` — including the two cases that must NOT hand over (all verified; still waiting on a reviewer)
- `reviewerAttemptsExhausted` — pinned against `reviewerHandledThisCycle`, which is *also* true for a reviewer that ran fine
- `noPrHandoffDue` — grace boundary, plus a card with no recorded cycle at all

`bun run fmt`, `bun run lint` (0 errors), `bun run --cwd=apps/api check`, and `knip` all clean.

## Follow-up, not in this PR

The GitHub MCP connection is currently shedding load — 22 `too many requests` in a 45-minute log window, `pull_request_read` failing across ~8 repos in different orgs. That's the live blocker for 2 of the 12 and it's infra, not code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops cards from silently stranding In Review. Previously, four terminal states returned with no signal and the sweeper retried forever; now we auto-resolve conflicts or hand the task to a human and stop automation.

- Approved PRs that later conflict: the sweeper’s merge retry now triggers the conflict reaction to rebase via the Super Agent; rate-limited refusals (429) do not trigger an extra PR read.
- Full approvals with an unverified one: detect the unsatisfiable auto-merge gate and unassign to a human with the reason on the timeline.
- Reviewer exhausted attempts this cycle: detect spent attempts on failed runs and hand to a human; no further retries are attempted.
- In Review with no linked PR: after a 15‑minute grace, unassign to a human because there’s nothing to review.
- Handover is idempotent: unassigning the Super Agent removes the card from sweeps while keeping status In Review; nothing auto‑merges that wasn’t already mergeable.

<sup>Written for commit e41ab49088a05fa428354315e865061bc12bfce4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

