### PR TITLE
fix(task-board): TASK_ADD_REPO looked up the wrong sandbox on a pinned re-run

### DIFF
--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -685,7 +685,8 @@ async function provisionSandbox(
   // Decopilot agent, so also persist the record on the thread — the only place
   // the frontend reads previewUrl/handle from for these sandboxes. Applies to
   // EVERY provisioning path (load_repo, SANDBOX_START auto-start, fs tools).
-  const threadId = threadIdFromBranch(branch);
+  // ctx fallback: a `pinnedRef` run is keyed by a real git ref, not `thread:<id>`.
+  const threadId = threadIdFromBranch(branch) ?? ctx.metadata?.threadId;
   if (threadId) {
     await setThreadSandboxMapEntry(
       ctx,

--- a/apps/api/src/tools/task-board/add-repo.ts
+++ b/apps/api/src/tools/task-board/add-repo.ts
@@ -15,9 +15,9 @@
  * repo (`pickSoleTaskRepo`) because the checkout was resolved at dispatch;
  * everything else fell back to Decopilot.
  *
- * The sandbox key stays the BARE `thread:<id>` for the whole run — see
- * `resolveSandboxBranch`. Deriving it from the repo (as `load_repo` does) would
- * move the claim handle out from under the live pod.
+ * The sandbox key is whatever the run was DISPATCHED on (`threads.branch`) — see
+ * `resolveSandboxBranch`. Deriving it (from the repo like `load_repo`, or as the
+ * bare key this tool used to assume) misses the pod the agent loop is in.
  */
 
 import { z } from "zod";
@@ -29,6 +29,7 @@ import {
   type StudioContext,
 } from "@/core/studio-context";
 import { selectLoadableRepos } from "@/harnesses/decopilot/built-in-tools/load-repo";
+import { pickGitBranch } from "@/sandbox/head-ref";
 import { resolveSandboxProvider } from "@/sandbox/resolve-provider";
 import {
   buildCloneInfo,
@@ -199,9 +200,8 @@ export const TASK_ADD_REPO = defineTool({
     const thread = await ctx.storage.threads.get(threadId);
     if (!thread) throw new Error(`Thread not found: ${threadId}`);
 
-    // The pod is keyed by the BARE thread branch — the key this run was
-    // dispatched on, and the one `resolveSandboxBranch` keeps returning for it.
-    const branch = threadBranch(threadId);
+    // The key this run was dispatched on — bare thread branch, or a pinned ref.
+    const branch = thread.branch ?? threadBranch(threadId);
     const sandboxUserId = await resolveSandboxUserId(ctx, branch, userId);
     const { provider, kind } = await resolveSandboxProvider(ctx, {
       userId: sandboxUserId,
@@ -267,7 +267,12 @@ export const TASK_ADD_REPO = defineTool({
     // provision, so no install and no dev server follow. The explicit
     // `setup/clone` behind it makes the outcome independent of that
     // classification — the step no-ops when the checkout is already there.
-    const gitRef = syntheticBranchToGitRef(branch);
+    const gitRef = pickGitBranch({
+      branch,
+      derivedRef: syntheticBranchToGitRef(branch),
+      recordedHeadRef: null,
+      sticky: false,
+    });
     const configRes = await provider.proxyDaemonRequest(
       record.sandboxHandle,
       "/_sandbox/config",


### PR DESCRIPTION
## Summary

A task re-run whose PR already exists is dispatched on that PR's head ref (`enqueue-task-run`'s `pinnedRef`), so its sandbox is keyed by a **real git ref** instead of the synthetic `thread:<id>`. Two places assumed the synthetic key:

- `provisionSandbox` (`tools/sandbox/start.ts`) recovered the thread id from the branch alone (`threadIdFromBranch`, null for a real ref), so a pinned run's pod was recorded on the agent row only — never on the thread. `ensureSandbox` one screen above already had the `ctx.metadata.threadId` fallback; provisioning didn't.
- `TASK_ADD_REPO` looked the pod up under `threadBranch(threadId)` — the bare key.

So `TASK_ADD_REPO` answered `No sandbox is registered for this run (thread …)` and the run did nothing but comment "blocked by infrastructure".

## Evidence (prod)

Task `board_kxUGBu9-gW9B6p-3ulVsQ` (montecarlo, "Revisar preview"): **8 consecutive Super Agent runs** failed this way over two days. Every failing thread has `branch = 'fix/exit-intent-pdp-counter-expired'` and an empty `metadata.sandboxMap`; every reviewer/QA thread — keyed `thread:<id>` — cloned fine and has a `sandboxMap` entry. The task burned quota re-dispatching a run that could never touch the repo.

## Fix

`threads.branch` already holds the key each run was dispatched on, so read it instead of deriving. The daemon config push routes it through the existing `pickGitBranch`, which returns a real ref unchanged (deriving would have asked the daemon for `sandbox/thread-fix-exit-intent-...`, forking off the wrong ref).

## Testing

`bun run --cwd=apps/api check`, `bun test apps/api/src/tools/task-board apps/api/src/sandbox` green. The two branch rules this leans on are already unit-tested (`head-ref.test.ts`: a non-synthetic branch is never rewritten). The behavior itself — a pinned run resolving its live pod — needs a real pod, so it is not unit-testable; it is verifiable in prod by re-running the task above.

## Related

The same run also pushed daemon-managed files into the PR — separate fix in #(daemon excludes PR).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sandbox lookup for pinned task re-runs by using the dispatch branch key instead of assuming a synthetic thread key. Previously, pinned runs (dispatched on a PR head ref) failed with “No sandbox is registered for this run”; now they resolve the live pod and proceed. Reviewer/QA runs keyed to thread remain unchanged.

- In sandbox provisioning, fall back to ctx.metadata.threadId when the branch is a real ref so the sandbox map is recorded on the thread.
- In TASK_ADD_REPO, read the dispatch key from thread.branch (fallback to threadBranch(threadId)) and send the daemon config ref through pickGitBranch so real refs remain unchanged.

<sup>Written for commit b392965387963fcb2a9cc997c3ac2f2d656f6d2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

