### PR TITLE
fix(web): stop leaking the live thread connection onto window

### DIFF
--- a/apps/web/src/components/chat/store/thread-connection.ts
+++ b/apps/web/src/components/chat/store/thread-connection.ts
@@ -1637,9 +1637,6 @@ export function getOrOpenStream(
   }
   current?.dispose();
   current = new ThreadConnection(orgSlug, threadId, opts);
-  // DEBUG (temporary): expose the live store for inspecting in-memory order.
-  if (typeof window !== "undefined")
-    (window as unknown as { __conn?: ThreadConnection }).__conn = current;
   return current;
 }
 


### PR DESCRIPTION
**Source:** bug found while auditing the sandbox-runtime-guard area (`hosted-runtime-guard.ts`'s consumers, incl. `thread-connection.ts`/`thread-manager-store.ts`). The guard logic itself is already well-tested; this is a real defect found in the adjacent connection-registry module it feeds.

**Why a maintainer wants this:** `getOrOpenStream` (the module `hosted-runtime-guard`'s `isBatchHarness` result feeds into) unconditionally assigned the just-opened `ThreadConnection` — which holds the in-memory message transcript — onto `window.__conn`, in every environment including production. It was marked `// DEBUG (temporary)` but shipped ungated behind any dev check.

**Failure scenario:** any user's browser tab exposes the full live chat transcript object via `window.__conn` to anything with devtools/console access (browser extensions, XSS payloads, etc.) — an unnecessary data-exposure surface with zero product benefit, since nothing in the codebase ever reads it.

**Fix:** delete the three-line debug assignment. Confirmed via `rg -n "__conn\b"` across `apps/web`, `apps/native`, and `packages` that the write site was the only reference — no readers exist, so this is a behavior-preserving deletion.

**Reviewer check:** `bun test apps/web/src/components/chat/store/thread-connection.test.ts apps/web/src/components/chat/store/thread-connection-replay.test.ts`

**Locally verified:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, the two targeted test files above (84 pass), and `bunx oxlint` on the changed file (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the debug leak that exposed the live ThreadConnection (including its in-memory transcript) on window.__conn. Previously, getOrOpenStream always assigned the new connection to window.__conn in all environments; now it does not. No feature impact because nothing reads window.__conn.

**Review notes**
- Only change is deleting the assignment inside getOrOpenStream; verified no other references to "__conn".
- Sanity check: run the two targeted test files for thread-connection and replay. No migration required.

<sup>Written for commit 3dd73585f875b2860ff1aa066511fd465b672eb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

