### PR TITLE
fix(decopilot): close a DNS-rebinding gap in the reference-image URL guard

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  assertUrlDoesNotResolvePrivate,
   buildScreenshotOptions,
   buildScreenshotRequestBody,
   jpegHeight,
@@ -140,6 +141,32 @@ describe("validateExternalUrl", () => {
     expect(() =>
       validateExternalUrl("https://example.com/image.png", false),
     ).not.toThrow();
+  });
+});
+
+describe("assertUrlDoesNotResolvePrivate", () => {
+  // The DNS-rebinding case validateExternalUrl's literal-hostname check misses.
+  it("rejects a hostname whose DNS resolves to a private address", async () => {
+    const resolveHost = async () => ["169.254.169.254"];
+    await expect(
+      assertUrlDoesNotResolvePrivate("https://evil.example/x", resolveHost),
+    ).rejects.toThrow();
+  });
+
+  it("allows a hostname resolving only to public addresses", async () => {
+    const resolveHost = async () => ["93.184.216.34"];
+    await expect(
+      assertUrlDoesNotResolvePrivate("https://example.com/x", resolveHost),
+    ).resolves.toBeUndefined();
+  });
+
+  it("skips the DNS lookup for an IP literal — already vetted synchronously", async () => {
+    const resolveHost = async (): Promise<string[]> => {
+      throw new Error("resolveHost should not be called for an IP literal");
+    };
+    await expect(
+      assertUrlDoesNotResolvePrivate("https://127.0.0.1/x", resolveHost),
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.ts
@@ -1,5 +1,6 @@
 import { generateImage, tool, type UIMessageStreamWriter } from "ai";
 import { zodSchema } from "ai";
+import { lookup } from "node:dns/promises";
 import { z } from "zod";
 import {
   parseStudioStorageKey,
@@ -338,6 +339,59 @@ export function validateExternalUrl(url: string, allowHttp: boolean): void {
   }
 }
 
+/** Bare resolved IP (no brackets) against the same private/loopback/link-local
+ *  ranges `PRIVATE_HOST_PATTERNS` vets on the literal hostname. */
+function isPrivateIpAddress(ip: string): boolean {
+  const v4 = ip.match(/^(\d+)\.(\d+)\.(\d+)\.(\d+)$/);
+  if (v4) {
+    const a = Number(v4[1]);
+    const b = Number(v4[2]);
+    if (a === 127 || a === 10 || a === 0) return true;
+    if (a === 172 && b >= 16 && b <= 31) return true;
+    if (a === 192 && b === 168) return true;
+    if (a === 169 && b === 254) return true;
+    return false;
+  }
+  const v6 = ip.toLowerCase();
+  return (
+    v6 === "::1" ||
+    v6.startsWith("::ffff:") ||
+    v6.startsWith("fc") ||
+    v6.startsWith("fd") ||
+    v6.startsWith("fe80")
+  );
+}
+
+/**
+ * DNS-rebinding guard: `validateExternalUrl` only vets the literal hostname
+ * written in the URL, so a domain whose DNS record points at a private or
+ * cloud-metadata address (an attacker-controlled A record) sails right
+ * through it and reaches an internal service through this tool's own
+ * `fetch`. `resolveHost` is injectable for tests; production resolves real DNS.
+ */
+export async function assertUrlDoesNotResolvePrivate(
+  url: string,
+  resolveHost: (host: string) => Promise<string[]> = async (host) =>
+    (await lookup(host, { all: true })).map((r) => r.address),
+): Promise<void> {
+  const hostname = new URL(url).hostname;
+  const isIpLiteral =
+    /^\d+\.\d+\.\d+\.\d+$/.test(hostname) ||
+    (hostname.startsWith("[") && hostname.endsWith("]"));
+  // An IP literal is already fully vetted synchronously by validateExternalUrl.
+  if (isIpLiteral) return;
+  let addresses: string[];
+  try {
+    addresses = await resolveHost(hostname);
+  } catch {
+    // Can't verify where this hostname actually points — fail closed.
+    throw new Error("Image URL must not point to a private network address");
+  }
+  if (addresses.length === 0 || addresses.some(isPrivateIpAddress)) {
+    throw new Error("Image URL must not point to a private network address");
+  }
+}
+
 async function readFromObjectStorage(
   key: string,
   objectStorage: PortableMediaObjectStorage | null | undefined,
@@ -381,6 +435,7 @@ async function fetchImageBytes(
   }
 
   validateExternalUrl(url, params.allowHttpExternalUrls === true);
+  await assertUrlDoesNotResolvePrivate(url);
   const res = await fetch(url, { signal: params.abortSignal });
   if (!res.ok) {
     throw new Error(`Failed to fetch image from ${url}: ${res.status}`);


### PR DESCRIPTION
**Source:** a real trust-boundary gap I found reading `portable-media-tools.ts` while hunting for follow-up hardening in the task-board/decopilot area — not tied to an issue.

**The bug:** `generateImageCore`'s reference-image fetch (and the `take_screenshot` reference path) validates a user-supplied image URL with `validateExternalUrl`, which only vets the *literal* hostname string in the URL via `PRIVATE_HOST_PATTERNS`. It never resolves DNS. A domain the attacker controls (or a rebinding domain) can have an A/AAAA record pointing at `169.254.169.254`, `127.0.0.1`, or any other private/link-local address, sail straight through the literal check, and have the server's own `fetch` reach it — a classic DNS-rebinding SSRF. The exact same guard is already resolved via DNS elsewhere in this repo (`apps/api/src/tools/registry/discover-tools.ts`'s `resolvesToPrivateAddress`, hardened across #4929/#5031/#5488/#5628/#5686/#5943/#5962) — this file just never got the same treatment.

**Why it matters:** this is a network fetch from the API process triggered by untrusted (LLM/tool-input-controlled) URLs — the textbook case this guard exists to close, and it's presently only half-closed.

**The fix:** added `assertUrlDoesNotResolvePrivate`, a self-contained DNS-resolving check (can't import the registry tree's version — `harnesses/lib` is a portable tree that the cross-tree-import lint bans from reaching into `apps/api/src/tools`), and call it right after `validateExternalUrl` in `fetchImageBytes`. IP-literal hostnames are skipped (already fully vetted synchronously); a resolution failure fails closed.

**Regression test:** `portable-media-tools.test.ts` — three new cases with an injected `resolveHost`: rejects a hostname resolving to a private address, allows one resolving only to public addresses, and confirms an IP literal skips the DNS lookup entirely (no real network calls in the test).

**Reviewer command:** `bun test apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts`

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test file above (18/18 pass), and `bunx oxlint` on both touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes a DNS‑rebinding gap in Decopilot’s reference‑image fetch by resolving hostnames before fetches. Previously we only checked the literal hostname; now we resolve DNS and block if any address is private or if resolution fails, while IP‑literal hosts are unchanged.

- Adds `assertUrlDoesNotResolvePrivate` (uses `node:dns/promises.lookup`), and calls it in `fetchImageBytes` immediately after `validateExternalUrl`.
- Fails closed on DNS errors; some domains that previously passed may now be rejected with “Image URL must not point to a private network address.”
- Kept local to the harness due to cross‑tree import restrictions; IP literals skip DNS resolution.
- Tests: three new cases in portable-media-tools.test cover private, public, and IP‑literal paths. Run: bun test apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts

<sup>Written for commit 70569faff2a1bb22330576c5224fec04a8c7abc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

