### PR TITLE
fix(task-board): route pickActivePr's GitHub read through the throttled queue

### DIFF
--- a/apps/api/src/tools/task-board/pick-active-pr.test.ts
+++ b/apps/api/src/tools/task-board/pick-active-pr.test.ts
@@ -8,7 +8,28 @@
  */
 
 import { describe, expect, it } from "bun:test";
-import { pickActivePrIndex } from "./prs-get";
+import type { StudioContext } from "@/core/studio-context";
+import type { TaskBoardItemPrRef } from "@/storage/types";
+import { pickActivePr, pickActivePrIndex } from "./prs-get";
+
+/** Throws on any access — proves a code path never touches `ctx`. */
+const UNTOUCHABLE_CTX = new Proxy(
+  {},
+  {
+    get(_target, prop) {
+      throw new Error(`pickActivePr must not read ctx.${String(prop)}`);
+    },
+  },
+) as StudioContext;
+
+const pr = (number: number): TaskBoardItemPrRef => ({
+  repoOwner: "deco",
+  repoName: "studio",
+  number,
+  url: `https://github.com/deco/studio/pull/${number}`,
+  connectionId: "conn_1",
+  createdAt: new Date(0).toISOString(),
+});
 
 describe("pickActivePrIndex", () => {
   it("takes the newest PR when it is open", () => {
@@ -35,5 +56,21 @@ describe("pickActivePrIndex", () => {
 
   it("holds for an empty read — the caller indexes an empty list to undefined", () => {
     expect(pickActivePrIndex([])).toBe(0);
+  });
+});
+
+describe("pickActivePr", () => {
+  // The multi-PR read must go through the rate-limited queue, not straight at GitHub.
+  it("never reads ctx — the multi-PR read goes through the throttled queue", async () => {
+    await expect(
+      pickActivePr(UNTOUCHABLE_CTX, "org_1", [pr(2), pr(1)]),
+    ).resolves.toBeDefined();
+  });
+
+  it("skips the read entirely for a single linked PR", async () => {
+    const only = pr(1);
+    await expect(pickActivePr(UNTOUCHABLE_CTX, "org_1", [only])).resolves.toBe(
+      only,
+    );
   });
 });

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -14,6 +14,7 @@ import { recordTaskActivity } from "./activity";
 import { emitTaskBoardUpdated } from "./run-reactions";
 import { enqueueEnabledReviewers } from "./enqueue-reviewer";
 import { reactToApprovedPrConflict } from "./conflict-reaction";
+import { readPrStateThrottled } from "./dbos-github-read";
 
 /** Cap a single live PR fetch — the modal shouldn't hang on a slow GitHub. */
 const PR_FETCH_TIMEOUT_MS = 8000;
@@ -918,20 +919,26 @@ export function pickActivePrIndex(
  * reviewed one leaves the newest link pointing at an abandoned branch, so the
  * merge gate reads ITS red checks and reports `checks_failing` forever while
  * the approved, green PR sits unmerged.
+ *
+ * `ctx` is unused here on purpose — kept so callers don't need a special case
+ * — the read goes through `readPrStateThrottled`, the same rate-limited DBOS
+ * queue the review sweep's own candidate pass uses. This runs on every merge
+ * attempt and every review decision, not just the sweep's own timer tick, so
+ * calling `fetchPrCandidateState` straight at GitHub here would reopen the
+ * exact unbounded-reads problem the queue exists to cap.
  */
 export async function pickActivePr(
-  ctx: StudioContext,
+  _ctx: StudioContext,
   orgId: string,
   prs: TaskBoardItemPrRef[],
 ): Promise<TaskBoardItemPrRef | undefined> {
   if (prs.length <= 1) return prs[0];
   const states: ("open" | "closed" | null)[] = [];
   for (const pr of prs) {
-    const { state } = await fetchPrCandidateState(ctx, orgId, pr);
+    const { state } = await readPrStateThrottled(orgId, pr);
     states.push(state);
     // Stop at the first usable PR: the common case is one extra read, not one
-    // per link, which is what the GitHub rate limit cares about. The read is the
-    // same cached `get` the sweep's own candidate pass makes.
+    // per link, which is what the GitHub rate limit cares about.
     if (state !== "closed") break;
   }
   return prs[pickActivePrIndex(states)];


### PR DESCRIPTION
Follows #6003 and #6001, both merged in the same session ~24 minutes apart.

#6001 added `readPrStateThrottled`, a globally rate-limited DBOS queue, specifically because unbounded PR-state reads had spent the shared `github-mcp` budget and caused 429s across orgs. #6003, merged right after, added `pickActivePr` to fix a different bug (taking `listPrs()[0]` blindly), but its multi-PR loop calls `fetchPrCandidateState(ctx, ...)` directly — the exact unthrottled GitHub read #6001 had just capped — and it runs from `mergeLinkedPr` and `review-decision.ts`, i.e. on every merge attempt and every review decision, not just the sweeper's own timer tick.

Fix: `pickActivePr` now calls `readPrStateThrottled` (the same queue the sweeper's own candidate pass uses) instead of `fetchPrCandidateState`. `ctx` is kept as a parameter (unused) so the four call sites in `merge-pr.ts` and `review-decision.ts` don't need changes.

Failure scenario: a task with 2+ linked PRs (any task that had a review bounce) whose reviewers approve — `retryAutoMergeIfApproved` runs on every sweep tick for such a card and calls `mergeLinkedPr` → `pickActivePr`, bypassing the queue's rate limit and concurrency cap on every tick.

Regression test in `pick-active-pr.test.ts`: `pickActivePr` is called with a `ctx` that throws on any property access. It fails on the pre-fix code (real error: `pickActivePr must not read ctx.storage`) and passes after routing through the queue.

Reviewer check: `bun test apps/api/src/tools/task-board/pick-active-pr.test.ts`

Locally verified: `bunx tsc --noEmit` in apps/api, the targeted test file, `bunx oxlint` on both changed files, `bun run fmt`. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes `pickActivePr` GitHub reads through the throttled queue to honor org-wide rate limits and avoid 429s. Previously, multi-PR selection called `fetchPrCandidateState` directly; now it uses `readPrStateThrottled`. `ctx` remains in the signature but is unused.

- Multi-PR tasks now read via the global queue; single-PR tasks skip the read.
- No call-site changes required.
- Adds `pick-active-pr.test.ts` to assert no `ctx` access and single-PR fast path.
- Review: run `bun test apps/api/src/tools/task-board/pick-active-pr.test.ts`.

<sup>Written for commit c88da0af9194014fa38e3b1e30d8ff864871762b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

