### PR TITLE
fix(task-board): a hung reviewer must not own its cycle forever

### DIFF
--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -152,6 +152,20 @@ function threadHasClonableRepo(metadata: unknown): boolean {
   return typeof url === "string" && url.length > 0;
 }
 
+/** The newer of two nullable timestamps, as ISO. Both are the thread's own
+ *  heartbeat columns, so at least `updated_at` is always set. */
+function newestIso(
+  updatedAt: Date | string,
+  lastProgressAt: Date | string | null,
+): string {
+  const ms = (v: Date | string) =>
+    v instanceof Date ? v.getTime() : new Date(v).getTime();
+  const a = ms(updatedAt);
+  const b =
+    lastProgressAt === null ? Number.NEGATIVE_INFINITY : ms(lastProgressAt);
+  return new Date(Math.max(a, b)).toISOString();
+}
+
 export class TaskBoardStorage {
   constructor(private db: Kysely<Database>) {}
 
@@ -1330,6 +1344,8 @@ export class TaskBoardStorage {
         "t.title as title",
         "t.virtual_mcp_id as virtualMcpId",
         "t.metadata as metadata",
+        "t.updated_at as updatedAt",
+        "t.last_progress_at as lastProgressAt",
         "lastmsg.payload as lastMessagePayload",
         // Was this thread ever used? Both storage formats, any role — v2 writes
         // parts, deprecated v1 threads still have `thread_messages` rows, and a
@@ -1367,6 +1383,7 @@ export class TaskBoardStorage {
         lastMessage: extractPartText(row.lastMessagePayload),
         hasPreview: threadHasClonableRepo(row.metadata),
         hasMessages: !!row.hasMessages,
+        lastActiveAt: newestIso(row.updatedAt, row.lastProgressAt),
         createdAt:
           row.createdAt instanceof Date
             ? row.createdAt.toISOString()

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -1792,6 +1792,11 @@ export interface TaskBoardItemThreadRef {
    *  thread looks finished without ever having run. Status alone can't tell the
    *  two apart; see `shouldAdvanceToReview`. */
   hasMessages: boolean;
+  /** Newest of the thread's `updated_at` / `last_progress_at` — the same
+   *  heartbeat the stall reaper trusts. A non-terminal thread whose heartbeat
+   *  went cold is not running, whatever its status says; see
+   *  `reviewerHandledThisCycle`. */
+  lastActiveAt: string;
   createdAt: string;
 }
 

--- a/apps/api/src/tools/task-board/enqueue-reviewer.test.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.test.ts
@@ -7,7 +7,7 @@
 import { describe, expect, it, test } from "bun:test";
 import type { TaskBoardItem } from "@/storage/types";
 import {
-  hasFailedAttemptThisCycle,
+  hasSpentAttemptThisCycle,
   MAX_REVIEWER_ATTEMPTS,
   REVIEWER_DISALLOWED_TOOLS,
   reviewerAttemptsExhausted,
@@ -17,12 +17,24 @@ import { REVIEW_RUN_TOOL_NAMES } from "./task-run-context";
 
 /** Cycle start (the task last entered In Review) at 10:00. */
 const CYCLE_START = new Date("2026-01-01T10:00:00Z").getTime();
+/** "Now" for every liveness check below — ten minutes into the cycle. */
+const NOW = new Date("2026-01-01T10:10:00Z").getTime();
 
+/**
+ * `lastActiveAt` defaults to `createdAt`, which for these fixtures is inside
+ * the stall window relative to `NOW` — so a non-terminal thread reads as live
+ * unless a test deliberately backdates it.
+ */
 const thread = (o: {
   title: string;
   status: string | null;
   createdAt: string;
-}) => ({ threadId: `t-${o.createdAt}`, ...o });
+  lastActiveAt?: string;
+}) => ({
+  threadId: `t-${o.createdAt}-${o.lastActiveAt ?? ""}`,
+  ...o,
+  lastActiveAt: o.lastActiveAt ?? o.createdAt,
+});
 
 const taskWith = (threads: ReturnType<typeof thread>[]): TaskBoardItem =>
   ({ threads }) as unknown as TaskBoardItem;
@@ -59,9 +71,10 @@ describe("reviewerHandledThisCycle", () => {
         title: "QA Agent: fix",
         status: "in_progress",
         createdAt: "2026-01-01T09:00:00Z", // even from a prior cycle, live counts
+        lastActiveAt: "2026-01-01T10:09:00Z",
       }),
     ]);
