### PR TITLE
fix(sections-editor): label inline-union array items by active branch

### DIFF
--- a/apps/web/src/components/sections-editor/array-item-display.test.ts
+++ b/apps/web/src/components/sections-editor/array-item-display.test.ts
@@ -95,6 +95,116 @@ describe("getArrayItemLabel", () => {
     );
   });
 
+  // Inline unions carry a per-branch Mustache title, resolved against branch data.
+  const matcherUnionSchema: SchemaProperty = {
+    type: "inline-union",
+    inlineUnionBranches: [
+      {
+        title: "Categoria {{{id}}}",
+        discriminators: { matcherType: "category" },
+        schema: {
+          type: "object",
+          properties: {
+            matcherType: { type: "string" },
+            id: { type: "string" },
+          },
+        },
+      },
+      {
+        title: "Cluster {{{value}}}",
+        discriminators: { matcherType: "cluster" },
+        schema: {
+          type: "object",
+          properties: {
+            matcherType: { type: "string" },
+            value: { type: "string" },
+          },
+        },
+      },
+    ],
+  };
+
+  test("labels an inline-union item by its active branch (discriminator match)", () => {
+    expect(
+      getArrayItemLabel(
+        { matcherType: "category", id: "123" },
+        0,
+        matcherUnionSchema,
+      ),
+    ).toBe("Categoria 123");
+    expect(
+      getArrayItemLabel(
+        { matcherType: "cluster", value: "45" },
+        1,
+        matcherUnionSchema,
+      ),
+    ).toBe("Cluster 45");
+  });
+
+  test("keeps the static branch prefix when Mustache fields are empty", () => {
+    expect(
+      getArrayItemLabel({ matcherType: "category" }, 0, matcherUnionSchema),
+    ).toBe("Categoria");
+  });
+
+  test("falls back past a purely-Mustache branch title with empty data", () => {
+    const schema: SchemaProperty = {
+      type: "inline-union",
+      inlineUnionBranches: [
+        {
+          title: "{{{value}}}",
+          discriminators: { matcherType: "cluster" },
+          schema: {
+            type: "object",
+            properties: {
+              matcherType: { type: "string" },
+              value: { type: "string" },
+            },
+          },
+        },
+      ],
+    };
+    expect(getArrayItemLabel({ matcherType: "cluster" }, 2, schema)).toBe(
+      "Item 3",
+    );
+  });
+
+  test("infers the branch by field presence when no discriminator matches", () => {
+    const schema: SchemaProperty = {
+      type: "inline-union",
+      inlineUnionBranches: [
+        {
+          title: "Período {{{start}}}",
+          schema: {
+            type: "object",
+            properties: { start: { type: "string" }, end: { type: "string" } },
+          },
+        },
+        {
+          title: "Produto {{{value}}}",
+          schema: {
+            type: "object",
+            properties: { value: { type: "string" } },
+          },
+        },
+      ],
+    };
+    expect(getArrayItemLabel({ value: "prod-9" }, 0, schema)).toBe(
+      "Produto prod-9",
+    );
+  });
+
+  test("colliding inline-union items share a clean label (no positional suffix)", () => {
+    const items = [
+      { matcherType: "category", id: "10" },
+      { matcherType: "category", id: "10" },
+    ];
+    expect(getArrayItemDisplayLabels(items, matcherUnionSchema)).toEqual([
+      "Categoria 10",
+      "Categoria 10",
+    ]);
+  });
+
   test("colliding items keep an identical base label (no positional suffix)", () => {
     // Items with no distinguishing field share a label — intentional: the
     // breadcrumb addresses an item by index (Crumb.itemIndex), never by a unique

--- a/apps/web/src/components/sections-editor/array-item-display.test.ts
+++ b/apps/web/src/components/sections-editor/array-item-display.test.ts
@@ -4,6 +4,7 @@ import {
   getArrayItemImageSrc,
   getArrayItemLabel,
   renderMustacheTemplate,
+  stripMustacheTokens,
 } from "./array-item-display";
 import type { SchemaProperty } from "./resolve-schema";
 
@@ -194,6 +195,48 @@ describe("getArrayItemLabel", () => {
     );
   });
 
+  test("labels a static (token-free) branch title verbatim", () => {
+    const schema: SchemaProperty = {
+      type: "inline-union",
+      inlineUnionBranches: [
+        {
+          title: "Localização",
+          discriminators: { kind: "location" },
+          schema: {
+            type: "object",
+            properties: { kind: { type: "string" }, city: { type: "string" } },
+          },
+        },
+      ],
+    };
+    expect(getArrayItemLabel({ kind: "location" }, 0, schema)).toBe(
+      "Localização",
+    );
+  });
+
+  // resolve-schema fills titleless branches with `Option N`; it must not shadow the item's own label.
+  test("falls through a synthetic 'Option N' branch title to the field scan", () => {
+    const schema: SchemaProperty = {
+      type: "inline-union",
+      inlineUnionBranches: [
+        {
+          title: "Option 1",
+          discriminators: { name: "max-age" },
+          schema: {
+            type: "object",
+            properties: {
+              name: { type: "string" },
+              maxAge: { type: "number" },
+            },
+          },
+        },
+      ],
+    };
+    expect(getArrayItemLabel({ name: "max-age", maxAge: 60 }, 0, schema)).toBe(
+      "max-age",
+    );
+  });
+
   test("colliding inline-union items share a clean label (no positional suffix)", () => {
     const items = [
       { matcherType: "category", id: "10" },
@@ -297,6 +340,31 @@ describe("getArrayItemImageSrc", () => {
     expect(getArrayItemImageSrc(item, schema)).toBe(
       "https://example.com/mobile.jpg",
     );
+  });
+});
+
+describe("stripMustacheTokens", () => {
+  test("strips triple-brace tokens, keeping static text", () => {
+    expect(stripMustacheTokens("Categoria {{{id}}}")).toBe("Categoria");
+  });
+
+  test("strips double-brace tokens", () => {
+    expect(stripMustacheTokens("Cluster {{value}}")).toBe("Cluster");
+  });
+
+  test("collapses whitespace left between multiple tokens", () => {
+    expect(stripMustacheTokens("Período {{{start}}} — {{{end}}}")).toBe(
+      "Período —",
+    );
+  });
+
+  test("returns a token-free title unchanged", () => {
+    expect(stripMustacheTokens("Localização")).toBe("Localização");
+  });
+
+  test("returns empty string for a purely-Mustache title", () => {
+    expect(stripMustacheTokens("{{{value}}}")).toBe("");
+    expect(stripMustacheTokens("")).toBe("");
   });
 });
 

--- a/apps/web/src/components/sections-editor/array-item-display.ts
+++ b/apps/web/src/components/sections-editor/array-item-display.ts
@@ -86,6 +86,21 @@ function stripHtmlTags(html: string): string {
   return html.replace(/<[^>]*>/g, "").trim();
 }
 
+/** Drop Mustache tokens from a title, leaving only its static text
+ * (`Categoria {{{id}}}` → `Categoria`). For contexts with no item data. */
+export function stripMustacheTokens(title: string): string {
+  return title
+    .replace(/\{\{\{?[^{}]*\}?\}\}/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Resolve-schema fills a titleless inline-union branch with `Option N`; that
+ * synthetic default must not shadow the item's own fields when labelling. */
+function isSyntheticBranchTitle(title: string): boolean {
+  return /^Option \d+$/.test(title);
+}
+
 function readTitleByValue(
   obj: Record<string, unknown>,
   titleBy: string,
@@ -138,7 +153,7 @@ function baseArrayItemLabel(
         })),
       );
       const branchTitle = itemSchema.inlineUnionBranches[idx]?.title;
-      if (branchTitle) {
+      if (branchTitle && !isSyntheticBranchTitle(branchTitle)) {
         const rendered = renderMustacheTemplate(branchTitle, obj);
         if (rendered) return rendered;
         if (!branchTitle.includes("{")) return branchTitle;

--- a/apps/web/src/components/sections-editor/array-item-display.ts
+++ b/apps/web/src/components/sections-editor/array-item-display.ts
@@ -1,6 +1,7 @@
 import { arrayItemDisplayValue } from "./array-item-hidden";
 import { lazyWrappedInner } from "./block-ref-field-utils";
 import { extractUrl } from "./fields/extract-url";
+import { inferInlineUnionIndex } from "./fields/inline-union-value";
 import type { SchemaProperty } from "./resolve-schema";
 import { labelFromResolveType } from "./section-types";
 import { safeEditorImageUrl } from "./safe-editor-image-url";
@@ -126,6 +127,22 @@ function baseArrayItemLabel(
     if (itemSchema?.titleBy) {
       const fromTitleBy = readTitleByValue(obj, itemSchema.titleBy);
       if (fromTitleBy) return fromTitleBy;
+    }
+    // Inline unions carry titles per-branch, not on `items`: label by the active branch.
+    if (itemSchema?.inlineUnionBranches?.length) {
+      const idx = inferInlineUnionIndex(
+        obj,
+        itemSchema.inlineUnionBranches.map((b) => ({
+          discriminators: b.discriminators,
+          propertyKeys: Object.keys(b.schema?.properties ?? {}),
+        })),
+      );
+      const branchTitle = itemSchema.inlineUnionBranches[idx]?.title;
+      if (branchTitle) {
+        const rendered = renderMustacheTemplate(branchTitle, obj);
+        if (rendered) return rendered;
+        if (!branchTitle.includes("{")) return branchTitle;
+      }
     }
     for (const key of [
       "name",

--- a/apps/web/src/components/sections-editor/fields/inline-union-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/inline-union-field.tsx
@@ -7,6 +7,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@decocms/ui/components/select.tsx";
+import { stripMustacheTokens } from "../array-item-display";
 import type { SchemaProperty } from "../resolve-schema";
 import { SchemaForm } from "../schema-form";
 import { FieldLabel } from "./field-label";
@@ -19,17 +20,6 @@ import { LocationField } from "./location-field";
 import { isLocationShape } from "./location/location-value";
 
 type Branch = NonNullable<SchemaProperty["inlineUnionBranches"]>[number];
-
-/** The dropdown has no item data, so show only the static part of a branch
- * title — drop Mustache tokens (`Categoria {{{id}}}` → `Categoria`). */
-function branchOptionLabel(title: string, index: number): string {
-  return (
-    title
-      .replace(/\{\{\{?[^{}]*\}?\}\}/g, "")
-      .replace(/\s+/g, " ")
-      .trim() || `Option ${index + 1}`
-  );
-}
 
 /** Drop const discriminator fields from a branch schema — they're implied by
  * the selected branch and shouldn't render as editable inputs. */
@@ -116,7 +106,10 @@ export function InlineUnionField(props: FieldProps) {
           <SelectContent>
             {branches.map((branch, index) => (
               <SelectItem key={branch.title} value={String(index)}>
-                {branchOptionLabel(branch.title, index)}
+                {stripMustacheTokens(branch.title) ||
+                  t("sectionsEditor.inlineUnionField.branchFallback", {
+                    index: index + 1,
+                  })}
               </SelectItem>
             ))}
           </SelectContent>

--- a/apps/web/src/components/sections-editor/fields/inline-union-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/inline-union-field.tsx
@@ -20,6 +20,17 @@ import { isLocationShape } from "./location/location-value";
 
 type Branch = NonNullable<SchemaProperty["inlineUnionBranches"]>[number];
 
+/** The dropdown has no item data, so show only the static part of a branch
+ * title — drop Mustache tokens (`Categoria {{{id}}}` → `Categoria`). */
+function branchOptionLabel(title: string, index: number): string {
+  return (
+    title
+      .replace(/\{\{\{?[^{}]*\}?\}\}/g, "")
+      .replace(/\s+/g, " ")
+      .trim() || `Option ${index + 1}`
+  );
+}
+
 /** Drop const discriminator fields from a branch schema — they're implied by
  * the selected branch and shouldn't render as editable inputs. */
 function branchFormSchema(branch: Branch): SchemaProperty | null {
@@ -105,7 +116,7 @@ export function InlineUnionField(props: FieldProps) {
           <SelectContent>
             {branches.map((branch, index) => (
               <SelectItem key={branch.title} value={String(index)}>
-                {branch.title}
+                {branchOptionLabel(branch.title, index)}
               </SelectItem>
             ))}
           </SelectContent>

--- a/apps/web/src/i18n/en/sections-editor.ts
+++ b/apps/web/src/i18n/en/sections-editor.ts
@@ -73,6 +73,7 @@ export const sectionsEditor = {
     "Uploaded {fileName}; extra files were ignored (single-select field).",
   "sectionsEditor.imageField.uploading": "Uploading…",
   "sectionsEditor.imageField.urlPlaceholder": "https://...",
+  "sectionsEditor.inlineUnionField.branchFallback": "Option {index}",
   "sectionsEditor.inlineUnionField.selectPlaceholder": "Select...",
   "sectionsEditor.locationField.cityDefault": "City",
   "sectionsEditor.locationField.cityHelperText":

--- a/apps/web/src/i18n/pt-br/sections-editor.ts
+++ b/apps/web/src/i18n/pt-br/sections-editor.ts
@@ -77,6 +77,7 @@ export const sectionsEditor = {
     "Enviado {fileName}; arquivos adicionais foram ignorados (campo de seleção única).",
   "sectionsEditor.imageField.uploading": "Enviando…",
   "sectionsEditor.imageField.urlPlaceholder": "https://...",
+  "sectionsEditor.inlineUnionField.branchFallback": "Opção {index}",
   "sectionsEditor.inlineUnionField.selectPlaceholder": "Selecionar...",
   "sectionsEditor.locationField.cityDefault": "Cidade",
   "sectionsEditor.locationField.cityHelperText":


### PR DESCRIPTION
## Summary

Array items whose type is an **inline union** (`anyOf` of discriminated objects — e.g. the `matchers` field on faststoretorra PLPs, branches *Período | Padrão de URL | Produto | Cluster | Categoria*) rendered as `Item 1`, `Item 2`… instead of the branch content, because the per-branch `title` lives on `inlineUnionBranches`, not on the `items` node that labelling consulted.

This fix resolves the active branch and labels each row by that branch's title, with Mustache rendered against the item data (e.g. `@title "Categoria {{{id}}}"` → **"Categoria 123"**).

### Changes
- **`array-item-display.ts`** — in `baseArrayItemLabel`, after the `titleBy` block and before the generic key scan, resolve the active branch via the existing `inferInlineUnionIndex` helper (discriminator match first, field-presence fallback) and label by its Mustache-rendered `title`. Placed before the key scan so the branch label ("Categoria 123") wins over the raw id ("123").
  - Static prefix survives empty fields: `{ matcherType: "category" }` → `"Categoria"`.
  - A *purely*-Mustache title that renders empty falls through to the key scan / `Item N`.
- **`inline-union-field.tsx`** — the branch selector dropdown has no item data, so it strips Mustache tokens from branch titles (`Categoria {{{id}}}` → `"Categoria"`) instead of showing the raw template.

## Coordination

Counterpart to the already-merged **agencia-e-plus/faststoretorra#67**, which switched the 5 matcher `@title`s to Mustache across 10 sections + `.deco/meta.gen.json`. Without this studio fix, #67 only pollutes the dropdown with raw templates — this is what makes those titles actually render in the editor.

## Testing
- `array-item-display.test.ts` — +5 cases (21 pass): discriminator-matched label, static-prefix-with-empty-fields, purely-Mustache fallback to `Item N`, field-presence inference, colliding same-branch items keeping a clean un-suffixed display label.
- `bun test` ✅  ·  `bun run check` ✅  ·  `bun run lint` (0 errors) ✅  ·  `bun run fmt` applied.

## Notes
- Edge case: the dropdown token-stripper leaves a trailing separator for multi-token titles like `Período {{{start}}} — {{{end}}}` → `"Período —"`. Cosmetic, selector-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Label inline-union array items by the active branch title instead of “Item N” or a raw key. It resolves the active branch and renders its Mustache title against item data; synthetic “Option N” titles no longer shadow item labels.

- array-item-display.ts: before the key scan, infers the active branch via `inferInlineUnionIndex` and renders that branch’s `title`; keeps static prefixes when fields are empty; purely-Mustache titles that render empty fall through to the key scan/“Item N”; ignores synthetic `Option N` branch titles. Exports `stripMustacheTokens` for shared use.
- fields/inline-union-field.tsx: strips Mustache tokens from branch titles in the selector and falls back to `sectionsEditor.inlineUnionField.branchFallback` when empty.
- i18n: adds `sectionsEditor.inlineUnionField.branchFallback` in `en` and `pt-br`.
- Tests: adds coverage for discriminator match, empty-field prefixes, pure-Mustache fallback, field-presence inference, synthetic `Option N` bypass, duplicate labels, and `stripMustacheTokens`.

<sup>Written for commit 206440d87fab5fa060075d8a4d673a32a0ffaea3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

