### PR TITLE
fix(decopilot): bound the take_screenshot Browserless fetch with a timeout

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts
@@ -3,6 +3,7 @@ import {
   assertUrlDoesNotResolvePrivate,
   buildScreenshotOptions,
   buildScreenshotRequestBody,
+  createPortableTakeScreenshotTool,
   jpegHeight,
   validateExternalUrl,
 } from "./portable-media-tools";
@@ -167,6 +168,42 @@ describe("assertUrlDoesNotResolvePrivate", () => {
     await expect(
       assertUrlDoesNotResolvePrivate("https://127.0.0.1/x", resolveHost),
     ).resolves.toBeUndefined();
+  });
+});
+
+describe("createPortableTakeScreenshotTool", () => {
+  it("returns a graceful error instead of throwing when the browserless fetch aborts", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      const err = new Error("The operation was aborted");
+      err.name = "TimeoutError";
+      throw err;
+    }) as unknown as typeof fetch;
+
+    try {
+      const writer = { write: () => {} } as never;
+      const screenshotTool = createPortableTakeScreenshotTool(writer, {
+        toolOutputMap: new Map(),
+        pendingImages: [],
+        browserlessToken: "browserless-test-token",
+      });
+      const result = (await (
+        screenshotTool as unknown as {
+          execute: (
+            input: { url: string },
+            options: { toolCallId: string },
+          ) => Promise<{ success: boolean; error?: string }>;
+        }
+      ).execute({ url: "https://example.com" }, { toolCallId: "tool-1" })) as {
+        success: boolean;
+        error?: string;
+      };
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("timed out");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });
 

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.ts
@@ -13,6 +13,9 @@ const FILES_URL_PATTERN = /\/api\/[^/]+\/files\/([^?#]+)/;
 const MAX_REFERENCE_IMAGE_BYTES = 20 * 1024 * 1024;
 const JPEG_QUALITY = 80;
 
+/** Headroom over Browserless's own 30s page.goto timeout, so an unresponsive Browserless can't hang the harness run forever. */
+const BROWSERLESS_SCREENSHOT_TIMEOUT_MS = 45_000;
+
 /**
  * Emulation presets for `take_screenshot`. `mobile` carries a phone viewport
  * AND `isMobile`/`hasTouch` — but the load-bearing part for QA is that the tool
@@ -156,10 +159,22 @@ async function captureScreenshot(params: {
         body: JSON.stringify(
           buildScreenshotRequestBody(url, device, fullPage, clamped),
         ),
+        signal: AbortSignal.timeout(BROWSERLESS_SCREENSHOT_TIMEOUT_MS),
       },
     );
 
-  const response = await shoot(false);
+  let response: Response;
+  try {
+    response = await shoot(false);
+  } catch (err) {
+    const isTimeout = err instanceof Error && err.name === "TimeoutError";
+    return {
+      ok: false,
+      error: isTimeout
+        ? `Browserless screenshot of ${url} timed out after ${BROWSERLESS_SCREENSHOT_TIMEOUT_MS}ms`
+        : `Browserless screenshot failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
   if (!response.ok) {
     const errorText = await response.text().catch(() => "Unknown error");
     return {
@@ -174,8 +189,8 @@ async function captureScreenshot(params: {
     return { ok: true, bytes, mediaType: "image/jpeg" };
   }
 
-  const retry = await shoot(true);
-  const clipped = retry.ok ? new Uint8Array(await retry.arrayBuffer()) : null;
+  const retry = await shoot(true).catch(() => null);
+  const clipped = retry?.ok ? new Uint8Array(await retry.arrayBuffer()) : null;
   // Emitting an oversized capture would brick the thread, so fail the call
   // instead — the caller can retry without `fullPage`.
   if (!clipped || (jpegHeight(clipped) ?? 0) > MAX_SCREENSHOT_HEIGHT) {


### PR DESCRIPTION
Follows #5894 (open) hardening, which added `AbortSignal.timeout` to the scrape/inspect Browserless calls in `portable-built-ins.ts` but missed the sibling `take_screenshot` tool's own Browserless `/screenshot` fetch in `portable-media-tools.ts` — a different file, so this is not a duplicate.

**Why a maintainer wants it**: `captureScreenshot`'s two `fetch` calls to Browserless (initial + clamped retry) had no `signal` at all. If Browserless hangs, the outer fetch never resolves and the harness run hangs forever with no error surfaced to the user — the exact failure mode #5894 fixed for `scrape_url`/`inspect_page`.

**Failure scenario**: Browserless becomes unresponsive mid-request → `take_screenshot`'s fetch never times out → the agent run stalls indefinitely instead of getting a retryable error.

**Fix**: add `AbortSignal.timeout(45_000)` (45s, headroom over Browserless's own 30s `page.goto` timeout, matching the constant used in #5894) to both the initial and clamped-retry screenshot fetches, and catch the abort to return a graceful `{ ok: false, error }` instead of throwing uncaught — the retry path previously had no error handling at all since it never had a reason to throw.

Added `portable-media-tools.test.ts` coverage mirroring #5894's own test: stubs `globalThis.fetch` to throw a `TimeoutError` and asserts `createPortableTakeScreenshotTool`'s `execute` returns `{ success: false, error: /timed out/ }` instead of throwing.

**To verify**: `bun test apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts`

**Locally ran**: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test above (19 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds `take_screenshot` Browserless `/screenshot` fetches with a 45s timeout to prevent hangs. Previously, these calls had no `signal`, so if Browserless stalled the harness run could block indefinitely; now they abort after 45s and return a structured error.

- Add `AbortSignal.timeout(45_000)` to both the initial and clamped-retry screenshot requests in `portable-media-tools.ts`, matching `scrape_url`/`inspect_page` and leaving headroom over Browserless’s 30s `page.goto`.
- Catch timeouts and fetch errors and return `{ ok: false, error }` instead of throwing; retry path now guarded and non-OK responses surface their body text.
- Test: `portable-media-tools.test.ts` stubs `fetch` to throw a `TimeoutError` and asserts `createPortableTakeScreenshotTool.execute` returns `success: false` with a “timed out” message. Run: `bun test apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts`.

<sup>Written for commit f36cda2bef99b01d9d37b6d7a69445627661abaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

