### PR TITLE
feat(analytics): add A/B testing on top of PostHog

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,6 +347,36 @@ shallow-merge (explicit `false` persists, omitted keys survive); unset reads as
 off. Flags are product gating, not access control. Anything non-boolean or ever
 needing an index/constraint gets its own column instead.
 
+### A/B tests (PostHog experiments)
+
+Different mechanism from org flags above, different job: org flags are
+deterministic gating we set; an experiment is a randomized assignment PostHog
+sets. Never use one for the other.
+
+Read the variant with `useExperiment("<flag-key>")`
+(`apps/web/src/hooks/use-experiment.ts`). Reading IS the exposure
+(`$feature_flag_called`), so call it only where the experiment applies —
+reading it "just to know" pollutes the control group. It returns `undefined`
+until flags load and on deployments without `POSTHOG_KEY`, so every caller
+needs a control-equivalent fallback.
+
+**In-product experiments are randomized by organization**, never by user — two
+teammates in one workspace must not see different UIs. Set that on the flag in
+PostHog (aggregate by the `organization` group type); `PostHogGroupSync`
+already binds the org to the session, so nothing is needed in app code.
+User-level randomization is for pre-signup surfaces only, where no org exists
+yet.
+
+Declare the success-metric event (`track(...)` in web, `captureOrgEvent(...)` in
+api) *before* writing variant code — an experiment without a pre-declared
+primary metric is a coin flip you watch. The permanent `experiment-pipeline-check`
+A/A flag is the noise floor: read a real experiment's lift against it.
+
+Above-the-fold variants will flash control first, because flags resolve after
+`/api/config`. The fix when that matters is to evaluate flags server-side in the
+`/api/config` handler and pass them to `posthog.init` via
+`bootstrap: { featureFlags }` — not yet implemented.
+
 ### Style & Formatting
 - **Biome** enforces two-space indentation and double quotes
 - **ALWAYS** run `bun run fmt` after making code changes (pre-commit hook via lefthook)

--- a/apps/web/ct/harness/experiment-harness.tsx
+++ b/apps/web/ct/harness/experiment-harness.tsx
@@ -1,0 +1,51 @@
+/**
+ * Mounts `useExperiment` against a REAL posthog-js instance under the real
+ * provider, with variants supplied through posthog's `bootstrap` option so the
+ * browser needs no network and no PostHog project.
+ *
+ * What it guards: the wiring. `useExperiment` reads from React context, so a
+ * missing `PostHogProvider` throws at mount rather than degrading — the kind of
+ * break that otherwise only shows up in production, on the one screen running
+ * an experiment.
+ */
+
+import posthog from "posthog-js";
+import { PostHogProvider } from "posthog-js/react";
+
+import { useExperiment } from "@/hooks/use-experiment";
+
+/** Unroutable: requests fail fast, so flags can only come from bootstrap. */
+const OFFLINE_API_HOST = "http://127.0.0.1:1/ph";
+
+let initialized = false;
+
+function Variant({ flag }: { flag: string }) {
+  const variant = useExperiment(flag);
+  return <div>{variant ?? "(unassigned)"}</div>;
+}
+
+export function ExperimentHarness({
+  flag,
+  flags,
+}: {
+  flag: string;
+  flags: Record<string, string | boolean>;
+}) {
+  if (!initialized) {
+    initialized = true;
+    posthog.init("phc_component_test_key", {
+      api_host: OFFLINE_API_HOST,
+      autocapture: false,
+      capture_pageview: false,
+      capture_exceptions: false,
+      disable_session_recording: true,
+      bootstrap: { featureFlags: flags },
+    });
+  }
+
+  return (
+    <PostHogProvider client={posthog}>
+      <Variant flag={flag} />
+    </PostHogProvider>
+  );
+}

--- a/apps/web/ct/tests/experiment.ct.tsx
+++ b/apps/web/ct/tests/experiment.ct.tsx
@@ -1,0 +1,30 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import { ExperimentHarness } from "../harness/experiment-harness";
+
+const FLAG = "experiment-pipeline-check";
+
+test("renders the assigned variant key", async ({ mount }) => {
+  const component = await mount(
+    <ExperimentHarness flag={FLAG} flags={{ [FLAG]: "test" }} />,
+  );
+
+  await expect(component).toHaveText("test");
+});
+
+test("reads unassigned when the flag is absent", async ({ mount }) => {
+  const component = await mount(
+    <ExperimentHarness flag={FLAG} flags={{ "other-flag": true }} />,
+  );
+
+  await expect(component).toHaveText("(unassigned)");
+});
+
+test("reads unassigned for a boolean (non-multivariate) flag", async ({
+  mount,
+}) => {
+  const component = await mount(
+    <ExperimentHarness flag={FLAG} flags={{ [FLAG]: true }} />,
+  );
+
+  await expect(component).toHaveText("(unassigned)");
+});

