### PR TITLE
fix(decopilot): block fc00::/8 unique-local addresses in image URL guard

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts
@@ -3,6 +3,7 @@ import {
   buildScreenshotOptions,
   buildScreenshotRequestBody,
   jpegHeight,
+  validateExternalUrl,
 } from "./portable-media-tools";
 
 describe("buildScreenshotOptions", () => {
@@ -123,6 +124,24 @@ function jpegWith(height: number, width = 1280): Uint8Array {
     ...sof,
   ]);
 }
+
+describe("validateExternalUrl", () => {
+  it("rejects loopback", () => {
+    expect(() => validateExternalUrl("https://127.0.0.1/x", false)).toThrow();
+  });
+
+  // fc00::/7 unique local addresses span fc00::/8 AND fd00::/8.
+  it("rejects fc00::/8 unique local addresses, not just fd00::/8", () => {
+    expect(() => validateExternalUrl("https://[fc00::1]/x", false)).toThrow();
+    expect(() => validateExternalUrl("https://[fd00::1]/x", false)).toThrow();
+  });
+
+  it("allows a normal public https URL", () => {
+    expect(() =>
+      validateExternalUrl("https://example.com/image.png", false),
+    ).not.toThrow();
+  });
+});
 
 describe("jpegHeight", () => {
   it("reads the height past intervening segments", () => {

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.ts
@@ -299,7 +299,8 @@ const PRIVATE_HOST_PATTERNS = [
   /^169\.254\./,
   /^0\./,
   /^\[::1\]$/,
-  /^\[fd/,
+  // RFC 4193 unique local addresses are fc00::/7 — first byte fc OR fd.
+  /^\[f[cd]/,
   /^\[fe80:/,
   /^\[::ffff:/i,
   /^localhost$/i,
@@ -315,7 +316,7 @@ function assertReferenceImageSize(bytes: number): void {
   }
 }
 
-function validateExternalUrl(url: string, allowHttp: boolean): void {
+export function validateExternalUrl(url: string, allowHttp: boolean): void {
   let parsed: URL;
   try {
     parsed = new URL(url);


### PR DESCRIPTION
`validateExternalUrl` (used by both the `take_screenshot` URL and `generate_image`'s `referenceImages`/external-image fetch path in `apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.ts`) denylists private-network hosts before letting the decopilot harness fetch an arbitrary URL. RFC 4193 unique local IPv6 addresses span `fc00::/7` — i.e. the first byte is `fc` OR `fd` — but the pattern only matched `fd`, so a URL pointing at an `fc00::/8` host (e.g. `https://[fc00::1]/x`) sailed through the guard uncaught while the semantically identical `fd00::/8` was blocked.

**Why it matters**: this is the SSRF guard standing between an LLM-controlled URL (a reference image URI or an image-generation input) and Studio's internal network; a gap in it lets a crafted URL reach an internal-only host under `fc00::/8`.

**Fix**: widened the regex from `/^\[fd/` to `/^\[f[cd]/` so both halves of the ULA range are blocked. Added `validateExternalUrl` to the file's exports (it was previously module-private) and a regression test asserting both `fc00::1` and `fd00::1` are rejected, plus a sanity check that a normal public HTTPS URL still passes.

**Reviewer check**: `cd apps/api && bun test src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts`

**Verified locally**: `bun run fmt`, `bunx tsc --noEmit` in `apps/api`, the targeted test file above (15 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Blocks IPv6 unique-local `fc00::/8` image URLs in Decopilot’s external URL guard to close an SSRF gap. Previously `validateExternalUrl` blocked only `fd00::/8`, letting `fc00::/8` through; now both are denied with no change to public URL handling.

- Widened the denylist regex from `/^\[fd/` to `/^\[f[cd]/` in `PRIVATE_HOST_PATTERNS` (covers RFC 4193 `fc00::/7`).
- Exported `validateExternalUrl` and added tests rejecting `fc00::1`/`fd00::1` and accepting a normal public HTTPS URL.
- Reviewer check: `cd apps/api && bun test src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts`.

<sup>Written for commit fc5947f50597c704e6f86ced3fb5b32d6e76c82a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

