### PR TITLE
feat(task-board): let manual Ship bypass pending CI checks

### DIFF
--- a/apps/api/src/tools/task-board/merge-pr.test.ts
+++ b/apps/api/src/tools/task-board/merge-pr.test.ts
@@ -9,7 +9,7 @@
 import { describe, expect, it } from "bun:test";
 import type { ReviewCycleActivity } from "@decocms/shared/task-board";
 import { approvedButUnverified } from "@decocms/shared/task-board";
-import { mayBeConflict } from "./merge-pr";
+import { checksBlockMerge, mayBeConflict } from "./merge-pr";
 
 const BOTH = ["qa", "code_review"] as const;
 const at = "2026-08-12T00:00:00.000Z";
@@ -60,6 +60,31 @@ describe("mayBeConflict", () => {
     ] as const) {
       expect(mayBeConflict({ merged: false, reason })).toBe(false);
     }
+  });
+});
+
+describe("checksBlockMerge", () => {
+  it("blocks red CI for every caller, override or not", () => {
+    expect(checksBlockMerge("failing")).toBe(true);
+    expect(checksBlockMerge("failing", { allowPendingChecks: true })).toBe(
+      true,
+    );
+  });
+
+  it("blocks pending CI by default (the automatic paths must wait)", () => {
+    expect(checksBlockMerge("pending")).toBe(true);
+  });
+
+  it("lets a human ship over pending CI with allowPendingChecks", () => {
+    expect(checksBlockMerge("pending", { allowPendingChecks: true })).toBe(
+      false,
+    );
+  });
+
+  it("never blocks on passing or unknown checks", () => {
+    expect(checksBlockMerge("passing")).toBe(false);
+    expect(checksBlockMerge(null)).toBe(false);
+    expect(checksBlockMerge(null, { allowPendingChecks: true })).toBe(false);
   });
 });
 

