### PR TITLE
fix(task-board): show the handed-to-human badge in the list view too

### DIFF
--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -2154,6 +2154,7 @@ function ListRow({
         {item.title}
       </span>
       {isTaskBlocked(item) && <BlockedBadge />}
+      {isTaskHandedToHuman(item) && <HandedToHumanBadge />}
       {item.priority !== "none" && (
         <span className="hidden sm:inline-flex">
           <PriorityPill priority={item.priority} />


### PR DESCRIPTION
Follows #6003, which added a "Needs you" badge (`isTaskHandedToHuman`) for In Review tasks the automation handed off to a person — but wired it into only one render site, the board card's footer row (`index.tsx`'s card component). `ListRow`, the compact list view of the same board data, still only checks `isTaskBlocked` and never renders `HandedToHumanBadge`, so a handed-off task in list view renders exactly like one still waiting on its reviewers — the exact confusion #6003 set out to fix (five cards sat In Review for a week in one org with nobody noticing).

A maintainer wants this because it's a one-line, low-risk fix that closes a gap in a fix they just shipped, before it ships inconsistently to users who use the list view.

Failure scenario: an org uses the task-board's list view (not just the card/board view); a task the Super Agent hands off (all reviewers approved, merge failed, or similar) sits In Review with no assignee; in list view it shows no badge at all, indistinguishable from a task still being reviewed normally.

Fix: add the same `isTaskHandedToHuman(item) && <HandedToHumanBadge />` check already present in the board-card render path to `ListRow`.

To confirm: open the task board in list view (mobile or narrow width) with a task that is `in_review` and unassigned — it should now show the "Needs you" badge alongside the existing "Needs input" badge.

Locally verified: `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, and `bunx oxlint apps/web/src/layouts/task-board/index.tsx` (0 errors/warnings) — no test file renders `ListRow` directly, and the underlying `isTaskHandedToHuman` logic is unchanged and already covered by `config.test.ts`. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the "Needs you" badge for handed-off tasks in the task-board list view. Previously, only board cards showed it; list rows showed nothing, making handed-off In Review tasks look like normal review items.

**Review notes**
- Adds `{isTaskHandedToHuman(item) && <HandedToHumanBadge />}` in `ListRow` next to the existing blocked badge; no change to `isTaskHandedToHuman` logic.
- Display-only change that mirrors the existing board-card path.

**How to verify**
- In list view, open a board with an `in_review`, unassigned task that was handed off by automation; the row now shows the "Needs you" badge (alongside "Needs input" when applicable).

<sup>Written for commit 9e73f8f00a6f03fd5fa2ad3c23786a694dbe9e0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

