### PR TITLE
fix(decofile): resolve GitHub credentials for refreshable repo children

### DIFF
--- a/apps/api/src/decofile/client-for-repo.ts
+++ b/apps/api/src/decofile/client-for-repo.ts
@@ -1,6 +1,12 @@
 import type { GithubRepo } from "@decocms/shared/sdk/types";
+import { getRepoScope } from "@decocms/shared/github-repo-scope";
 import type { StudioContext } from "@/core/studio-context";
 import { ensureRepoScopedToken } from "@/oauth/github-mint";
+import {
+  getValidDownstreamAccessToken,
+  RECONNECT_ERROR,
+} from "@/oauth/token-refresh";
+import { DownstreamTokenStorage } from "@/storage/downstream-token";
 import { createGitDataClient, GitHubApiError } from "./github-git-data";
 import type { GitDataClient } from "./github-git-data";
 
@@ -35,10 +41,34 @@ export async function gitDataClientForRepo(
       "Project's GitHub connection is missing — reconnect GitHub",
     );
   }
-  const accessToken = await ensureRepoScopedToken(ctx, connection);
+  const accessToken = await repoAccessToken(ctx, connection);
+  if (!accessToken) {
+    throw new GitHubApiError(401, "AUTH", "connection", RECONNECT_ERROR);
+  }
   return createGitDataClient({
     owner: githubRepo.owner,
     repo: githubRepo.name,
     accessToken,
   });
+}
+
+/**
+ * GitHub credential for a repo-scoped connection, forked the same way as the
+ * MCP proxy's `outbound/headers`: legacy children re-mint their ~1h `ghs_`
+ * token, current ones read the refreshable grant in `downstream_tokens`.
+ * `ensureRepoScopedToken` alone rejects the latter before consulting it.
+ */
+async function repoAccessToken(
+  ctx: StudioContext,
+  connection: Parameters<typeof ensureRepoScopedToken>[1],
+): Promise<string | null> {
+  if (getRepoScope(connection)?.sourceConnectionId) {
+    return ensureRepoScopedToken(ctx, connection);
+  }
+  const tokenResult = await getValidDownstreamAccessToken({
+    connectionId: connection.id,
+    connectionUrl: connection.connection_url,
+    tokenStorage: new DownstreamTokenStorage(ctx.db, ctx.vault),
+  });
+  return tokenResult.accessToken;
 }

