### PR TITLE
fix(sandbox): read the whole export body in the telemetry test

### DIFF
--- a/packages/sandbox/daemon-go/internal/telemetry/telemetry_test.go
+++ b/packages/sandbox/daemon-go/internal/telemetry/telemetry_test.go
@@ -2,6 +2,7 @@ package telemetry
 
 import (
 	"context"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -23,10 +24,16 @@ func TestInitExportsToEndpoint(t *testing.T) {
 	var mu sync.Mutex
 	var bodies []string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		buf := make([]byte, 1<<16)
-		n, _ := r.Body.Read(buf)
+		// ReadAll, not one Read: an io.Reader may return fewer bytes than asked
+		// for, so a single Read keeps only the first segment of an export the
+		// runner happened to split — dropping whichever metric names sit past
+		// the cut and failing the assertions below on a payload that was fine.
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("reading export body: %v", err)
+		}
 		mu.Lock()
-		bodies = append(bodies, r.URL.Path+"\x00"+string(buf[:n]))
+		bodies = append(bodies, r.URL.Path+"\x00"+string(body))
 		mu.Unlock()
 		w.Write([]byte("{}"))
 	}))


### PR DESCRIPTION
## Why

`daemon-e2e` failed on an unrelated PR with:

```
--- FAIL: TestInitExportsToEndpoint (2.41s)
    telemetry_test.go:92: export missing "sandbox.daemon.devserver.exit"
```

One metric name missing, the rest present — the signature of a truncated capture, not a missing export. `RecordDevServerExit` is unconditional, so the metric was recorded.

The test server does:

```go
buf := make([]byte, 1<<16)
n, _ := r.Body.Read(buf)
bodies = append(bodies, r.URL.Path+"\x00"+string(buf[:n]))
```

A single `Read`. `io.Reader` is explicitly allowed to return fewer bytes than the buffer holds, so when the runner splits the export across segments the handler keeps only the first one and silently drops the tail of the protobuf — taking whichever metric names sit past the cut with it. It also caps at 64 KiB with no error.

## Fix

`io.ReadAll`, and report a read error rather than discarding it (`_` hid this class of failure). Test-only; no daemon behavior changes.

## Testing

`go test ./internal/telemetry/ -count=1` ×5, plus `go vet` and `gofmt`, all clean.

Note this does not reproduce on a fast loopback — the whole body arrives in one read locally, which is why it only shows up as an occasional CI failure. Beware `-count=N` when reproducing: `Init` binds package-level instruments to the first provider in the process, so runs 2+ always fail for an unrelated reason.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Read the full export body in the telemetry test server to eliminate a CI flake. Old behavior: a single `r.Body.Read` into a 64 KiB buffer with errors discarded, which truncated segmented exports and made metrics like `sandbox.daemon.devserver.exit` appear missing. New behavior: use `io.ReadAll` and report read errors; assertions now run against the complete payload.

- Change is limited to `packages/sandbox/daemon-go/internal/telemetry/telemetry_test.go` (handler in `TestInitExportsToEndpoint`).
- Test-only; no daemon behavior or export format changes.

<sup>Written for commit 83485174e13be997d1557ee7946ddc4c105ac91d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

