### PR TITLE
fix(task-board): fence handTaskToHuman against a concurrent reassignment

### DIFF
--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -1191,6 +1191,40 @@ export class TaskBoardStorage {
   }
 
   /**
+   * Atomically hand a task from the Super Agent to a human: clear
+   * `assigneeId` ONLY if it's still the Super Agent, returning the updated
+   * item, or null if it already changed. `handTaskToHuman`'s caller re-checks
+   * a stale, previously-read `item.assigneeId` before calling this — several
+   * dead-end paths (a bounce limit, a burned reviewer retry, a PR-less card)
+   * can race to hand off the SAME card, and a human can reassign it away from
+   * the Super Agent in between. Without this fence, a plain `update()` would
+   * stomp that human's reassignment back to null. Same conditional-UPDATE
+   * pattern as `claimInReviewSuperAgentSlot`.
+   */
+  async unassignSuperAgent(
+    id: string,
+    organizationId: string,
+    by: string,
+  ): Promise<TaskBoardItem | null> {
+    const row = await this.db
+      .updateTable("task_board_items")
+      .set({
+        assignee_id: null,
+        updated_by: by,
+        updated_at: new Date().toISOString(),
+      })
+      .where("id", "=", id)
+      .where("organization_id", "=", organizationId)
+      .where("assignee_id", "=", SUPER_AGENT_ASSIGNEE_ID)
+      .returningAll()
+      .executeTakeFirst();
+    if (!row) return null;
+    const item = this.itemFromDbRow(row);
+    await this.attachRefs([item], organizationId);
+    return item;
+  }
+
+  /**
    * Populate each item's `threads` and `tags` — one transaction, so a card
    * can't read its threads from before a concurrent edit and its tags from
    * after.

--- a/apps/api/src/tools/task-board/run-reactions.test.ts
+++ b/apps/api/src/tools/task-board/run-reactions.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "bun:test";
 import {
   capturePrForRun,
+  handTaskToHuman,
   isPrCreateBashCommand,
   isPrCreateMcpTool,
   resolveAdvanceTargets,
 } from "./run-reactions";
+import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
+import type { TaskBoardItem } from "@/storage/types";
 
 type LinkPrCall = {
   taskBoardItemId: string;
@@ -188,5 +191,65 @@ describe("isPrCreateBashCommand", () => {
     expect(
       isPrCreateBashCommand("curl https://api.github.com/repos/o/r/pulls"),
     ).toBe(false);
+  });
+});
+
+function makeItem(overrides: Partial<TaskBoardItem> = {}): TaskBoardItem {
+  return {
+    id: "item-1",
+    organizationId: "org-1",
+    title: "t",
+    description: null,
+    status: "in_review",
+    priority: "medium",
+    assigneeId: SUPER_AGENT_ASSIGNEE_ID,
+    assignedBy: null,
+    repo: null,
+    dueDate: null,
+    sortOrder: 0,
+    retryAttempts: 0,
+    threads: [],
+    tags: [],
+    createdBy: "system",
+    createdAt: "now",
+    updatedBy: "system",
+    updatedAt: "now",
+    ...overrides,
+  };
+}
+
+describe("handTaskToHuman", () => {
+  it("records the handover when unassignSuperAgent wins the race", async () => {
+    const activityCalls: unknown[] = [];
+    const ctx = {
+      storage: {
+        taskBoard: {
+          unassignSuperAgent: async () => makeItem({ assigneeId: null }),
+          recordActivity: async (p: unknown) => {
+            activityCalls.push(p);
+          },
+        },
+      },
+    } as never;
+    const handed = await handTaskToHuman(ctx, makeItem(), "burned retries");
+    expect(handed).toBe(true);
+    expect(activityCalls).toHaveLength(1);
+  });
+
+  it("does not record activity when a concurrent reassignment already won", async () => {
+    const activityCalls: unknown[] = [];
+    const ctx = {
+      storage: {
+        taskBoard: {
+          unassignSuperAgent: async () => null,
+          recordActivity: async (p: unknown) => {
+            activityCalls.push(p);
+          },
+        },
+      },
+    } as never;
+    const handed = await handTaskToHuman(ctx, makeItem(), "burned retries");
+    expect(handed).toBe(false);
+    expect(activityCalls).toHaveLength(0);
   });
 });

--- a/apps/api/src/tools/task-board/run-reactions.ts
+++ b/apps/api/src/tools/task-board/run-reactions.ts
@@ -446,12 +446,13 @@ export async function handTaskToHuman(
   const orgId = item.organizationId;
   if (item.assigneeId !== SUPER_AGENT_ASSIGNEE_ID) return false;
   try {
-    const handed = await ctx.storage.taskBoard.update(
+    // Re-checks the assignee against the DB, not this stale `item`.
+    const handed = await ctx.storage.taskBoard.unassignSuperAgent(
       item.id,
       orgId,
-      { assigneeId: null },
       item.updatedBy,
     );
+    if (!handed) return false;
     await recordTaskActivity(ctx, {
       taskBoardItemId: item.id,
       action: "assignee_changed",


### PR DESCRIPTION
Follows the review-gate/reassignment concurrency hardening from #5984/#5983/#5956: those fixed dead-ending In Review and stale-token replay, but the new `handTaskToHuman` helper they introduced (`run-reactions.ts`) has the same TOCTOU shape those PRs closed elsewhere.

**Bug**: `handTaskToHuman` checks `item.assigneeId !== SUPER_AGENT_ASSIGNEE_ID` against a stale, previously-read `item`, then unconditionally writes `assigneeId: null` via the generic `taskBoard.update()`. Every caller (review-decision.ts's bounce-limit, enqueue-reviewer.ts, merge-pr.ts, review-sweeper.ts) reads its `item` earlier in the request. If a human reassigns the card in the gap between that read and this write, the write silently stomps the human's reassignment back to unassigned — the exact class of bug #5984's own doc comment calls out ("every automatic path requires the Super Agent as assignee" is what's supposed to make this idempotent, but the check was never atomic with the write).

The fix mirrors the pattern the codebase already uses for this exact race: `claimConflictResolution`/`claimReviewChangesBounce` fence their claim with a conditional `UPDATE ... WHERE assignee_id = SUPER_AGENT_ASSIGNEE_ID`, re-checking at write time instead of trusting a stale read (see `claimInReviewSuperAgentSlot`'s doc comment). Added `unassignSuperAgent()` to `TaskBoardStorage` using the identical WHERE-clause fence, and switched `handTaskToHuman` to call it instead of `update()`; when the fenced UPDATE affects zero rows (a human already reassigned it), `handTaskToHuman` now returns `false` and skips recording a bogus "handed to a human" activity entry instead of overwriting the reassignment.

**Regression test**: added to `run-reactions.test.ts` (unit, mocked storage) asserting `handTaskToHuman` records the handover when `unassignSuperAgent` succeeds, and does NOT record activity / returns `false` when it returns `null` (simulating the lost race).

Reviewer check: `git diff` on `apps/api/src/storage/task-board.ts` — confirm `unassignSuperAgent`'s WHERE clause matches `claimInReviewSuperAgentSlot` just above it.

Verified locally: `bunx tsc --noEmit` in `apps/api` (green), `bun test apps/api/src/tools/task-board/run-reactions.test.ts` (18 pass), `bunx oxlint` on the three changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fences `handTaskToHuman` against a concurrent reassignment so we do not clear a human’s reassignment. Old: checked a stale `item.assigneeId` then unconditionally `update({ assigneeId: null })`. New: atomically clear only when `assignee_id` is `SUPER_AGENT_ASSIGNEE_ID`; otherwise no-op and skip activity.

- Adds `TaskBoardStorage.unassignSuperAgent(id, organizationId, by)` using `UPDATE ... WHERE assignee_id = SUPER_AGENT_ASSIGNEE_ID`, returning the updated item or `null` (mirrors the `claimInReviewSuperAgentSlot` fence).
- Switches `handTaskToHuman` to use `unassignSuperAgent`; returns `false` and does not record an "assignee_changed" activity when the fenced update affects zero rows.
- Adds regression tests in `apps/api/src/tools/task-board/run-reactions.test.ts` for both the winning and lost-race paths.

<sup>Written for commit eb35d3ae2846f37ca98d4eb2ad7006300b848222. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

