### PR TITLE
fix(analytics): instrument the report-funnel gaps found in the PostHog audit

### DIFF
--- a/apps/api/src/api/routes/task-board-import.ts
+++ b/apps/api/src/api/routes/task-board-import.ts
@@ -389,9 +389,9 @@ export const createTaskBoardImportRoutes = () => {
       }
     }
 
-    // Funnel event: the only signal a diagnostic run reached the board.
+    // Receiver's counterpart to the engine's diagnostic_tasks_pushed — join on run_id, never sum.
     captureOrgEvent({
-      event: "report_tasks_pushed",
+      event: "task_board_import_landed",
       organizationId,
       properties: {
         created: outcome.created,

--- a/apps/api/src/api/routes/task-board-import.ts
+++ b/apps/api/src/api/routes/task-board-import.ts
@@ -6,6 +6,7 @@ import {
   nextTagColor,
   SUPER_AGENT_ASSIGNEE_ID,
 } from "@decocms/shared/task-board";
+import { captureOrgEvent } from "@/posthog";
 import { TagStorage } from "@/storage/tags";
 import { TaskBoardStorage } from "@/storage/task-board";
 import type { TaskBoardItem } from "@/storage/types";
@@ -387,6 +388,23 @@ export const createTaskBoardImportRoutes = () => {
           });
       }
     }
