### PR TITLE
fix(task-board): reset the bounce budget when a person re-delegates

### DIFF
--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -403,8 +403,9 @@ export function resolveConfig(
       envVars.STUDIO_SANDBOX_PROVIDER,
     ),
     sandboxStickyHeadRefEnabled: toBool(envVars.SANDBOX_STICKY_HEAD_REF),
-    taskBoardRerunReusesPrBranch: toBool(
+    taskBoardRerunReusesPrBranch: toBoolWithDefault(
       envVars.TASK_BOARD_RERUN_REUSES_PR_BRANCH,
+      true,
     ),
     sandboxReleaseOnRunEndEnabled: toBool(envVars.SANDBOX_RELEASE_ON_RUN_END),
     sandboxReleaseGraceMs: toPositiveIntegerOrDefault(

--- a/apps/api/src/settings/types.ts
+++ b/apps/api/src/settings/types.ts
@@ -177,9 +177,10 @@ export interface Settings {
    *  gates and why it ships behind its own flag. */
   sandboxStickyHeadRefEnabled: boolean;
   /** A task re-run pushes to the existing pull request's branch instead of
-   *  forking a new one (TASK_BOARD_RERUN_REUSES_PR_BRANCH). Own flag because it
-   *  changes which sandbox a dispatch resolves to; off by default. See
-   *  `enqueue-super-agent.ts`. */
+   *  forking a new one (TASK_BOARD_RERUN_REUSES_PR_BRANCH). ON by default —
+   *  forking is what makes a reviewer reject the fork as obsolete against
+   *  `main`, so the loop never converges. Set the env var to `false` to get the
+   *  old forking behavior back. See `enqueue-super-agent.ts`. */
   taskBoardRerunReusesPrBranch: boolean;
   /** Bring a `cloneOnly` sandbox's shutdown forward when its harness run
    *  finishes, instead of leaving it idle to the 15-min claim TTL

--- a/packages/shared/src/task-board.test.ts
+++ b/packages/shared/src/task-board.test.ts
@@ -6,6 +6,7 @@ import {
   reviewBounceLimitReached,
   reviewCycleStart,
   reviewCycleVerdicts,
+  SUPER_AGENT_ASSIGNEE_ID,
   type ReviewCycleActivity,
 } from "./task-board";
 
@@ -204,6 +205,60 @@ describe("reviewBounceLimitReached", () => {
       bounce("2026-01-01T03:00:00.000Z"),
     ];
     expect(reviewBounceLimitReached(acrossCycles)).toBe(true);
+  });
+
+  // The reset that makes a re-run mean something. Four cards carrying 5-7 old
+  // bounces were re-delegated in prod and each was handed straight back on its
+  // FIRST change-request — one review round, zero retries.
+  it("counts only from the most recent hand-back to the Super Agent", () => {
+    const burntOut = Array.from({ length: 6 }, (_, i) =>
+      bounce(`2026-01-0${i + 1}T00:00:00.000Z`),
+    );
+    expect(reviewBounceLimitReached(burntOut)).toBe(true);
+
+    const reDelegated: ReviewCycleActivity[] = [
+      ...burntOut,
+      {
+        action: "assignee_changed",
+        data: { from: null, to: SUPER_AGENT_ASSIGNEE_ID },
+        occurredAt: "2026-01-08T00:00:00.000Z",
+      },
+    ];
+    expect(reviewBounceLimitReached(reDelegated)).toBe(false);
+  });
+
+  // ...and the loop still terminates: only a hand-back TO the Super Agent
+  // resets, and the automatic hand-off writes `to: null`.
+  it("is not reset by the automatic hand-off to a human", () => {
+    const four = Array.from({ length: 4 }, (_, i) =>
+      bounce(`2026-01-01T0${i}:00:00.000Z`),
+    );
+    expect(
+      reviewBounceLimitReached([
+        ...four,
+        {
+          action: "assignee_changed",
+          data: { from: SUPER_AGENT_ASSIGNEE_ID, to: null, reason: "burned" },
+          occurredAt: "2026-01-01T05:00:00.000Z",
+        },
+      ]),
+    ).toBe(true);
+  });
+
+  it("still trips within one delegation, after the reset", () => {
+    const reDelegated: ReviewCycleActivity[] = [
+      bounce("2026-01-01T00:00:00.000Z"),
+      bounce("2026-01-01T01:00:00.000Z"),
+      {
+        action: "assignee_changed",
+        data: { from: null, to: SUPER_AGENT_ASSIGNEE_ID },
+        occurredAt: "2026-01-02T00:00:00.000Z",
+      },
+      ...Array.from({ length: MAX_REVIEW_BOUNCES - 1 }, (_, i) =>
+        bounce(`2026-01-02T0${i + 1}:00:00.000Z`),
+      ),
+    ];
+    expect(reviewBounceLimitReached(reDelegated)).toBe(true);
   });
 
   it("ignores approvals and unrelated activity", () => {

--- a/packages/shared/src/task-board.ts
+++ b/packages/shared/src/task-board.ts
@@ -184,19 +184,54 @@ export function approvedButUnverified(
 export const MAX_REVIEW_BOUNCES = 5;
 
 /**
+ * When the task was most recently handed TO the Super Agent (ms since epoch),
+ * else 0 — the start of its current delegation, and the point the bounce budget
+ * counts from.
+ *
+ * `assignee_changed` with `to` = the Super Agent is only ever written by
+ * `TASK_BOARD_ITEM_UPDATE`, i.e. a person assigning the card (or the intake
+ * auto-assign). The automatic hand-off writes `to: null`, so it can't reset
+ * anything — a runaway loop still terminates.
+ */
+export function delegationStart(activity: ReviewCycleActivity[]): number {
+  let latest = 0;
+  for (const a of activity) {
+    if (a.action !== "assignee_changed") continue;
+    if (
+      (a.data as { to?: unknown } | null | undefined)?.to !==
+      SUPER_AGENT_ASSIGNEE_ID
+    ) {
+      continue;
+    }
+    latest = Math.max(latest, new Date(a.occurredAt).getTime());
+  }
+  return latest;
+}
+
+/**
  * True when this task has already been handed back to the Super Agent
  * `MAX_REVIEW_BOUNCES` times, counting the change-request about to be recorded.
  *
- * Deliberately counts across ALL review cycles, not the current one: the
- * runaway loop IS the cycles: each bounce starts a fresh cycle, so a per-cycle
- * count is always 1 and would never trip.
+ * Counts across all review CYCLES since the current delegation, not the current
+ * cycle: the runaway loop IS the cycles — each bounce starts a fresh one, so a
+ * per-cycle count is always 1 and would never trip.
+ *
+ * But it resets when a person hands the card back (see {@link delegationStart}).
+ * Counting a card's whole lifetime made re-running a burnt-out task pointless:
+ * four cards carrying 5-7 old bounces were re-delegated, and the very first
+ * change-request tripped `6 + 1 >= 5` and handed each straight back — one review
+ * round, zero retries. A person re-assigning the card is them saying "try
+ * again"; this is what makes that mean something.
  */
 export function reviewBounceLimitReached(
   activity: ReviewCycleActivity[],
   limit: number = MAX_REVIEW_BOUNCES,
 ): boolean {
+  const since = delegationStart(activity);
   const bounces = activity.filter(
-    (a) => a.action === "review_changes_requested",
+    (a) =>
+      a.action === "review_changes_requested" &&
+      new Date(a.occurredAt).getTime() >= since,
   ).length;
   return bounces + 1 >= limit;
 }


### PR DESCRIPTION
Follow-up to #6003. That PR fixed *merging* — a fully-approved card now ships (`board_mB5poJNnjW1HMEGM427GV` went to Done in prod minutes after the deploy). This one fixes *converging*.

## The bug

`reviewBounceLimitReached` counted every `review_changes_requested` the card had ever logged, for its whole lifetime. So re-running a task that had already burned its five bounces gave it **zero** retries: the first change-request evaluated `6 + 1 >= 5` → true → immediate hand-off.

Measured in prod, four cards re-delegated at 19:57 UTC:

| task | bounces before re-run | after |
|---|---|---|
| `board_fEufdXfSnk4_R8f9VXUZZ` | 6 | 1 → handed off |
| `board_i0TyqN4wddkH35ixBn-Yc` | 6 | 2 → handed off |
| `board_pA_7SsIEhMmcStEcAidCs` | 7 | 1 |
| `board_wdUjots9uvrRae1mDB-Xu` | 5 | 1 → handed off |

`board_wdUjots9uvrRae1mDB-Xu` end to end: re-assigned 19:57 → In Review 19:59 → reviewers dispatched 20:02 → QA **approves** 20:05 → Code Reviewer requests changes 20:08 → handed back 22ms later. One round.

## The fix

Counting across review *cycles* stays — that part is correct, and the comment explaining why is right: each bounce starts a fresh cycle, so a per-cycle count is always 1 and would never trip. What was missing is a reset when a **person** hands the card back.

`delegationStart` returns the most recent `assignee_changed` whose `to` is the Super Agent. That entry is only ever written by `TASK_BOARD_ITEM_UPDATE` — a person assigning the card, or the intake auto-assign. The automatic hand-off writes `to: null`, so it cannot reset anything and a runaway loop still terminates on its own. A person re-assigning is them saying "try again"; this makes that mean something.

## Also: `TASK_BOARD_RERUN_REUSES_PR_BRANCH` now defaults ON

This is the reason the bounces got burned. With it off, the sandbox branch is thread-derived, so every re-run boots on a fresh `sandbox/thread-<new-id>` and the daemon's shutdown push opens a **second** PR rather than updating the reviewed one. The reviewer then reads the fork, finds `main` already contains the fix, and requests changes — the loop provably cannot converge. During the prod re-run above, `fEuf` went #310 → #331 and two other cards each grew a second PR.

It was `off by default` as a new-risky-path gate. It has since shipped and the failure mode of leaving it off is worse than the one it was guarding. The env var still works — set it to `false` for the old forking behavior.

## Testing

- `packages/shared/src/task-board.test.ts` — new cases: the reset (a 6-bounce card re-delegated reads as not-limited), that the automatic `to: null` hand-off does **not** reset, and that the limit still trips within one delegation after a reset. Verified the reset test fails against the old predicate.
- Existing `counts bounces from earlier review cycles, not just the current one` left intact and passing — that behavior is unchanged.
- 965 pass / 0 fail across `packages/shared/src`, `apps/api/src/tools/task-board/`, `apps/api/src/settings/`, `apps/api/src/storage/` (real Postgres).
- `fmt` / `lint` (18 warnings, unchanged) / `check` / `knip` clean.

No UI change, so no screenshots.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resets the review bounce budget when a human re-delegates a task and defaults reruns to reuse the existing PR branch. Previously, we counted all lifetime bounces and often forked new PRs, so the first change request after a rerun immediately handed the card back.

**Behavior changes**
- `reviewBounceLimitReached` now counts `review_changes_requested` since the most recent `assignee_changed` to the Super Agent; automatic hand-offs (`to: null`) do not reset; still counts across cycles within the current delegation. Introduces `delegationStart` to compute this reset point.
- `TASK_BOARD_RERUN_REUSES_PR_BRANCH` defaults ON (via `toBoolWithDefault(..., true)`); set the env var to `false` to restore the old forking behavior.

**Review and rollout**
- Review `packages/shared/src/task-board.ts` (new `delegationStart`, updated predicate) and tests in `packages/shared/src/task-board.test.ts`; settings default in `apps/api/src/settings/resolve-config.ts` and `apps/api/src/settings/types.ts`.
- Required action only if you need the old behavior: set `TASK_BOARD_RERUN_REUSES_PR_BRANCH=false`. No UI changes; runaway loops still terminate because automatic hand-offs do not reset.

<sup>Written for commit 38695813b978f62610c5367f6f4f392270aeec52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

