### PR TITLE
refactor(task-board): dedupe the enabled-reviewer-kinds filter

### DIFF
--- a/apps/api/src/tools/task-board/conflict-reaction.ts
+++ b/apps/api/src/tools/task-board/conflict-reaction.ts
@@ -2,8 +2,7 @@ import type { StudioContext } from "@/core/studio-context";
 import type { TaskBoardItem } from "@/storage/types";
 import {
   allReviewersApproved,
-  REVIEWER_FLAG,
-  REVIEWER_KINDS,
+  enabledReviewerKinds,
   type ReviewCycleActivity,
   SUPER_AGENT_ASSIGNEE_ID,
 } from "@decocms/shared/task-board";
@@ -83,9 +82,7 @@ export async function reactToApprovedPrConflict(
   // token-verified approval in the current cycle. With no reviewer enabled
   // `allReviewersApproved` is false, so a conflict never auto-resolves without
   // an approval standing behind it.
-  const enabled = REVIEWER_KINDS.filter(
-    (k) => flags[REVIEWER_FLAG[k]] === true,
-  );
+  const enabled = enabledReviewerKinds(flags);
   const activity = await ctx.storage.taskBoard.listActivity(item.id, orgId);
   if (!allReviewersApproved(activity, enabled, { verifiedOnly: true })) {
     return false;

--- a/apps/api/src/tools/task-board/enqueue-reviewer.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.ts
@@ -1,9 +1,8 @@
 import type { StudioContext } from "@/core/studio-context";
 import type { TaskBoardItem } from "@/storage/types";
 import {
+  enabledReviewerKinds,
   isReviewerThreadTitle,
-  REVIEWER_FLAG,
-  REVIEWER_KINDS,
   REVIEWER_LABEL,
   reviewCycleStart,
   type ReviewerKind,
@@ -111,10 +110,7 @@ export async function enqueueEnabledReviewers(
   const settings = await ctx.storage.organizationSettings.get(
     task.organizationId,
   );
-  const flags = settings?.flags ?? {};
-  const enabled = REVIEWER_KINDS.filter(
-    (k) => flags[REVIEWER_FLAG[k]] === true,
-  );
+  const enabled = enabledReviewerKinds(settings?.flags);
   if (enabled.length === 0) return;
 
   // A reviewer belongs to the current cycle if its thread is still live, or was

--- a/apps/api/src/tools/task-board/merge-pr.ts
+++ b/apps/api/src/tools/task-board/merge-pr.ts
@@ -4,8 +4,7 @@ import { clientFromConnection } from "@/mcp-clients";
 import {
   allReviewersApproved,
   approvedButUnverified,
-  REVIEWER_FLAG,
-  REVIEWER_KINDS,
+  enabledReviewerKinds,
 } from "@decocms/shared/task-board";
 import { recordTaskActivity } from "./activity";
 import { reactToApprovedPrConflict } from "./conflict-reaction";
@@ -203,10 +202,7 @@ export async function allEnabledReviewersVerifiedApproved(
   taskBoardItemId: string,
 ): Promise<boolean> {
   const settings = await ctx.storage.organizationSettings.get(orgId);
-  const flags = settings?.flags ?? {};
-  const enabled = REVIEWER_KINDS.filter(
-    (k) => flags[REVIEWER_FLAG[k]] === true,
-  );
+  const enabled = enabledReviewerKinds(settings?.flags);
   const activity = await ctx.storage.taskBoard.listActivity(
     taskBoardItemId,
     orgId,
@@ -233,10 +229,7 @@ async function handUnverifiedApprovalToHuman(
   const settings = await ctx.storage.organizationSettings.get(
     item.organizationId,
   );
-  const flags = settings?.flags ?? {};
-  const enabled = REVIEWER_KINDS.filter(
-    (k) => flags[REVIEWER_FLAG[k]] === true,
-  );
+  const enabled = enabledReviewerKinds(settings?.flags);
   const activity = await ctx.storage.taskBoard.listActivity(
     item.id,
     item.organizationId,

--- a/apps/api/src/tools/task-board/promote-to-production.ts
+++ b/apps/api/src/tools/task-board/promote-to-production.ts
@@ -4,8 +4,7 @@ import { requireAuth } from "@/core/studio-context";
 import type { TaskBoardItem } from "@/storage/types";
 import {
   allReviewersApproved,
-  REVIEWER_FLAG,
-  REVIEWER_KINDS,
+  enabledReviewerKinds,
   type ReviewCycleActivity,
   type ReviewerKind,
 } from "@decocms/shared/task-board";
@@ -70,10 +69,7 @@ export const TASK_BOARD_PROMOTE_TO_PRODUCTION = defineTool({
     }
 
     const settings = await ctx.storage.organizationSettings.get(organizationId);
-    const flags = settings?.flags ?? {};
-    const enabled = REVIEWER_KINDS.filter(
-      (k) => flags[REVIEWER_FLAG[k]] === true,
-    );
+    const enabled = enabledReviewerKinds(settings?.flags);
     const activity = await ctx.storage.taskBoard.listActivity(
       taskBoardItemId,
       organizationId,

--- a/packages/shared/src/task-board.test.ts
+++ b/packages/shared/src/task-board.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   allReviewersApproved,
+  enabledReviewerKinds,
   isReviewerThreadTitle,
   MAX_REVIEW_BOUNCES,
   reviewBounceLimitReached,
@@ -9,6 +10,31 @@ import {
   SUPER_AGENT_ASSIGNEE_ID,
   type ReviewCycleActivity,
 } from "./task-board";
+
+describe("enabledReviewerKinds", () => {
+  it("returns nothing for missing/empty flags", () => {
+    expect(enabledReviewerKinds(null)).toEqual([]);
+    expect(enabledReviewerKinds(undefined)).toEqual([]);
+    expect(enabledReviewerKinds({})).toEqual([]);
+  });
+
+  it("returns only the reviewers whose flag is exactly true", () => {
+    expect(
+      enabledReviewerKinds({
+        qa_agent_enabled: true,
+        code_reviewer_enabled: false,
+      }),
+    ).toEqual(["qa"]);
+    expect(
+      enabledReviewerKinds({
+        qa_agent_enabled: true,
+        code_reviewer_enabled: true,
+      }),
+    ).toEqual(["qa", "code_review"]);
+    // Truthy-but-not-`true` must not enable it (org flags are booleans).
+    expect(enabledReviewerKinds({ qa_agent_enabled: "true" })).toEqual([]);
+  });
+});
 
 const at = (
   action: string,

--- a/packages/shared/src/task-board.ts
+++ b/packages/shared/src/task-board.ts
@@ -72,6 +72,15 @@ export const REVIEWER_FLAG: Record<
   code_review: "code_reviewer_enabled",
 };
 
+/** The reviewer kinds this org has enabled, per its settings flags. Single
+ *  home for a filter repeated at every call site that reads the review gate
+ *  (enqueue, auto-merge, conflict resolution, manual ship). */
+export function enabledReviewerKinds(
+  flags: Record<string, unknown> | null | undefined,
+): ReviewerKind[] {
+  return REVIEWER_KINDS.filter((k) => flags?.[REVIEWER_FLAG[k]] === true);
+}
+
 /** True when a thread title belongs to the given reviewer's run. */
 export function isReviewerThreadTitle(
   title: string | null | undefined,


### PR DESCRIPTION
**Source**: C1 code-reduction hunt in the task-board revamp area (no issue) — a duplicated helper across the review-gate logic.

**Why**: `REVIEWER_KINDS.filter((k) => flags[REVIEWER_FLAG[k]] === true)` was copy-pasted at 5 call sites across 4 files: `enqueue-reviewer.ts`, `merge-pr.ts` (x2), `conflict-reaction.ts`, `promote-to-production.ts`. Every one of these is a review-gate check (enqueue reviewers, auto-merge, conflict auto-resolve, manual ship) reading the same org-settings flags the same way — a fifth near-identical copy is exactly the kind of drift that makes one of these sites diverge unnoticed later.

**Change**: collapsed the filter into one pure `enabledReviewerKinds(flags)` helper in `packages/shared/src/task-board.ts`, next to the other reviewer-gate reducers (`allReviewersApproved`, `reviewCycleVerdicts`, etc.) it composes with. Net: -27/+44 lines including a new unit test, but -5 duplicated inline filters down to 1 shared one-liner call each. Behavior is byte-identical: same `REVIEWER_KINDS`/`REVIEWER_FLAG` tables, same `=== true` check, same `flags` fallback (`flags?.[...]` vs the old `(settings?.flags ?? {})[...]`) — confirmed by a new `enabledReviewerKinds` unit test covering empty/null flags and the truthy-but-not-`true` edge case, plus the existing `task-board.test.ts` suite passing unchanged.

**Reviewer command**: `bun test packages/shared/src/task-board.test.ts` and `cd apps/api && bunx tsc --noEmit`.

**Verified locally**: `bun run fmt`, `bun test packages/shared/src/task-board.test.ts` (18 pass), `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint` on all 6 changed files (0 warnings/errors). Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates the enabled-reviewer-kinds gate into a shared helper to prevent copy-paste drift; behavior remains unchanged.

**Review notes**
- Adds `enabledReviewerKinds(flags)` in `packages/shared/src/task-board.ts` and replaces inline filters in `enqueue-reviewer.ts`, `merge-pr.ts` (2 sites), `conflict-reaction.ts`, and `promote-to-production.ts`.
- Preserves logic: same `REVIEWER_KINDS`/`REVIEWER_FLAG` mapping, `=== true` check, and optional `flags` handling.
- Adds unit tests in `packages/shared/src/task-board.test.ts` for empty/null flags and truthy-not-true cases.
- To verify: run `bun test packages/shared/src/task-board.test.ts` and `cd apps/api && bunx tsc --noEmit`.

<sup>Written for commit 30957aa0dc37860aac2b977464291654a19fd999. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

