### PR TITLE
fix(billing): hang AI-credit top-ups off one Stripe product

### DIFF
--- a/apps/api/src/billing/stripe-api.ts
+++ b/apps/api/src/billing/stripe-api.ts
@@ -165,6 +165,12 @@ export async function createTopUpCheckoutSession(input: {
     input.currency,
     await getUsdToBrl(),
   );
+  const productId = getSettings().stripeTopupProductId;
+  const topupMetadata = {
+    kind: "topup",
+    orgId: input.organizationId,
+    creditCents,
+  };
   const label =
     input.currency === "brl"
       ? `Studio AI credits (R$ ${(input.amountCents / 100).toFixed(2)})`
@@ -182,17 +188,18 @@ export async function createTopUpCheckoutSession(input: {
           price_data: {
             currency: input.currency,
             unit_amount: chargeCents,
-            product_data: { name: label },
+            // Ad-hoc price, one fixed catalog Product — see stripeTopupProductId.
+            ...(productId
+              ? { product: productId }
+              : { product_data: { name: label } }),
           },
         },
       ],
       success_url: input.successUrl,
       cancel_url: input.cancelUrl,
-      metadata: {
-        kind: "topup",
-        orgId: input.organizationId,
-        creditCents,
-      },
+      // On the PaymentIntent too — the charge is what finance exports.
+      metadata: topupMetadata,
+      payment_intent_data: { metadata: topupMetadata },
     },
   });
   if (!session.url) throw new StripeApiError(500, "checkout session lacks url");

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -305,6 +305,7 @@ export function resolveConfig(
     stripeWebhookSecret: envVars.STRIPE_WEBHOOK_SECRET,
     stripeSecretKey: envVars.STRIPE_SECRET_KEY,
     stripeOrgPriceId: envVars.STRIPE_ORG_PRICE_ID,
+    stripeTopupProductId: envVars.STRIPE_TOPUP_PRODUCT_ID,
     // Capped at 100: above that is a fat-fingered misconfig ("150" for "15")
     // that would silently more-than-double every top-up charge. 0 is valid —
     // a self-hosted deployment may want to waive the fee entirely.

--- a/apps/api/src/settings/types.ts
+++ b/apps/api/src/settings/types.ts
@@ -88,6 +88,12 @@ export interface Settings {
   /** The flat monthly org-subscription price (created in the Stripe
    *  dashboard); quantity is always 1. */
   stripeOrgPriceId: string | undefined;
+  /** The single catalog Product every top-up charge hangs off (created once in
+   *  the Stripe dashboard). Top-up amounts are arbitrary, so the Price is
+   *  ad-hoc per checkout — but it must point at THIS product, or Stripe's
+   *  catalog fills with one throwaway product per purchase and revenue can't
+   *  be aggregated. Unset → legacy per-purchase products. */
+  stripeTopupProductId: string | undefined;
   /** Fee on AI-credit top-ups, percent (default 15 — gateway parity). */
   topupFeePercent: number;
 


### PR DESCRIPTION
## Summary

Every AI-credit top-up minted a throwaway Stripe Product via `price_data.product_data`, so the Stripe catalog became a purchase log — one product per purchase, named after its amount. Top-up revenue couldn't be aggregated, and ops had no single entry to report on.

Product/Price in Stripe are the *catalog*; PaymentIntent/Charge are the *transaction log*. The amount is per-transaction, so the price stays ad-hoc — but it now hangs off one fixed catalog Product, configured via `STRIPE_TOPUP_PRODUCT_ID`.

Also mirrors the top-up metadata (`kind`, `orgId`, `creditCents`) onto the PaymentIntent. Checkout Sessions fall out of reporting; the charge is what finance exports.

## Rollout

Ships dormant: with `STRIPE_TOPUP_PRODUCT_ID` unset, behavior is byte-identical to today. To enable, create one Product in the Stripe dashboard (no price — the price is ad-hoc per checkout) and set the env var.

Purchases made before the flip stay on their old per-purchase products; unifying that history is a separate `product.update` sweep, if we want it at all.

## Testing

- `bun run check`, `bun run lint` (0 errors), `bun run fmt` clean
- `bun test src/billing/` — 41/41 unit pass; the two `*.integration.test.ts` need a live Postgres and were not run
- Not covered by a test: the config branch itself. Asserting it means mocking `stripeRequest`, which `TESTING.md` sends to e2e. A real check would be an e2e that creates a session and reads `line_items.price.product` back — happy to add it as a follow-up if we want the wire contract pinned.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes AI‑credit top-ups to a single Stripe Product instead of creating a new Product per purchase, so finance can aggregate revenue and the catalog stays clean. Legacy behavior persists when `STRIPE_TOPUP_PRODUCT_ID` is unset; when set, the ad‑hoc Price points at that Product and top‑up metadata is mirrored onto the PaymentIntent for charge‑level reporting.

- **Rollout**
  - No change until `STRIPE_TOPUP_PRODUCT_ID` is set.
  - To enable: create one Product in Stripe (no Price) and set `STRIPE_TOPUP_PRODUCT_ID`.
  - Existing purchases remain on their per‑purchase Products; any unification is a separate catalog sweep.

- **Review notes**
  - Check `stripeTopupProductId` wiring and that we switch between `price_data.product` and `price_data.product_data` correctly.
  - Confirm `kind`, `orgId`, and `creditCents` are present in both `metadata` and `payment_intent_data.metadata`.

<sup>Written for commit 7c7707c3f7c3183873d79e12fdda7406ddcffe60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

