### PR TITLE
fix(task-board): stop tasks parking In Review forever

### DIFF
--- a/apps/api/src/storage/task-board-pending-review.integration.test.ts
+++ b/apps/api/src/storage/task-board-pending-review.integration.test.ts
@@ -2,10 +2,16 @@
  * Real-Postgres coverage for the review sweeper's work list.
  *
  * This is the query that decides which stuck cards get rescued, so its
- * predicates are the contract: Super Agent only (a human's card is not the
- * sweeper's business), In Review only, dismissed cards excluded, oldest-touched
- * first so a long backlog drains fairly instead of starving the cards that have
- * been stuck longest, and bounded by `limit` so one tick can't scan the world.
+ * predicates are the contract: In Review only, dismissed cards excluded,
+ * oldest-touched first so a long backlog drains fairly instead of starving the
+ * cards that have been stuck longest, and bounded by `limit` so one tick can't
+ * scan the world.
+ *
+ * Deliberately NOT filtered on assignee. It used to be Super Agent only, which
+ * made every hand-off terminal: a card whose reviewers all approved but whose
+ * merge failed was unassigned, vanished from this query and never merged again.
+ * `reconcileItem` re-applies the assignee gate to everything except that merge
+ * retry, so a handed-off card still burns no agent runs.
  *
  * Cross-org on purpose — the sweeper is a process-level reconciler with no
  * request org — which is exactly the kind of thing an in-memory fake would get
@@ -123,9 +129,10 @@ describe("listItemsPendingReview (real Postgres)", () => {
     expect(ids).not.toContain(shipped.id);
   });
 
-  // A human's card in review is a human's business — dispatching a reviewer at
-  // it would burn a run nobody asked for.
-  it("skips a card that is not the Super Agent's", async () => {
+  // Approvals belong to the card, not to whoever holds it — an unassigned card
+  // is precisely the one the merge retry exists for. `reconcileItem` is what
+  // stops a reviewer being dispatched at either of these.
+  it("keeps a card that is not the Super Agent's", async () => {
     const mine = await card({ org: ORG_A, title: "mine", assignee: USER });
     const nobodys = await card({
       org: ORG_A,
@@ -134,8 +141,8 @@ describe("listItemsPendingReview (real Postgres)", () => {
     });
 
     const ids = (await taskBoard.listItemsPendingReview(50)).map((p) => p.id);
-    expect(ids).not.toContain(mine.id);
-    expect(ids).not.toContain(nobodys.id);
+    expect(ids).toContain(mine.id);
+    expect(ids).toContain(nobodys.id);
   });
 
   it("skips a dismissed card", async () => {

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -547,13 +547,18 @@ export class TaskBoardStorage {
    * without bounding what the sweep can ever reach.
    */
   /**
-   * The review sweeper's work list: Super Agent cards parked In Review that are
-   * DUE a sweep, i.e. never swept or last swept before `dueBefore`.
+   * The review sweeper's work list: cards parked In Review that are DUE a
+   * sweep, i.e. never swept or last swept before `dueBefore`.
    *
    * That predicate is what bounds the sweeper's GitHub cost. Without it the same
    * cards came back on every tick of every replica — a card whose checks never
    * go green never leaves this set — so the cost was (cards x replicas x ticks)
    * rather than (cards x intervals). See migration 166.
+   *
+   * Deliberately NOT filtered on the Super Agent assignee. A card handed to a
+   * human keeps its reviewers' approvals, and if they all approved it is still
+   * merge-eligible — `reconcileItem` is what re-applies the assignee gate to
+   * everything except that merge retry.
    */
   async listItemsPendingReview(
     limit: number,
@@ -564,7 +569,6 @@ export class TaskBoardStorage {
       .selectFrom("task_board_items")
       .select(["id", "organization_id as organizationId", "updated_at"])
       .where("status", "=", "in_review")
-      .where("assignee_id", "=", SUPER_AGENT_ASSIGNEE_ID)
       .where("dismissed_at", "is", null);
     if (dueBefore) {
       // A never-swept card (NULL) is always due — `<` alone would exclude it.

--- a/apps/api/src/tools/task-board/merge-pr.ts
+++ b/apps/api/src/tools/task-board/merge-pr.ts
@@ -14,6 +14,7 @@ import {
   fetchPrConflict,
   invalidatePrReads,
   isRateLimitError,
+  pickActivePr,
   resolveGithubConnection,
 } from "./prs-get";
 import { emitTaskBoardUpdated, handTaskToHuman } from "./run-reactions";
@@ -106,7 +107,7 @@ export async function mergeLinkedPr(
   };
 
   const prs = await ctx.storage.taskBoard.listPrs(taskBoardItemId, orgId);
-  const pr = prs[0];
+  const pr = await pickActivePr(ctx, orgId, prs);
   if (!pr) {
     console.warn(
       `[task-board] merge skipped — no linked PR on ${taskBoardItemId}`,
@@ -283,8 +284,8 @@ async function resolveConflictAfterRefusedMerge(
   if (!mayBeConflict(outcome)) return;
   const orgId = item.organizationId;
   const prs = await ctx.storage.taskBoard.listPrs(item.id, orgId);
-  // The newest linked PR — the one `mergeLinkedPr` just tried to merge.
-  const pr = prs[0];
+  // The same PR `mergeLinkedPr` just tried to merge.
+  const pr = await pickActivePr(ctx, orgId, prs);
   if (!pr) return;
   await reactToApprovedPrConflict(ctx, orgId, item, {
     pr: { number: pr.number, url: pr.url },

--- a/apps/api/src/tools/task-board/pick-active-pr.test.ts
+++ b/apps/api/src/tools/task-board/pick-active-pr.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Which linked PR the automation acts on. `listPrs` is newest-first and every
+ * caller used to take `[0]`, which stranded a real card: a bounce opened PR
+ * #327 instead of pushing to the reviewed #325, #327 was closed with a red
+ * check, and the merge gate then reported `checks_failing` every five minutes
+ * for a day while #325 sat approved, green and open. Pure; the GitHub read
+ * itself is e2e.
+ */
+
+import { describe, expect, it } from "bun:test";
+import { pickActivePrIndex } from "./prs-get";
+
+describe("pickActivePrIndex", () => {
+  it("takes the newest PR when it is open", () => {
+    expect(pickActivePrIndex(["open"])).toBe(0);
+    expect(pickActivePrIndex(["open", "closed"])).toBe(0);
+  });
+
+  it("skips a closed newest PR for the newest open one — the stranded card", () => {
+    expect(pickActivePrIndex(["closed", "open"])).toBe(1);
+    expect(pickActivePrIndex(["closed", "closed", "open"])).toBe(2);
+  });
+
+  // A GitHub blip must not silently redirect a merge to an older PR.
+  it("treats an unreadable PR as usable, not as closed", () => {
+    expect(pickActivePrIndex([null])).toBe(0);
+    expect(pickActivePrIndex([null, "open"])).toBe(0);
+    expect(pickActivePrIndex(["closed", null, "open"])).toBe(1);
+  });
+
+  it("falls back to the newest when every PR read closed", () => {
+    expect(pickActivePrIndex(["closed"])).toBe(0);
+    expect(pickActivePrIndex(["closed", "closed"])).toBe(0);
+  });
+
+  it("holds for an empty read — the caller indexes an empty list to undefined", () => {
+    expect(pickActivePrIndex([])).toBe(0);
+  });
+});

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -892,6 +892,51 @@ export async function fetchPrCandidateState(
   };
 }
 
+/**
+ * Index of the PR the automation should act on, given each linked PR's live
+ * state in `listPrs` order (newest first): the newest one not definitively
+ * closed, falling back to the newest.
+ *
+ * `null` (GitHub unreadable) counts as usable — a blip must not silently
+ * redirect a merge to an older PR. `states` may be shorter than the PR list,
+ * since {@link pickActivePr} stops reading at the first usable one.
+ */
+export function pickActivePrIndex(
+  states: readonly ("open" | "closed" | null)[],
+): number {
+  const i = states.findIndex((state) => state !== "closed");
+  // Every PR read closed — the newest is still the best guess, and the merged
+  // ones are handled by the reconcile-to-Done path.
+  return i === -1 ? 0 : i;
+}
+
+/**
+ * Which of a task's linked PRs the automation should act on.
+ *
+ * `listPrs` is newest-first, and taking `[0]` blindly is wrong once a task has
+ * more than one PR — a bounce that opens a fresh PR instead of pushing to the
+ * reviewed one leaves the newest link pointing at an abandoned branch, so the
+ * merge gate reads ITS red checks and reports `checks_failing` forever while
+ * the approved, green PR sits unmerged.
+ */
+export async function pickActivePr(
+  ctx: StudioContext,
+  orgId: string,
+  prs: TaskBoardItemPrRef[],
+): Promise<TaskBoardItemPrRef | undefined> {
+  if (prs.length <= 1) return prs[0];
+  const states: ("open" | "closed" | null)[] = [];
+  for (const pr of prs) {
+    const { state } = await fetchPrCandidateState(ctx, orgId, pr);
+    states.push(state);
+    // Stop at the first usable PR: the common case is one extra read, not one
+    // per link, which is what the GitHub rate limit cares about. The read is the
+    // same cached `get` the sweep's own candidate pass makes.
+    if (state !== "closed") break;
+  }
+  return prs[pickActivePrIndex(states)];
+}
+
 export const TASK_BOARD_ITEM_PRS_GET = defineTool({
   name: "TASK_BOARD_ITEM_PRS_GET",
   description:

--- a/apps/api/src/tools/task-board/review-decision.ts
+++ b/apps/api/src/tools/task-board/review-decision.ts
@@ -12,7 +12,7 @@ import { recordTaskActivity } from "./activity";
 import { emitTaskBoardUpdated, handTaskToHuman } from "./run-reactions";
 import { enqueueSuperAgentForTask } from "./enqueue-super-agent";
 import { allEnabledReviewersVerifiedApproved, mergeLinkedPr } from "./merge-pr";
-import { fetchPrConflict } from "./prs-get";
+import { fetchPrConflict, pickActivePr } from "./prs-get";
 import { reactToApprovedPrConflict } from "./conflict-reaction";
 import { TaskQuotaError } from "@/billing/task-quota";
 
@@ -203,12 +203,12 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
       }
       emitTaskBoardUpdated(organizationId, updated);
       // Pass the PR under review so the re-run updates it in place (checks out
-      // its branch) instead of opening a second PR. Newest linked PR is the one.
+      // its branch) instead of opening a second PR.
       const prs = await ctx.storage.taskBoard.listPrs(
         taskBoardItemId,
         organizationId,
       );
-      const pr = prs[0];
+      const pr = await pickActivePr(ctx, organizationId, prs);
       // Best-effort, like the auto-merge conflict path below — a dispatch
       // failure (no model configured, queue error) must never fail this
       // decision: the bounce-to-in_progress + activity write already
@@ -290,9 +290,8 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
         taskBoardItemId,
         organizationId,
       );
-      // The newest linked PR is the one under review (the same one
-      // `mergeLinkedPr` just tried to merge) — detect and act on it.
-      const pr = prs[0];
+      // The same PR `mergeLinkedPr` just tried to merge — detect and act on it.
+      const pr = await pickActivePr(ctx, organizationId, prs);
       // Best-effort, like the poll path in `prs-get` — a dispatch failure (no
       // model configured, queue error) must never fail this decision: the
       // approval + bounce-to-in_progress + activity write already committed,

--- a/apps/api/src/tools/task-board/review-sweeper.ts
+++ b/apps/api/src/tools/task-board/review-sweeper.ts
@@ -457,17 +457,14 @@ export class TaskBoardReviewSweeper {
     const item = await this.taskBoard.getById(id, organizationId);
     if (!item) return false;
     // Re-check against the fresh row: `listItemsPendingReview` scanned a
-    // possibly-stale snapshot, and a human can bounce/reassign the card between
-    // that scan and this reconcile. Without this the sweeper would still
-    // dispatch reviewers at a task that's no longer awaiting the Super Agent's
-    // review — the same gate `TASK_BOARD_ITEM_PRS_GET` applies before its own
-    // `enqueueEnabledReviewers` call.
-    if (
-      item.status !== "in_review" ||
-      item.assigneeId !== SUPER_AGENT_ASSIGNEE_ID
-    ) {
-      return false;
-    }
+    // possibly-stale snapshot, and a human can bounce the card between that scan
+    // and this reconcile.
+    if (item.status !== "in_review") return false;
+    // Everything below EXCEPT the merge retry needs the Super Agent to still own
+    // the card — the same gate `TASK_BOARD_ITEM_PRS_GET` applies before its own
+    // `enqueueEnabledReviewers` call. A handed-off card burns no agent runs, but
+    // its approvals stay valid, so it stays eligible to merge.
+    const owned = item.assigneeId === SUPER_AGENT_ASSIGNEE_ID;
 
     // Claim the interval BEFORE the GitHub work, not after: that is what makes a
     // second replica skip this card, and what stops a card that comes back
@@ -486,7 +483,7 @@ export class TaskBoardReviewSweeper {
     if (!ctx) return false;
 
     if (prs.length === 0) {
-      await this.handOffReviewWithoutPr(ctx, item);
+      if (owned) await this.handOffReviewWithoutPr(ctx, item);
       return false;
     }
 
@@ -497,6 +494,7 @@ export class TaskBoardReviewSweeper {
     // a card that has no reviewer left to enqueue. Gated on verified approval +
     // auto-merge inside, so it can't ship anything the reviewers didn't.
     if (await retryAutoMergeIfApproved(ctx, item)) return true;
+    if (!owned) return false;
 
     // One `get` per PR through the rate-limited queue, never straight at
     // GitHub: `listPrs` carries no live state, and telling an open PR from a

--- a/apps/web/src/i18n/en/task-board.ts
+++ b/apps/web/src/i18n/en/task-board.ts
@@ -35,8 +35,11 @@ export const taskBoard = {
   "taskBoard.taskBoard.connectGithubDescription":
     "Auto-fix puts the Super Agent to work on this task and saves the change to your codebase, ready for your team to review and approve.",
   "taskBoard.taskBoard.connectGithubTitle": "Connect GitHub",
+  "taskBoard.taskBoard.handedToHumanBadgeTitle":
+    "Automation stopped on this task — open it to see why",
   "taskBoard.taskBoard.layoutViewAriaLabel": "{label} view",
   "taskBoard.taskBoard.needsInput": "Needs input",
+  "taskBoard.taskBoard.needsYou": "Needs you",
   "taskBoard.taskBoard.newTask": "New task",
   "taskBoard.taskBoard.newTaskInLaneAriaLabel": "New task in {lane}",
   "taskBoard.taskBoard.newTaskInLaneTitle": "New task in {lane}",

--- a/apps/web/src/i18n/pt-br/task-board.ts
+++ b/apps/web/src/i18n/pt-br/task-board.ts
@@ -38,8 +38,11 @@ export const taskBoard = {
   "taskBoard.taskBoard.connectGithubDescription":
     "O Auto-fix coloca o Super Agent para trabalhar nesta tarefa e salva a mudança no seu projeto, pronta para seu time revisar e aprovar.",
   "taskBoard.taskBoard.connectGithubTitle": "Conectar GitHub",
+  "taskBoard.taskBoard.handedToHumanBadgeTitle":
+    "A automação parou nesta tarefa — abra para ver o motivo",
   "taskBoard.taskBoard.layoutViewAriaLabel": "visualização {label}",
   "taskBoard.taskBoard.needsInput": "Precisa de entrada",
+  "taskBoard.taskBoard.needsYou": "Precisa de você",
   "taskBoard.taskBoard.newTask": "Nova tarefa",
   "taskBoard.taskBoard.newTaskInLaneAriaLabel": "Nova tarefa em {lane}",
   "taskBoard.taskBoard.newTaskInLaneTitle": "Nova tarefa em {lane}",

--- a/apps/web/src/layouts/task-board/config.test.ts
+++ b/apps/web/src/layouts/task-board/config.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
-import { insertSortOrder, runSortOrders, statusIconClassName } from "./config";
+import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
+import {
+  insertSortOrder,
+  isTaskHandedToHuman,
+  runSortOrders,
+  statusIconClassName,
+} from "./config";
 import type { TaskBoardItem } from "./config";
 
 function item(id: string, sortOrder: number): TaskBoardItem {
@@ -88,5 +94,35 @@ describe("statusIconClassName", () => {
 
   test("other statuses keep their static class", () => {
     expect(statusIconClassName(item("a", 0))).toBe("text-muted-foreground");
+  });
+});
+
+/**
+ * The card badge for a task the automation gave up on. Without it a handed-off
+ * card renders exactly like one still waiting on its reviewers, which is how
+ * five sat In Review for a week in one org with nobody noticing.
+ */
+describe("isTaskHandedToHuman", () => {
+  const inReview = (assigneeId: string | null): TaskBoardItem => ({
+    ...item("t", 0),
+    status: "in_review",
+    assigneeId,
+  });
+
+  test("an In Review card with no assignee is waiting on a person", () => {
+    expect(isTaskHandedToHuman(inReview(null))).toBe(true);
+  });
+
+  test("a card the Super Agent or a human still owns is not", () => {
+    expect(isTaskHandedToHuman(inReview(SUPER_AGENT_ASSIGNEE_ID))).toBe(false);
+    expect(isTaskHandedToHuman(inReview("user-1"))).toBe(false);
+  });
+
+  // Unassigned is the norm everywhere else on the board — only In Review means
+  // automation stopped.
+  test("an unassigned card in any other lane is not", () => {
+    for (const status of ["triage", "todo", "in_progress", "done"] as const) {
+      expect(isTaskHandedToHuman({ ...item("t", 0), status })).toBe(false);
+    }
   });
 });

--- a/apps/web/src/layouts/task-board/config.tsx
+++ b/apps/web/src/layouts/task-board/config.tsx
@@ -42,6 +42,18 @@ export function isTaskBlocked(item: TaskBoardItem): boolean {
 }
 
 /**
+ * A task the automation gave up on: parked In Review with no assignee.
+ *
+ * Every automatic path except the auto-merge retry requires the Super Agent as
+ * assignee, so this card is waiting on a person — but it renders exactly like
+ * one still waiting on its reviewers. The hand-off reason is on the timeline
+ * (`assignee_changed`); the badge is what makes it findable at all.
+ */
+export function isTaskHandedToHuman(item: TaskBoardItem): boolean {
+  return item.status === "in_review" && !item.assigneeId;
+}
+
+/**
  * Status-icon classes for a task card/row. An in-progress task's spinner spins,
  * but one waiting on input stops spinning and pulses in `warning` — same token
  * as its "Needs input" badge, so a stalled task doesn't look like it's working.

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -95,6 +95,7 @@ import {
   insertSortOrder,
   isReviewerThreadTitle,
   isTaskBlocked,
+  isTaskHandedToHuman,
   HIDDEN_STATUSES,
   primaryThread,
   reviewerThreads,
@@ -178,6 +179,19 @@ function BlockedBadge() {
     >
       <HelpCircle size={14} />
       {t("taskBoard.taskBoard.needsInput")}
+    </span>
+  );
+}
+
+function HandedToHumanBadge() {
+  const t = useT();
+  return (
+    <span
+      className={cn(PILL, "border-warning/30 text-warning")}
+      title={t("taskBoard.taskBoard.handedToHumanBadgeTitle")}
+    >
+      <HelpCircle size={14} />
+      {t("taskBoard.taskBoard.needsYou")}
     </span>
   );
 }
@@ -1945,11 +1959,13 @@ function TaskCard({
       </div>
 
       {(isTaskBlocked(item) ||
+        isTaskHandedToHuman(item) ||
         item.priority !== "none" ||
         Boolean(item.dueDate) ||
         item.tags.length > 0) && (
         <div className="flex flex-wrap items-center gap-1.5 pl-6">
           {isTaskBlocked(item) && <BlockedBadge />}
+          {isTaskHandedToHuman(item) && <HandedToHumanBadge />}
           {item.priority !== "none" && (
             <PriorityPill priority={item.priority} />
           )}


### PR DESCRIPTION
## Summary

Five tasks in `deco-studio` had been parked In Review since Aug 5, re-swept every few minutes and never finishing. Three separate bugs, each of which alone is enough to strand a card.

**1. The merge gate read the wrong PR.** Every caller took `listPrs()[0]` — the *newest* link, not necessarily an open one. When a bounce opens a fresh PR instead of pushing to the reviewed one, the newest link points at an abandoned branch.

Live example: task `board_mB5poJNnjW1HMEGM427GV` had 3 approvals and 0 changes-requested. Both reviewers read and approved **#325** (`OPEN`, `MERGEABLE`, `mergeStateStatus: CLEAN`, checks green) and said so in their notes. But **#327** (`CLOSED`, one `FAILURE` check) was created 45 min later, so it was `prs[0]`. The gate fetched *its* checks, returned `checks_failing`, and retried every ~5 min for a day — also burning GitHub quota (10 × `refused: too many requests` in 3 days).

New `pickActivePr` takes the newest PR that is not definitively closed. An unreadable PR (`null`) counts as usable, so a GitHub blip can't silently redirect a merge to an older PR. Applied in the merge gate, the conflict reaction, and the rework dispatch (which was checking out the closed branch for the same reason).

**2. Hand-off was a black hole.** `handTaskToHuman` only nulls the assignee — status stays `in_review` by design. But the sweeper's work list filtered `assignee_id = SUPER_AGENT_ASSIGNEE_ID`, so an unassigned card became invisible to *every* automated path, including the merge retry. A card whose reviewers all approved but whose merge failed once could never merge again.

The query now returns all In Review cards; `reconcileItem` re-applies the assignee gate to everything except `retryAutoMergeIfApproved`. That retry is already gated on *In Review + `auto_merge` on + every enabled reviewer verifiably approved*, so it can't ship anything the reviewers didn't. Reviewer dispatch, the no-PR hand-off and the conflict-resolution claim (fenced in SQL on the assignee) stay Super-Agent-only, so a handed-off card still burns zero agent runs.

**3. Nothing showed it had stopped.** A handed-off card rendered exactly like one still waiting on its reviewers. Adds a "Needs you" badge for In Review + unassigned. The reason is already on the timeline as an `assignee_changed` entry ("5 review bounces reached", "QA Agent failed 2 times", …).

Deliberately **not** adding a `blocked` status: `in_review` + no assignee already is the state, and a new enum value would touch the schema, filters, archive sweep and UI for nothing new.

## Not in this PR

The bounce loop itself. Cards fork a new PR per bounce because the sandbox branch is thread-derived (`enqueue-super-agent.ts`), and reviewers then reject the fork as obsolete against `main` — one card's final verdict was literally *"a PR está obsoleta: `main` já contém a mesma correção"*. The flag for that already exists (`taskBoardRerunReusesPrBranch`) and just needs enabling per-org. Fix 1 makes the multi-PR case survivable meanwhile.

Also unchanged: `prs-get.ts` moves a card to Done if **any** linked PR is merged, while `archive-merged.ts` requires **every** linked PR merged — so a multi-PR task reaching Done is visited by the hourly archive sweep forever and never archives. Worth a follow-up.

## Testing

- `pick-active-pr.test.ts` — new, pure: closed-newest skip, unreadable-as-usable, all-closed fallback.
- `task-board-pending-review.integration.test.ts` — **inverted** the assertion that encoded the old behavior (`skips a card that is not the Super Agent's` → `keeps`). Verified it fails against the old query and passes against the new one.
- `config.test.ts` — `isTaskHandedToHuman`.
- Real-Postgres run of `apps/api/src/tools/task-board/`, `apps/api/src/storage/`, `apps/web/src/layouts/task-board/`: 565 pass, 0 fail.
- `bun run fmt`, `bun run lint` (18 warnings, unchanged from base), `bun run check`, `knip` all clean.

Not run: the full repo `bun test` sweep (timed out locally) and e2e.

## Screenshots

None — the only UI change is a warning-token pill reusing the existing `BlockedBadge` styling, on a state I can't reproduce locally without seeding a stuck card.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops tasks getting stuck In Review by acting on the right linked PR, letting safe auto‑merge retries continue after hand‑off, and surfacing a “Needs you” badge when automation stops.

- PR selection: replace `listPrs()[0]` with `pickActivePr` (newest PR not definitively closed; unreadable counts as usable; fallback to newest). Used in merge gate, rework dispatch, and conflict handler to avoid false `checks_failing` loops and GitHub churn.
- Sweeper scope: `listItemsPendingReview` now returns all In Review cards. In `review-sweeper`, re‑apply the Super Agent assignee gate to every action except `retryAutoMergeIfApproved`, so hand‑offs don’t spawn runs but can still merge what reviewers approved.
- UI: add a “Needs you” pill for In Review + unassigned via `isTaskHandedToHuman`; i18n strings added; no status or schema changes.
- Tests: new `pick-active-pr` unit tests; inverted pending‑review integration test to match new scope; added config tests.

<sup>Written for commit 2213f5cf57f0aef4f1e3419547609cd836beed73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

