### PR TITLE
fix(task-board): count one bounce per review cycle, not per verdict row

### DIFF
--- a/packages/shared/src/task-board.test.ts
+++ b/packages/shared/src/task-board.test.ts
@@ -154,66 +154,79 @@ describe("allReviewersApproved", () => {
 // bounce starts a new cycle, so a per-cycle count is always 1 and would never
 // trip, which is exactly how a board reached 179 change-requests.
 
-function bounce(at: string): ReviewCycleActivity {
+function bounce(at: string, reviewer = "code_review"): ReviewCycleActivity {
   return {
     action: "review_changes_requested",
-    data: { reviewer: "code_review" },
+    data: { reviewer },
     occurredAt: at,
   };
+}
+
+function enteredReview(at: string): ReviewCycleActivity {
+  return {
+    action: "status_changed",
+    data: { to: "in_review" },
+    occurredAt: at,
+  };
+}
+
+/**
+ * `n` real bounces: a card enters In Review, a reviewer requests changes, the
+ * card goes back and re-enters. A bare run of `review_changes_requested` rows
+ * is NOT n bounces — the counter groups by cycle, because one dispatch can land
+ * more than one verdict.
+ */
+function bounceCycles(n: number, fromHour = 0): ReviewCycleActivity[] {
+  return Array.from({ length: n }, (_, i) => {
+    const h = String(fromHour + i).padStart(2, "0");
+    return [
+      enteredReview(`2026-01-01T${h}:00:00.000Z`),
+      bounce(`2026-01-01T${h}:30:00.000Z`),
+    ];
+  }).flat();
 }
 
 describe("reviewBounceLimitReached", () => {
   it("allows the first bounces through", () => {
     expect(reviewBounceLimitReached([])).toBe(false);
-    expect(
-      reviewBounceLimitReached([
-        bounce("2026-01-01T00:00:00.000Z"),
-        bounce("2026-01-01T01:00:00.000Z"),
-        bounce("2026-01-01T02:00:00.000Z"),
-      ]),
-    ).toBe(false);
+    expect(reviewBounceLimitReached(bounceCycles(3))).toBe(false);
   });
 
   it("trips on the bounce that would reach the limit, counting the pending one", () => {
-    const four = Array.from({ length: 4 }, (_, i) =>
-      bounce(`2026-01-01T0${i}:00:00.000Z`),
+    expect(reviewBounceLimitReached(bounceCycles(MAX_REVIEW_BOUNCES - 1))).toBe(
+      true,
     );
-    expect(four).toHaveLength(MAX_REVIEW_BOUNCES - 1);
-    expect(reviewBounceLimitReached(four)).toBe(true);
+  });
+
+  // The claim fences the DISPATCH, not the decision, so a reviewer can land two
+  // verdicts against one dispatch — only the first moves the card. Charging
+  // both halved the real budget on three of four cards in one org.
+  it("counts one bounce per cycle, however many verdicts land in it", () => {
+    // The prod shape: two cycles, QA landing a duplicate verdict in each. Four
+    // rows — which the old row-count read as four bounces and tripped on.
+    const doubleCharged: ReviewCycleActivity[] = [
+      enteredReview("2026-01-01T00:00:00.000Z"),
+      bounce("2026-01-01T00:30:00.000Z", "qa"),
+      bounce("2026-01-01T00:31:00.000Z", "qa"),
+      enteredReview("2026-01-01T01:00:00.000Z"),
+      bounce("2026-01-01T01:30:00.000Z", "qa"),
+      bounce("2026-01-01T01:31:00.000Z", "qa"),
+    ];
+    expect(reviewBounceLimitReached(doubleCharged)).toBe(false);
+
+    // Four REAL cycles still trip, on the same number of rows.
+    expect(reviewBounceLimitReached(bounceCycles(4))).toBe(true);
   });
 
   it("counts bounces from earlier review cycles, not just the current one", () => {
-    const acrossCycles: ReviewCycleActivity[] = [
-      bounce("2026-01-01T00:00:00.000Z"),
-      {
-        action: "status_changed",
-        data: { to: "in_review" },
-        occurredAt: "2026-01-01T00:30:00.000Z",
-      },
-      bounce("2026-01-01T01:00:00.000Z"),
-      {
-        action: "status_changed",
-        data: { to: "in_review" },
-        occurredAt: "2026-01-01T01:30:00.000Z",
-      },
-      bounce("2026-01-01T02:00:00.000Z"),
-      {
-        action: "status_changed",
-        data: { to: "in_review" },
-        occurredAt: "2026-01-01T02:30:00.000Z",
-      },
-      bounce("2026-01-01T03:00:00.000Z"),
-    ];
-    expect(reviewBounceLimitReached(acrossCycles)).toBe(true);
+    expect(reviewBounceLimitReached(bounceCycles(4))).toBe(true);
   });
 
   // The reset that makes a re-run mean something. Four cards carrying 5-7 old
   // bounces were re-delegated in prod and each was handed straight back on its
   // FIRST change-request — one review round, zero retries.
   it("counts only from the most recent hand-back to the Super Agent", () => {
-    const burntOut = Array.from({ length: 6 }, (_, i) =>
-      bounce(`2026-01-0${i + 1}T00:00:00.000Z`),
-    );
+    const burntOut = bounceCycles(6);
     expect(reviewBounceLimitReached(burntOut)).toBe(true);
 
     const reDelegated: ReviewCycleActivity[] = [
@@ -230,12 +243,9 @@ describe("reviewBounceLimitReached", () => {
   // ...and the loop still terminates: only a hand-back TO the Super Agent
   // resets, and the automatic hand-off writes `to: null`.
   it("is not reset by the automatic hand-off to a human", () => {
-    const four = Array.from({ length: 4 }, (_, i) =>
-      bounce(`2026-01-01T0${i}:00:00.000Z`),
-    );
     expect(
       reviewBounceLimitReached([
-        ...four,
+        ...bounceCycles(4),
         {
           action: "assignee_changed",
           data: { from: SUPER_AGENT_ASSIGNEE_ID, to: null, reason: "burned" },
@@ -247,16 +257,13 @@ describe("reviewBounceLimitReached", () => {
 
   it("still trips within one delegation, after the reset", () => {
     const reDelegated: ReviewCycleActivity[] = [
-      bounce("2026-01-01T00:00:00.000Z"),
-      bounce("2026-01-01T01:00:00.000Z"),
+      ...bounceCycles(2),
       {
         action: "assignee_changed",
         data: { from: null, to: SUPER_AGENT_ASSIGNEE_ID },
-        occurredAt: "2026-01-02T00:00:00.000Z",
+        occurredAt: "2026-01-01T05:00:00.000Z",
       },
-      ...Array.from({ length: MAX_REVIEW_BOUNCES - 1 }, (_, i) =>
-        bounce(`2026-01-02T0${i + 1}:00:00.000Z`),
-      ),
+      ...bounceCycles(MAX_REVIEW_BOUNCES - 1, 6),
     ];
     expect(reviewBounceLimitReached(reDelegated)).toBe(true);
   });

--- a/packages/shared/src/task-board.ts
+++ b/packages/shared/src/task-board.ts
@@ -228,12 +228,28 @@ export function reviewBounceLimitReached(
   limit: number = MAX_REVIEW_BOUNCES,
 ): boolean {
   const since = delegationStart(activity);
-  const bounces = activity.filter(
-    (a) =>
-      a.action === "review_changes_requested" &&
-      new Date(a.occurredAt).getTime() >= since,
-  ).length;
-  return bounces + 1 >= limit;
+  // Count review CYCLES that ended in a change-request, not change-request
+  // rows. A reviewer can land more than one verdict against a single dispatch
+  // — the claim fences the dispatch, not the decision — and only the first
+  // moves the card, so counting rows charged a card twice for one bounce and
+  // halved the real budget. Three of four cards in one org did exactly that.
+  const bounced = new Set<number>();
+  let cycle = 0;
+  for (const a of [...activity].sort((x, y) =>
+    x.occurredAt.localeCompare(y.occurredAt),
+  )) {
+    const at = new Date(a.occurredAt).getTime();
+    if (a.action === "status_changed") {
+      if ((a.data as { to?: unknown } | null | undefined)?.to === "in_review") {
+        cycle = at;
+      }
+      continue;
+    }
+    if (a.action === "review_changes_requested" && at >= since) {
+      bounced.add(cycle);
+    }
+  }
+  return bounced.size + 1 >= limit;
 }
 
 /**


### PR DESCRIPTION
Third in the series (#6003 merging, #6011 the bounce reset). With #6011 in prod the four stuck cards finally cycle instead of being dumped after one round — but they burn the budget twice as fast as configured.

## The bug

The reviewer claim fences the **dispatch**, not the **decision**. One claim row is issued per `(task, reviewer, cycle)`, but `TASK_BOARD_REVIEW_DECISION` will accept a verdict against it more than once. Only the first actually moves the card — `claimReviewChangesBounce` rejects the rest — yet `reviewBounceLimitReached` counted every `review_changes_requested` **row**. So one bounce could be charged two or three times, and the real budget was a fraction of `MAX_REVIEW_BOUNCES`.

Prod, within fifteen minutes of the #6011 re-delegation — three of four cards double-charged:

| task | verdicts landed in one cycle |
|---|---|
| `board_fEufdXfSnk4_R8f9VXUZZ` | qa × 2 (21:18:09, 21:19:07 — near-identical notes, 58s apart) |
| `board_pA_7SsIEhMmcStEcAidCs` | qa × 2 |
| `board_wdUjots9uvrRae1mDB-Xu` | code_review × 2 |

Both claims for `fEuf`'s cycle were issued once each at 21:06:55, so this is not a duplicate dispatch — it is one reviewer answering twice.

## The fix

Count review **cycles** that ended in a change-request, not rows. A row's cycle is the latest `status_changed → in_review` at or before it, which makes the fix retroactive: no new column, and existing history recounts correctly. Cross-cycle semantics are unchanged — four real cycles still trip, on the same number of rows as the double-charged fixture that now doesn't.

## Test fixtures were wrong

They built bounces as bare `review_changes_requested` rows, which is not what a bounce looks like — a bounce is a card entering In Review and a reviewer sending it back. They now build real cycles via a `bounceCycles()` helper. That's why several existing cases changed shape while asserting the same thing.

I verified the new case discriminates in both directions: it fails against the old row-count predicate and passes against the new one. (My first draft of it didn't — three rows in one cycle passes either way — so it's now the actual prod shape, two cycles × two verdicts.)

## Follow-up, not here

`TASK_BOARD_REVIEW_DECISION` should reject a second verdict from the same reviewer in the same cycle rather than recording it. That's the root cause; this PR stops it corrupting the budget. Fixing the endpoint means consuming the claim token on use, which touches the token lifecycle and could break legitimate retries — worth doing deliberately, not as a rider.

## Testing

- 610 pass / 0 fail across `packages/shared/src` and `apps/api/src/tools/task-board/` (real Postgres).
- `fmt` / `lint` (18 warnings, unchanged) / `check` clean.

No UI change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Counts one review “bounce” per review cycle instead of per `review_changes_requested` row to stop double‑charging when a reviewer submits multiple verdicts in the same cycle. This restores the intended `MAX_REVIEW_BOUNCES` budget without changing cross‑cycle behavior.

- Old vs new behavior: previously counted each `review_changes_requested` row since the last delegation; now counts unique cycles that ended in a change‑request (the cycle is the latest `status_changed → in_review` at or before the verdict). Still trips when the pending bounce would reach the limit.
- Implementation: `reviewBounceLimitReached` iterates time‑ordered activity, tracks the active cycle timestamp, and adds one entry per cycle to a set when a change‑request occurs after `delegationStart`; compares `bounced.size + 1` to the limit.
- Tests: fixtures now model real cycles via `bounceCycles()`. Adds a prod‑shaped case with duplicate verdicts in a cycle (no longer trips) and confirms four real cycles still trip.
- Rollout: no schema change, no UI change, and retroactive on existing history. Follow‑up (separate PR): reject a second verdict in the same cycle in `TASK_BOARD_REVIEW_DECISION`.

<sup>Written for commit 4b9ba8e3edd466b0e39573f9ddbaca13db9d9424. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