+
+    // Funnel event: the only signal a diagnostic run reached the board.
+    captureOrgEvent({
+      event: "report_tasks_pushed",
+      organizationId,
+      properties: {
+        created: outcome.created,
+        updated: outcome.updated,
+        skipped: outcome.skipped,
+        delegated,
+        quota_blocked: quotaBlocked,
+        ...(runId ? { run_id: runId } : {}),
+        ...(parsed.data.source?.url
+          ? { source_url: parsed.data.source.url }
+          : {}),
+      },
+    });
 
     return c.json({
       created: outcome.created,

--- a/apps/web/src/layouts/task-board/backlog-paywall.tsx
+++ b/apps/web/src/layouts/task-board/backlog-paywall.tsx
@@ -88,11 +88,13 @@ function BacklogPaywallModal({
   open,
   onOpenChange,
   cdClient,
+  organizationId,
   onExpired,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   cdClient: CommerceDiscoveryClient | null;
+  organizationId: string;
   /** Called when checkout can't start because the report app is the only place
    *  that can (no client) — falls back to opening it. */
   onExpired: () => void;
@@ -101,7 +103,14 @@ function BacklogPaywallModal({
   const [starting, setStarting] = useState(false);
 
   const startCheckout = async () => {
+    track("board_paywall_checkout_started", {
+      organization_id: organizationId,
+    });
     if (!cdClient) {
+      track("board_paywall_checkout_failed", {
+        organization_id: organizationId,
+        reason: "no_client",
+      });
       onExpired();
       return;
     }
@@ -114,11 +123,18 @@ function BacklogPaywallModal({
       const { url } = unwrapToolResult<{ url: string }>(result);
       if (new URL(url).protocol !== "https:")
         throw new Error("unsafe checkout url");
+      track("board_paywall_checkout_opened", {
+        organization_id: organizationId,
+      });
       // Stripe hosted checkout opens in a new tab; on return the diagnostic
       // re-polls and unlocks (locked → false), clearing the banner/modal.
       window.open(url, "_blank", "noopener,noreferrer");
       onOpenChange(false);
     } catch {
+      track("board_paywall_checkout_failed", {
+        organization_id: organizationId,
+        reason: "tool_error",
+      });
       // Couldn't start checkout here — fall back to the report app, which owns
       // the full paywall + checkout flow.
       onExpired();
@@ -255,6 +271,7 @@ function BacklogPaywallBannerInner() {
         open={modalOpen}
         onOpenChange={dismiss}
         cdClient={cdClient}
+        organizationId={org.id}
         onExpired={openReport}
       />
     </>

--- a/apps/web/src/layouts/task-board/backlog-paywall.tsx
+++ b/apps/web/src/layouts/task-board/backlog-paywall.tsx
@@ -88,13 +88,11 @@ function BacklogPaywallModal({
   open,
   onOpenChange,
   cdClient,
-  organizationId,
   onExpired,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   cdClient: CommerceDiscoveryClient | null;
-  organizationId: string;
   /** Called when checkout can't start because the report app is the only place
    *  that can (no client) — falls back to opening it. */
   onExpired: () => void;
@@ -103,14 +101,7 @@ function BacklogPaywallModal({
   const [starting, setStarting] = useState(false);
 
   const startCheckout = async () => {
-    track("board_paywall_checkout_started", {
-      organization_id: organizationId,
-    });
     if (!cdClient) {
-      track("board_paywall_checkout_failed", {
-        organization_id: organizationId,
-        reason: "no_client",
-      });
       onExpired();
       return;
     }
@@ -123,18 +114,11 @@ function BacklogPaywallModal({
       const { url } = unwrapToolResult<{ url: string }>(result);
       if (new URL(url).protocol !== "https:")
         throw new Error("unsafe checkout url");
-      track("board_paywall_checkout_opened", {
-        organization_id: organizationId,
-      });
       // Stripe hosted checkout opens in a new tab; on return the diagnostic
       // re-polls and unlocks (locked → false), clearing the banner/modal.
       window.open(url, "_blank", "noopener,noreferrer");
       onOpenChange(false);
     } catch {
-      track("board_paywall_checkout_failed", {
-        organization_id: organizationId,
-        reason: "tool_error",
-      });
       // Couldn't start checkout here — fall back to the report app, which owns
       // the full paywall + checkout flow.
       onExpired();
@@ -271,7 +255,6 @@ function BacklogPaywallBannerInner() {
         open={modalOpen}
         onOpenChange={dismiss}
         cdClient={cdClient}
-        organizationId={org.id}
         onExpired={openReport}
       />
     </>

--- a/apps/web/src/routes/commerce-onboarding.tsx
+++ b/apps/web/src/routes/commerce-onboarding.tsx
@@ -14,6 +14,7 @@ import {
   useActiveOrganizations,
 } from "@/lib/auth-client";
 import { isPostHogInitialized, track } from "@/lib/posthog-client";
+import { reportAttributionFromSearch } from "@/routes/reports/track";
 import { KEYS } from "@/lib/query-keys";
 import { useT } from "@/i18n/use-t.ts";
 import { usePreferences } from "@/hooks/use-preferences.ts";
@@ -271,9 +272,14 @@ function CommerceOnboardingPage() {
 
   if (!onboardingViewTracked && isPostHogInitialized()) {
     onboardingViewTracked = true;
+    // Joins back to the report deck's connect CTA — see reports/onboarding.ts.
+    const reportAttribution = reportAttributionFromSearch(
+      window.location.search,
+    );
     track("commerce_onboarding_viewed", {
       site_url: siteUrl,
       domain: siteHost ?? undefined,
+      ...reportAttribution,
       // Person-level copy so the store follows the user across sessions.
       ...(siteHost ? { $set: { last_scanned_domain: siteHost } } : {}),
     });

--- a/apps/web/src/routes/commerce-onboarding/use-connect-companion.ts
+++ b/apps/web/src/routes/commerce-onboarding/use-connect-companion.ts
@@ -1,5 +1,6 @@
 import { authenticateAndPersistOAuth } from "@/lib/authenticate-and-persist-oauth";
 import { track } from "@/lib/posthog-client";
+import { reportAttributionFromSearch } from "@/routes/reports/track";
 import { KEYS } from "@/lib/query-keys";
 import type { RegistryItem } from "@/components/store/types";
 import { extractConnectionData } from "@/utils/extract-connection-data";
@@ -63,6 +64,7 @@ export function useConnectCompanion({
       organization_id: org.id,
       domain,
       site_url: siteUrl,
+      ...reportAttributionFromSearch(window.location.search),
     };
     track("commerce_onboarding_companion_connect_clicked", basePayload);
     try {
@@ -188,6 +190,7 @@ export function useConnectCompanion({
       organization_id: org.id,
       domain,
       site_url: siteUrl,
+      ...reportAttributionFromSearch(window.location.search),
     };
     track("commerce_onboarding_companion_disconnect_clicked", basePayload);
     try {

--- a/apps/web/src/routes/reports/onboarding.ts
+++ b/apps/web/src/routes/reports/onboarding.ts
@@ -1,12 +1,21 @@
 import type { MouseEvent } from "react";
-import { captureReport } from "./track";
+import { captureReport, reportAttributionFromSearch } from "./track";
 
 /** The "connect my store" destination. Every connect CTA in the report deck
  *  lands the visitor on the commerce onboarding flow with the scanned store
- *  URL preserved (so onboarding starts pre-filled for the same store).
+ *  URL preserved (so onboarding starts pre-filled for the same store), and
+ *  the report's attribution carried along so `commerce_onboarding_*` events
+ *  can be joined back to the report view that sent them here.
  *  Same-origin now — no cross-domain `ph_did` stamp needed. */
 export function onboardingUrl(storeUrl: string): string {
-  return `/commerce-onboarding?siteUrl=${encodeURIComponent(storeUrl)}`;
+  const params = new URLSearchParams({ siteUrl: storeUrl });
+  const attribution = reportAttributionFromSearch(
+    typeof window === "undefined" ? "" : window.location.search,
+  );
+  for (const [key, value] of Object.entries(attribution)) {
+    if (typeof value === "string") params.set(key, value);
+  }
+  return `/commerce-onboarding?${params.toString()}`;
 }
 
 export interface ConnectCtaContext {


### PR DESCRIPTION
## Summary

Follow-up to a PostHog instrumentation audit of the diagnostic-report → kanban → payment funnel. Fixes two verified, previously-uncovered gaps:

- **Kanban push had zero instrumentation.** `task-board-import.ts` (the diagnostic-worker → task-board endpoint) had no `posthog.capture` calls at all. Adds `task_board_import_landed` (created/updated/skipped/delegated + `run_id`), fired once per non-deduped import, after commit. This is the **receiver's** view of the same moment the reports engine already emits as `diagnostic_tasks_pushed` (the **sender's** view, from `pushBacklogToStudio`) — the two carry the same `run_id` and are meant to be joined, not summed.
- **Report-side and onboarding-side events weren't linkable.** `report_cta_clicked` (report deck) and `commerce_onboarding_*` (onboarding flow) had no shared attribution. `onboardingUrl()` now carries the report's attribution (`entrypoint`, `share_id`, `email_run_id`, `utm_*`) through the URL, echoed back on `commerce_onboarding_viewed` and the companion connect/disconnect events. This composes with reports#341's server-side stitching (LP visitor's PostHog id persisted on the diagnostic) rather than overlapping it.

**Dropped after review**: the `board_paywall_checkout_*` instrumentation on `backlog-paywall.tsx`. Caught in review: `start_checkout` and the `locked` flag it depends on are both gone from the reports engine (reports#344), so the banner never renders and the tool call can't succeed — instrumenting it would have produced a chart that reads as "nobody clicks unlock" when the truth is "there is no button." The component itself is dead UI, being removed in #6005.

**Correction from review**: I'd originally noted the client-side funnel and server-side Stripe webhook events (`subscription_started` etc.) couldn't be joined due to different distinct_id schemes. That's wrong as of #5860 — `captureOrgEvent` sets `distinctId: "org:<id>"` **and** `groups: { organization: <id> }`, and the client-side events here carry `organization_id`. The join exists at the **organization/group level**, just not at the person level (a webhook has no acting user). Left as a follow-up, not included here.

## Test plan
- [x] `bun run check` — all workspaces pass, including `decocms` (api) and `@decocms/studio-web`
- [x] `bun run lint` — 0 errors; 0 warnings in any touched file
- [x] `bun run fmt` — no changes needed
- [x] `bun test` on the touched frontend areas (commerce-onboarding, reports) — 152 pass / 0 fail
- [x] `bun test` on `task-board-import` — pre-existing integration-test failures confirmed identical with/without this change (require a real Postgres not available in this sandbox); nothing newly broken
- [ ] Manual: trigger a diagnostic → kanban push and confirm `task_board_import_landed` shows up in PostHog, joinable to `diagnostic_tasks_pushed` on `run_id`

🤖 Generated with [Claude Code](https://claude.com/claude-code)