### PR TITLE
fix(decopilot): bound the reference-image fetch with a timeout

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts
@@ -4,6 +4,7 @@ import {
   buildScreenshotOptions,
   buildScreenshotRequestBody,
   createPortableTakeScreenshotTool,
+  fetchImageBytes,
   jpegHeight,
   validateExternalUrl,
 } from "./portable-media-tools";
@@ -201,6 +202,26 @@ describe("createPortableTakeScreenshotTool", () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain("timed out");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe("fetchImageBytes", () => {
+  it("times out instead of hanging forever on an unresponsive reference-image host", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      const err = new Error("The operation was aborted");
+      err.name = "TimeoutError";
+      throw err;
+    }) as unknown as typeof fetch;
+
+    try {
+      await expect(
+        // IP literal skips the DNS-rebinding check's real lookup.
+        fetchImageBytes("https://93.184.216.34/reference.png", {}),
+      ).rejects.toThrow(/timed out/);
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.ts
@@ -13,6 +13,11 @@ const FILES_URL_PATTERN = /\/api\/[^/]+\/files\/([^?#]+)/;
 const MAX_REFERENCE_IMAGE_BYTES = 20 * 1024 * 1024;
 const JPEG_QUALITY = 80;
 
+/** Without this, an unresponsive reference-image host hangs the fetch (and the
+ *  whole harness run) forever — `params.abortSignal` only covers user-initiated
+ *  cancellation, not a stalled remote server. */
+const REFERENCE_IMAGE_FETCH_TIMEOUT_MS = 45_000;
+
 /** Headroom over Browserless's own 30s page.goto timeout, so an unresponsive Browserless can't hang the harness run forever. */
 const BROWSERLESS_SCREENSHOT_TIMEOUT_MS = 45_000;
 
@@ -423,7 +428,7 @@ async function readFromObjectStorage(
   return bytes;
 }
 
-async function fetchImageBytes(
+export async function fetchImageBytes(
   url: string,
   params: {
     objectStorage?: PortableMediaObjectStorage | null;
@@ -451,7 +456,21 @@ async function fetchImageBytes(
 
   validateExternalUrl(url, params.allowHttpExternalUrls === true);
   await assertUrlDoesNotResolvePrivate(url);
-  const res = await fetch(url, { signal: params.abortSignal });
+  const timeoutSignal = AbortSignal.timeout(REFERENCE_IMAGE_FETCH_TIMEOUT_MS);
+  const signal = params.abortSignal
+    ? AbortSignal.any([params.abortSignal, timeoutSignal])
+    : timeoutSignal;
+  let res: Response;
+  try {
+    res = await fetch(url, { signal });
+  } catch (err) {
+    if (err instanceof Error && err.name === "TimeoutError") {
+      throw new Error(
+        `Fetching image from ${url} timed out after ${REFERENCE_IMAGE_FETCH_TIMEOUT_MS}ms`,
+      );
+    }
+    throw err;
+  }
   if (!res.ok) {
     throw new Error(`Failed to fetch image from ${url}: ${res.status}`);
   }


### PR DESCRIPTION
Follows the same lane as #5903/#5925/#5940/#5943/#5962/#5982/#5993/#6007/#6012, which bounded every other browserless/external fetch in the decopilot built-in tools with a hard timeout. `generate_image`'s reference-image fetch (`fetchImageBytes` in `portable-media-tools.ts`) was the one path still relying entirely on the caller-supplied `abortSignal` for cancellation, with no fallback timeout.

**Failure scenario:** `createGenerateImageTool` (the inline/desktop adapter in `apps/api/src/harnesses/decopilot/built-in-tools/generate-image.ts`) never passes an `abortSignal` through to `generateImageCore` at all. So when a user attaches a reference image hosted on a slow or unresponsive server, the plain `fetch(url, { signal: undefined })` call in `fetchImageBytes` has nothing to bound it and can hang forever, wedging the harness run. The background-job path (`background-tool-workflow.ts`) does wire its own `abortSignal`, but that only covers user-cancel, not a stalled remote host.

**Fix:** add a 45s hard timeout (matching `BROWSERLESS_FETCH_TIMEOUT_MS` elsewhere in this same directory), combined with any caller-provided `abortSignal` via `AbortSignal.any`, so the fetch is bounded either way and reports a clear "timed out" error instead of hanging.

**To verify:** `bun test apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts` — added a test asserting `fetchImageBytes` rejects with a "timed out" error when the underlying fetch aborts, exercising the exact path that previously had no timeout.

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the `generate_image` reference-image fetch with a 45s timeout so unresponsive hosts no longer hang Decopilot runs. Previously it relied only on a caller `abortSignal`; the inline desktop path passed none, so the fetch could hang indefinitely. Now we always enforce a 45s timeout and combine it with any caller `abortSignal`.

- Uses `AbortSignal.timeout(45_000)` and `AbortSignal.any(...)`; on timeout throws “Fetching image from <url> timed out after 45000ms”.
- Matches the existing `BROWSERLESS_FETCH_TIMEOUT_MS` used for other external/browserless fetches.
- Exports `fetchImageBytes` and adds a unit test to verify the timeout error.

<sup>Written for commit aa0c9eb65c9ba99d5f837bfe996f37c9c59e4820. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

