### PR TITLE
perf(task-board): cap the review sweep's GitHub reads with a DBOS queue

### DIFF
--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -25,6 +25,11 @@ import {
   registerTaskBoardArchiveSweepWorkflow,
   setTaskBoardArchiveSweepRuntime,
 } from "@/tools/task-board/dbos-archive-sweep";
+import {
+  GITHUB_READS_QUEUE_PARAMS,
+  registerTaskBoardGithubReadWorkflow,
+  setTaskBoardGithubReadRuntime,
+} from "@/tools/task-board/dbos-github-read";
 import { getPublicUrl } from "@/core/server-constants";
 import { usesLocalObjectStorage } from "../tools/connection/dev-assets";
 import { DECO_STORE_URL, isDecoHostedMcp } from "@/core/deco-constants";
@@ -178,6 +183,7 @@ import {
   THREAD_GATE_PARTITION_CONCURRENCY,
   THREAD_GATE_QUEUE,
 } from "../dispatch-queue";
+import { GITHUB_READS_QUEUE } from "../dispatch-queue/queue-names";
 import { hostedRunStats } from "../dispatch-queue/hosted-run-concurrency";
 import { setProjectorWorkflowRuntime } from "./routes/decopilot/projector-workflow";
 import { synthesizedErrorMessageId } from "./routes/decopilot/message-ids";
@@ -906,6 +912,7 @@ const DBOS_QUEUE_NAMES = new Set([
   THREAD_GATE_QUEUE,
   HOSTED_HARNESS_QUEUE,
   BACKGROUND_TOOLS_QUEUE,
+  GITHUB_READS_QUEUE,
 ]);
 const getHandleOAuthProtectedResourceMetadata = () =>
   oAuthProtectedResourceMetadata(auth);
@@ -1513,6 +1520,9 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Hourly auto-archive of settled Done cards, one org leg per candidate org.
   setTaskBoardArchiveSweepRuntime({ db: database.db });
 
+  // The review sweep's rate-limited GitHub reads.
+  setTaskBoardGithubReadRuntime({ db: database.db });
+
   // ============================================================================
   // Automation Runtime — wire storage + streaming into the DBOS workflow
   // ============================================================================
@@ -1777,6 +1787,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   registerPublicSetsSyncWorkflow();
   registerOrgRepoSyncWorkflow();
   registerTaskBoardArchiveSweepWorkflow();
+  registerTaskBoardGithubReadWorkflow();
 
   const automationRunner: StudioContext["automationRunner"] = async (
     automationId,
@@ -2290,6 +2301,10 @@ export async function createApp(options: CreateAppOptions = {}) {
       partitionQueue: true,
       concurrency: BACKGROUND_TOOLS_PARTITION_CONCURRENCY,
     });
+    // The board's review sweep reads PR state through here. `rateLimit` is
+    // enforced in the system DB, so it is a cap on ALL replicas together —
+    // the one thing an in-process token bucket could never be.
+    await DBOS.registerQueue(GITHUB_READS_QUEUE, GITHUB_READS_QUEUE_PARAMS);
     await reconcileAutomationSchedules(automationsStorage);
 
     // One-time cleanup of the retired per-automation/global gate queues.

--- a/apps/api/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/api/src/dbos/workflow-source-guard.snapshot.json
@@ -7,5 +7,6 @@
   "file-storage/dbos-public-sets-sync.ts": "efd9c4bfd9ae29b13970e6b1072e067f43f151b3530d552efc1b4daf038bea7e",
   "harnesses/decopilot/background-tool-workflow.ts": "9febb699f45b63b418481ed998aee0ec8251c97cb5c409d54d714eb365a08fd0",
   "monitoring/dbos-retention-workflow.ts": "757e9999af900d9395c6629d4966b84c723512d0a5a8e488f70b7ba634752bd8",
-  "tools/task-board/dbos-archive-sweep.ts": "6afd648ad2d8f464e80d542bee2858bd54bf54f1c08ab8b0c5ac42593b5bed40"
+  "tools/task-board/dbos-archive-sweep.ts": "c3f1848b23c18bbb2aeb8b85c8f763ce2d9edb4fba6d2698a53b051e062ee571",
+  "tools/task-board/dbos-github-read.ts": "bc498f9d45d1470e08efb1992434d07148e1bd444d2c19fc2bfcb2d2d096aa49"
 }

