### PR TITLE
fix(commerce): translate the generic Commerce Discovery error sentinel

### DIFF
--- a/apps/web/src/routes/commerce-onboarding/self-tool-result.test.ts
+++ b/apps/web/src/routes/commerce-onboarding/self-tool-result.test.ts
@@ -32,9 +32,9 @@ describe("parseSelfToolResult", () => {
     ).toThrow("mensagem real");
   });
 
-  it("throws the default message when isError is set with no usable content", () => {
+  it("throws the sentinel message when isError is set with no usable content", () => {
     expect(() => parseSelfToolResult({ isError: true })).toThrow(
-      "A configuração do Commerce Discovery falhou.",
+      "__configurationFailed",
     );
   });
 

--- a/apps/web/src/routes/commerce-onboarding/self-tool-result.ts
+++ b/apps/web/src/routes/commerce-onboarding/self-tool-result.ts
@@ -5,9 +5,9 @@ interface SelfToolResult {
 }
 
 function getToolErrorMessage(result: SelfToolResult): string {
+  // Sentinel, translated by the caller's translateSiteError.
   return (
-    result.content?.find((item) => item.text)?.text ??
-    "A configuração do Commerce Discovery falhou."
+    result.content?.find((item) => item.text)?.text ?? "__configurationFailed"
   );
 }
 


### PR DESCRIPTION
**Source:** a bug found while auditing the commerce-onboarding route/i18n wiring for this tick's focus area.

**Why:** `parseSelfToolResult` (shared by `/commerce-onboarding` and the commerce-connect modal) threw a hardcoded Portuguese string — `"A configuração do Commerce Discovery falhou."` — as its fallback error message whenever a failed tool call had no usable `content` text. `commerce-onboarding.tsx`'s `setupMutation.onError` stores `error.message` directly as `inlineError` and renders it through `translateSiteError`, whose `default` case passes unknown strings through as-is. So an English-locale user hitting this fallback path would see raw Portuguese text instead of a translated message — the flow doesn't recover gracefully into the current locale.

**Fix:** the module has no access to the current locale, so it now returns the `__configurationFailed` sentinel — the exact same sentinel this file already defines and translates via `translateSiteError` (`t("routes.commerceOnboarding.configurationFailed")`) for its other non-Error fallback path. No new i18n key needed; behavior for real server error messages (the common case) is unchanged since those still pass through `content[].text` untouched.

**Failure scenario:** an English-locale user's Commerce Discovery setup tool call fails with `isError: true` and no `content` text (e.g. a bare tool error) → they see a raw Portuguese sentence in the inline error instead of an English message.

**Regression test:** updated `self-tool-result.test.ts`'s "throws the default message when isError is set with no usable content" case to assert the `__configurationFailed` sentinel instead of the old hardcoded string.

**Reviewer check:** `bun test apps/web/src/routes/commerce-onboarding/self-tool-result.test.ts`

**Local verification:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, targeted test above, `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Commerce Discovery onboarding fallback errors by returning the `__configurationFailed` sentinel instead of a hardcoded Portuguese string, so inline errors localize to the user’s current locale. Previously, users could see Portuguese when a tool error had no content; now the sentinel translates via `translateSiteError`.

- In `parseSelfToolResult`, when `isError` is true and no content text exists, return `__configurationFailed`; existing server error messages still pass through unchanged and are displayed as-is.
- Updated test: `apps/web/src/routes/commerce-onboarding/self-tool-result.test.ts` asserts the sentinel. Run `bun test apps/web/src/routes/commerce-onboarding/self-tool-result.test.ts` to verify.

<sup>Written for commit 079b8a5a1d9463bbe2e1d77b068825fc3e669197. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