-    expect(reviewerHandledThisCycle(task, "qa", CYCLE_START)).toBe(true);
+    expect(reviewerHandledThisCycle(task, "qa", CYCLE_START, NOW)).toBe(true);
   });
 
   it("is true for a terminal reviewer thread created THIS cycle", () => {
@@ -72,7 +85,7 @@ describe("reviewerHandledThisCycle", () => {
         createdAt: "2026-01-01T10:05:00Z",
       }),
     ]);
-    expect(reviewerHandledThisCycle(task, "qa", CYCLE_START)).toBe(true);
+    expect(reviewerHandledThisCycle(task, "qa", CYCLE_START, NOW)).toBe(true);
   });
 
   it("is FALSE for a terminal reviewer thread from a PRIOR cycle — so re-review re-runs it", () => {
@@ -83,7 +96,7 @@ describe("reviewerHandledThisCycle", () => {
         createdAt: "2026-01-01T09:30:00Z",
       }),
     ]);
-    expect(reviewerHandledThisCycle(task, "qa", CYCLE_START)).toBe(false);
+    expect(reviewerHandledThisCycle(task, "qa", CYCLE_START, NOW)).toBe(false);
   });
 
   // The bug: a FAILED reviewer thread satisfied "created this cycle", so when
@@ -98,8 +111,60 @@ describe("reviewerHandledThisCycle", () => {
         createdAt: "2026-01-01T10:05:00Z",
       }),
     ]);
-    expect(reviewerHandledThisCycle(task, "qa", CYCLE_START)).toBe(false);
-    expect(hasFailedAttemptThisCycle(task, "qa", CYCLE_START)).toBe(true);
+    expect(reviewerHandledThisCycle(task, "qa", CYCLE_START, NOW)).toBe(false);
+    expect(hasSpentAttemptThisCycle(task, "qa", CYCLE_START, NOW)).toBe(true);
+  });
+
+  /**
+   * The deadlock. A reviewer whose pod dies mid-run keeps `in_progress`
+   * forever: the per-pod idle reaper can't see it and `failNeverStartedThreads`
+   * only covers runs that never started. Taking the status at face value made
+   * the thread own the cycle permanently — claim spent, nothing re-dispatched,
+   * and a merge gate waiting on a verdict that was never coming. One card sat
+   * that way while its co-reviewer had approved in 68 seconds.
+   */
+  it("is FALSE for a non-terminal thread whose heartbeat went cold", () => {
+    const task = taskWith([
+      thread({
+        title: "QA Agent: fix",
+        status: "in_progress",
+        createdAt: "2026-01-01T10:01:00Z",
+        lastActiveAt: "2026-01-01T09:30:00Z", // past the stall window
+      }),
+    ]);
+    expect(reviewerHandledThisCycle(task, "qa", CYCLE_START, NOW)).toBe(false);
+    // …and its claim row is released first, or the retry loses to the corpse.
+    expect(hasSpentAttemptThisCycle(task, "qa", CYCLE_START, NOW)).toBe(true);
+  });
+
+  it("a warm heartbeat still owns the cycle — a slow reviewer is not a hung one", () => {
+    const task = taskWith([
+      thread({
+        title: "QA Agent: fix",
+        status: "in_progress",
+        createdAt: "2026-01-01T10:01:00Z",
+        lastActiveAt: "2026-01-01T10:09:00Z",
+      }),
+    ]);
+    expect(reviewerHandledThisCycle(task, "qa", CYCLE_START, NOW)).toBe(true);
+    expect(hasSpentAttemptThisCycle(task, "qa", CYCLE_START, NOW)).toBe(false);
+  });
+
+  // The opposite mistake to the deadlock: a reviewer whose pod keeps dying must
+  // not be re-dispatched forever just because it never wrote `failed`.
+  it("hung attempts count toward the budget, like failures", () => {
+    const task = taskWith(
+      Array.from({ length: MAX_REVIEWER_ATTEMPTS }, (_, i) =>
+        thread({
+          title: "QA Agent: fix",
+          status: "in_progress",
+          createdAt: `2026-01-01T10:0${i + 1}:00Z`,
+          lastActiveAt: "2026-01-01T09:30:00Z",
+        }),
+      ),
+    );
+    expect(reviewerHandledThisCycle(task, "qa", CYCLE_START, NOW)).toBe(true);
+    expect(reviewerAttemptsExhausted(task, "qa", CYCLE_START, NOW)).toBe(true);
   });
 
   it("stops retrying once the cycle has spent MAX_REVIEWER_ATTEMPTS", () => {
@@ -112,9 +177,9 @@ describe("reviewerHandledThisCycle", () => {
         }),
       ),
     );