--- a/apps/web/src/hooks/use-experiment.ts
+++ b/apps/web/src/hooks/use-experiment.ts
@@ -1,0 +1,37 @@
+/**
+ * Read the variant a PostHog experiment assigned to the current visitor.
+ *
+ * Reading the variant IS the exposure: posthog-js emits `$feature_flag_called`
+ * on the first read, and PostHog's experiment analysis is built on that event.
+ * So call this only where the experiment actually applies — never "just to
+ * know", or the control group fills up with people who never saw the surface.
+ *
+ * Returns `undefined` until flags load, and forever on deployments without
+ * `POSTHOG_KEY` (self-hosted / open-source). Every caller therefore needs a
+ * fallback that renders the control experience. Boolean (non-multivariate)
+ * flags also read as `undefined` — an experiment is always multivariate.
+ *
+ * ## Randomization unit
+ *
+ * In-product experiments are randomized by ORGANIZATION: two teammates in one
+ * workspace must never see different UIs. That is a property of the flag in
+ * PostHog ("aggregate by" the `organization` group type), not of this hook —
+ * `PostHogGroupSync` already binds the active org to the session, so an
+ * org-aggregated flag resolves correctly here with no extra wiring.
+ *
+ * Randomize by user only on pre-signup surfaces (landing → signup), where no
+ * org exists yet.
+ *
+ * ## Not the same as org flags
+ *
+ * `useOrgFlag()` reads `organization_settings.flags` — deterministic product
+ * gating we own and set per org. This hook reads a randomized assignment we
+ * do not control. Don't use one for the other's job.
+ */
+
+import { useFeatureFlagVariantKey } from "posthog-js/react";
+
+export function useExperiment(key: string): string | undefined {
+  const variant = useFeatureFlagVariantKey(key);
+  return typeof variant === "string" ? variant : undefined;
+}

--- a/apps/web/src/providers/posthog-group-sync.tsx
+++ b/apps/web/src/providers/posthog-group-sync.tsx
@@ -13,6 +13,23 @@ import {
   flushBootstrapTiming,
   setOrganizationGroup,
 } from "@/lib/posthog-client";
+import { useExperiment } from "@/hooks/use-experiment";
+
+/**
+ * A/A test validating the experiment pipeline end to end: assignment is
+ * org-aggregated, both variants render the identical (empty) UI, so any
+ * difference the analysis reports between them is pipeline noise, not a
+ * product effect. Keep it running as the baseline for reading real
+ * experiments — it is what tells us a "win" is bigger than the floor.
+ *
+ * Must render below the `setOrganizationGroup` call: the exposure has to
+ * carry the org group, or an org-aggregated flag falls back to per-user
+ * bucketing.
+ */
+function ExperimentPipelineCheck() {
+  useExperiment("experiment-pipeline-check");
+  return null;
+}
 
 export function PostHogGroupSync({
   activeOrg,
@@ -23,12 +40,13 @@ export function PostHogGroupSync({
     slug?: string | null;
   } | null;
 }) {
-  if (activeOrg) {
-    setOrganizationGroup(activeOrg.id, {
-      name: activeOrg.name ?? undefined,
-      slug: activeOrg.slug ?? undefined,
-    });
-    flushBootstrapTiming();
-  }
-  return null;
+  if (!activeOrg) return null;
+
+  setOrganizationGroup(activeOrg.id, {
+    name: activeOrg.name ?? undefined,
+    slug: activeOrg.slug ?? undefined,
+  });
+  flushBootstrapTiming();
+
+  return <ExperimentPipelineCheck />;
 }

--- a/apps/web/src/providers/posthog-provider.tsx
+++ b/apps/web/src/providers/posthog-provider.tsx
@@ -6,9 +6,14 @@
  *   is present (server returns `posthog: null` when unconfigured).
  * - Calls `identify` when a logged-in user is present.
  * - Calls `reset` when the session clears (logout).
+ * - Puts the singleton on React context so `useExperiment` (and any other
+ *   posthog-js/react hook) can subscribe to feature-flag loads.
  *
  * Must render below the Suspense boundary that fetches /api/config.
  */
+
+import posthog from "posthog-js";
+import { PostHogProvider } from "posthog-js/react";
 
 import { authClient } from "@/lib/auth-client";
 import { identifyUser, initPostHog, resetUser } from "@/lib/posthog-client";
@@ -41,5 +46,5 @@ export function PostHogIdentitySync({
     }
   }
 
-  return <>{children}</>;
+  return <PostHogProvider client={posthog}>{children}</PostHogProvider>;
 }


### PR DESCRIPTION
## Summary

We had PostHog fully wired for **capture** (identify, `organization` groups, autocapture, replay, web vitals, exceptions) but nothing that **reads a feature flag** — and the PostHog project had zero flags. This adds the missing half so we can actually run experiments.

