### PR TITLE
fix(task-board): pin the PR branch when a person re-delegates, too

### DIFF
--- a/apps/api/src/tools/task-board/claude-code-task-run.test.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.test.ts
@@ -72,6 +72,21 @@ describe("buildClaudeCodeTaskPrompt", () => {
     expect(prompt).toContain("do NOT open a new one");
   });
 
+  /**
+   * A person re-delegating a card that already has an open PR. The sandbox
+   * boots on that PR's branch, so the prompt must say continue-this-PR rather
+   * than the default open-a-new-one.
+   */
+  test("a PR with no feedback leads with continue-this-PR", () => {
+    const prompt = buildClaudeCodeTaskPrompt(task, repo, {
+      pr: { number: 7, url: "https://github.com/acme/web/pull/7" },
+    });
+    expect(prompt).toContain("already has an open pull request");
+    expect(prompt).toContain("#7");
+    expect(prompt).toContain("do NOT open a new one");
+    expect(prompt).toContain("push to the existing one");
+  });
+
   test("feedback with no PR asks for the fix without a checkout", () => {
     const prompt = buildClaudeCodeTaskPrompt(task, repo, {
       feedback: "Wrong approach.",

--- a/apps/api/src/tools/task-board/claude-code-task-run.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.ts
@@ -232,6 +232,15 @@ export function buildClaudeCodeTaskPrompt(
         : "Address this feedback.",
       "",
     );
+  } else if (opts?.pr) {
+    // A person re-delegated a task that already has an open PR. No feedback to
+    // lead with, but the sandbox booted on that PR's branch, so "open a pull
+    // request" below would contradict where the run actually is.
+    lines.push(
+      `This task already has an open pull request #${opts.pr.number} (${opts.pr.url}), and you are already on its branch.`,
+      `Continue that work: commit and push to update the SAME pull request — do NOT open a new one. If it already does everything the task asks, say so and stop rather than changing it.`,
+      "",
+    );
   }
 
   lines.push(

--- a/apps/api/src/tools/task-board/enqueue-super-agent.test.ts
+++ b/apps/api/src/tools/task-board/enqueue-super-agent.test.ts
@@ -12,14 +12,42 @@ const pr = { number: 7, url: "https://github.com/x/y/pull/7" };
 
 const CONFLICT_LEAD = "MERGE CONFLICT";
 const FEEDBACK_LEAD = "A reviewer requested changes";
+const CONTINUE_LEAD = "already has an open pull request";
+const OPEN_A_PR = "commit on a new branch, push, and open a pull request";
 
 describe("buildSuperAgentTaskPrompt", () => {
-  it("a fresh attempt has neither lead block", () => {
+  it("a fresh attempt has no lead block, and opens a PR", () => {
     const p = buildSuperAgentTaskPrompt(task);
     expect(p).not.toContain(CONFLICT_LEAD);
     expect(p).not.toContain(FEEDBACK_LEAD);
+    expect(p).not.toContain(CONTINUE_LEAD);
+    expect(p).toContain(OPEN_A_PR);
     expect(p).toContain("Fix the thing");
     expect(p).toContain("(task id: board_1)");
+  });
+
+  /**
+   * A person re-delegating a card with an open PR. The sandbox boots on that
+   * PR's branch, so the prompt must not also say "open a pull request" — that
+   * contradiction is what produced a third PR on three cards in one afternoon.
+   */
+  it("a PR with no feedback leads with continue-this-PR, and never says open one", () => {
+    const p = buildSuperAgentTaskPrompt(task, { pr });
+    expect(p).toContain(CONTINUE_LEAD);
+    expect(p).toContain("#7");
+    expect(p).toContain("do NOT open a new one");
+    expect(p).not.toContain(OPEN_A_PR);
+    expect(p).not.toContain(CONFLICT_LEAD);
+    expect(p).not.toContain(FEEDBACK_LEAD);
+  });
+
+  it("feedback and conflict still win over the plain continue lead", () => {
+    expect(
+      buildSuperAgentTaskPrompt(task, { pr, feedback: "x" }),
+    ).not.toContain(CONTINUE_LEAD);
+    expect(
+      buildSuperAgentTaskPrompt(task, { pr, resolveConflict: true }),
+    ).not.toContain(CONTINUE_LEAD);
   });
 
   it("a conflict re-run leads with the conflict-resolution instruction", () => {

--- a/apps/api/src/tools/task-board/enqueue-super-agent.ts
+++ b/apps/api/src/tools/task-board/enqueue-super-agent.ts
@@ -13,6 +13,7 @@ import { getSettings } from "@/settings";
 import { enqueueAgentRunForTask } from "./enqueue-task-run";
 import type { RunClass } from "@/dispatch-queue/run-priority";
 import { fetchPrHeadRef } from "./prs-get";
+import { readPrStateThrottled } from "./dbos-github-read";
 import {
   buildClaudeCodeTaskPrompt,
   resolveTaskRepoChoice,
@@ -123,13 +124,26 @@ export function buildSuperAgentTaskPrompt(
               : "Address this feedback.",
             "",
           ].join("\n")
-        : "",
+        : // A person re-delegated a task that already has an open PR. No
+          // feedback to lead with, but the sandbox booted on that PR's branch,
+          // so the default "commit on a new branch and open a pull request"
+          // below would contradict where the run actually is — and produce the
+          // second PR this pin exists to prevent.
+          opts?.pr
+          ? [
+              `This task already has an open pull request #${opts.pr.number} (${opts.pr.url}), and you are already on its branch.`,
+              `Continue that work: commit and push to update the SAME pull request — do NOT open a new one or start a new branch. If you find it already does everything the task asks, say so and stop rather than changing it.`,
+              "",
+            ].join("\n")
+          : "",
     "How to work:",
     "- First decide whether this task requires changing code in a repository. Some tasks (research, answering a question, planning) don't. If it doesn't, just do the work directly — don't load a repo or open a PR.",
     // A re-run's lead block above (reviewer feedback OR conflict resolution)
     // overrides this: only a FIRST attempt opens a new branch + PR; a re-run
     // checks out the existing PR's branch and pushes to it.
-    "- If it DOES need code changes: use the `load_repo` tool to load the relevant repository, then make the change, commit on a new branch, push, and open a pull request. Only then does a PR apply.",
+    opts?.pr
+      ? "- If it DOES need code changes: use the `load_repo` tool to load the relevant repository, make the change, then commit and push to the pull request named above."
+      : "- If it DOES need code changes: use the `load_repo` tool to load the relevant repository, then make the change, commit on a new branch, push, and open a pull request. Only then does a PR apply.",
     "- Prefer the GitHub tool to open the PR. If it errors or targets the wrong repo, fall back to `git push` + the GitHub REST API (the auth token is embedded in the `origin` URL).",
     "- If a dev server is running it hot-reloads your changes — don't restart it, hunt for its port, or run a full typecheck/build just to verify a small edit.",
     "- Change only what the task needs. Don't trace the definition of a pre-existing symbol that's incidental to your change — note it in one line and move on. Prefer one or two broad searches over many narrow retries.",
@@ -157,6 +171,33 @@ async function resolveRerunBranch(
   const pr = prs.find((p) => p.number === prNumber);
   if (!pr) return null;
   return fetchPrHeadRef(ctx, task.organizationId, pr).catch(() => null);
+}
+
+/**
+ * The task's own OPEN pull request, for a dispatch nobody named one for.
+ *
+ * Only a reviewer bounce passes `opts.pr`. A person re-delegating the card
+ * (`TASK_BOARD_ITEM_UPDATE`, `TASK_BOARD_ITEM_RERUN`) passes nothing, so the
+ * branch pin below never applied to the path people actually use — three cards
+ * grew a third pull request that way in one afternoon, each one the reviewer
+ * then rejected as obsolete against `main`.
+ *
+ * Open only, deliberately: `pickActivePr` falls back to the newest link when
+ * every PR reads closed, and resuming work on a merged or abandoned branch is
+ * worse than starting a fresh one. Reads go through the same throttled queue.
+ */
+async function openPrForTask(
+  ctx: StudioContext,
+  task: TaskBoardItem,
+): Promise<{ number: number; url: string } | undefined> {
+  const prs = await ctx.storage.taskBoard
+    .listPrs(task.id, task.organizationId)
+    .catch(() => []);
+  for (const pr of prs) {
+    const { state } = await readPrStateThrottled(task.organizationId, pr);
+    if (state === "open") return { number: pr.number, url: pr.url };
+  }
+  return undefined;
 }
 
 export async function enqueueSuperAgentForTask(
@@ -194,10 +235,22 @@ export async function enqueueSuperAgentForTask(
     // push updates the same PR. Best-effort: a null head ref (GitHub
     // unreachable, PR already closed/merged) falls back to today's behavior
     // rather than pinning a ref we can't confirm exists.
+    //
+    // Applies to a person re-delegating the card too, not just a reviewer
+    // bounce: only the bounce names a PR, and the human path is the one that
+    // kept forking (see `openPrForTask`).
+    const reusesPrBranch = getSettings().taskBoardRerunReusesPrBranch;
+    const pr =
+      opts?.pr ?? (reusesPrBranch ? await openPrForTask(ctx, task) : undefined);
     const pinnedRef =
-      getSettings().taskBoardRerunReusesPrBranch && opts?.pr
-        ? await resolveRerunBranch(ctx, task, opts.pr.number)
+      reusesPrBranch && pr
+        ? await resolveRerunBranch(ctx, task, pr.number)
         : null;
+    // The prompt must name the same PR the sandbox booted on. Only widened when
+    // the flag is on: naming a PR the run is NOT pinned to is the combination
+    // that produced the duplicates.
+    const promptOpts: SuperAgentPromptOpts | undefined =
+      pr && pr !== opts?.pr ? { ...opts, pr } : opts;
 
     // Sandbox-hosted claude-code takes every task that has a repo it could work
     // in — bound before dispatch when there's exactly one, otherwise chosen
@@ -213,7 +266,7 @@ export async function enqueueSuperAgentForTask(
         ...(opts?.runClass ? { runClass: opts.runClass } : {}),
         ...(pinnedRef ? { pinnedRef } : {}),
         prompt: buildClaudeCodeTaskPrompt(task, repo, {
-          ...opts,
+          ...promptOpts,
           // Names the candidates in the prompt so the run doesn't spend its first
           // step asking what exists.
           ...("choices" in choice ? { repoChoices: choice.choices } : {}),
@@ -226,7 +279,7 @@ export async function enqueueSuperAgentForTask(
       await enqueueAgentRunForTask(ctx, task, {
         title: `Super Agent: ${task.title}`,
         ...(opts?.runClass ? { runClass: opts.runClass } : {}),
-        prompt: buildSuperAgentTaskPrompt(task, opts),
+        prompt: buildSuperAgentTaskPrompt(task, promptOpts),
         temperature: 0.5,
         ...(pinnedRef ? { pinnedRef } : {}),
       });


### PR DESCRIPTION
Gap in what #6011 shipped. I said that PR made branch-reuse the default; it did, but the flag only ever applied to a path people don't use.

## The bug

`taskBoardRerunReusesPrBranch` gates on `opts.pr`, and **only a reviewer bounce passes one**. A person re-delegating a card — `TASK_BOARD_ITEM_UPDATE` (assignee → Super Agent) or `TASK_BOARD_ITEM_RERUN` — passes nothing. So the sandbox boots on a fresh `sandbox/thread-<new-id>` branch, the daemon's HEAD-based shutdown push publishes *that*, and the task gets another pull request.

Observed right after #6011 deployed, on the re-delegation of the four stuck cards: `board_fEufdXfSnk4_R8f9VXUZZ`, `board_i0TyqN4wddkH35ixBn-Yc` and `board_wdUjots9uvrRae1mDB-Xu` each went from 2 linked PRs to 3. `fEuf`'s newest is #334, described by its own reviewer as *"supersedes #310/#331"*. That rejection-as-obsolete is what burns the bounce budget, so this is upstream of the counter fixes.

## The fix

`enqueueSuperAgentForTask` falls back to the task's own **open** pull request when no caller named one.

- **Open only.** `pickActivePr` falls back to the newest link when every PR reads closed; resuming work on a merged or abandoned branch is worse than starting fresh, so this walks the links and takes the first that reads `open`, else nothing.
- **In the enqueue funnel, not at each call site.** `create` and the reports import have no linked PRs, so the lookup is a no-op there and needs no special case — and any future caller is covered.
- Reads go through `readPrStateThrottled`, the same rate-limited queue #6006 moved `pickActivePr` onto.
- Gated on the flag, so turning it off restores the old behavior wholesale rather than leaving a half-state.

## The pin alone was not enough

With a PR pinned but **no reviewer feedback**, both prompt builders fell through to their default:

> "commit on a new branch, push, and open a pull request"

…while the sandbox was already sitting on the PR's branch. The prompt was instructing the agent to do the exact thing the pin exists to prevent. Both `buildSuperAgentTaskPrompt` and `buildClaudeCodeTaskPrompt` now have a third lead block — continue-this-PR — and the how-to line stops asking for a new PR when one is named. Conflict-resolution and feedback still take precedence.

The continue lead also tells the agent to stop and say so if the PR already satisfies the task, rather than editing it to look busy — which is the situation several of these cards are actually in.

## Testing

- `enqueue-super-agent.test.ts` — the new lead appears with a PR and no feedback, never says "open a pull request", and loses to both feedback and conflict.
- `claude-code-task-run.test.ts` — same for the sandbox prompt.
- Existing "fresh attempt" case tightened to assert it still *does* ask for a new PR, so the branch can't leak into first attempts.
- 612 pass / 0 fail across `apps/api/src/tools/task-board/` and `packages/shared/src` (real Postgres).
- `fmt` / `lint` (18 warnings, unchanged) / `check` / `knip` clean.

The `openPrForTask` lookup itself is I/O, so it is not unit-tested here — the prompt selection it feeds is. Consistent with how the rest of this file is covered.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the sandbox to an existing task’s open PR on re-delegation and updates prompts to continue that PR. Previously, only reviewer bounces reused the PR branch; re-delegations started a new branch and opened a duplicate PR.

- Branch pinning: In `enqueueSuperAgentForTask`, when `opts.pr` is absent and `taskBoardRerunReusesPrBranch` is on, fall back to the task’s own open PR (read via `readPrStateThrottled`) and resolve its head ref with `fetchPrHeadRef`. The prompt receives the same PR to avoid mismatches.
- Prompt behavior: `buildSuperAgentTaskPrompt` and `buildClaudeCodeTaskPrompt` add a continue-this-PR lead when a PR is present and there’s no feedback, and stop instructing “open a pull request”. Feedback and conflict still take precedence. Prompts tell the agent to stop if the PR already satisfies the task.
- Safety and rollout: Feature-flagged; turning the flag off restores prior behavior. Only open PRs are selected to avoid resuming closed/merged work. The fallback runs in the enqueue funnel so callers need no changes. New tests cover continue-this-PR and precedence rules.

<sup>Written for commit 625d12fe74494b518d102dcc8b16cde5e5c4f7a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

