### PR TITLE
fix(sandbox): re-register git excludes after a clone, never commit the endpoint file

### DIFF
--- a/packages/sandbox/daemon-go/internal/gitx/exclude.go
+++ b/packages/sandbox/daemon-go/internal/gitx/exclude.go
@@ -4,12 +4,20 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+)
+
+var (
+	requestedMu sync.Mutex
+	requested   = map[string][]string{}
 )
 
 // EnsureExclude registers `line` in `<repoDir>/.git/info/exclude` — local-only,
 // unlike .gitignore — so the shutdown `git add -A` never commits daemon-managed
-// paths. Best-effort; no-op without a `.git` dir.
+// paths. Best-effort; no-op without a `.git` dir, but the request is remembered
+// for {@link ReapplyExcludes}.
 func EnsureExclude(repoDir, line string) {
+	remember(repoDir, line)
 	gitDir := filepath.Join(repoDir, ".git")
 	st, err := os.Lstat(gitDir)
 	if err != nil || !st.IsDir() {
@@ -36,4 +44,29 @@ func EnsureExclude(repoDir, line string) {
 	}
 	defer f.Close()
 	f.WriteString(line + "\n")
+}
+
+// ReapplyExcludes re-registers every line EnsureExclude was asked for on this
+// repoDir. Call it whenever a `.git` appears: a repo-less pod writes its
+// daemon-managed paths (the org-fs links, the tools catalog) BEFORE any clone,
+// where EnsureExclude has nowhere to write — and `git init` in that non-empty
+// dir then hands the shutdown `git add -A` a clean slate that commits them.
+func ReapplyExcludes(repoDir string) {
+	requestedMu.Lock()
+	lines := append([]string(nil), requested[repoDir]...)
+	requestedMu.Unlock()
+	for _, line := range lines {
+		EnsureExclude(repoDir, line)
+	}
+}
+
+func remember(repoDir, line string) {
+	requestedMu.Lock()
+	defer requestedMu.Unlock()
+	for _, l := range requested[repoDir] {
+		if l == line {
+			return
+		}
+	}
+	requested[repoDir] = append(requested[repoDir], line)
 }

--- a/packages/sandbox/daemon-go/internal/gitx/exclude_test.go
+++ b/packages/sandbox/daemon-go/internal/gitx/exclude_test.go
@@ -1,0 +1,72 @@
+package gitx
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func gitIn(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return string(out)
+}
+
+// The repo-less pod's order: daemon-managed paths are written (and excluded)
+// BEFORE any checkout, then `TASK_ADD_REPO` git-inits the non-empty dir. Without
+// the reapply, that fresh `.git` has no excludes and the shutdown `git add -A`
+// commits the catalog — which is how a run's MCP bearer token reached a PR.
+func TestReapplyExcludesSurvivesAGitInitAfterTheWrite(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".deco", "tools"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".deco", "tools", ".endpoint.json"), []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	EnsureExclude(dir, "/.deco/tools/")
+
+	gitIn(t, dir, "init", "-q")
+	if status := gitIn(t, dir, "status", "--porcelain"); !strings.Contains(status, ".deco") {
+		t.Fatalf("expected the pre-init exclude to be lost, got %q", status)
+	}
+
+	ReapplyExcludes(dir)
+
+	if status := gitIn(t, dir, "status", "--porcelain"); strings.Contains(status, ".deco") {
+		t.Fatalf("catalog still visible to `git add -A`: %q", status)
+	}
+}
+
+// Belt for the above: whatever the exclude state, publish must not commit the
+// endpoint file — it holds the run's bearer token, and a push is irreversible.
+func TestPublishNeverCommitsTheEndpointCredential(t *testing.T) {
+	repo := initRepoOnBranch(t, "feature/x")
+	if err := os.MkdirAll(filepath.Join(repo, ".deco", "tools"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, ".deco", "tools", ".endpoint.json"), []byte(`{"headers":{"Authorization":"Bearer synthetic-not-a-real-token"}}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "app.ts"), []byte("export const x = 1;\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fails at the push (no remote); the commit it builds first is the artifact.
+	_ = Publish(PublishDeps{RepoDir: repo}, "sync")
+
+	committed := gitIn(t, repo, "show", "--pretty=format:", "--name-only", "HEAD")
+	if strings.Contains(committed, ".endpoint.json") {
+		t.Fatalf("publish committed the credential file: %q", committed)
+	}
+	if !strings.Contains(committed, "app.ts") {
+		t.Fatalf("publish dropped the user's work too: %q", committed)
+	}
+}

--- a/packages/sandbox/daemon-go/internal/gitx/publish.go
+++ b/packages/sandbox/daemon-go/internal/gitx/publish.go
@@ -101,6 +101,32 @@ func changedPaths(status WorkingTreeStatus) []string {
 	return out
 }
 
+// NeverCommit are paths publish drops from the commit unconditionally, whatever
+// `.git/info/exclude` says: they are daemon-managed, and `.deco/tools/` holds the
+// run's MCP bearer token, which a push would leak into the repo's history.
+var NeverCommit = []string{".deco/tools/"}
+
+// dropNeverCommit filters {@link NeverCommit} paths out of a publish's file list.
+func dropNeverCommit(paths []string) []string {
+	out := make([]string, 0, len(paths))
+	for _, p := range paths {
+		rel := strings.TrimPrefix(filepath.ToSlash(p), "./")
+		skip := false
+		for _, deny := range NeverCommit {
+			if rel == strings.TrimSuffix(deny, "/") || strings.HasPrefix(rel, deny) {
+				skip = true
+				break
+			}
+		}
+		if skip {
+			slog.Warn("skipping from sync", "reason", "daemon-managed path", "path", rel)
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
 // filterInvalidDecofileBlocks is publish's last-resort net: /write and /edit
 // already reject invalid blocks, but a mutation that bypassed them (bash, a git
 // merge) would otherwise be committed verbatim and break the whole site render.
@@ -224,7 +250,7 @@ func Publish(deps PublishDeps, message string) error {
 	}
 	paths, err := filterInvalidDecofileBlocks(
 		repoDir,
-		expandUntrackedDirs(repoDir, changedPaths(status)),
+		dropNeverCommit(expandUntrackedDirs(repoDir, changedPaths(status))),
 		deps.OnInvalidBlock,
 	)
 	if err != nil {

--- a/packages/sandbox/daemon-go/internal/setup/clone.go
+++ b/packages/sandbox/daemon-go/internal/setup/clone.go
@@ -394,6 +394,8 @@ func SpawnClone(deps CloneDeps) CloneResult {
 	// fetch so both acquisition paths and both branch cases get submodules.
 	finalize := func(res CloneResult) CloneResult {
 		if res.Code == 0 {
+			// This `.git` is new; the excludes asked for before it existed are not.
+			gitx.ReapplyExcludes(dir)
 			// runStep, NOT runNetworkStep: `--recursive` emits aggregate output, so
 			// one permanently dead submodule host matches `isTransient` ("Could not
 			// resolve host") and buys 4 full recursive passes plus 9s of sleeps —


### PR DESCRIPTION
## Summary

`.git/info/exclude` is how the daemon keeps its own artifacts out of the shutdown `git add -A`. But `EnsureExclude` **silently no-ops when there is no `.git` yet** — and in a repo-less pod that is exactly the state at dispatch, when the daemon writes:

- `org` → the org-fs mount symlink
- `.claude/skills/orgfs-*` → public-skill symlinks
- `.deco/tools/` → the tools catalog **and `.endpoint.json`, which holds the run's MCP bearer token**

`TASK_ADD_REPO` then clones into that non-empty dir, which takes the `git init` + `fetch` path (`isNonEmptyWithoutGit`). The fresh `.git` has no excludes, and the shutdown publish commits everything.

## Evidence

deco-sites/montecarlo#1213, commit `48ace18` "chore(daemon): sync all local changes to remote on shutdown": 33 dangling `.claude/skills/orgfs-*` symlinks, 10 `.deco/tools/*.json`, and `.deco/tools/.endpoint.json` containing a live `Authorization: Bearer …` for the run's task-run MCP endpoint plus the org id. The reviewer agent on the same task flagged it as a merge blocker. **That token is being rotated separately; treat it as public (a force-push does not undo a leak).**

## Fix

Two layers, both small:

1. **Root cause** — `EnsureExclude` remembers every line it was asked for; `ReapplyExcludes(dir)` replays them once a `.git` exists, called from the clone's single success funnel (`finalize`). Keeps the exclude strings owned by their writers, so no new place to drift, and fixes any future writer that runs before the checkout.
2. **Belt** — `Publish` drops `.deco/tools/` from the commit unconditionally, whatever the exclude state. Strip at the write, fail closed: a pushed credential is not recoverable.

`org` and the skill symlinks are covered by (1) only — they are broken content, not a credential, and unconditionally dropping user-visible paths is the riskier default.

## Testing

`internal/gitx/exclude_test.go`, both against real git:
- exclude requested before `git init` → visible to `git add -A` after init (the bug), invisible after `ReapplyExcludes`.
- `Publish` with an `.endpoint.json` present and no excludes at all → commit contains `app.ts`, not the credential file. Asserts on the commit's bytes, not the path list.

`go build ./... && go test ./internal/gitx ./internal/setup ./internal/toolscatalog ./internal/orgfs` green. The synthetic token in the fixture is not a real credential.

## Related

The same task run failed 8 times before this because `TASK_ADD_REPO` looked up the wrong sandbox key — #6027.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-registers git excludes after clone and prevents committing `.deco/tools/`. Previously, excludes requested before `.git` existed were lost after `git init` in a non-empty dir, so daemon-managed paths (including `.deco/tools/.endpoint.json` with a bearer token) were committed; now excludes are replayed and `.deco/tools/` is filtered at publish.

- `gitx.EnsureExclude` now remembers requested lines; `gitx.ReapplyExcludes(repoDir)` re-applies them once a `.git` exists and is called from `setup.SpawnClone`’s success path.
- `gitx.Publish` drops `.deco/tools/` unconditionally via `dropNeverCommit`, ensuring credentials are never committed while preserving user changes.
- Adds `gitx/exclude_test.go` to verify reapply behavior and that `.endpoint.json` never lands in a commit.
- No migration or config changes required.

<sup>Written for commit 2254014382a51f6fe3c3af7ca5103dd7e659d7ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