- **`useExperiment(key)`** (`apps/web/src/hooks/use-experiment.ts`) returns the assigned variant. Reading *is* the exposure (`$feature_flag_called`), which is what PostHog's experiment analysis is built on — so it must only be called where the experiment applies, never "just to know". Returns `undefined` until flags load and on deployments without `POSTHOG_KEY`, so callers need a control-equivalent fallback.
- **`PostHogIdentitySync`** now also puts the posthog singleton on React context (`PostHogProvider client={posthog}`), which posthog-js/react's flag hooks require. No behavior change to identify/reset.
- **`PostHogGroupSync`** renders the exposure *below* the `setOrganizationGroup` call, so an org-aggregated flag can't silently fall back to per-user bucketing.

## Randomization unit: organization

In-product experiments randomize by **organization**, not by user — two teammates in one workspace must never see different UIs. That's a property of the flag in PostHog ("aggregate by" the `organization` group type), not of app code: `PostHogGroupSync` already binds the active org to the session, so an org-aggregated flag just resolves. User-level randomization is reserved for pre-signup surfaces (landing → signup), where no org exists yet.

Documented in `AGENTS.md`, next to the org-flags section — the two are easy to confuse and must not be used for each other's job (`organization_settings.flags` = deterministic gating we set; an experiment = a randomized assignment we don't control).

## First consumer: an A/A test

The first flag is [`experiment-pipeline-check`](https://us.posthog.com/project/394178/feature_flags/816263) — org-aggregated, 50/50, **both variants render identical UI**. It's created and active in the `studio` PostHog project.

It validates assignment + exposure end to end without shipping a product change, and it stays as the noise floor: a real experiment's "win" should be read against what the A/A reports between two identical variants. Replace or extend it when the first real experiment lands.

## Testing

- New component tests (`apps/web/ct/tests/experiment.ct.tsx`) mount `useExperiment` against a **real** posthog-js instance under the real provider, with variants supplied via posthog's `bootstrap` option — no network, no mocks. Guards the wiring: `useExperiment` reads React context, so a missing provider throws at mount rather than degrading, which would otherwise only surface in production on the one screen running an experiment. Covers assigned variant, absent flag, and boolean (non-multivariate) flag. `bun run --cwd=apps/web test:ct experiment` → 3 passed.
- `bun run check`, `bun run lint` (0 errors), `bun run knip`, `bun run fmt` all clean.
- `bun run --cwd=apps/web test` fails 105 tests on this branch — identical count with these changes stashed, so pre-existing and untouched by this PR.
- **Not verified at runtime yet**: no local PostHog key, so the actual exposure firing in a browser against the real project is unconfirmed. After deploy, check `last_called_at` on the flag and `$feature_flag_called` events broken down by variant — a roughly 50/50 split of *organizations* is the signal the org-level pipeline works.

## Deliberately not in scope

- **Server-side flags.** `posthog-node`'s `getFeatureFlag` isn't exposed on the `PostHogLike` type in `apps/api/src/posthog.ts`. Nothing needs it yet; adding it now would be dead code. Straightforward follow-up when a server-rendered or backend-gated experiment appears.
- **Flicker on above-the-fold variants.** Flags resolve after `/api/config`, so a variant rendered above the fold flashes control first. The fix is to evaluate flags server-side in the `/api/config` handler and pass them to `posthog.init` via `bootstrap: { featureFlags }` — that route already blocks the shell, so it's nearly free. Worth doing when an experiment actually needs it, not before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds client-side PostHog experiments and an always-on A/A flag so we can run and analyze org-aggregated A/B tests. Previously we only captured events; now `useExperiment(key)` reads a flag and emits exposure on first read.

- New: `useExperiment(key)` returns the assigned variant or `undefined` until flags load or when `POSTHOG_KEY` is absent; callers must provide a control fallback. `PostHogIdentitySync` now wraps children with `PostHogProvider` from `posthog-js/react`. `PostHogGroupSync` triggers exposure only after binding the organization group to prevent per-user fallback. Adds an A/A flag (`experiment-pipeline-check`) with no UI change.

**Review notes**
- Core implementation: `apps/web/src/hooks/use-experiment.ts` (hook using `posthog-js/react`), `apps/web/src/providers/posthog-provider.tsx` (adds `PostHogProvider`), `apps/web/src/providers/posthog-group-sync.tsx` (orders org binding before exposure).
- Tests: `apps/web/ct/harness/experiment-harness.tsx` boots a real `posthog-js` client offline via `bootstrap`; `apps/web/ct/tests/experiment.ct.tsx` covers assigned, absent, and boolean flags.
- Docs: `AGENTS.md` documents experiment usage, org-level randomization, and known above-the-fold flicker.

**Rollout**
- No migration required. When adopting experiments, call `useExperiment` only where the experience renders and handle `undefined` as control.
- After deploy, verify `experiment-pipeline-check` shows recent `$feature_flag_called` and ~50/50 split by organization in PostHog.

<sup>Written for commit 661fd0b786173d71a012499a7ea07933a07b9e96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

