### PR TITLE
fix(decopilot): bound the generate_image provider call with a timeout

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts
@@ -5,6 +5,7 @@ import {
   buildScreenshotRequestBody,
   createPortableTakeScreenshotTool,
   fetchImageBytes,
+  generateImageCore,
   jpegHeight,
   validateExternalUrl,
 } from "./portable-media-tools";
@@ -224,6 +225,48 @@ describe("fetchImageBytes", () => {
       ).rejects.toThrow(/timed out/);
     } finally {
       globalThis.fetch = originalFetch;
+    }
+  });
+});
+
+describe("generateImageCore", () => {
+  it("times out instead of hanging forever on an unresponsive image provider", async () => {
+    const originalTimeout = AbortSignal.timeout;
+    // Stub out the real 120s wait with an already-aborted signal.
+    AbortSignal.timeout = (() => {
+      const controller = new AbortController();
+      controller.abort(new DOMException("timed out", "TimeoutError"));
+      return controller.signal;
+    }) as typeof AbortSignal.timeout;
+
+    const doGenerate = (opts: { abortSignal?: AbortSignal }) =>
+      new Promise((_resolve, reject) => {
+        opts.abortSignal?.addEventListener("abort", () =>
+          reject(new DOMException("aborted", "AbortError")),
+        );
+      });
+
+    try {
+      await expect(
+        generateImageCore(
+          { prompt: "a cat wearing a hat" },
+          {
+            provider: {
+              aiSdk: {
+                imageModel: () =>
+                  ({ doGenerate }) as unknown as ReturnType<
+                    Parameters<
+                      typeof generateImageCore
+                    >[1]["provider"]["aiSdk"]["imageModel"]
+                  >,
+              },
+            },
+            imageModelInfo: { id: "test-model" },
+          },
+        ),
+      ).rejects.toThrow(/timed out/);
+    } finally {
+      AbortSignal.timeout = originalTimeout;
     }
   });
 });

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.ts
@@ -21,6 +21,12 @@ const REFERENCE_IMAGE_FETCH_TIMEOUT_MS = 45_000;
 /** Headroom over Browserless's own 30s page.goto timeout, so an unresponsive Browserless can't hang the harness run forever. */
 const BROWSERLESS_SCREENSHOT_TIMEOUT_MS = 45_000;
 
+/** Same reasoning as REFERENCE_IMAGE_FETCH_TIMEOUT_MS above: `params.abortSignal`
+ *  only fires on user/run cancellation, so an unresponsive image-model provider
+ *  would otherwise hang the harness run forever. Longer than the other timeouts
+ *  in this file because image generation is genuinely slower than a plain fetch. */
+const GENERATE_IMAGE_TIMEOUT_MS = 120_000;
+
 /**
  * Emulation presets for `take_screenshot`. `mobile` carries a phone viewport
  * AND `isMobile`/`hasTouch` — but the load-bearing part for QA is that the tool
@@ -525,13 +531,27 @@ export async function generateImageCore(
   const prompt = hasRefs
     ? { text: input.prompt, images: refImageBytes }
     : input.prompt;
-  const result = await generateImage({
-    model: imageModel,
-    prompt,
-    n: input.n ?? 1,
-    ...(input.aspectRatio ? { aspectRatio: input.aspectRatio } : {}),
-    ...(params.abortSignal ? { abortSignal: params.abortSignal } : {}),
-  });
+  const timeoutSignal = AbortSignal.timeout(GENERATE_IMAGE_TIMEOUT_MS);
+  const signal = params.abortSignal
+    ? AbortSignal.any([params.abortSignal, timeoutSignal])
+    : timeoutSignal;
+  let result: Awaited<ReturnType<typeof generateImage>>;
+  try {
+    result = await generateImage({
+      model: imageModel,
+      prompt,
+      n: input.n ?? 1,
+      ...(input.aspectRatio ? { aspectRatio: input.aspectRatio } : {}),
+      abortSignal: signal,
+    });
+  } catch (err) {
+    if (timeoutSignal.aborted && !params.abortSignal?.aborted) {
+      throw new Error(
+        `Image generation timed out after ${GENERATE_IMAGE_TIMEOUT_MS}ms`,
+      );
+    }
+    throw err;
+  }
 
   if (!objectStorage) {
     throw new Error(


### PR DESCRIPTION
Same-day PRs #6017/#6012/#6020 bounded every other unbounded network call in this file/harness family (reference-image fetch, Browserless screenshot fetch, Gemini Interactions calls) with a fetch timeout, on the reasoning documented in this file's own comments: `params.abortSignal` only fires on user/run cancellation, not on a stalled remote — so an unresponsive dependency hangs the whole harness run forever. That reasoning was never applied to the one remaining unbounded call in this file: `generateImageCore`'s call to the image-model provider's `generateImage()`, which previously passed only the optional user-cancellation `abortSignal` with no timeout at all.

Why a maintainer wants this: an unresponsive image-model provider (rate-limited, degraded, or just slow) would hang the decopilot run indefinitely with no way out short of the user manually cancelling — the same failure mode already fixed for every other external call this harness makes.

Change: combine the existing optional `params.abortSignal` with a new 120s `AbortSignal.timeout` (longer than the other timeouts in this file since image generation is inherently slower than a plain fetch), and surface a clear "Image generation timed out" error instead of hanging. The timeout-vs-cancellation distinction is made by checking which signal actually fired, not by string-matching the error name, since the underlying `ai` SDK's error shape on abort isn't guaranteed.

Regression test: `generateImageCore` now has a test (mirroring the existing `fetchImageBytes` timeout test in this same file) that stubs `AbortSignal.timeout` to fire immediately and a fake provider `doGenerate` that hangs until aborted, asserting the call rejects with a timeout error instead of hanging.

Reviewer command: `bun test apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts`

Locally verified: `bun test` on the targeted file (21 pass), `bunx tsc --noEmit` in apps/api (clean), `bunx oxlint` on both changed files (0 warnings/errors), `bun run fmt`. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the decopilot image generation provider call to 120s to prevent indefinite hangs on unresponsive providers. Previously it relied only on user/run cancellation; now it combines that with a 120s timeout and throws a clear timeout error instead of hanging.

- Adds `GENERATE_IMAGE_TIMEOUT_MS = 120_000` and uses `AbortSignal.timeout` with `AbortSignal.any` when calling the provider’s `generateImage()`. Distinguishes timeout vs user cancel by checking which signal fired; rethrows other errors unchanged.
- Adds a regression test for `generateImageCore` that forces a timeout and asserts the call rejects with a timeout error.
- To verify: run `bun test apps/api/src/harnesses/lib/decopilot/built-in-tools/portable-media-tools.test.ts`.

<sup>Written for commit dc7c97331922c366203907d8071747fda7724d2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