-    expect(reviewerHandledThisCycle(task, "qa", CYCLE_START)).toBe(true);
+    expect(reviewerHandledThisCycle(task, "qa", CYCLE_START, NOW)).toBe(true);
     // …and says WHY: no verdict is coming, so the card needs a human.
-    expect(reviewerAttemptsExhausted(task, "qa", CYCLE_START)).toBe(true);
+    expect(reviewerAttemptsExhausted(task, "qa", CYCLE_START, NOW)).toBe(true);
   });
 
   it("a completed review alongside a failed attempt is still handled", () => {
@@ -130,7 +195,7 @@ describe("reviewerHandledThisCycle", () => {
         createdAt: "2026-01-01T10:06:00Z",
       }),
     ]);
-    expect(reviewerHandledThisCycle(task, "qa", CYCLE_START)).toBe(true);
+    expect(reviewerHandledThisCycle(task, "qa", CYCLE_START, NOW)).toBe(true);
   });
 
   // A retry must never run alongside a live attempt.
@@ -147,7 +212,7 @@ describe("reviewerHandledThisCycle", () => {
         createdAt: "2026-01-01T10:06:00Z",
       }),
     ]);
-    expect(reviewerHandledThisCycle(task, "qa", CYCLE_START)).toBe(true);
+    expect(reviewerHandledThisCycle(task, "qa", CYCLE_START, NOW)).toBe(true);
   });
 
   it("a failure from a PRIOR cycle is not a spent attempt of this one", () => {
@@ -158,7 +223,7 @@ describe("reviewerHandledThisCycle", () => {
         createdAt: "2026-01-01T09:30:00Z",
       }),
     ]);
-    expect(hasFailedAttemptThisCycle(task, "qa", CYCLE_START)).toBe(false);
+    expect(hasSpentAttemptThisCycle(task, "qa", CYCLE_START, NOW)).toBe(false);
   });
 
   it("scopes to the given reviewer — the other reviewer's thread and the Super Agent's don't count", () => {
@@ -174,10 +239,10 @@ describe("reviewerHandledThisCycle", () => {
         createdAt: "2026-01-01T10:05:00Z",
       }),
     ]);
-    expect(reviewerHandledThisCycle(task, "qa", CYCLE_START)).toBe(false);
-    expect(reviewerHandledThisCycle(task, "code_review", CYCLE_START)).toBe(
-      true,
-    );
+    expect(reviewerHandledThisCycle(task, "qa", CYCLE_START, NOW)).toBe(false);
+    expect(
+      reviewerHandledThisCycle(task, "code_review", CYCLE_START, NOW),
+    ).toBe(true);
   });
 });
 
@@ -187,7 +252,7 @@ describe("reviewerAttemptsExhausted", () => {
 
   it("is false below the attempt budget", () => {
     const task = taskWith([failed("2026-01-01T10:01:00Z")]);
-    expect(reviewerAttemptsExhausted(task, "qa", CYCLE_START)).toBe(false);
+    expect(reviewerAttemptsExhausted(task, "qa", CYCLE_START, NOW)).toBe(false);
   });
 
   // The distinction that matters: `reviewerHandledThisCycle` is also true for a
@@ -201,8 +266,8 @@ describe("reviewerAttemptsExhausted", () => {
         createdAt: "2026-01-01T10:02:00Z",
       }),
     ]);
-    expect(reviewerHandledThisCycle(task, "qa", CYCLE_START)).toBe(true);
-    expect(reviewerAttemptsExhausted(task, "qa", CYCLE_START)).toBe(false);
+    expect(reviewerHandledThisCycle(task, "qa", CYCLE_START, NOW)).toBe(true);
+    expect(reviewerAttemptsExhausted(task, "qa", CYCLE_START, NOW)).toBe(false);
   });
 
   it("is false while an attempt is still live", () => {
@@ -214,7 +279,7 @@ describe("reviewerAttemptsExhausted", () => {
         createdAt: "2026-01-01T10:02:00Z",
       }),
     ]);
