### PR TITLE
fix(decopilot): bound Gemini Interactions API calls with a timeout

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/gemini-interactions.test.ts
+++ b/apps/api/src/harnesses/lib/decopilot/gemini-interactions.test.ts
@@ -1,0 +1,43 @@
+/**
+ * A stalled Gemini Interactions connection must never hang the harness run
+ * forever — `opts.abortSignal` only covers user/run cancellation, not a dead
+ * connection to Google, so each call needs its own timeout.
+ */
+import { describe, expect, it } from "bun:test";
+import { pollInteraction, submitInteraction } from "./gemini-interactions";
+
+function stubTimeoutFetch() {
+  return (async () => {
+    const err = new Error("The operation was aborted");
+    err.name = "TimeoutError";
+    throw err;
+  }) as unknown as typeof fetch;
+}
+
+describe("submitInteraction", () => {
+  it("times out instead of hanging forever on an unresponsive endpoint", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = stubTimeoutFetch();
+    try {
+      await expect(
+        submitInteraction({ apiKey: "key", agent: "agent", query: "q" }),
+      ).rejects.toThrow(/timed out/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe("pollInteraction", () => {
+  it("times out instead of hanging forever on an unresponsive endpoint", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = stubTimeoutFetch();
+    try {
+      await expect(
+        pollInteraction({ apiKey: "key", interactionId: "id-1" }),
+      ).rejects.toThrow(/timed out/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/apps/api/src/harnesses/lib/decopilot/gemini-interactions.ts
+++ b/apps/api/src/harnesses/lib/decopilot/gemini-interactions.ts
@@ -33,6 +33,18 @@ function interactionsBaseUrl(): string {
 
 const DEFAULT_POLL_INTERVAL_MS = 5_000;
 
+/** Each Interactions API call is a metadata request (submit the job, or check
+ *  its status) — not the async job itself, which legitimately runs for
+ *  minutes. `opts.abortSignal` only covers user/run cancellation, not a
+ *  stalled connection to Google, so an unresponsive endpoint would hang the
+ *  harness run forever without this. */
+const INTERACTIONS_FETCH_TIMEOUT_MS = 30_000;
+
+function withFetchTimeout(signal?: AbortSignal): AbortSignal {
+  const timeoutSignal = AbortSignal.timeout(INTERACTIONS_FETCH_TIMEOUT_MS);
+  return signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+}
+
 export function isInteractionsOnlyModel(modelId: string): boolean {
   // All Gemini Deep Research variants share the `deep-research-` prefix
   // (deep-research-preview-*, deep-research-max-preview-*,
@@ -78,23 +90,33 @@ interface OutputBlock {
 export async function submitInteraction(
   opts: SubmitInteractionOptions,
 ): Promise<{ interactionId: string }> {
-  const res = await fetch(interactionsBaseUrl(), {
-    method: "POST",
-    headers: {
-      "x-goog-api-key": opts.apiKey,
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      agent: opts.agent,
-      input: opts.query,
-      background: true,
-      agent_config: {
-        type: "deep-research",
-        thinking_summaries: "auto",
+  let res: Response;
+  try {
+    res = await fetch(interactionsBaseUrl(), {
+      method: "POST",
+      headers: {
+        "x-goog-api-key": opts.apiKey,
+        "Content-Type": "application/json",
       },
-    }),
-    signal: opts.abortSignal,
-  });
+      body: JSON.stringify({
+        agent: opts.agent,
+        input: opts.query,
+        background: true,
+        agent_config: {
+          type: "deep-research",
+          thinking_summaries: "auto",
+        },
+      }),
+      signal: withFetchTimeout(opts.abortSignal),
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "TimeoutError") {
+      throw new Error(
+        `Gemini Interactions submit timed out after ${INTERACTIONS_FETCH_TIMEOUT_MS}ms`,
+      );
+    }
+    throw err;
+  }
 
   if (!res.ok) {
     const detail = await res.text().catch(() => "");
@@ -122,10 +144,20 @@ export async function pollInteraction(
       throw makeAbortError(opts.abortSignal);
     }
 
-    const res = await fetch(url, {
-      headers: { "x-goog-api-key": opts.apiKey },
-      signal: opts.abortSignal,
-    });
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        headers: { "x-goog-api-key": opts.apiKey },
+        signal: withFetchTimeout(opts.abortSignal),
+      });
+    } catch (err) {
+      if (err instanceof Error && err.name === "TimeoutError") {
+        throw new Error(
+          `Gemini Interactions poll timed out after ${INTERACTIONS_FETCH_TIMEOUT_MS}ms`,
+        );
+      }
+      throw err;
+    }
 
     if (!res.ok) {
       const detail = await res.text().catch(() => "");


### PR DESCRIPTION
Source: a reduction/reliability fix found while auditing the codebase for the same class of bug fixed in the just-merged #6017 (bounding an unbounded fetch with a timeout).

Google's async Interactions API (used by the `deep-research-*` model family) is polled every 5s for the run's lifetime. Both `submitInteraction`'s and `pollInteraction`'s `fetch()` calls only carried `opts.abortSignal` — the run's user/cancellation signal, not a per-request deadline. A stalled or unresponsive connection to Google on any single submit or poll call would hang the fetch (and the whole harness run) forever, with no error and no progress ever surfacing. This exact bug shape was just fixed in #6017 for the portable reference-image fetch, and previously for the Browserless calls in `scrape-url.ts`/`inspect-page.ts` — this module was the one place still missing it.

Fix: each Interactions API call now races the caller's abort signal against a 30s `AbortSignal.timeout` (via `AbortSignal.any`), and a timeout surfaces as a clear `"... timed out after 30000ms"` Error instead of hanging — which is also the same regular-`Error` shape `pollInteraction`'s docs already say transient failures should take (the job may still be running server-side, so the caller keeps the handle for a future reconnect; only Google's own `failed`/`cancelled` status throws the terminal error).

Failure scenario without the fix: Google's Interactions endpoint accepts the TCP connection but never responds (a real, observed failure mode for third-party APIs) → the fetch inside `pollInteraction`'s loop never resolves or rejects → the harness run for that deep-research task hangs indefinitely with no way to detect or recover from it.

Regression test: `apps/api/src/harnesses/lib/decopilot/gemini-interactions.test.ts` stubs `fetch` to throw a `TimeoutError` and asserts both `submitInteraction` and `pollInteraction` reject with a "timed out" message rather than the raw abort error.

To verify: `bun test apps/api/src/harnesses/lib/decopilot/gemini-interactions.test.ts`

Checked locally: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound all Gemini Interactions API fetches with a 30s timeout so runs no longer hang on unresponsive endpoints. Previously, submit and poll only honored the run abort signal and could wait forever; now each call times out and throws a clear “... timed out after 30000ms” error.

- Applies to both `submitInteraction` and `pollInteraction` via `AbortSignal.any` with `AbortSignal.timeout(30_000)`; user/run cancellation still works.
- Changes error shape on network stalls to a regular Error with “timed out” in the message; terminal errors still come from Google’s `failed`/`cancelled` statuses.
- Poll cadence and long-running server-side jobs are unchanged; only per-request fetches get a deadline.
- Regression test added at `apps/api/src/harnesses/lib/decopilot/gemini-interactions.test.ts`; run with: `bun test apps/api/src/harnesses/lib/decopilot/gemini-interactions.test.ts`.

<sup>Written for commit 7e489877b9a3d8c7bb3f1c9826fa215059d25683. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

