### PR TITLE
feat(task-board): sync URL when opening a task via card click

### DIFF
--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -501,6 +501,12 @@ export function TaskBoardPage() {
   const openEdit = (item: TaskBoardItem) => {
     setEditingItem(item);
     setDialogOpen(true);
+    // Keep the URL shareable regardless of how the modal was opened.
+    navigate({
+      to: ".",
+      search: (prev: Record<string, unknown>) => ({ ...prev, task: item.id }),
+      replace: true,
+    });
   };
 
   // Opening a card always opens the task modal. The modal's activity area is


### PR DESCRIPTION
## What is this contribution about?
Opening a task card wasn't always updating the URL's `task` search param, so links to a card weren't reliably shareable. `openEdit` now calls `navigate` to set `task` in the URL search params (replacing history) whenever a card is opened, regardless of how the modal was triggered.

## How did you verify your code works?
Verified manually: opened a task card and confirmed the `task` query param appears in the URL, and that copying the URL and reloading reopens the same task.

## Screenshots/Demonstration
No UI change; behavior is a URL-state fix.

## How to Test
1. Go to a task board.
2. Click any task card to open its modal.
3. Confirm the URL now contains `?task=<id>` and that reloading or sharing that URL reopens the same task.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the task board URL in sync when opening a card so links stay shareable. Previously, the `task` query param only updated for direct-link opens; clicking a card now sets `?task=<id>` and replaces history.

- Implemented in `openEdit` using `navigate({ to: ".", search: prev => ({ ...prev, task: item.id }), replace: true })` in `apps/web/src/layouts/task-board/index.tsx`.
- No UI or routing changes; history is not padded (replace used). Reloading or sharing the URL reopens the same task.

<sup>Written for commit f801bdd8724d71524f0681732de988f73d212a45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

