### PR TITLE
fix(commerce-onboarding): translate companion connect error messages

### DIFF
--- a/apps/web/src/i18n/en/commerce-onboarding.ts
+++ b/apps/web/src/i18n/en/commerce-onboarding.ts
@@ -22,6 +22,10 @@ export const commerceOnboarding = {
   "commerceOnboarding.companionCard.required": "Required",
   "commerceOnboarding.connectSourceDialog.connecting": "Connecting {title}...",
   "commerceOnboarding.connectSourceDialog.loading": "Loading...",
+  "commerceOnboarding.connectSourceDialog.noConnectionMethod":
+    "{title} cannot be connected: no connection method available",
+  "commerceOnboarding.connectSourceDialog.signInFailed":
+    "Couldn't sign in to {title}: {error}",
   "commerceOnboarding.connectSourceDialog.title": "Connect data source",
   "commerceOnboarding.githubConfigForm.cancel": "Cancel",
   "commerceOnboarding.githubConfigForm.failedToSave":

--- a/apps/web/src/i18n/pt-br/commerce-onboarding.ts
+++ b/apps/web/src/i18n/pt-br/commerce-onboarding.ts
@@ -24,6 +24,10 @@ export const commerceOnboarding = {
   "commerceOnboarding.companionCard.required": "Obrigatório",
   "commerceOnboarding.connectSourceDialog.connecting": "Conectando {title}...",
   "commerceOnboarding.connectSourceDialog.loading": "Carregando...",
+  "commerceOnboarding.connectSourceDialog.noConnectionMethod":
+    "{title} não pode ser conectado: nenhum método de conexão disponível",
+  "commerceOnboarding.connectSourceDialog.signInFailed":
+    "Não foi possível entrar em {title}: {error}",
   "commerceOnboarding.connectSourceDialog.title": "Conectar fonte de dados",
   "commerceOnboarding.githubConfigForm.cancel": "Cancelar",
   "commerceOnboarding.githubConfigForm.failedToSave":

--- a/apps/web/src/routes/commerce-onboarding/use-connect-companion.ts
+++ b/apps/web/src/routes/commerce-onboarding/use-connect-companion.ts
@@ -1,4 +1,5 @@
 import { authenticateAndPersistOAuth } from "@/lib/authenticate-and-persist-oauth";
+import { translate } from "@/i18n/use-t";
 import { track } from "@/lib/posthog-client";
 import { reportAttributionFromSearch } from "@/routes/reports/track";
 import { KEYS } from "@/lib/query-keys";
@@ -96,7 +97,12 @@ export function useConnectCompanion({
             error: "no_connection_method",
           });
           setError(
-            `${card.title} cannot be connected: no connection method available`,
+            translate(
+              "commerceOnboarding.connectSourceDialog.noConnectionMethod",
+              {
+                title: card.title,
+              },
+            ),
           );
           return false;
         }
@@ -125,7 +131,12 @@ export function useConnectCompanion({
           ...basePayload,
           error: auth.error,
         });
-        setError(`Couldn't sign in to ${card.title}: ${auth.error}`);
+        setError(
+          translate("commerceOnboarding.connectSourceDialog.signInFailed", {
+            title: card.title,
+            error: auth.error ?? "",
+          }),
+        );
         return false; // keep connection, no CD write
       }
 


### PR DESCRIPTION
This follows the same i18n fix as #6022 ("translate the generic Commerce Discovery error sentinel"), applied to the companion-connect flow.

`useConnectCompanion`'s `connect()` built two user-facing error strings with raw template literals ("{title} cannot be connected: no connection method available" and "Couldn't sign in to {title}: {error}"), bypassing the i18n system entirely. These are rendered directly via `role="alert"` in `OauthConnectDialog` (connect-source-dialog.tsx), so pt-br users saw hardcoded English instead of a translated message.

Added `commerceOnboarding.connectSourceDialog.noConnectionMethod` and `.signInFailed` keys to both `en` and `pt-br` dictionaries, and switched the hook to use `translate()` (the non-reactive i18n helper already used elsewhere for non-component modules, e.g. `desktop/agent-terminal/terminal-controller.ts`).

Reviewer check: `cd apps/web && bunx tsc --noEmit` (clean) and `bunx oxlint apps/web/src/routes/commerce-onboarding/use-connect-companion.ts apps/web/src/i18n/en/commerce-onboarding.ts apps/web/src/i18n/pt-br/commerce-onboarding.ts` (0 warnings/errors).

Verified locally: `bun run fmt`, `bunx tsc --noEmit` (apps/web workspace), `bunx oxlint` on the three touched files. No behavior change beyond the displayed string; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes companion connect error messages in the connect-source dialog so pt-br users see translated text. Previously these two errors were hardcoded in English; now they use i18n keys with interpolation for title and error.

- Adds `commerceOnboarding.connectSourceDialog.noConnectionMethod` and `commerceOnboarding.connectSourceDialog.signInFailed` to the `en` and `pt-br` dictionaries.
- Replaces template literals in `useConnectCompanion.connect()` with `translate(...)` to render localized errors.
- No functional change beyond displayed text; OAuth flow and analytics remain unchanged.

<sup>Written for commit 9202ceab81de41a88939388276511c708539c2f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

