### PR TITLE
fix(task-board): don't lose an approved merge to a 429 or a re-run

### DIFF
--- a/apps/api/src/tools/task-board/merge-pr.test.ts
+++ b/apps/api/src/tools/task-board/merge-pr.test.ts
@@ -35,14 +35,17 @@ describe("mayBeConflict", () => {
   });
 
   // A 429 says nothing about mergeability, and re-asking IS the burst.
-  it("is false for a rate-limited refusal", () => {
+  it("is false for a rate limit however it is detailed", () => {
     expect(
       mayBeConflict({
         merged: false,
-        reason: "refused",
+        reason: "rate_limited",
         detail: "Streamable HTTP error: too many requests",
       }),
     ).toBe(false);
+    expect(mayBeConflict({ merged: false, reason: "rate_limited" })).toBe(
+      false,
+    );
   });
 
   it("is false for every non-refusal outcome", () => {
@@ -52,6 +55,7 @@ describe("mayBeConflict", () => {
       "checks_pending",
       "checks_failing",
       "no_connection",
+      "rate_limited",
       "error",
     ] as const) {
       expect(mayBeConflict({ merged: false, reason })).toBe(false);

--- a/apps/api/src/tools/task-board/merge-pr.ts
+++ b/apps/api/src/tools/task-board/merge-pr.ts
@@ -32,6 +32,7 @@ export type MergeFailureReason =
   | "checks_pending"
   | "checks_failing"
   | "no_connection"
+  | "rate_limited"
   | "refused"
   | "error";
 
@@ -156,6 +157,13 @@ export async function mergeLinkedPr(
       const content = JSON.stringify(
         (result as { content?: unknown })?.content,
       );
+      // A 429 arrives in the refusal's shape; calling it one reads as terminal.
+      if (isRateLimitError(content)) {
+        console.warn(
+          `[task-board] merge rate-limited on PR #${pr.number} — sweep retries`,
+        );
+        return fail("rate_limited", content?.slice(0, 500));
+      }
       console.error(
         `[task-board] merge refused by GitHub on PR #${pr.number}:`,
         content,
@@ -167,8 +175,11 @@ export async function mergeLinkedPr(
     invalidatePrReads(conn.id);
     return { merged: true };
   } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    // Same 429, thrown rather than returned — the transport decides which.
+    if (isRateLimitError(err)) return fail("rate_limited", detail);
     console.error("[task-board] merge PR failed", err);
-    return fail("error", err instanceof Error ? err.message : String(err));
+    return fail("error", detail);
   } finally {
     await client.close().catch(() => {});
   }
@@ -243,13 +254,12 @@ async function handUnverifiedApprovalToHuman(
  * whether the PR conflicts. Pure — unit-tested.
  *
  * Only a refusal can be a conflict; every other reason (no PR, no connection,
- * red or pending checks) is definitely not one. A rate-limited refusal is
- * excluded too: it says nothing about mergeability, and paying another GitHub
- * call into a 429 is the burst that keeps the limit shut.
+ * red or pending checks) is definitely not one. `rate_limited` is a separate
+ * reason precisely so it lands here: it says nothing about mergeability, and
+ * paying another GitHub call into a 429 is the burst that keeps the limit shut.
  */
 export function mayBeConflict(outcome: MergeOutcome): boolean {
-  if (outcome.merged || outcome.reason !== "refused") return false;
-  return !isRateLimitError(outcome.detail ?? "");
+  return !outcome.merged && outcome.reason === "refused";
 }
 
 /**

--- a/apps/api/src/tools/task-board/rerun-merge-pending.integration.test.ts
+++ b/apps/api/src/tools/task-board/rerun-merge-pending.integration.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Real-Postgres coverage for the one thing a re-run must NOT do: throw away a
+ * merge that is already queued.
+ *
+ * A re-run starts a new review cycle, and the auto-merge gate reads only the
+ * current one — so re-running a card every reviewer already approved discards
+ * the pending merge and hands the PR back to a review loop that can bounce
+ * until a human is called in. Real PG rather than a fake because the gate is a
+ * fold over `task_board_activity` rows plus the org's `flags` jsonb, and both
+ * are exactly what an in-memory stub gets to be lenient about.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { sql } from "kysely";
+import type { StudioContext } from "../../core/studio-context";
+import type { StudioDatabase } from "../../database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../../database/test-db-pg";
+import { OrganizationSettingsStorage } from "../../storage/organization-settings";
+import { TaskBoardStorage } from "../../storage/task-board";
+import { refuseIfMergePending } from "./rerun";
+
+const ORG = "org_rerun_1";
+const USER = "user_r1";
+
+describe("refuseIfMergePending", () => {
+  let database: StudioDatabase;
+  let taskBoard: TaskBoardStorage;
+  let organizationSettings: OrganizationSettingsStorage;
+  let ctx: StudioContext;
+
+  /** A card In Review whose reviewers left `verdicts` in the current cycle. */
+  const cardWithVerdicts = async (
+    verdicts: { reviewer: string; verified: boolean }[],
+  ) => {
+    const item = await taskBoard.create({
+      organizationId: ORG,
+      title: "ship me",
+      by: USER,
+    });
+    for (const { reviewer, verified } of verdicts) {
+      await taskBoard.recordActivity({
+        taskBoardItemId: item.id,
+        action: "review_approved",
+        actorId: null,
+        data: { reviewer, verified },
+      });
+    }
+    return { id: item.id, status: "in_review", organizationId: ORG };
+  };
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    const now = new Date().toISOString();
+    await database.db
+      .insertInto("organization")
+      .values({ id: ORG, name: ORG, slug: "org-rerun-1", createdAt: now })
+      .execute();
+    // Raw SQL: real Postgres types emailVerified BOOLEAN, the table shape TEXT.
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES (${USER}, ${"r1@rerun.test"}, false, ${USER}, ${now}, ${now})
+    `.execute(database.db);
+    taskBoard = new TaskBoardStorage(database.db);
+    organizationSettings = new OrganizationSettingsStorage(database.db);
+    await organizationSettings.upsert(ORG, {
+      flags: {
+        auto_merge: true,
+        qa_agent_enabled: true,
+        code_reviewer_enabled: true,
+      },
+    });
+    ctx = {
+      storage: { taskBoard, organizationSettings },
+    } as unknown as StudioContext;
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  it("refuses when every enabled reviewer verifiably approved", async () => {
+    const item = await cardWithVerdicts([
+      { reviewer: "qa", verified: true },
+      { reviewer: "code_review", verified: true },
+    ]);
+    await expect(refuseIfMergePending(ctx, item)).rejects.toThrow(
+      /merge is retrying/,
+    );
+  });
+
+  it("allows a re-run when a reviewer has not approved yet", async () => {
+    const item = await cardWithVerdicts([{ reviewer: "qa", verified: true }]);
+    await expect(refuseIfMergePending(ctx, item)).resolves.toBeUndefined();
+  });
+
+  // An unverified approval is the dead end a re-run is the only way out of.
+  it("allows a re-run when an approval did not verify", async () => {
+    const item = await cardWithVerdicts([
+      { reviewer: "qa", verified: true },
+      { reviewer: "code_review", verified: false },
+    ]);
+    await expect(refuseIfMergePending(ctx, item)).resolves.toBeUndefined();
+  });
+
+  it("allows a re-run of a card that is not In Review", async () => {
+    const item = await cardWithVerdicts([
+      { reviewer: "qa", verified: true },
+      { reviewer: "code_review", verified: true },
+    ]);
+    await expect(
+      refuseIfMergePending(ctx, { ...item, status: "in_progress" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("allows a re-run when the org has auto-merge off", async () => {
+    const item = await cardWithVerdicts([
+      { reviewer: "qa", verified: true },
+      { reviewer: "code_review", verified: true },
+    ]);
+    await organizationSettings.upsert(ORG, {
+      flags: {
+        auto_merge: false,
+        qa_agent_enabled: true,
+        code_reviewer_enabled: true,
+      },
+    });
+    await expect(refuseIfMergePending(ctx, item)).resolves.toBeUndefined();
+  });
+});

--- a/apps/api/src/tools/task-board/rerun.ts
+++ b/apps/api/src/tools/task-board/rerun.ts
@@ -45,6 +45,7 @@ import { cancelThreadGateHead } from "@/dispatch-queue/thread-gate-queue";
 import { recordTaskActivity } from "./activity";
 import { emitTaskBoardUpdated } from "./run-reactions";
 import { enqueueSuperAgentForTask } from "./enqueue-super-agent";
+import { allEnabledReviewersVerifiedApproved } from "./merge-pr";
 import {
   ensureTaskExecutionAllowed,
   userInitiatedTaskQuotaConfig,
@@ -133,6 +134,42 @@ async function stopSupersededRun(
   broadcastRunCancel(threadId);
 }
 
+/**
+ * Refuse a re-run of a card whose merge is already queued and will retry.
+ *
+ * A re-run opens a NEW review cycle, and the auto-merge gate
+ * (`retryAutoMergeIfApproved`) reads only the current one — so re-running an
+ * In Review card that every enabled reviewer verifiably approved discards a
+ * merge that was one sweep tick from shipping, and the fresh cycle can bounce
+ * forever instead. Observed on `board_pA_7SsIEhMmcStEcAidCs`: a rate-limited
+ * merge, then a re-run, then five review bounces and a hand-off to a human on a
+ * PR that had already been approved twice.
+ *
+ * Narrow on purpose: a card sitting In Review WITHOUT that gate satisfied is
+ * exactly the wedge this tool exists to clear, so it still re-runs.
+ */
+export async function refuseIfMergePending(
+  ctx: StudioContext,
+  item: { id: string; status: string; organizationId: string },
+): Promise<void> {
+  if (item.status !== "in_review") return;
+  const settings = await ctx.storage.organizationSettings.get(
+    item.organizationId,
+  );
+  if (settings?.flags?.auto_merge !== true) return;
+  const approved = await allEnabledReviewersVerifiedApproved(
+    ctx,
+    item.organizationId,
+    item.id,
+  );
+  if (!approved) return;
+  throw new Error(
+    "Every reviewer approved this task and its merge is retrying — re-running " +
+      "would throw that away and start a new review cycle. Wait for the merge, " +
+      "or use the ship button if the PR needs a nudge.",
+  );
+}
+
 export const TASK_BOARD_ITEM_RERUN = defineTool({
   name: "TASK_BOARD_ITEM_RERUN",
   description:
@@ -186,6 +223,8 @@ export const TASK_BOARD_ITEM_RERUN = defineTool({
           "the Super Agent instead — that queues a run by itself.",
       );
     }
+
+    await refuseIfMergePending(ctx, item);
 
     // Paywall before any write: a refused re-run must leave the card untouched.
     await ensureTaskExecutionAllowed(ctx, item, userInitiatedTaskQuotaConfig());

--- a/apps/web/src/i18n/en/task-board.ts
+++ b/apps/web/src/i18n/en/task-board.ts
@@ -97,6 +97,8 @@ export const taskBoard = {
     "couldn't merge — the pull request's checks are failing",
   "taskBoard.taskDialog.activityMergeFailedNoConnection":
     "couldn't merge — this organization has no GitHub connection for {detail}. Connect that repository to ship this task.",
+  "taskBoard.taskDialog.activityMergeFailedRateLimited":
+    "couldn't merge yet — GitHub is rate-limiting us. This retries automatically.",
   "taskBoard.taskDialog.activityMergeFailedRefused":
     "GitHub refused the merge: {detail}",
   "taskBoard.taskDialog.activityMergeFailedError":

--- a/apps/web/src/i18n/pt-br/task-board.ts
+++ b/apps/web/src/i18n/pt-br/task-board.ts
@@ -104,6 +104,8 @@ export const taskBoard = {
     "não conseguiu mesclar — as verificações do pull request estão falhando",
   "taskBoard.taskDialog.activityMergeFailedNoConnection":
     "não conseguiu mesclar — esta organização não tem conexão do GitHub para {detail}. Conecte esse repositório para publicar esta tarefa.",
+  "taskBoard.taskDialog.activityMergeFailedRateLimited":
+    "ainda não deu para fazer o merge — o GitHub está limitando nossas requisições. Isso é tentado de novo automaticamente.",
   "taskBoard.taskDialog.activityMergeFailedRefused":
     "o GitHub recusou o merge: {detail}",
   "taskBoard.taskDialog.activityMergeFailedError":

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -1809,6 +1809,8 @@ function describeActivity(
                 detail,
               })
             : t("taskBoard.taskDialog.activityMergeFailed");
+        case "rate_limited":
+          return t("taskBoard.taskDialog.activityMergeFailedRateLimited");
         case "refused":
           return detail
             ? t("taskBoard.taskDialog.activityMergeFailedRefused", { detail })


### PR DESCRIPTION
## Summary

Debugging why [`board_pA_7SsIEhMmcStEcAidCs`](https://studio.decocms.com/deco-studio) ("Reduzir o Speed Index no post de 17.9s para abaixo de 3.4s") never auto-merged turned up two independent bugs in the same path. Both are fixed here.

### 1. A rate limit was recorded as a refusal

Both reviewers approved at 15:19 and 15:35, auto-merge fired, and the card's timeline got:

```
merge_failed  reason: "refused"
              detail: "Streamable HTTP error: Error POSTing to endpoint: too many requests"
```

`mergeLinkedPr` treats *any* `isError` on the GitHub MCP tool call as `refused` — the reason that means "GitHub said no, a human has to act". A 429 on the transport is the opposite: routine, says nothing about the PR, and the sweep's `retryAutoMergeIfApproved` handles it on its own. `isRateLimitError` was already imported into this file, but only consulted by `mayBeConflict`.

`rate_limited` is now its own `MergeFailureReason`, matched on both the returned-`isError` and thrown paths, with its own timeline copy ("this retries automatically") in en + pt-br. `mayBeConflict` loses its detail-text sniffing as a result — the reason now carries that information.

Deliberately **not** added to `SILENT_REASONS`: the dedup (keyed on the newest entry) already prevents spam, and this timeline entry is the only reason the outage was diagnosable at all.

### 2. A re-run threw the pending merge away

At 17:13 the card was re-run. `TASK_BOARD_ITEM_RERUN` opens a **new** review cycle, and the auto-merge gate reads only the current one — so the approvals that would have let the next sweep ship it were discarded. The fresh cycle then bounced five times and handed the card to a human, on a PR that had already been approved twice.

`refuseIfMergePending` now blocks that, naming the merge in the error. Narrow on purpose: an In Review card *without* the gate satisfied still re-runs — including the unverified-approval dead end that `handUnverifiedApprovalToHuman` exists for, where a re-run is the only way out.

## Testing

- `apps/api/src/tools/task-board/rerun-merge-pending.integration.test.ts` — new, real Postgres. Covers refuse-when-approved plus all four allow cases (not approved / unverified / not In Review / auto-merge off). Picked up automatically by `storage-integration.yml`.
- `merge-pr.test.ts` — the rate-limit `mayBeConflict` case is **inverted** onto the new reason rather than appended to, and `rate_limited` added to the non-refusal sweep.
- `bun run --cwd=apps/api check`, `bun run --cwd=apps/web check`, `bun run fmt`, `bun run lint` all pass (lint: 18 pre-existing warnings, 0 errors).
- Not run locally: the new integration test (no Docker on this machine) — CI runs it.

## Affected areas

Task board auto-merge and re-run. No schema change; `reason` lives in the activity row's jsonb `data`. UI change is one new timeline case in `task-dialog.tsx` + two dictionary keys.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop losing approved task-board merges to GitHub 429s or re-runs. Previously, 429s were recorded as “refused” and re-running an In Review card started a new cycle that discarded a pending auto-merge; now 429s are “rate_limited” (auto-retry) and re-runs are refused when a merge is already queued.

**Key changes**
- Classifies 429s as `rate_limited` in `mergeLinkedPr` for both returned and thrown errors; updates `mayBeConflict` to treat only `refused` as a potential conflict; adds UI copy and i18n keys (en/pt-br) and dialog mapping for the new reason.
- Adds `refuseIfMergePending` to `TASK_BOARD_ITEM_RERUN` to block re-runs only when all enabled reviewers verifiably approved and auto-merge is on; allows re-runs in all other cases; includes a real Postgres integration test and updates unit tests.

<sup>Written for commit cae7d94826898138391f46eba88b80d88b98e35d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/5999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

