### PR TITLE
fix(task-board): don't lose the PR-branch pin to a GitHub read blip

### DIFF
--- a/apps/api/src/tools/task-board/enqueue-super-agent.test.ts
+++ b/apps/api/src/tools/task-board/enqueue-super-agent.test.ts
@@ -5,7 +5,10 @@
  * that wrong sends the agent to re-do the task or open a second PR.
  */
 import { describe, expect, it } from "bun:test";
-import { buildSuperAgentTaskPrompt } from "./enqueue-super-agent";
+import {
+  buildSuperAgentTaskPrompt,
+  prStateIsPinnable,
+} from "./enqueue-super-agent";
 
 const task = { id: "board_1", title: "Fix the thing", description: null };
 const pr = { number: 7, url: "https://github.com/x/y/pull/7" };
@@ -82,5 +85,26 @@ describe("buildSuperAgentTaskPrompt", () => {
     // guard so a bad call can't emit a conflict instruction with no branch.
     const p = buildSuperAgentTaskPrompt(task, { resolveConflict: true });
     expect(p).not.toContain(CONFLICT_LEAD);
+  });
+});
+
+/**
+ * The bug: `openPrForTask` used to require `state === "open"`, so a throttled
+ * or unreachable GitHub read (`readPrStateThrottled`'s `null`) silently fell
+ * through to "no PR found" — the exact default, forking behavior this whole
+ * path exists to prevent, just triggered by a read blip instead of a missing
+ * PR.
+ */
+describe("prStateIsPinnable", () => {
+  it("is true for open", () => {
+    expect(prStateIsPinnable("open")).toBe(true);
+  });
+
+  it("is true for unknown (a GitHub read blip must not un-pin the branch)", () => {
+    expect(prStateIsPinnable(null)).toBe(true);
+  });
+
+  it("is false for a definitively closed PR", () => {
+    expect(prStateIsPinnable("closed")).toBe(false);
   });
 });

--- a/apps/api/src/tools/task-board/enqueue-super-agent.ts
+++ b/apps/api/src/tools/task-board/enqueue-super-agent.ts
@@ -174,7 +174,20 @@ async function resolveRerunBranch(
 }
 
 /**
- * The task's own OPEN pull request, for a dispatch nobody named one for.
+ * Whether a PR's live state is trustworthy enough to pin the branch to: it
+ * isn't DEFINITIVELY closed. `null` (GitHub unreachable, the throttled queue
+ * timed out) counts as usable for the same reason it does in
+ * `pickActivePrIndex` — a read blip must not silently fall through to "no PR
+ * found", which is exactly the default, forking behavior this whole path
+ * exists to avoid. Pure; exported for the unit test.
+ */
+export function prStateIsPinnable(state: "open" | "closed" | null): boolean {
+  return state !== "closed";
+}
+
+/**
+ * The task's own open (or unreadable) pull request, for a dispatch nobody
+ * named one for.
  *
  * Only a reviewer bounce passes `opts.pr`. A person re-delegating the card
  * (`TASK_BOARD_ITEM_UPDATE`, `TASK_BOARD_ITEM_RERUN`) passes nothing, so the
@@ -182,9 +195,9 @@ async function resolveRerunBranch(
  * grew a third pull request that way in one afternoon, each one the reviewer
  * then rejected as obsolete against `main`.
  *
- * Open only, deliberately: `pickActivePr` falls back to the newest link when
- * every PR reads closed, and resuming work on a merged or abandoned branch is
- * worse than starting a fresh one. Reads go through the same throttled queue.
+ * Never falls back to a definitively-closed PR, unlike `pickActivePr`:
+ * resuming work on a merged or abandoned branch is worse than starting a
+ * fresh one. Reads go through the same throttled queue.
  */
 async function openPrForTask(
   ctx: StudioContext,
@@ -195,7 +208,7 @@ async function openPrForTask(
     .catch(() => []);
   for (const pr of prs) {
     const { state } = await readPrStateThrottled(task.organizationId, pr);
-    if (state === "open") return { number: pr.number, url: pr.url };
+    if (prStateIsPinnable(state)) return { number: pr.number, url: pr.url };
   }
   return undefined;
 }


### PR DESCRIPTION
Follows #6015 ("pin the PR branch when a person re-delegates, too"), which added `openPrForTask` to find a task's own open PR so a re-delegated Super Agent run boots on that PR's branch instead of forking a duplicate one.

**The gap:** `openPrForTask` required `state === "open"`. `readPrStateThrottled` returns `{ state: null }` on any GitHub-unreachable or throttled-queue-timeout read (see `dbos-github-read.ts`'s `UNKNOWN` sentinel) — not just for closed PRs. A transient read blip during re-delegation therefore fell straight through the loop to `undefined`, silently disabling the branch pin and reproducing the exact duplicate-PR bug #6015 exists to prevent, just triggered by a flaky read instead of a missing PR.

The existing sibling selector `pickActivePrIndex` in `prs-get.ts` already treats `null` as usable for the same reason ("a blip must not silently redirect..."); `openPrForTask` diverged from that convention without the tests to catch it — the function has no existing coverage.

**Fix:** extracted the one-line predicate as `prStateIsPinnable(state)` (`state !== "closed"`, matching `pickActivePrIndex`'s bar), and use it in `openPrForTask` instead of the strict `=== "open"` check. Added `enqueue-super-agent.test.ts` coverage for the predicate's three states (open/null/closed) — the pure logic is unit-testable even though `openPrForTask` itself (which calls `ctx.storage` + a DBOS-backed read) is not, per this repo's unit-vs-integration split.

Reviewer check: `cd apps/api && bun test src/tools/task-board/enqueue-super-agent.test.ts`.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), the targeted test above (10 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate PRs by preserving the PR-branch pin during Super Agent re-delegation when GitHub reads return null. Previously `openPrForTask` required `state === "open"`, so a throttled/unreachable read (`null`) dropped the pin and forked a new PR; now we pin any PR that is not definitively closed.

- Extracts `prStateIsPinnable(state)` (`state !== "closed"`) and uses it in `openPrForTask`, matching `pickActivePrIndex` semantics.
- Adds unit tests for the predicate (open/null/closed) in `enqueue-super-agent.test.ts`.
- Review tip: run `cd apps/api && bun test src/tools/task-board/enqueue-super-agent.test.ts`.

<sup>Written for commit f869abec0a267fd80dd9b90787559ce1f5726d8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