--- a/apps/api/src/dispatch-queue/queue-names.test.ts
+++ b/apps/api/src/dispatch-queue/queue-names.test.ts
@@ -8,6 +8,7 @@ describe("DBOS queue names", () => {
       THREAD_GATE_QUEUE: "thread-gate",
       HOSTED_HARNESS_QUEUE: "decopilot-hosted-harness",
       BACKGROUND_TOOLS_QUEUE: "background-tools",
+      GITHUB_READS_QUEUE: "task-board-github-reads",
     });
     expect(queueNames).not.toHaveProperty("PROJECTOR_QUEUE");
   });

--- a/apps/api/src/dispatch-queue/queue-names.ts
+++ b/apps/api/src/dispatch-queue/queue-names.ts
@@ -10,3 +10,5 @@ export const THREAD_GATE_QUEUE = "thread-gate";
 export const HOSTED_HARNESS_QUEUE = "decopilot-hosted-harness";
 export const AUTOMATIONS_QUEUE = "automations";
 export const BACKGROUND_TOOLS_QUEUE = "background-tools";
+/** Rate-limited GitHub reads for the task board's review sweep. */
+export const GITHUB_READS_QUEUE = "task-board-github-reads";

--- a/apps/api/src/index.test.ts
+++ b/apps/api/src/index.test.ts
@@ -15,6 +15,10 @@ describe("DBOS worker queue selection", () => {
       "THREAD_GATE_QUEUE",
       "HOSTED_HARNESS_QUEUE",
       "BACKGROUND_TOOLS_QUEUE",
+      // The review sweeper AWAITS its enqueued read, so an "api"-role pod that
+      // enqueued one no worker dequeues would block until the workflow timeout
+      // — every sweep, forever.
+      "GITHUB_READS_QUEUE",
     ]) {
       expect(runQueues).toContain(queue);
     }

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -12,6 +12,7 @@ import { retry, sleep } from "@decocms/shared/std";
 import {
   AUTOMATIONS_QUEUE,
   BACKGROUND_TOOLS_QUEUE,
+  GITHUB_READS_QUEUE,
   HOSTED_HARNESS_QUEUE,
   THREAD_GATE_QUEUE,
 } from "./dispatch-queue/queue-names";
@@ -77,6 +78,10 @@ const RUN_QUEUES = [
   // "worker"-role pods must dequeue them too — otherwise a split deployment
   // enqueues the job but never runs it.
   BACKGROUND_TOOLS_QUEUE,
+  // The board's throttled GitHub reads. The review sweeper runs on every pod
+  // and awaits its enqueued read, so an "api"-only deployment would block
+  // forever if no worker dequeued this.
+  GITHUB_READS_QUEUE,
 ];
 const listenQueues: string[] | undefined =
   settings.dispatchRole === "worker"

--- a/apps/api/src/tools/task-board/dbos-archive-sweep.ts
+++ b/apps/api/src/tools/task-board/dbos-archive-sweep.ts
@@ -18,11 +18,10 @@
 
 import { DBOS, SchedulerMode } from "@dbos-inc/dbos-sdk";
 import type { Kysely } from "kysely";
-import { ContextFactory, rebindOrgScope } from "@/core/context-factory";
-import type { StudioContext } from "@/core/studio-context";
 import { TaskBoardStorage } from "@/storage/task-board";
 import type { Database } from "@/storage/types";
 import { archiveMergedForOrg, groupByOrg } from "./archive-merged";
+import { buildOrgContext } from "./org-context";
 
 /** Hourly, at :23 — off the other sweeps' ticks so one pod never runs two. */
 const ARCHIVE_SWEEP_CRONTAB = "23 * * * *";
@@ -55,25 +54,6 @@ function requireRuntime(): TaskBoardArchiveSweepRuntime {
     );
   }
   return runtime;