--- a/packages/e2e/tests/decofile-api.spec.ts
+++ b/packages/e2e/tests/decofile-api.spec.ts
@@ -87,24 +87,32 @@ interface FastPreviewProject {
 }
 
 /**
- * Full Fast Preview project wiring: org GitHub connection + repo-scoped child
- * (metadata.repoScope with sourceConnectionId — required even on the cached-
- * token path), a pre-seeded unexpired downstream token (short-circuits
- * minting), and a virtual MCP whose metadata carries the Fast Preview gate
- * (fastPreview + productionUrl) and githubRepo.connectionId listed among its
- * connections.
+ * Full Fast Preview project wiring: repo-scoped GitHub child + unexpired
+ * downstream token + a virtual MCP carrying the Fast Preview gate.
+ * `repoScopeMode` picks which real repo-child shape to seed; the two resolve
+ * credentials down different paths (see `client-for-repo`), and the default is
+ * the one every repo imported since refreshable grants landed actually has.
  */
 async function createFastPreviewProject(
   ctx: APIRequestContext,
   org: string,
-  params: { owner: string; repo: string },
+  params: {
+    owner: string;
+    repo: string;
+    repoScopeMode?: "refreshable" | "legacy-mint";
+  },
 ): Promise<FastPreviewProject> {
-  const { owner, repo } = params;
+  const { owner, repo, repoScopeMode = "refreshable" } = params;
 
-  const orgConn = await createHttpConnection(ctx, org, {
-    title: `Org GitHub ${Date.now()}`,
-    url: "https://example.com/mcp",
-  });
+  const sourceConnectionId =
+    repoScopeMode === "legacy-mint"
+      ? (
+          await createHttpConnection(ctx, org, {
+            title: `Org GitHub ${Date.now()}`,
+            url: "https://example.com/mcp",
+          })
+        ).id
+      : undefined;
 
   const child = await callSelfMcpTool<{ item: { id: string } }>(
     ctx,
@@ -118,7 +126,7 @@ async function createFastPreviewProject(
         connection_url: "https://example.com/mcp",
         metadata: {
           repoScope: {
-            sourceConnectionId: orgConn.id,
+            ...(sourceConnectionId ? { sourceConnectionId } : {}),
             installationId: 1,
             repositoryId: 99,
             owner,
@@ -132,7 +140,7 @@ async function createFastPreviewProject(
   const childConnectionId = child.item.id;
   expect(childConnectionId).toBeTruthy();
 
-  // Unexpired token -> ensureRepoScopedToken returns it without minting.
+  // Unexpired token: read back directly, or short-circuits the legacy mint.
   const tokenRes = await ctx.post(
     `/api/${org}/connections/${childConnectionId}/oauth-token`,
     {
@@ -416,6 +424,38 @@ test.describe("decofile API", () => {
       await ctx.dispose();
       await anon.dispose();
       await outsider.dispose();
+    }
+  });
+
+  test("legacy repo children (repoScope.sourceConnectionId) read through the mint path", async ({
+    playwright,
+  }) => {
+    const ctx = await newApiContext(playwright);
+    try {
+      const user = await signUpViaApi(ctx);
+      const owner = uniqueOwner();
+      const repo = "site";
+      await seedStubRepo(ctx, {
+        owner,
+        repo,
+        defaultBranch: "main",
+        branches: {
+          main: { files: { ".deco/blocks/Hero.json": '{"n":1}\n' } },
+        },
+      });
+
+      const project = await createFastPreviewProject(ctx, user.orgSlug, {
+        owner,
+        repo,
+        repoScopeMode: "legacy-mint",
+      });
+
+      const res = await ctx.get(decofileUrl(project, "main"));
+      expect(res.status()).toBe(200);
+      const body = (await res.json()) as DecofileGetBody;
+      expect(body.decofile["Hero"]).toEqual({ n: 1 });
+    } finally {
+      await ctx.dispose();
     }
   });
 


### PR DESCRIPTION
## Summary

Fast Preview (#5951) is broken for **every real project** and had to be disabled in production. `GET /api/:org/decofile/:vmcpId/:branch` returns:

```
500 {"error":"GitHub token refresh failed — reconnect the mcp-github integration."}
```

The web fast-preview branch of `resolveBlocksTabState` treats a failed decofile read as immediately terminal (no sandbox lifecycle is coming to re-invalidate it), so the CMS renders the **"Blocks unavailable"** card. `/git/status` fails through the same helper and `sandbox-proxy.ts:307` maps it to 502, leaving the header stuck on "Loading branch…".

## Root cause

`decofile/client-for-repo.ts` resolved the credential with `ensureRepoScopedToken` alone. There are two shapes of repo-scoped GitHub child connection, and that call only supports one:

| shape | `repoScope.sourceConnectionId` | credential |
|---|---|---|
| **legacy** | present | ~1h `ghs_` re-minted via the org connection's `MINT_REPO_TOKEN` |
| **current** (every repo imported since refreshable grants landed) | absent | refreshable grant in `downstream_tokens` |

`ensureRepoScopedToken` rejects the second kind outright — `if (!recipe.sourceConnectionId) throw new Error(RECONNECT_ERROR)` (`github-mint.ts:171`) — **before it ever consults the stored token**.

The MCP proxy already forks correctly on this (`mcp-clients/outbound/headers.ts:165-192`), and `file-storage/org-repo-sync.ts:92` carries a comment warning about exactly this trap ("Using `ensureRepoScopedToken` alone would reject source-less children before even checking the cache"). The new decofile helper didn't.

Confirmed live on both `deco-sites/faststore-fila` connections — prod `conn_9cwWG7NGWNQYQm6R4eKI9` and staging `conn_JZQNrP6su-Zs2jonrp2_o` both carry `repoScope` with `grantProvider: "github-mcp"` and no `sourceConnectionId`. All 17 repo children in the staging org lack it, so the decofile API could never have served any of them.

## Changes

- **`apps/api/src/decofile/client-for-repo.ts`** — fork on `sourceConnectionId` the same way `outbound/headers` does: legacy → `ensureRepoScopedToken`, current → `getValidDownstreamAccessToken`. A null token becomes a 401 `GitHubApiError` instead of an unhandled 500.
- **`packages/e2e/tests/decofile-api.spec.ts`** — the fixture hardcoded `sourceConnectionId` with the comment *"required even on the cached-token path"*, so the suite only ever exercised the legacy shape and stayed green through all of this. `createFastPreviewProject` now defaults to the **refreshable** shape, with `repoScopeMode: "legacy-mint"` as an explicit opt-in, plus a new test pinning the legacy path so both are covered.

## Testing

Ran against real Postgres + the GitHub Git Data stub:

- **10/10 pass** with the fix.
- Reverting `client-for-repo.ts` alone turns **7 of 10 red** (all reads, PATCHes, publishes) — the 3 that survive are the legacy-mint test, the Fast-Preview-gate 404 test, and the invalid-input test, exactly as expected.

`bun run check` clean on `apps/api` and `packages/e2e`, `bun run lint` 0 errors, `bun run fmt` applied.

## Rollout

No migration, no flag. Once deployed, `metadata.fastPreview` can be re-enabled on the affected projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GitHub credential resolution for refreshable repo-scoped repo children in the decofile API so Fast Preview and git status endpoints work again. Previously, we always called ensureRepoScopedToken, which rejected children without repoScope.sourceConnectionId and threw a 500; now we select the mint path for legacy children and read the refreshable downstream token for current children, returning a 401 when missing.

- apps/api: add repoAccessToken to fork on sourceConnectionId; legacy children mint via ensureRepoScopedToken, current children read from downstream_tokens via getValidDownstreamAccessToken; null token now throws a 401 GitHubApiError instead of a 500.
- e2e: default Fast Preview fixture to the refreshable shape; add repoScopeMode: "legacy-mint" opt-in and a test that pins the legacy path so both shapes are covered.
- Impact: GET /api/:org/decofile/:vmcpId/:branch and /git/status succeed for refreshable repo children; missing/expired credentials surface as 401s (caller can prompt reconnect) instead of terminal 500s.
- Validation: 10/10 e2e pass with the fix; reverting client-for-repo.ts alone turns 7/10 red (all read/patch/publish paths).

**Rollout**
- No migration, no flag.
- After deploy, re-enable metadata.fastPreview on affected projects.

<sup>Written for commit 68cef0c73596a496b8fd41d9cdd66bedbf59d616. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5996?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