--- a/apps/api/src/tools/task-board/merge-pr.ts
+++ b/apps/api/src/tools/task-board/merge-pr.ts
@@ -9,6 +9,7 @@ import {
 import { recordTaskActivity } from "./activity";
 import { reactToApprovedPrConflict } from "./conflict-reaction";
 import {
+  type ChecksStatus,
   fetchPrChecksStatus,
   fetchPrConflict,
   invalidatePrReads,
@@ -42,6 +43,24 @@ export type MergeOutcome =
 
 /** Reasons worth a timeline entry — see {@link MergeFailureReason}. */
 const SILENT_REASONS = new Set<MergeFailureReason>(["checks_pending"]);
+
+/**
+ * Whether a PR's CI state should stop the merge. Pure — unit-tested.
+ *
+ * Red CI (`failing`) blocks every caller, always. In-flight CI (`pending`)
+ * blocks the automatic paths (auto-merge, a stale client), but a human clicking
+ * "Ship to production" passes `allowPendingChecks` to override it — they decided
+ * the pending run isn't worth waiting for. An unknown state (`null`) never
+ * blocks: we can't prove it's bad, and GitHub branch protection is the real gate.
+ */
+export function checksBlockMerge(
+  checks: ChecksStatus,
+  opts: { allowPendingChecks?: boolean } = {},
+): boolean {
+  if (checks === "failing") return true;
+  if (checks === "pending") return !opts.allowPendingChecks;
+  return false;
+}
 
 /**
  * Append a `merge_failed` entry, unless the task's newest entry is already a
@@ -96,6 +115,7 @@ export async function mergeLinkedPr(
   ctx: StudioContext,
   orgId: string,
   taskBoardItemId: string,
+  opts: { allowPendingChecks?: boolean } = {},
 ): Promise<MergeOutcome> {
   const fail = async (
     reason: MergeFailureReason,
@@ -113,11 +133,8 @@ export async function mergeLinkedPr(
     );
     return fail("no_pr");
   }
-  // Never ship on red or in-flight CI — the ship button hides in this case, but
-  // guard the server path too (auto-merge, a stale client). Only a definite
-  // failing/pending blocks; an unknown (null) does not.
   const checks = await fetchPrChecksStatus(ctx, orgId, pr);
-  if (checks === "failing" || checks === "pending") {
+  if (checksBlockMerge(checks, opts)) {
     console.warn(
       `[task-board] merge blocked — checks ${checks} on PR #${pr.number}`,
     );

--- a/apps/api/src/tools/task-board/promote-to-production.ts
+++ b/apps/api/src/tools/task-board/promote-to-production.ts
@@ -82,7 +82,10 @@ export const TASK_BOARD_PROMOTE_TO_PRODUCTION = defineTool({
 
     // A refused merge is already on the card's timeline (`mergeLinkedPr` writes
     // the reason), so the button no longer looks like it did nothing.
-    const outcome = await mergeLinkedPr(ctx, organizationId, taskBoardItemId);
+    const outcome = await mergeLinkedPr(ctx, organizationId, taskBoardItemId, {
+      // The human clicked Ship, so in-flight CI doesn't block — only red does.
+      allowPendingChecks: true,
+    });
     if (!outcome.merged) {
       const refreshed =
         (await ctx.storage.taskBoard.getById(

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -1109,9 +1109,8 @@ function PrCard({
   const style = prStateStyle(pr, t);
   const checksHeader = prChecksStyle(pr.checksStatus, t);
   const isOpen = pr.state === "open" && !pr.merged;
-  // Never ship on red/in-flight CI — only passing or no checks.
-  const checksOk =
-    pr.checksStatus !== "failing" && pr.checksStatus !== "pending";
+  // Hide Ship only on red CI; a human may ship over in-flight (pending) checks.
+  const checksOk = pr.checksStatus !== "failing";
   const showShip = reviewsReady && isOpen && checksOk;
   const hasActions = !!previewThread || !!pr.previewUrl || showShip;
   // Null-safe: react-query cache from before `checks` shipped can lack it.


### PR DESCRIPTION
## Summary

The manual **"Ship to production"** button (`TASK_BOARD_PROMOTE_TO_PRODUCTION`) used to refuse to merge whenever the PR's CI was still in flight (`pending`) — the card would stay In Review with `{ status: "in_review", merged: false }` and, because `checks_pending` is a *silent* reason, **no timeline entry** explaining why. A human clicking Ship should be able to ship over a pending run.

This makes the **manual** path bypass pending checks. **Red CI (`failing`) still blocks every caller**, and the **automatic** paths (auto-merge sweep + inline `review-decision` merge) keep waiting for CI exactly as before — only a human clicking the button overrides.

## Changes

- **`merge-pr.ts`**: `mergeLinkedPr` gains an opt-in `{ allowPendingChecks }` (default `false`). Extracted the CI gate into a pure, unit-tested `checksBlockMerge(checks, opts)` helper: `failing` → always blocks; `pending` → blocks unless `allowPendingChecks`; `passing`/`null` → never blocks.
- **`promote-to-production.ts`**: manual path calls `mergeLinkedPr(..., { allowPendingChecks: true })`.
- **`task-dialog.tsx`** (web): the Ship button now shows on pending CI (hidden only on `failing`), so the manual action is actually reachable.
- **`merge-pr.test.ts`**: 4 new tests covering red / pending / override / unknown.

## Notes / caveats

- **GitHub branch protection still governs.** If the repo requires status checks, GitHub itself refuses the merge with pending checks — that comes back as `refused` (with a timeline entry), not `checks_pending`. This bypass only relaxes Studio's own gate.
- **No extra confirmation dialog** was added — the click merges directly. Easy to add a confirm if we want one now that shipping over in-flight CI is possible.

## Testing

- `bun run fmt`, `bun run check` (api + web), `bun run lint` — clean (no new warnings on touched files).
- Affected unit tests: `merge-pr.test.ts` + `promote-to-production.test.ts` — 15/15 pass.
- The merge round-trip itself is e2e (needs GitHub); the gate decision is now covered by the pure `checksBlockMerge` unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Manual Ship to production can now merge over pending CI. Previously it refused with a silent checks_pending reason, leaving the card In Review without a timeline entry. Failing CI still blocks, and automatic paths continue to wait for CI.

- `mergeLinkedPr` adds `{ allowPendingChecks }` (default false); the manual promote path passes `true`.
- Extracts the CI gate to `checksBlockMerge(checks, opts)`: failing always blocks; pending blocks unless `allowPendingChecks`; passing/unknown never blocks.
- Web shows the Ship button on pending CI; hides only on failing.
- Refused merges now write a timeline entry; GitHub branch protection may still prevent merges and return `refused`.
- Adds unit tests for `checksBlockMerge` and the manual promote flow.

<sup>Written for commit cf6322a337911eabf3e5be32ae60b08303074d64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