-}
-
-/** User-less StudioContext bound to one org — the sweep needs `ctx.organization`
- *  for the GitHub connection lookup and the org-rebound storage facets. Null when
- *  the org row is gone. */
-async function buildOrgContext(
-  db: Kysely<Database>,
-  orgId: string,
-): Promise<StudioContext | null> {
-  const org = await db
-    .selectFrom("organization")
-    .select(["id", "slug", "name"])
-    .where("id", "=", orgId)
-    .executeTakeFirst();
-  if (!org) return null;
-  const ctx = await ContextFactory.create();
-  ctx.organization = { id: org.id, slug: org.slug, name: org.name };
-  rebindOrgScope(ctx, { id: org.id, slug: org.slug });
-  return ctx;
 }
 
 /** One org, folded to a result — the step body must never throw. */

--- a/apps/api/src/tools/task-board/dbos-github-read.ts
+++ b/apps/api/src/tools/task-board/dbos-github-read.ts
@@ -1,0 +1,163 @@
+/**
+ * The review sweep's GitHub reads, behind a globally rate-limited DBOS queue.
+ *
+ * Nothing capped how fast the board asked GitHub for PR state. The sweep alone
+ * polled ~77 PRs on a 5-minute interval at four-plus calls each, and the load
+ * is lopsided — 47 of those PRs live in two repos — so one org's backlog of
+ * parked cards spent the whole shared `github-mcp` budget and every other org's
+ * reads came back 429. The card that prompted this had both reviewers approved
+ * and its merge refused with "too many requests".
+ *
+ * The existing guards each fix a different multiplier and none of them is a
+ * ceiling: `last_swept_at` stops three replicas sweeping the same card, the
+ * read cache stops two viewers of one PR costing two calls, and `isRetriable`
+ * stops a 429 becoming three. What was missing is a limit on the TOTAL, and a
+ * DBOS queue's `rateLimit` is enforced in the system database across every
+ * replica — which an in-process token bucket cannot be.
+ *
+ * Only the READ half runs here. The sweeper's reviewer dispatch bottoms out in
+ * `DBOS.startWorkflow`, which DBOS rejects from inside a step, and that is the
+ * whole reason the sweeper is a plain timer rather than a workflow. So the
+ * caller enqueues this, awaits the state, and dispatches out in its own
+ * non-workflow context exactly as before.
+ *
+ * Throttling makes the sweep SLOWER, deliberately. It is the floor, not the
+ * fast path: the dialog's poll and the run's terminal hook still react
+ * immediately, `markSwept` claims a card's interval before this call so a slow
+ * tick simply visits fewer cards, and the sweeper's `running` flag stops ticks
+ * overlapping. A card waits on CI for minutes anyway.
+ */
+
+import { DBOS } from "@dbos-inc/dbos-sdk";
+import type { Kysely } from "kysely";
+import { GITHUB_READS_QUEUE } from "@/dispatch-queue/queue-names";
+import type { Database, TaskBoardItemPrRef } from "@/storage/types";
+import { buildOrgContext } from "./org-context";
+import { fetchPrCandidateState } from "./prs-get";
+
+/**
+ * Reads started per minute across ALL replicas.
+ *
+ * Sized off what the sweep costs at rest: ~77 polled PRs on a 5-minute card
+ * interval is ~15 PRs/min, and each is now one workflow and one GitHub call.
+ * 20/min leaves headroom for a backlog to drain while staying well inside what
+ * the shared gateway answers without 429s — and everything else that talks to
+ * GitHub (the dialog poll, the merge, the reviewers' own `gh` calls in their
+ * sandboxes) is unthrottled and has to fit alongside it.
+ */
+const READS_PER_MINUTE = 20;
+
+/**
+ * Reads in flight at once, across all replicas.
+ *
+ * A rate limit alone would let a whole minute's allowance start together, and
+ * the limit being hit here is GitHub's SECONDARY one, which punishes exactly
+ * that shape — concurrent bursts, not a raw hourly count (see
+ * `isRateLimitError`). Four workflows × three calls caps the burst at a dozen.
+ *
+ * Global rather than per-worker, so it means the same thing however many
+ * replicas run. The cost of global is that any PENDING workflow holds a slot,
+ * which is what {@link READ_TIMEOUT_MS} exists to bound.
+ */
+const CONCURRENT_READS = 4;
+
+/**
+ * Ceiling on one read, so a wedged workflow can't hold a concurrency slot
+ * forever. Generous against the read's own budget — one call at the 8s
+ * per-call cap, plus a cold MCP handshake.
+ */
+const READ_TIMEOUT_MS = 60_000;
+
+export const GITHUB_READS_QUEUE_PARAMS = {
+  concurrency: CONCURRENT_READS,
+  rateLimit: { limitPerPeriod: READS_PER_MINUTE, periodSec: 60 },
+} as const;
+
+export interface TaskBoardGithubReadRuntime {
+  db: Kysely<Database>;
+}
+
+let runtime: TaskBoardGithubReadRuntime | null = null;
+
+/** Wire deps for the workflow body. Safe to call before `DBOS.launch()`:
+ *  it only writes a module-level pointer, no DBOS API calls. */
+export function setTaskBoardGithubReadRuntime(
+  rt: TaskBoardGithubReadRuntime,
+): void {
+  runtime = rt;
+}
+
+/** What `prReadyForReview` and the sweep's logging consume. Narrow because it
+ *  crosses the workflow boundary and is recorded in the DBOS journal — the
+ *  dialog's richer `PrLiveState` (checks, preview URL, per-check summaries) is
+ *  not fetched on this path at all. */
+export type SweptPrState = {
+  state: "open" | "closed" | null;
+  merged: boolean | null;
+};
+
+const UNKNOWN: SweptPrState = { state: null, merged: null };
+
+async function readPrState(
+  organizationId: string,
+  pr: TaskBoardItemPrRef,
+): Promise<SweptPrState> {
+  if (!runtime) {
+    throw new Error(
+      "[task-board-github-read] runtime not initialized — setTaskBoardGithubReadRuntime() must run before the workflow fires",
+    );
+  }
+  const ctx = await buildOrgContext(runtime.db, organizationId);
+  if (!ctx) return UNKNOWN;
+  return await fetchPrCandidateState(ctx, organizationId, pr);
+}
+
+async function githubReadWorkflowFn(
+  organizationId: string,
+  pr: TaskBoardItemPrRef,
+): Promise<SweptPrState> {
+  return await DBOS.runStep(() => readPrState(organizationId, pr), {
+    name: "readPrState",
+  });
+}
+
+let registeredWorkflow: typeof githubReadWorkflowFn | null = null;
+
+/**
+ * Must run before DBOS.launch(). Guarded so HMR repeats don't re-register.
+ *
+ * ⚠️ Durable DBOS workflow. Changing its STEP SEQUENCE (add/remove/reorder a
+ * step, or change a step's recorded I/O) requires bumping
+ * DBOS_WORKFLOW_VERSION — see apps/api/src/dbos/workflow-version.ts.
+ */
+export function registerTaskBoardGithubReadWorkflow(): void {
+  if (registeredWorkflow) return;
+  registeredWorkflow = DBOS.registerWorkflow(githubReadWorkflowFn, {
+    name: "taskBoardGithubReadWorkflow",
+  });
+}
+
+/**
+ * Read a PR's state through the rate-limited queue, waiting for its turn.
+ *
+ * Best-effort like every other GitHub read on this path: an unreachable
+ * workflow yields all-nulls, which `prReadyForReview` treats as "we could not
+ * ask" rather than "no" — the distinction that stopped a quiet GitHub freezing
+ * the whole review pipeline once already.
+ */
+export async function readPrStateThrottled(
+  organizationId: string,
+  pr: TaskBoardItemPrRef,
+): Promise<SweptPrState> {
+  if (!registeredWorkflow) return UNKNOWN;
+  try {
+    const handle = await DBOS.startWorkflow(registeredWorkflow, {
+      queueName: GITHUB_READS_QUEUE,
+      timeoutMS: READ_TIMEOUT_MS,
+    })(organizationId, pr);
+    return await handle.getResult();
+  } catch (err) {
+    console.error("[task-board-github-read] throttled PR read failed", err);
+    return UNKNOWN;
+  }
+}

