### PR TITLE
refactor(web): remove dead active-OAuth-session tracking map

### DIFF
--- a/apps/web/src/sdk/lib/mcp-oauth.ts
+++ b/apps/web/src/sdk/lib/mcp-oauth.ts
@@ -23,19 +23,6 @@ import type {
 } from "@modelcontextprotocol/sdk/shared/auth.js";
 import { resolveStudioUrl } from "./studio-url";
 
-/**
- * Simple hash function for server URLs
- */
-function hashServerUrl(url: string): string {
-  let hash = 0;
-  for (let i = 0; i < url.length; i++) {
-    const char = url.charCodeAt(i);
-    hash = (hash << 5) - hash + char;
-    hash = hash & hash;
-  }
-  return Math.abs(hash).toString(16);
-}
-
 function getOAuthRedirectOrigin(): string {
   return window.location.origin;
 }
@@ -56,11 +43,6 @@ function isLocalDev(): boolean {
     return false;
   }
 }
-
-/**
- * Global in-memory store for active OAuth sessions.
- */
-const activeOAuthSessions = new Map<string, McpOAuthProvider>();
 
 /**
  * Storage key prefix for OAuth callback fallback
@@ -171,7 +153,6 @@ export interface McpOAuthProviderOptions {
  * No localStorage or sessionStorage - everything is ephemeral.
  */
 class McpOAuthProvider implements OAuthClientProvider {
-  private serverUrl: string;
   private _clientMetadata: OAuthClientMetadata;
   private _redirectUrl: string;
   private _windowMode: OAuthWindowMode;
@@ -183,7 +164,6 @@ class McpOAuthProvider implements OAuthClientProvider {
   private _tokens: OAuthTokens | null = null;
 
   constructor(options: McpOAuthProviderOptions) {
-    this.serverUrl = options.serverUrl;
     // An explicit callbackUrl still wins; otherwise an installed adapter picks
     // the target, because the page that receives the redirect has to be one
     // the adapter can actually read the result back out of.
@@ -209,9 +189,6 @@ class McpOAuthProvider implements OAuthClientProvider {
       // Only include scope if explicitly provided - some servers have their own scope requirements
       ...(scopeStr && { scope: scopeStr }),
     };
-
-    // Register this session for callback handling
-    activeOAuthSessions.set(hashServerUrl(this.serverUrl), this);
   }
 
   get redirectUrl(): string {
@@ -302,14 +279,6 @@ class McpOAuthProvider implements OAuthClientProvider {
     this._tokens = null;
     this._codeVerifier = null;
     this._state = null;
-  }
-
-  getServerUrl(): string {
-    return this.serverUrl;
-  }
-
-  cleanup(): void {
-    activeOAuthSessions.delete(hashServerUrl(this.serverUrl));
   }
 }
 
@@ -663,8 +632,6 @@ export async function authenticateMcp(params: {
       tokenInfo: null,
       error: error instanceof Error ? error.message : String(error),
     };
-  } finally {
-    provider.cleanup();
   }
 }
 


### PR DESCRIPTION
**Source:** C1 dead-code reduction, found while auditing `apps/web/src/sdk/lib/mcp-oauth.ts` (this tick's focus area: MCP OAuth & virtual-MCP SDK cleanup). No open PR touches this file.

**Payoff:** deletes tracking state that does nothing — `activeOAuthSessions` was only ever written to (`.set()` on provider construction, `.delete()` in `cleanup()`) and never read anywhere in the repo. `hashServerUrl()` existed solely to key that map, `getServerUrl()` was never called by any caller, and the provider's private `serverUrl` field/assignment existed only to feed those two dead paths. Removing them is pure simplification with zero behavior change.

**Verification that behavior is unchanged:** `rg` across `apps/web`, `apps/api`, and `packages` confirms zero reads of `activeOAuthSessions`, zero calls to `getServerUrl()`, and zero other usages of `hashServerUrl` — the map/hash/getter/cleanup-call were write-only or unreachable. Net diff: -33 / +0.

**Command a reviewer runs to confirm:**
```
grep -rn "activeOAuthSessions\|getServerUrl\b\|hashServerUrl" apps/web apps/api packages --include="*.ts" --include="*.tsx"
```
should show no leftover references.

**Checks run locally:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean), `bun test apps/web/src/sdk/lib/mcp-oauth.test.ts` (1 pass), `bunx oxlint apps/web/src/sdk/lib/mcp-oauth.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the dead in-memory OAuth session tracking map from the web SDK and its support code. This reduces complexity with no behavior change because the map was write-only and never read.

**Review notes**
- Deleted: `activeOAuthSessions` map, `hashServerUrl`, `McpOAuthProvider.serverUrl`, `getServerUrl()`, and `cleanup()`; also removed the `finally { provider.cleanup() }` call in `authenticateMcp`.
- Auth flow, redirects, and tokens are unchanged; the public API used by callers is unaffected.
- Verify by grepping for `activeOAuthSessions|getServerUrl\b|hashServerUrl` across `apps/web`, `apps/api`, and `packages` (expect no matches).

<sup>Written for commit 656046014abe12a85ebe99da8870a1d26319b7cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

