### PR TITLE
fix(task-board): hide archived tasks from the list view too

### DIFF
--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -395,6 +395,7 @@ export function TaskBoardPage() {
 
   const [layout, setLayout] = useState<Layout>("board");
   const [filters, setFilters] = useState<TaskFilters>(EMPTY_FILTERS);
+  const [preferences] = usePreferences();
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const toggleSelect = (id: string) =>
     setSelectedIds((prev) => {
@@ -495,6 +496,12 @@ export function TaskBoardPage() {
 
   const visibleItems = items.filter((item) =>
     taskMatchesFilters(item, filters),
+  );
+  // The list view has no "Hidden columns" drawer, so it drops hidden lanes outright.
+  const visibleListItems = visibleItems.filter(
+    (item) =>
+      !HIDDEN_STATUSES.includes(item.status) ||
+      preferences.shownTaskBoardLanes.includes(item.status),
   );
 
   const openCreate = () => {
@@ -691,7 +698,7 @@ export function TaskBoardPage() {
       ) : (
         <div className="min-h-0 flex-1 overflow-y-auto px-4 pt-6 pb-16 sm:px-8">
           <div className="mx-auto flex max-w-[820px] flex-col gap-2">
-            {visibleItems.map((item) => (
+            {visibleListItems.map((item) => (
               <ListRow
                 key={item.id}
                 item={item}


### PR DESCRIPTION
#5990 added an Archived lane that's hidden by default — tucked behind the board's "Hidden columns" drawer — but the list view maps `visibleItems` directly with no such drawer of its own. Switching to List view surfaces every archived task the board deliberately keeps out of sight, the same leak `home-tasks.tsx` had to special-case for the home surface in the same PR.

Why a maintainer wants this: a person who switches to List view (or has it as their default) sees every archived task mixed in with live ones, defeating the point of #5990's default-hidden Archived lane.

Failure scenario before the fix: archive a Done task (or wait for the hourly sweep), switch the board to List view — the archived card renders indistinguishably from an active one. After: filters the list view against the same `shownTaskBoardLanes` preference the board's Hidden-columns drawer already reads, leaving the board's own item list (and its Hidden-columns count) untouched.

Reviewer check: open a board with an archived task, switch to List view — it should not appear until its lane is shown via "Hidden columns" → Show.

Verified locally: `bun run fmt`, `bunx oxlint` on the changed file (0 errors/warnings), `bunx tsc --noEmit` in apps/web (clean). No unit test added — this is component wiring (which list a filter reads from), not a pure function; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hides archived tasks in Task Board List view to match the board view’s default-hidden Archived lane. Previously List view showed archived tasks; now it filters `visibleItems` by the user’s `shownTaskBoardLanes`, so archived tasks stay hidden unless their lane is shown.

**Review notes**
- Scope: only List view mapping changes to use `visibleListItems`; the board’s item list and Hidden-columns count are unchanged.
- Verify: open a board with an archived task, switch to List view; it should not appear until you unhide the lane via Hidden columns → Show.

<sup>Written for commit cac99f7072885e5bae00eee71d78cb9591722e89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