-    expect(reviewerAttemptsExhausted(task, "qa", CYCLE_START)).toBe(false);
+    expect(reviewerAttemptsExhausted(task, "qa", CYCLE_START, NOW)).toBe(false);
   });
 
   it("ignores failures from a prior cycle", () => {
@@ -222,7 +287,7 @@ describe("reviewerAttemptsExhausted", () => {
       failed("2026-01-01T09:00:00Z"),
       failed("2026-01-01T09:30:00Z"),
     ]);
-    expect(reviewerAttemptsExhausted(task, "qa", CYCLE_START)).toBe(false);
+    expect(reviewerAttemptsExhausted(task, "qa", CYCLE_START, NOW)).toBe(false);
   });
 
   it("scopes to the given reviewer", () => {
@@ -230,8 +295,8 @@ describe("reviewerAttemptsExhausted", () => {
       failed("2026-01-01T10:01:00Z"),
       failed("2026-01-01T10:02:00Z"),
     ]);
-    expect(reviewerAttemptsExhausted(task, "code_review", CYCLE_START)).toBe(
-      false,
-    );
+    expect(
+      reviewerAttemptsExhausted(task, "code_review", CYCLE_START, NOW),
+    ).toBe(false);
   });
 });

--- a/apps/api/src/tools/task-board/enqueue-reviewer.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.ts
@@ -12,10 +12,35 @@ import { recordTaskActivity } from "./activity";
 import { emitTaskBoardUpdated, handTaskToHuman } from "./run-reactions";
 import { enqueueAgentRunForTask } from "./enqueue-task-run";
 import { resolveTaskRepoChoice } from "./claude-code-task-run";
+import { isThreadRunStale } from "@/tools/thread/helpers";
 
 /** Thread statuses past which a reviewer run is done — a live run has a
  *  non-terminal status. Mirrors the storage-layer set. */
 const TERMINAL_THREAD_STATUSES = new Set(["completed", "failed", "expired"]);
+
+/**
+ * True when a reviewer thread is genuinely still running: non-terminal status
+ * AND a heartbeat inside the stall window.
+ *
+ * Status alone is not liveness. A reviewer whose pod died mid-run stays
+ * `in_progress` forever — the in-memory idle reaper is per-pod, and
+ * `failNeverStartedThreads` only covers runs that never started
+ * (`run_started_at IS NULL`), so a run that started and then went silent is
+ * reaped by nobody. Uses the same heartbeat and window as the rest of the
+ * codebase (`isThreadRunStale`), so "how long is too long" has one definition.
+ */
+function isReviewerThreadLive(
+  thr: TaskBoardItem["threads"][number],
+  now: number,
+): boolean {
+  if (thr.status === null || TERMINAL_THREAD_STATUSES.has(thr.status)) {
+    return false;
+  }
+  return !isThreadRunStale(
+    { updated_at: thr.lastActiveAt, last_progress_at: null },
+    now,
+  );
+}
 
 /**
  * Built-in harness tools each reviewer must NOT have — the enforcement behind
@@ -121,7 +146,7 @@ export async function enqueueEnabledReviewers(
       // there, and the claim key is (task, reviewer, cycle) — so without
       // releasing it first, `claimReviewer` below would lose to the corpse and
       // the retry would be a no-op.
-      if (hasFailedAttemptThisCycle(task, kind, lastInReviewAt)) {
+      if (hasSpentAttemptThisCycle(task, kind, lastInReviewAt)) {
         await ctx.storage.taskBoard
           .releaseReviewerClaim(task.id, kind, cycleAt)
           .catch((err) =>
@@ -176,19 +201,35 @@ export async function enqueueEnabledReviewers(
  */
 export const MAX_REVIEWER_ATTEMPTS = 2;
 
