### PR TITLE
fix(commerce-onboarding): keep siteUrl context when creating a new org

### DIFF
--- a/apps/web/src/components/create-organization-dialog.tsx
+++ b/apps/web/src/components/create-organization-dialog.tsx
@@ -46,11 +46,16 @@ type CreateOrgFormData = z.infer<typeof createOrgSchema>;
 interface CreateOrganizationDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** Called with the new org's slug on success, instead of the default
+   *  full-page redirect to `/${orgSlug}` — use this when the caller needs to
+   *  keep query-string context (e.g. commerce onboarding's `siteUrl`). */
+  onCreated?: (orgSlug: string) => void;
 }
 
 export function CreateOrganizationDialog({
   open,
   onOpenChange,
+  onCreated,
 }: CreateOrganizationDialogProps) {
   const t = useT();
   const form = useForm<CreateOrgFormData>({
@@ -85,6 +90,10 @@ export function CreateOrganizationDialog({
       return { orgSlug };
     },
     onSuccess: ({ orgSlug }) => {
+      if (onCreated) {
+        onCreated(orgSlug);
+        return;
+      }
       window.location.href = `/${orgSlug}`;
     },
   });

--- a/apps/web/src/routes/commerce-onboarding.tsx
+++ b/apps/web/src/routes/commerce-onboarding.tsx
@@ -465,6 +465,13 @@ function CommerceOnboardingContent({
         <CreateOrganizationDialog
           open={creatingOrg}
           onOpenChange={setCreatingOrg}
+          onCreated={(orgSlug) => {
+            invalidateOrganizationListCache();
+            navigate({
+              to: "/commerce-onboarding",
+              search: { org: orgSlug, siteUrl },
+            });
+          }}
         />
       </CommerceOnboardingLayout>
     );
@@ -528,6 +535,13 @@ function CommerceOnboardingContent({
         <CreateOrganizationDialog
           open={creatingOrg}
           onOpenChange={setCreatingOrg}
+          onCreated={(orgSlug) => {
+            invalidateOrganizationListCache();
+            navigate({
+              to: "/commerce-onboarding",
+              search: { org: orgSlug, siteUrl },
+            });
+          }}
         />
       </CommerceOnboardingLayout>
     );


### PR DESCRIPTION
Follows #6004 (add create-org button to the org chooser).

`CreateOrganizationDialog` is shared between `org-switcher.tsx` and the new commerce-onboarding "create new organization" flow. Its success handler unconditionally does `window.location.href = /${orgSlug}` — fine for the switcher, but commerce-onboarding.tsx's own `onSelected`/`onJoined` handlers next to it always navigate back to `/commerce-onboarding` with `{ org, siteUrl }` preserved in the URL, because `siteUrl` drives which site the rest of the onboarding flow (`CommerceSetup`) sets up.

**Failure scenario:** a merchant lands on `/commerce-onboarding?siteUrl=https://their-site.com`, has no org yet (or wants a new one), clicks "Create new organization", and after creating it gets bounced to the bare org home — `siteUrl` is gone and they have to re-enter their site URL and restart the funnel.

**Fix:** added an optional `onCreated(orgSlug)` override to `CreateOrganizationDialog` (default behavior unchanged, so `org-switcher.tsx`'s usage is untouched). commerce-onboarding.tsx's two call sites now pass `onCreated` that invalidates the org-list cache and navigates to `/commerce-onboarding` with `{ org: orgSlug, siteUrl }`, matching the existing sibling handlers in the same file.

**To confirm:** `cd apps/web && bunx tsc --noEmit`; manually: visit `/commerce-onboarding?siteUrl=https://example.com` with an account that has 0 orgs, click "Create new organization", submit — should land back on commerce-onboarding continuing with that org and siteUrl still set, not on `/`.

**Checks run locally:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint` on both changed files (0 warnings/errors). No unit-test seam exists for this dialog's mutation+navigate path (needs router/react-query context); full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves `siteUrl` during commerce onboarding when creating a new organization. Previously the dialog always redirected to `/${orgSlug}` and dropped `?siteUrl`; now commerce onboarding keeps context and continues the funnel.

- Add `onCreated?: (orgSlug: string) => void` to `CreateOrganizationDialog`; if provided, call it on success; otherwise keep the default redirect to `/${orgSlug}`.
- Update `commerce-onboarding.tsx` to pass `onCreated` that invalidates the org list and navigates to `/commerce-onboarding` with `{ org: orgSlug, siteUrl }`.
- Review focus: confirm `org-switcher` does not pass `onCreated` (default behavior unchanged) and that creating an org from `/commerce-onboarding?siteUrl=...` returns to onboarding with both `org` and `siteUrl` preserved.
- No migration required for existing callers; the new prop is optional with a backward-compatible default.

<sup>Written for commit 663f103dc582a28fd7767e094a41880dbebf8813. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

