### PR TITLE
feat(observability): upload web sourcemaps to PostHog error tracking

### DIFF
--- a/.github/workflows/release-studio.yaml
+++ b/.github/workflows/release-studio.yaml
@@ -117,6 +117,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      # Hoisted to the job because `secrets` is not readable from a step `if:`.
+      HAS_POSTHOG_SOURCEMAPS: ${{ secrets.POSTHOG_CLI_API_KEY != '' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -126,8 +129,38 @@ jobs:
           node-version: "24"
       - name: Setup Bun and install dependencies
         uses: ./.github/actions/setup-bun
+      # Sourcemaps are emitted ONLY when the PostHog secret exists, uploaded so
+      # error tracking can un-minify stack traces, then deleted before packing.
+      # Without them production frames name no file anyone can open.
       - name: Build combined Studio distribution
         run: bun run build:studio
+        env:
+          BUILD_SOURCEMAPS: ${{ env.HAS_POSTHOG_SOURCEMAPS == 'true' && '1' || '0' }}
+
+      # Telemetry must never break a release, so this cannot fail the job
+      # (`--no-fail` plus `continue-on-error`). The cleanup below runs
+      # regardless, so a partial upload still cannot leak sources.
+      - name: Upload sourcemaps to PostHog
+        if: env.HAS_POSTHOG_SOURCEMAPS == 'true'
+        continue-on-error: true
+        env:
+          POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
+          POSTHOG_CLI_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
+        run: |
+          npx --yes --package=@posthog/cli@0.11.0 posthog-cli --no-fail \
+            sourcemap process \
+            --directory apps/api/dist/client \
+            --release-name studio-web \
+            --release-version "${{ github.sha }}"
+
+      # Unconditional: a `.map` reaching this point would be published in the
+      # npm tarball AND the Docker image, since build-studio copies dist wholesale.
+      - name: Strip sourcemaps before packing
+        if: always()
+        run: |
+          find apps/web/dist apps/api/dist -name '*.map' -delete 2>/dev/null || true
+          remaining=$(find apps/web/dist apps/api/dist -name '*.map' 2>/dev/null | wc -l | tr -d ' ')
+          test "$remaining" = "0" || { echo "::error::$remaining sourcemap(s) survived cleanup"; exit 1; }
       - name: Verify combined distribution layout
         run: |
           test -f apps/web/dist/index.html

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -172,6 +172,20 @@ const sharedProxy = {
     : {}),
 };
 
+/**
+ * Emit sourcemaps so PostHog error tracking can un-minify stack traces —
+ * without them a real captured frame reads `Wr.optimisticHide` at
+ * `hooks-12yWjb31.js:15:9394`, naming no file anyone can open.
+ *
+ * Off unless `BUILD_SOURCEMAPS=1`, which ONLY the release workflow sets. The
+ * maps are uploaded and then deleted there, before anything is packed:
+ * `build-studio.ts` recursively copies `apps/web/dist` into the shipped
+ * package, so a `.map` left behind would publish Studio's sources.
+ * The upload lives in CI rather than in a build plugin because a failed
+ * upload must never fail a release, and must still clean up after itself.
+ */
+const emitSourcemaps = process.env.BUILD_SOURCEMAPS === "1" && !isNativeBuild;
+
 export default defineConfig({
   define: {
     // What `v{__STUDIO_VERSION__}` renders (account popover, settings
@@ -192,6 +206,7 @@ export default defineConfig({
   },
   build: {
     outDir: isNativeBuild ? "dist/native" : "dist",
+    sourcemap: emitSourcemaps,
     ...(isNativeBuild
       ? {
           rollupOptions: {


### PR DESCRIPTION
## Why

Production stack traces are minified. A real frame captured this week:

```
resolve_failure: "Could not find sourcemap for source url: .../hooks-12yWjb31.js"
mangled_name: "Wr.optimisticHide"   line: 15, column: 9394
```

No file, no line. That makes production errors expensive to action — for a human, and impossible for an agent asked to fix one. This also tags each build with a release + commit SHA, so an error can be traced to the deploy that introduced it.

## What

The release build emits sourcemaps, uploads them, then deletes them before packing.

- **vite** emits maps only under `BUILD_SOURCEMAPS=1`, set only by the release workflow. Local dev, `bun run build`, and native/Tauri builds are unchanged.
- **The upload is a CI step, not a build plugin.** I tried `@posthog/rollup-plugin` first and rejected it: with a bad key it failed the entire build *and* left 238 `.map` files behind, because its cleanup never ran. Telemetry must never break a release, and must never leak on failure.
- **Cleanup is a separate `if: always()` step** that hard-fails if any map survives. `build-studio.ts` does a recursive `cp` of `apps/web/dist` into `apps/api/dist/client`, which is packed into both the npm tarball and the Docker image — a stray `.map` would publish Studio's sources.
- **No dependency added.** The CLI is fetched on demand, pinned. Adding `@posthog/cli` to the root pruned 243 lines of platform binaries (including linux ones CI needs) from `bun.lock`; verified that churn came from the dependency, not from any local drift. `package.json` and `bun.lock` are untouched.

**Inert until `POSTHOG_CLI_API_KEY` is set** — without it `BUILD_SOURCEMAPS=0`, the upload step is skipped, and the build is byte-identical to today.

## Setup required before this does anything

1. Create a PostHog **personal API key** with `error tracking: write` + `organization: read` scopes
2. Add repo secrets: `POSTHOG_CLI_API_KEY` and `POSTHOG_PROJECT_ID` (`394178`)

Note this is a *personal* API key, distinct from the public `POSTHOG_KEY` the browser already ships.

## Test plan

- [x] `bun run --cwd=apps/web build` → exit 0, **0** `.map` files (unchanged default)
- [x] `BUILD_SOURCEMAPS=1 ... build` → exit 0, **238** `.map` files emitted
- [x] Strip step simulated against a real staged `apps/api/dist/client` → 0 remaining, `index.html` intact
- [x] `npx --yes --package=@posthog/cli@0.11.0 posthog-cli --version` → resolves and runs
- [x] `bun run --cwd=apps/web check` passes
- [x] `bun run lint` → 18 warnings, **identical to the `main` baseline** (verified by stashing)
- [x] `bun run fmt` clean
- [x] Workflow YAML parses; step order confirmed build → upload → strip → verify → pack
- [ ] Post-merge: confirm a release run uploads and that a new error resolves to a real file path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Uploads web sourcemaps to PostHog error tracking on release builds and strips them before packing, so production stack traces resolve to real files and lines instead of mangled frames. Local and native builds are unchanged; uploads run in CI and never fail a release.

**Rollout**
- `vite` sets `build.sourcemap` only when `BUILD_SOURCEMAPS=1`; CI enables it when `POSTHOG_CLI_API_KEY` exists.
- CI uploads via `npx --package=@posthog/cli@0.11.0 posthog-cli --no-fail`, then unconditionally deletes all `.map` files and hard-fails if any remain.
- No new dependency is added; the CLI is fetched on demand.
- Required: add repo secrets `POSTHOG_CLI_API_KEY` and `POSTHOG_PROJECT_ID`.

<sup>Written for commit e17e434d146e69a468c2426b9d87b422ffc19362. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