--- a/apps/api/src/tools/task-board/org-context.ts
+++ b/apps/api/src/tools/task-board/org-context.ts
@@ -1,0 +1,32 @@
+/**
+ * A user-less `StudioContext` bound to one organization.
+ *
+ * What a board workflow needs to reach GitHub: `ctx.organization` for the
+ * connection lookup, and org-rebound storage facets. No principal, because
+ * these run on a schedule or a queue rather than for a person.
+ *
+ * Shared by `dbos-archive-sweep.ts` and `dbos-github-read.ts` — the two
+ * workflows that touch a repo on nobody's behalf.
+ */
+
+import type { Kysely } from "kysely";
+import { ContextFactory, rebindOrgScope } from "@/core/context-factory";
+import type { StudioContext } from "@/core/studio-context";
+import type { Database } from "@/storage/types";
+
+/** Null when the org row is gone. */
+export async function buildOrgContext(
+  db: Kysely<Database>,
+  orgId: string,
+): Promise<StudioContext | null> {
+  const org = await db
+    .selectFrom("organization")
+    .select(["id", "slug", "name"])
+    .where("id", "=", orgId)
+    .executeTakeFirst();
+  if (!org) return null;
+  const ctx = await ContextFactory.create();
+  ctx.organization = { id: org.id, slug: org.slug, name: org.name };
+  rebindOrgScope(ctx, { id: org.id, slug: org.slug });
+  return ctx;
+}

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -746,7 +746,7 @@ export const prReadyForReview = (
   // A PR is a candidate unless we positively know it's finished with.
   prs.some((p) => p.state !== "closed" && p.merged !== true);
 
-export async function fetchPrLiveState(
+async function fetchPrLiveState(
   ctx: StudioContext,
   orgId: string,
   pr: TaskBoardItemPrRef,
@@ -813,17 +813,21 @@ export async function fetchPrLiveState(
 }
 
 /**
- * Just "is this PR merged?" — `null` when GitHub can't be reached, never read as
- * merged by callers. Deliberately NOT `fetchPrLiveState`, which also fetches
- * checks/preview extras (~5 calls per PR): the archive sweep reads every Done
- * task's PRs in one go, and that multiplier is exactly what took out the GitHub
- * App's rate limit once already (see `review-sweeper.ts`).
+ * ONE `pull_request_read get`, the whole call. Deliberately NOT
+ * `fetchPrLiveState`, which also fetches checks/preview extras (~5 calls per
+ * PR): the sweeps read every candidate PR in one go, and that multiplier is
+ * exactly what took out the GitHub App's rate limit once already (see
+ * `review-sweeper.ts`).
+ *
+ * Null on any failure, and never read as an answer by callers — an unreachable
+ * GitHub means "we could not ask", not "no".
  */
-export async function fetchPrMerged(
+async function fetchPrGet(
   ctx: StudioContext,
   orgId: string,
   pr: TaskBoardItemPrRef,
-): Promise<boolean | null> {
+  label: string,
+): Promise<Record<string, unknown> | null> {
   const conn = await resolveGithubConnection(ctx, orgId, pr.connectionId, {
     owner: pr.repoOwner,
     name: pr.repoName,
@@ -832,7 +836,7 @@ export async function fetchPrMerged(
   const client = await clientFromConnection(conn, ctx, true);
   const pending: Promise<void>[] = [];
   try {
-    const obj = await cachedPrRead(
+    return await cachedPrRead(
       client,
       conn.id,
       "pull_request_read",
@@ -842,15 +846,50 @@ export async function fetchPrMerged(
         repo: pr.repoName,
         pullNumber: pr.number,
       },
-      `${prLabel(pr)} (merged)`,
+      `${prLabel(pr)} (${label})`,
       pending,
     );
-    return typeof obj?.merged === "boolean" ? obj.merged : null;
   } catch {
     return null;
   } finally {
     void Promise.allSettled(pending).then(() => client.close().catch(() => {}));
   }
+}
+
+/** Just "is this PR merged?", for the archive sweep. */
+export async function fetchPrMerged(
+  ctx: StudioContext,
+  orgId: string,
+  pr: TaskBoardItemPrRef,
+): Promise<boolean | null> {
+  const obj = await fetchPrGet(ctx, orgId, pr, "merged");
+  return typeof obj?.merged === "boolean" ? obj.merged : null;
+}
+
+/**
+ * Exactly what `prReadyForReview` reads, and nothing else.
+ *
+ * The review sweep used to call `fetchPrLiveState` here — four GitHub calls per
+ * PR plus one per failing check — for two booleans. It has cost that since
+ * before the check gate was dropped from the dispatch decision, and a red PR
+ * parked In Review is swept forever, so it paid the per-failure summaries on
+ * every pass in perpetuity.
+ */
+export async function fetchPrCandidateState(
+  ctx: StudioContext,
+  orgId: string,
+  pr: TaskBoardItemPrRef,
+): Promise<{ state: "open" | "closed" | null; merged: boolean | null }> {
+  const obj = await fetchPrGet(ctx, orgId, pr, "candidate");
+  return {
+    state:
+      obj?.state === "closed"
+        ? "closed"
+        : obj?.state === "open"
+          ? "open"
+          : null,
+    merged: typeof obj?.merged === "boolean" ? obj.merged : null,
+  };
 }
 
 export const TASK_BOARD_ITEM_PRS_GET = defineTool({

--- a/apps/api/src/tools/task-board/review-sweeper.ts
+++ b/apps/api/src/tools/task-board/review-sweeper.ts
@@ -81,7 +81,8 @@ import {
 import { TaskQuotaError } from "@/billing/task-quota";
 import { ABANDONED_FAILURE_REASON } from "./stall-recovery";
 import { THREAD_EXPIRY_MS } from "@/tools/thread/helpers";
-import { fetchPrLiveState, prReadyForReview } from "./prs-get";
+import { prReadyForReview } from "./prs-get";
+import { readPrStateThrottled } from "./dbos-github-read";
 
 /** How often to LOOK for due cards. A minute is well under the time a human
  *  would take to notice a stuck card, and the work list is one index scan when
@@ -497,18 +498,19 @@ export class TaskBoardReviewSweeper {
     // auto-merge inside, so it can't ship anything the reviewers didn't.
     if (await retryAutoMergeIfApproved(ctx, item)) return true;
 
-    // Fetch live PR state (listPrs carries none) to tell an open PR from a
-    // closed/merged one — the same candidate check the dialog poll applies.
-    // Check status does NOT gate dispatch: reviewers run without waiting for CI
-    // (see `prReadyForReview`); the merge is gated on green checks separately,
-    // so nothing ships on red.
+    // One `get` per PR through the rate-limited queue, never straight at
+    // GitHub: `listPrs` carries no live state, and telling an open PR from a
+    // closed/merged one is all the dispatch decision needs. Check status does
+    // NOT gate it — reviewers run without waiting for CI (see
+    // `prReadyForReview`); the merge is gated on green checks separately, so
+    // nothing ships on red.
     const live = await Promise.all(
       prs.map(async (pr) => ({
         ...pr,
-        ...(await fetchPrLiveState(ctx, organizationId, pr)),
+        ...(await readPrStateThrottled(organizationId, pr)),
       })),
     );
-    // `fetchPrLiveState` is best-effort and yields ALL-NULL fields when the
+    // The read is best-effort and yields ALL-NULL fields when the
     // GitHub call fails, which is indistinguishable from a PR whose state we
     // simply haven't got. `prReadyForReview` no longer treats that as "not
     // ready" (it used to, and a quiet GitHub then froze every card), but a whole


### PR DESCRIPTION
Follow-up to #5999, which fixed how a 429 was *recorded*. This fixes why there were 429s.

## The measurement

Nothing limited how fast the board asked GitHub for PR state, and `github-mcp.decocms.com` is shared by **311 connections across 150 orgs**. Prod, right now:

| | |
|---|---|
| Cards parked In Review (super-agent) | **61** |
| Linked PRs polled by the sweep | **77** |
| Calls per PR per sweep | **4 + one per failing check** |
| Sweep interval per card | 5 min |
| Failed `pull_request_read`s, one pod, 30 min | **~80** |

And the load is lopsided — `deco-sites/demo-storefront` (30 PRs) and `deco-sites/electrolux` (17) are **47 of the 77**, in two orgs, and they top the 429 log. Two connections spend the shared budget; everyone else's reads come back 429.

The existing guards each cap a different multiplier and **none of them is a ceiling**: `last_swept_at` stops three replicas sweeping the same card, the read cache stops two viewers of one PR costing two calls, `isRetriable` stops a 429 becoming three. Two changes add the missing one.

## 1. A rate-limited DBOS queue

`rateLimit` is enforced in the system database, so it caps **every replica together** — which an in-process token bucket cannot be. `concurrency: 4` alongside it, because the limit being hit is GitHub's *secondary* one, which punishes concurrent bursts rather than a raw count (as `isRateLimitError`'s own doc says); a rate limit alone would let a whole minute's allowance start at once. A workflow timeout bounds the slot a wedged read could otherwise hold forever — global concurrency counts PENDING workflows.

Only the **read** half runs on the queue. The sweeper's reviewer dispatch bottoms out in `DBOS.startWorkflow`, which DBOS rejects from inside a step — that is the whole reason the sweeper is a plain timer and not a workflow — so the caller awaits the state and dispatches out in its own non-workflow context exactly as before.

## 2. One `get` per PR instead of four-plus

The sweep called `fetchPrLiveState` — `get` + `get_status` + `get_check_runs` + `get_comments`, plus a `GET_CHECK_RUN` per failing check — to read **two booleans**. `prReadyForReview` needs `state` and `merged` and nothing else, and has since the check gate was dropped from the dispatch decision. A red PR parked In Review is swept forever, so it paid for the preview scrape and every failure summary in perpetuity.

`fetchPrGet` is now the shared single-call body under `fetchPrMerged` and a new `fetchPrCandidateState`. `fetchPrLiveState` loses its last external caller and its export with it (knip).

**Net: ~15 PRs/min × 4+ calls, unbounded → 20 starts/min × 1 call, capped globally.**

## Deliberately slower

Throttling makes the sweep slower on purpose — it is the floor, not the fast path. The dialog's poll and the run's terminal hook still react immediately, `markSwept` claims a card's interval *before* the read so a slow tick simply visits fewer cards, and the sweeper's `running` flag stops ticks overlapping. A card waits on CI for minutes anyway.

## Testing

- Both queue-membership guards extended (`index.test.ts`, `queue-names.test.ts`) — they encode the split-deployment trap, and it's live here: the sweeper runs on every pod and **awaits** its enqueued read, so an `api`-role pod would block until the timeout if no worker dequeued the queue. `GITHUB_READS_QUEUE` is in `RUN_QUEUES`.
- `bun run --cwd=apps/api check`, `apps/web check`, `fmt`, `lint` (18 pre-existing warnings, 0 errors), `knip` clean, `build:server` succeeds.
- `bun test` on task-board + dbos + dispatch-queue: 289 pass. The 17 failures are the three real-Postgres `*.integration.test.ts` suites, identical on a clean tree — no Docker on this machine; CI runs them.

## Version / snapshot

**No `DBOS_WORKFLOW_VERSION` bump.** The new workflow has no in-flight instances to strand, and lifting `buildOrgContext` out of the archive sweep into `org-context.ts` leaves that workflow's step sequence untouched. The workflow-source snapshot is re-baselined (both files).

## Not in this PR

61 cards parked In Review — 30 on one repo — is itself the demand driver. Capping the reads stops them taking the gateway down for other orgs; it doesn't make those cards converge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the task board’s review sweep GitHub reads behind a globally rate‑limited `DBOS` queue and reduces each PR check to a single GET. Previously the sweep made 4+ calls per PR with no global ceiling (frequent 429s); now it performs 1 call per PR, capped at 20 starts/min with concurrency 4. The sweep runs slower by design; dialog polling and merge gating stay immediate.

- **Review and rollout**
  - Adds `GITHUB_READS_QUEUE` (`task-board-github-reads`) with rateLimit 20/min and concurrency 4; registered at startup and included in `RUN_QUEUES`.
  - Introduces durable `taskBoardGithubReadWorkflow` behind `GITHUB_READS_QUEUE`; no `DBOS_WORKFLOW_VERSION` bump; workflow snapshot updated.
  - `review-sweeper` now calls `readPrStateThrottled` and reads only `{ state, merged }`; drops `fetchPrLiveState`. New `fetchPrGet` backs `fetchPrMerged` and `fetchPrCandidateState`. `buildOrgContext` moved to `org-context.ts`.
  - Required: ensure worker pods dequeue `task-board-github-reads`; in split deployments, missing this queue causes sweeps to wait until the workflow timeout each tick.

<sup>Written for commit c3cbd56b1444477c6ad52ca41bfdcee47e9834bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

