### PR TITLE
fix(preview): send variant matcher override to Fast Preview iframe and open-in-tab link

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -608,13 +608,14 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
           workspace.state.variantOverride ?? [],
         )
       : display.mode === "production" && productionOriginReady
-        ? // The published site is the base for both modes while the sandbox
-          // provisions; Fast Preview swaps in the same page carrying a
-          // `?__draft=` pointer the moment one exists. Same origin either way,
-          // so the swap changes content, not surface.
-          withDeviceHint(
-            draftPreviewUrl ?? new URL(resolvedPath, display.iframeBase!).href,
-            previewDeviceSize,
+        ? // Fast Preview's draft route honours the variant matcher override like the sandbox dev server, so append it here too.
+          withVariantMatcherOverride(
+            withDeviceHint(
+              draftPreviewUrl ??
+                new URL(resolvedPath, display.iframeBase!).href,
+              previewDeviceSize,
+            ),
+            workspace.state.variantOverride ?? [],
           )
         : null;
 
@@ -656,12 +657,19 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
    * Preview this is the draft URL itself, which is shareable precisely because
    * the pointer is a query param on the site's own route.
    */
+  const productionOpenTabBase =
+    draftPreviewUrl ??
+    (display.iframeBase
+      ? new URL(resolvedPath, display.iframeBase).href
+      : null);
   const openInNewTabUrl =
     display.mode === "production"
-      ? (draftPreviewUrl ??
-        (display.iframeBase
-          ? new URL(resolvedPath, display.iframeBase).href
-          : null))
+      ? productionOpenTabBase
+        ? withVariantMatcherOverride(
+            productionOpenTabBase,
+            workspace.state.variantOverride ?? [],
+          )
+        : null
       : (iframeSrc ?? display.iframeBase);
 
   const handleOpenPreview = async () => {


### PR DESCRIPTION
## Summary

When **Fast Preview** is active, the preview renders in `production` display mode (the site's real route carrying a `?__draft=` pointer). Both the iframe `src` and the "open in new tab" link were built in that mode **without** `withVariantMatcherOverride`, so the variant matcher params (`x-deco-matchers-override`) were dropped — the frame silently rendered the **default** variant instead of the one selected in Blocks.

Only the `sandbox` display-mode branch applied the override, so the bug only shows with Fast Preview on.

## Changes

`apps/web/src/components/sandbox/preview/preview.tsx`:
- **iframe (`iframeSrc`)** — the `production` branch now wraps the URL with `withVariantMatcherOverride(..., workspace.state.variantOverride ?? [])`, mirroring the sandbox branch.
- **open in new tab (`openInNewTabUrl`)** — the `production` branch now applies the same override over the draft/site URL. `deviceHint` is still intentionally omitted from the shareable link (unchanged behavior).

Both are no-ops when no variant is selected (`?? []`), so normal flows are unaffected.

## Testing notes

- `bun run fmt` ✓
- `bun run --cwd=apps/web check` (tsc) ✓
- Related unit tests (variant-matcher-override, preview-display, blocks-preview-workspace-state): 27 pass ✓

No new unit test added: the `iframeSrc`/`openInNewTabUrl` composition is inline in the component with no pure seam (`withDeviceHint` reads `window.location.href`; the bun runner has no DOM). The core transform `withVariantMatcherOverride` is already unit-covered, and the fix replicates the already-tested sandbox branch. End-to-end coverage of "variant forced under Fast Preview" would be an e2e test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fast Preview now honors the selected variant by appending the variant matcher override to the production-mode iframe and the “open in new tab” link. Previously, Fast Preview dropped the override and rendered the default variant; now both URLs include the override, with no change when no variant is selected, and the shareable link still omits the device hint.

- `apps/web/src/components/sandbox/preview/preview.tsx`: in the production path, wrap both `iframeSrc` and `openInNewTabUrl` with `withVariantMatcherOverride(...)`.
- Affects only Fast Preview (production display mode); sandbox behavior is unchanged.

<sup>Written for commit 78ed28c71298183f7dec353605e0f3e299389ec3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

