### PR TITLE
refactor(decopilot): use @decocms/shared/std sleep in gemini-interactions poll loop

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/gemini-interactions.ts
+++ b/apps/api/src/harnesses/lib/decopilot/gemini-interactions.ts
@@ -14,6 +14,7 @@
  * `Error` for transient HTTP/network problems (the job may still be running,
  * keep the handle for a future reconnect).
  */
+import { sleep } from "@decocms/shared/std";
 import { AsyncResearchTerminalError } from "./async-research-terminal-error";
 
 /**
@@ -216,7 +217,7 @@ export async function pollInteraction(
       // "in_progress" / unknown → keep polling
     }
 
-    await sleep(interval, opts.abortSignal);
+    await sleep(interval, { signal: opts.abortSignal });
   }
 }
 
@@ -395,21 +396,6 @@ function parseUsage(payload: Record<string, unknown>): {
     numberField(usage, "output_tokens") ??
     Math.max(0, (numberField(usage, "total_tokens") ?? 0) - inputTokens);
   return { inputTokens, outputTokens };
-}
-
-function sleep(ms: number, signal?: AbortSignal): Promise<void> {
-  return new Promise((resolve, reject) => {
-    if (signal?.aborted) return reject(makeAbortError(signal));
-    const t = setTimeout(() => {
-      signal?.removeEventListener("abort", onAbort);
-      resolve();
-    }, ms);
-    const onAbort = () => {
-      clearTimeout(t);
-      reject(makeAbortError(signal));
-    };
-    signal?.addEventListener("abort", onAbort, { once: true });
-  });
 }
 
 function makeAbortError(signal?: AbortSignal): Error {


### PR DESCRIPTION
Follows #6020 (Gemini Interactions timeout hardening) — that PR just added `AbortSignal.timeout` handling to this same file, and its poll loop still hand-rolled a `sleep(ms, signal)` with `setTimeout`/`addEventListener("abort")` instead of using the repo's canonical `@decocms/shared/std` `sleep`, which the CLAUDE.md async-primitives section explicitly says never to reinvent.

This is a straight net reduction (-16/+2): the local `sleep` helper is deleted and the one call site swaps to the shared one (`sleep(interval, { signal })`). Behavior is preserved — on abort, the shared `delay()` rejects with `signal.reason` (a DOMException named `AbortError` for a plain `.abort()` call, same as the deleted helper's hand-built `Error` named `AbortError`); no caller inspects the error's concrete class, only `AsyncResearchTerminalError` is special-cased for terminal Google states. The other `makeAbortError` call site (immediate abort check before the first poll) is untouched.

Reviewer check: `cd apps/api && bunx tsc --noEmit` and `bun test apps/api/src/harnesses/lib/decopilot/gemini-interactions.test.ts` (both pass locally, covering `submitInteraction`/`pollInteraction` timeout behavior added in #6020).

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api), targeted test file above, `bunx oxlint` on the changed file (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the Gemini interactions poll loop to use the shared `sleep` from `@decocms/shared/std` instead of a local helper to remove duplication and align with our async primitives. Behavior is unchanged: poll cadence is the same and aborts still reject with `AbortError` via `signal.reason`; no callers depend on the concrete error class.

- Review notes
  - The only functional change is replacing the local helper with `sleep(interval, { signal })`; the pre-poll immediate abort check is unchanged.
  - Validate with: `cd apps/api && bunx tsc --noEmit` and `bun test apps/api/src/harnesses/lib/decopilot/gemini-interactions.test.ts`.

<sup>Written for commit cb0843a8bd289ce4eb774d8c9ab31fdc311544e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