-/** Does this cycle already have a FAILED reviewer thread of `kind`? Decides
- *  whether the dispatch below is a retry (and so has a stale claim row to clear
- *  first). Pure; exported for the unit test. */
-export function hasFailedAttemptThisCycle(
+/** Does this cycle already have a SPENT reviewer attempt of `kind` — one that
+ *  failed, or one stuck non-terminal with a cold heartbeat? Decides whether the
+ *  dispatch below is a retry (and so has a stale claim row to clear first).
+ *  Pure; exported for the unit test. */
+export function hasSpentAttemptThisCycle(
   task: TaskBoardItem,
   kind: ReviewerKind,
   lastInReviewAt: number,
+  now: number = Date.now(),
 ): boolean {
   return task.threads.some(
     (thr) =>
       isReviewerThreadTitle(thr.title, kind) &&
-      thr.status === "failed" &&
+      isSpentAttempt(thr, now) &&
       new Date(thr.createdAt).getTime() >= lastInReviewAt,
+  );
+}
+
+/** A reviewer attempt that produced no verdict and never will: it failed, or it
+ *  is non-terminal with a heartbeat past the stall window. */
+function isSpentAttempt(
+  thr: TaskBoardItem["threads"][number],
+  now: number,
+): boolean {
+  if (thr.status === "failed") return true;
+  return (
+    thr.status !== null &&
+    !TERMINAL_THREAD_STATUSES.has(thr.status) &&
+    !isReviewerThreadLive(thr, now)
   );
 }
 
@@ -199,12 +240,14 @@ function reviewerThreadsThisCycle(
   task: TaskBoardItem,
   kind: ReviewerKind,
   lastInReviewAt: number,
+  now: number = Date.now(),
 ): TaskBoardItem["threads"] {
   return task.threads.filter((thr) => {
     if (!isReviewerThreadTitle(thr.title, kind)) return false;
-    const live =
-      thr.status !== null && !TERMINAL_THREAD_STATUSES.has(thr.status);
-    return live || new Date(thr.createdAt).getTime() >= lastInReviewAt;
+    return (
+      isReviewerThreadLive(thr, now) ||
+      new Date(thr.createdAt).getTime() >= lastInReviewAt
+    );
   });
 }
 
@@ -225,11 +268,15 @@ export function reviewerAttemptsExhausted(
   task: TaskBoardItem,
   kind: ReviewerKind,
   lastInReviewAt: number,
+  now: number = Date.now(),
 ): boolean {
-  const thisCycle = reviewerThreadsThisCycle(task, kind, lastInReviewAt);
+  const thisCycle = reviewerThreadsThisCycle(task, kind, lastInReviewAt, now);
   return (
     thisCycle.length > 0 &&
-    thisCycle.every((thr) => thr.status === "failed") &&
+    // A hung attempt counts as spent, not just a failed one — otherwise a
+    // reviewer whose pod keeps dying is re-dispatched forever, which is the
+    // opposite mistake to the deadlock this replaced.
+    thisCycle.every((thr) => isSpentAttempt(thr, now)) &&
     thisCycle.length >= MAX_REVIEWER_ATTEMPTS
   );
 }
@@ -261,23 +308,23 @@ export function reviewerHandledThisCycle(
   task: TaskBoardItem,
   kind: ReviewerKind,
   lastInReviewAt: number,
+  now: number = Date.now(),
 ): boolean {
-  const thisCycle = reviewerThreadsThisCycle(task, kind, lastInReviewAt);
+  const thisCycle = reviewerThreadsThisCycle(task, kind, lastInReviewAt, now);
   if (thisCycle.length === 0) return false;
-  // A live run owns the cycle; never dispatch alongside it.
-  if (
-    thisCycle.some(
-      (thr) => thr.status !== null && !TERMINAL_THREAD_STATUSES.has(thr.status),
-    )
-  ) {
-    return true;
-  }
-  const failed = thisCycle.filter((thr) => thr.status === "failed");
-  // Every attempt failed and the budget is gone — stop, a human owns it now.
-  if (failed.length >= MAX_REVIEWER_ATTEMPTS) return true;
+  // A live run owns the cycle; never dispatch alongside it. "Live" is the
+  // heartbeat, not the status: a reviewer whose pod died mid-run keeps
+  // `in_progress` forever, and taking that at face value deadlocked the card —
+  // the claim stays spent so nothing re-dispatches, and the merge gate waits on
+  // a verdict that will never come. One sat that way while its co-reviewer had
+  // approved in 68 seconds.
+  if (thisCycle.some((thr) => isReviewerThreadLive(thr, now))) return true;
+  const spent = thisCycle.filter((thr) => isSpentAttempt(thr, now));
+  // Every attempt spent and the budget is gone — stop, a human owns it now.
+  if (spent.length >= MAX_REVIEWER_ATTEMPTS) return true;
   // Anything that finished without failing IS a review (a reviewer records its
   // decision and completes), so the cycle is handled.
-  return failed.length !== thisCycle.length;
+  return spent.length !== thisCycle.length;
 }
 
 /** When the task most recently entered In Review (ms), else 0. Drawn from the


### PR DESCRIPTION
The last of the four failure modes behind the stuck-In-Review cards, and the only one that is a hard deadlock rather than a budget problem.

## The bug

`reviewerHandledThisCycle` treated any non-terminal thread status as "a live run owns the cycle; never dispatch alongside it". But **status is not liveness**. A reviewer whose pod dies mid-run keeps `in_progress` forever:

- the idle reaper is in-memory and per-pod, so it cannot see a run whose pod is gone;
- `failNeverStartedThreads` only covers runs that never started (`run_started_at IS NULL`) — a run that *started* and then went silent is reaped by nobody.

So the card deadlocks: the reviewer's claim for the cycle stays spent → nothing re-dispatches it → the auto-merge gate waits on a verdict that will never arrive. There is no exit; the sweeper visits the card forever and does nothing.

Prod, `board_i0TyqN4wddkH35ixBn-Yc`:

| thread | status | last touched |
|---|---|---|
| Code Reviewer | `completed` (approved) | 20:59:56 — 68s after dispatch |
| QA Agent | **`in_progress`** | 21:01:04, then silence |

The card's `updated_at` froze at 20:58:34 and never moved again.

## The fix

Liveness is the heartbeat, not the status. `isThreadRunStale` — the same predicate and 30-minute window the response normalizer and board stall recovery already use — over the thread's newest `updated_at`/`last_progress_at`, exposed on the board's thread ref as `lastActiveAt`. A non-terminal attempt with a cold heartbeat is **spent**: its claim is released and the reviewer re-dispatched, exactly as a failed one already was.

Reusing `isThreadRunStale` is deliberate — "how long is too long" should have one definition in this codebase, not a new reviewer-specific timeout.

## The opposite mistake, guarded

A hung attempt now also counts toward `MAX_REVIEWER_ATTEMPTS`. Without that, a reviewer whose pod keeps dying would be re-dispatched forever — trading a deadlock for an infinite loop. With it, the second hung attempt exhausts the budget and the card is handed to a person with a reason, same as a twice-failed reviewer.

`hasFailedAttemptThisCycle` → `hasSpentAttemptThisCycle`, since "failed" is no longer the whole set.

## Testing

- Three new cases: a cold-heartbeat `in_progress` thread is not handled (and is a spent attempt); a **warm** one still owns the cycle, so a merely slow reviewer isn't killed; two hung attempts exhaust the budget.
- Verified all three fail against the old status-only liveness check.
- Existing fixtures gained `lastActiveAt` (defaulting to `createdAt`) and an explicit `now`, so "live" and "hung" are distinguishable at all — previously every fixture was implicitly live.
- 923 pass / 0 fail across `apps/api/src/tools/task-board/`, `apps/api/src/storage/`, `packages/shared/src`, `apps/web/src/layouts/task-board/` (real Postgres).
- `fmt` / `lint` (18 warnings, unchanged) / `check` / `knip` clean.

## Note on scope

This unblocks the card at the reviewer gate. It does **not** reap the orphaned thread itself — that row stays `in_progress` in the DB until something else fails it. A DB-side sweep for started-then-silent runs is the real fix for that and is worth doing separately; it is a broader change than this series, and the deadlock is what was hurting.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops reviewer deadlocks by treating liveness as a heartbeat, not status. Previously any non-terminal status owned the cycle forever; now a non-terminal thread with a cold heartbeat counts as spent, releases its claim, and allows re-dispatch.

- Adds `lastActiveAt` to `TaskBoardItemThreadRef` (newest of `updated_at`/`last_progress_at`) and selects these columns; computes via `newestIso`.
- Uses `isThreadRunStale` to decide liveness (`isReviewerThreadLive`); a warm heartbeat still owns the cycle, so slow runs are safe.
- Counts hung attempts toward `MAX_REVIEWER_ATTEMPTS`; renames `hasFailedAttemptThisCycle` to `hasSpentAttemptThisCycle` and updates logic in `reviewerHandledThisCycle` and `reviewerAttemptsExhausted`.
- Releases stale reviewer claims on retry when a spent attempt exists so the new dispatch wins.
- Tests cover cold vs warm heartbeats and budget behavior; fixtures default `lastActiveAt` to `createdAt`.
- Does not mark orphaned DB threads failed; a separate sweep for started-then-silent runs remains out of scope.

<sup>Written for commit abcfad8efea627d4fd43766dee5d01b1454956e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

