### PR TITLE
feat(commerce-onboarding): add create-org button to the org chooser

### DIFF
--- a/apps/web/src/components/organization-choice.tsx
+++ b/apps/web/src/components/organization-choice.tsx
@@ -1,6 +1,6 @@
 import { Avatar } from "@decocms/ui/components/avatar.tsx";
 import { Button } from "@decocms/ui/components/button.tsx";
-import { Loading01 } from "@untitledui/icons";
+import { Loading01, Plus } from "@untitledui/icons";
 import { useMutation } from "@tanstack/react-query";
 import { useState } from "react";
 
@@ -21,6 +21,8 @@ export interface OrganizationChoiceProps {
   onJoined?: (organization: OrganizationChoiceItem, slug: string) => void;
   onRequestCompleted?: (organization: OrganizationChoiceItem) => void;
   selectLabel?: string;
+  onCreateNew?: () => void;
+  createNewLabel?: string;
 }
 
 interface DomainJoinResult {
@@ -60,6 +62,8 @@ export function OrganizationChoice({
   onJoined,
   onRequestCompleted,
   selectLabel = "Select",
+  onCreateNew,
+  createNewLabel = "Create new organization",
 }: OrganizationChoiceProps) {
   const [localRequestedSlugs, setLocalRequestedSlugs] = useState<Set<string>>(
     new Set(),
@@ -116,6 +120,16 @@ export function OrganizationChoice({
 
   return (
     <div className="grid grid-cols-1 gap-2">
+      {onCreateNew && (
+        <button
+          type="button"
+          onClick={onCreateNew}
+          className="rounded-xl border border-dashed border-border p-4 flex items-center justify-center gap-2 text-sm font-medium text-muted-foreground hover:text-foreground hover:border-foreground/40 transition-colors"
+        >
+          <Plus size={16} />
+          {createNewLabel}
+        </button>
+      )}
       {organizations.map((org) => {
         const isJoining =
           joinOrgMutation.isPending && pendingJoinSlug === org.slug;

--- a/apps/web/src/i18n/en/routes.ts
+++ b/apps/web/src/i18n/en/routes.ts
@@ -99,6 +99,7 @@ export const routes = {
     "Could not prepare an organization for commerce setup. Try again from this page or contact support.",
   "routes.commerceOnboarding.couldNotVerifyCommerceSetting":
     "Unable to verify Commerce Discovery configuration.",
+  "routes.commerceOnboarding.createNewOrg": "Create new organization",
   "routes.commerceOnboarding.emailAccessMultipleOrgs":
     "Your email can access more than one organization. Choose where commerce setup should continue.",
   "routes.commerceOnboarding.onboardingNeedsSupport":

--- a/apps/web/src/i18n/pt-br/routes.ts
+++ b/apps/web/src/i18n/pt-br/routes.ts
@@ -100,6 +100,7 @@ export const routes = {
     "Não foi possível preparar uma organização para a configuração de commerce. Tente novamente por esta página ou fale com o suporte.",
   "routes.commerceOnboarding.couldNotVerifyCommerceSetting":
     "Não foi possível verificar a configuração do Commerce Discovery.",
+  "routes.commerceOnboarding.createNewOrg": "Criar nova organização",
   "routes.commerceOnboarding.emailAccessMultipleOrgs":
     "Seu e-mail pode acessar mais de uma organização. Escolha onde a configuração de commerce deve continuar.",
   "routes.commerceOnboarding.onboardingNeedsSupport":

--- a/apps/web/src/routes/commerce-onboarding.tsx
+++ b/apps/web/src/routes/commerce-onboarding.tsx
@@ -7,6 +7,7 @@ import { AuthEntry } from "@/components/auth-entry";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { AuthSplitLayout } from "@/components/auth-split-layout";
 import { OrganizationChoice } from "@/components/organization-choice";
+import { CreateOrganizationDialog } from "@/components/create-organization-dialog";
 import { ScrollReveal } from "@/components/scroll-reveal";
 import {
   authClient,
@@ -351,6 +352,7 @@ function CommerceOnboardingContent({
   );
   const [settledEnsureResult, setSettledEnsureResult] =
     useState<EnsureOrganizationResponse | null>(null);
+  const [creatingOrg, setCreatingOrg] = useState(false);
 
   const activeOrganizations: CommerceOrganization[] =
     organizationsQuery.data?.map((org: CommerceOrganization) => ({
@@ -443,7 +445,7 @@ function CommerceOnboardingContent({
               "routes.commerceOnboarding.selectWhereCommerceContinues",
             )}
           />
-          <ScrollReveal className="-mx-1 max-h-[60vh] overflow-y-auto px-1">
+          <ScrollReveal className="-mx-1 -my-1 max-h-[60vh] overflow-y-auto px-1 py-1">
             <OrganizationChoice
               organizations={activeOrganizations}
               selectLabel={t("routes.commerceOnboarding.authCopy.continue")}
@@ -455,9 +457,15 @@ function CommerceOnboardingContent({
                   search: { org: organization.slug, siteUrl },
                 })
               }
+              onCreateNew={() => setCreatingOrg(true)}
+              createNewLabel={t("routes.commerceOnboarding.createNewOrg")}
             />
           </ScrollReveal>
         </div>
+        <CreateOrganizationDialog
+          open={creatingOrg}
+          onOpenChange={setCreatingOrg}
+        />
       </CommerceOnboardingLayout>
     );
   }
@@ -500,7 +508,7 @@ function CommerceOnboardingContent({
             title={t("routes.commerceOnboarding.chooseOrg")}
             description={t("routes.commerceOnboarding.emailAccessMultipleOrgs")}
           />
-          <ScrollReveal className="-mx-1 max-h-[60vh] overflow-y-auto px-1">
+          <ScrollReveal className="-mx-1 -my-1 max-h-[60vh] overflow-y-auto px-1 py-1">
             <OrganizationChoice
               organizations={ensureResult.organizations}
               domain={ensureResult.domain ?? undefined}
@@ -512,9 +520,15 @@ function CommerceOnboardingContent({
                   search: { org: slug, siteUrl },
                 });
               }}
+              onCreateNew={() => setCreatingOrg(true)}
+              createNewLabel={t("routes.commerceOnboarding.createNewOrg")}
             />
           </ScrollReveal>
         </div>
+        <CreateOrganizationDialog
+          open={creatingOrg}
+          onOpenChange={setCreatingOrg}
+        />
       </CommerceOnboardingLayout>
     );
   }


### PR DESCRIPTION
## Summary
- Adds a "Create new organization" affordance to the commerce onboarding org-chooser screen (shown only when the user belongs to 2+ orgs, or when the domain-join flow matches multiple orgs). Renders as the first row in the org list via `OrganizationChoice`, styled like the list items but with a dashed border and no background, and opens the existing `CreateOrganizationDialog`.
- Fixes vertical clipping of the org list's rounded corners/shadow inside the scrollable container (was only compensating horizontally with negative margin/padding).
- The rest of the commerce onboarding flow (single-org auto-continue, direct org link, ensure-organization flow) is unchanged.

## Test plan
- [x] `bun run fmt` / `bun run --cwd=apps/web check` pass
- [x] Manually verified locally: signed in, created a second org, landed on the "Choose an organization" screen, confirmed the "Create new organization" row renders first with dashed styling and opens the create-org dialog; confirmed list items no longer clip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “Create new organization” option to the commerce onboarding org chooser for multi-org cases, opening the existing create dialog. Previously, users could only pick an existing org; now they can start a new org from that screen. Also fixes vertical clipping of the org list in the scroll container.

**Details**
- Shows “Create new organization” as the first list item with dashed styling; opens the CreateOrganizationDialog.
- Adds optional OrganizationChoice props: onCreateNew and createNewLabel (defaults preserve existing behavior).
- Wires the button into both multi-org chooser variants; controls dialog with local state; adds i18n key routes.commerceOnboarding.createNewOrg (en, pt-BR).
- Adjusts ScrollReveal container padding/margins to prevent vertical clipping of rounded corners/shadows.
- No changes to single-org auto-continue, direct org links, or ensure-organization flow. No migrations required.

<sup>Written for commit 24fd54b02a18f2603081ee14e1abbea7bac32cb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

