### PR TITLE
fix(bindings): cap the MCP proxy's per-connection tools cache

### DIFF
--- a/packages/bindings/src/core/client/proxy.ts
+++ b/packages/bindings/src/core/client/proxy.ts
@@ -18,7 +18,17 @@ type Tool = {
   description: string;
 };
 
+// Caps toolsMap so distinct connection keys (e.g. refreshed OAuth tokens) can't leak memory forever.
+const MAX_CACHED_CONNECTIONS = 500;
 const toolsMap = new Map<string, Promise<Array<Tool>>>();
+
+function rememberToolsPromise(key: string, promise: Promise<Array<Tool>>) {
+  toolsMap.set(key, promise);
+  if (toolsMap.size > MAX_CACHED_CONNECTIONS) {
+    const oldest = toolsMap.keys().next().value;
+    if (oldest !== undefined) toolsMap.delete(oldest);
+  }
+}
 
 const mapTool = (
   tool: Tool,
@@ -141,7 +151,7 @@ export function createMCPClientProxy<T extends Record<string, unknown>>(
 
         try {
           if (!toolsMap.has(key)) {
-            toolsMap.set(key, listToolsFn());
+            rememberToolsPromise(key, listToolsFn());
           }
 
           return await toolsMap.get(key)!;


### PR DESCRIPTION
## What
`createMCPClientProxy` (`packages/bindings/src/core/client/proxy.ts`) caches each connection's `listTools()` result in a module-level `toolsMap`, keyed by `JSON.stringify(connection)`. That map is never evicted or size-capped.

## Why it matters
This proxy backs every `Binder.forConnection(...)` call (well-known bindings like `TriggerBinding`, `BrandBinding`, `EventSubscriberBinding`, plus `packages/runtime/src/agents.ts`'s `MCPClient.forConnection`, used from `apps/api`'s public MCP server route). Any connection object that differs byte-for-byte from a prior one — most notably one carrying a refreshed OAuth token — mints a brand-new cache key that lives forever. In a long-running pod this is unbounded memory growth over the process lifetime, the same failure class the sibling `apps/api/src/mcp-clients/mcp-read-cache.ts` was explicitly hardened against after it "OOM'd pods before" (see its own comments).

## Fix
Cap `toolsMap` at 500 entries with oldest-first (insertion-order) eviction, mirroring the eviction strategy already used by `mcp-read-cache.ts`. Behavior-preserving: a cache miss still calls `listToolsFn()` exactly as before, only the map's growth is now bounded.

## How to verify
```
cd packages/bindings && bunx tsc --noEmit
bunx oxlint packages/bindings/src/core/client/proxy.ts
```

## Checks run locally
- `bun run fmt`
- `bunx tsc --noEmit` in `packages/bindings` (green)
- `bunx oxlint packages/bindings/src/core/client/proxy.ts` (0 warnings/errors)

No existing test covers this file's caching path (it requires a live MCP connection, which the unit-test tier disallows mocking for), so this was verified by code inspection + typecheck; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the per-connection tools cache in `createMCPClientProxy` to prevent unbounded memory growth from ever-changing connection keys (e.g., refreshed OAuth tokens). Previously `toolsMap` grew without eviction; now it is capped at 500 entries with oldest-first eviction. Cache misses still call `listToolsFn()` exactly as before.

**Reviewer notes**
- Adds `MAX_CACHED_CONNECTIONS = 500` and `rememberToolsPromise()` to enforce FIFO eviction.
- No API changes; if more than 500 distinct connections are active, evicted entries will refetch on next use.
- Mirrors the eviction approach already used by `apps/api`’s `mcp-read-cache`.

<sup>Written for commit 0d469a936d2cbcaf16efd900f7e9a1c13e38eff4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

