### PR TITLE
feat(task-board): surface deployment-based PR previews (VTEX FastStore)

### DIFF
--- a/apps/api/src/tools/task-board/checks-status.test.ts
+++ b/apps/api/src/tools/task-board/checks-status.test.ts
@@ -7,6 +7,8 @@ import { describe, expect, it } from "bun:test";
 import {
   conflictFromPrGet,
   extractPreviewUrl,
+  extractPreviewUrlFromDeployment,
+  headShaFromStatus,
   isRateLimitError,
   extractPreviewUrlFromComments,
   isTrustedPreviewHost,
@@ -372,6 +374,61 @@ describe("extractPreviewUrlFromComments", () => {
         { body: vercelBody },
       ]),
     ).toBe("https://envs-montecarlo--c8xgrn.decocdn.com");
+  });
+});
+
+describe("extractPreviewUrlFromDeployment", () => {
+  it("lifts a trusted environmentUrl from a GET_PREVIEW_DEPLOYMENT result", () => {
+    expect(
+      extractPreviewUrlFromDeployment({
+        environmentUrl: "https://sfj-b212cf4--torrafaststore.preview.vtex.app",
+        environment: "staging",
+        state: "success",
+        deploymentId: 42,
+      }),
+    ).toBe("https://sfj-b212cf4--torrafaststore.preview.vtex.app");
+  });
+
+  it("is null when no deployment has published a url yet (in-flight)", () => {
+    expect(
+      extractPreviewUrlFromDeployment({
+        environmentUrl: null,
+        environment: null,
+        state: null,
+        deploymentId: null,
+      }),
+    ).toBeNull();
+    expect(extractPreviewUrlFromDeployment(null)).toBeNull();
+    expect(extractPreviewUrlFromDeployment({})).toBeNull();
+  });
+
+  it("rejects an untrusted environmentUrl host", () => {
+    expect(
+      extractPreviewUrlFromDeployment({
+        environmentUrl:
+          "https://evil.example.com/torrafaststore.preview.vtex.app",
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("headShaFromStatus", () => {
+  it("reads the head sha from a combined-status response", () => {
+    expect(
+      headShaFromStatus({
+        state: "success",
+        sha: "f9f522ce9642cf7f2024e45b9ddc618a6f78bf8c",
+        total_count: 1,
+      }),
+    ).toBe("f9f522ce9642cf7f2024e45b9ddc618a6f78bf8c");
+  });
+
+  it("is null when the sha is absent or not a hex sha", () => {
+    expect(headShaFromStatus(null)).toBeNull();
+    expect(headShaFromStatus({})).toBeNull();
+    expect(headShaFromStatus({ sha: 123 })).toBeNull();
+    expect(headShaFromStatus({ sha: "not-a-sha" })).toBeNull();
+    expect(headShaFromStatus({ sha: "abc/../def" })).toBeNull();
   });
 });
 

--- a/apps/api/src/tools/task-board/checks-status.test.ts
+++ b/apps/api/src/tools/task-board/checks-status.test.ts
@@ -8,6 +8,7 @@ import {
   conflictFromPrGet,
   extractPreviewUrl,
   extractPreviewUrlFromDeployment,
+  headShaFromPrGet,
   headShaFromStatus,
   isRateLimitError,
   extractPreviewUrlFromComments,
@@ -409,6 +410,26 @@ describe("extractPreviewUrlFromDeployment", () => {
           "https://evil.example.com/torrafaststore.preview.vtex.app",
       }),
     ).toBeNull();
+  });
+});
+
+describe("headShaFromPrGet", () => {
+  it("reads head.sha from a pull_request_read get response", () => {
+    expect(
+      headShaFromPrGet({
+        state: "open",
+        head: { ref: "fix/x", sha: "f9f522ce9642cf7f2024e45b9ddc618a6f78bf8c" },
+      }),
+    ).toBe("f9f522ce9642cf7f2024e45b9ddc618a6f78bf8c");
+  });
+
+  it("is null when head/sha is absent or not a hex sha", () => {
+    expect(headShaFromPrGet(null)).toBeNull();
+    expect(headShaFromPrGet({})).toBeNull();
+    expect(headShaFromPrGet({ head: {} })).toBeNull();
+    expect(headShaFromPrGet({ head: { sha: 123 } })).toBeNull();
+    expect(headShaFromPrGet({ head: { sha: "not-a-sha" } })).toBeNull();
+    expect(headShaFromPrGet({ head: "nope" })).toBeNull();
   });
 });
 

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -410,17 +410,33 @@ export function extractPreviewUrlFromDeployment(
   return url && isTrustedPreviewHost(url) ? url : null;
 }
 
-/** The PR head commit sha from a combined-status response (`get_status`
- *  returns the head commit's status, which carries its `sha`). The
- *  deployment-preview lookup keys on it. `null` when absent or not a 7–40 char
- *  hex string, which also keeps a malformed value from reaching the GitHub
- *  query. Exported for the pure-logic unit test. */
+/** A git commit sha, validated 7–40 hex — also what keeps a malformed value
+ *  from reaching the GitHub query the deployment lookup builds from it. */
+function asHeadSha(sha: unknown): string | null {
+  return typeof sha === "string" && /^[0-9a-fA-F]{7,40}$/.test(sha)
+    ? sha
+    : null;
+}
+
+/** The PR head commit sha from a `pull_request_read get` response's `head.sha`
+ *  — the documented, stable source (present regardless of CI), preferred over
+ *  {@link headShaFromStatus}. `null` when absent or not a hex sha. Exported for
+ *  the pure-logic unit test. */
+export function headShaFromPrGet(
+  obj: Record<string, unknown> | null,
+): string | null {
+  const head = obj?.head as { sha?: unknown } | undefined;
+  return asHeadSha(head?.sha);
+}
+
+/** The PR head commit sha from a combined-status response (`get_status` returns
+ *  the head commit's status, which carries its `sha`). A fallback for
+ *  {@link headShaFromPrGet} when the `get` read is the one that flaked. `null`
+ *  when absent or not a hex sha. Exported for the pure-logic unit test. */
 export function headShaFromStatus(
   statusObj: Record<string, unknown> | null,
 ): string | null {
-  const sha =
-    statusObj && typeof statusObj.sha === "string" ? statusObj.sha : null;
-  return sha && /^[0-9a-fA-F]{7,40}$/.test(sha) ? sha : null;
+  return asHeadSha(statusObj?.sha);
 }
 
 /** Map a GitHub combined-status `state` to our three-value checks summary.
@@ -687,6 +703,7 @@ async function fetchPrStatusExtras(
   connectionId: string,
   pr: TaskBoardItemPrRef,
   pending: Promise<void>[],
+  prGet: Promise<Record<string, unknown> | null>,
 ): Promise<{
   checksStatus: ChecksStatus;
   checks: PrCheck[];
@@ -722,9 +739,11 @@ async function fetchPrStatusExtras(
   // Preview: a status `target_url` (rare) else the deploy bot's PR comment.
   let previewUrl =
     extractPreviewUrl(statusObj) ?? extractPreviewUrlFromComments(commentsRaw);
+  // TODO(e2e): cover the miss-path gate + head-sha threading below (only the pure extractors are unit-tested).
   if (!previewUrl) {
-    // Last resort: a GitHub Deployment env url (VTEX FastStore posts it only there), scanned only when the cheap sources missed and the head sha is known.
-    const headSha = headShaFromStatus(statusObj);
+    // Last resort: a GitHub Deployment env url (VTEX FastStore posts it only there), scanned only on the miss path once the head sha is known.
+    const headSha =
+      headShaFromPrGet(await prGet) ?? headShaFromStatus(statusObj);
     if (headSha) {
       previewUrl = extractPreviewUrlFromDeployment(
         await cachedPrRead(
@@ -811,21 +830,23 @@ async function fetchPrLiveState(
     // An open PR (the common case in the review dialog) is fully populated in a
     // single round-trip window instead of ~5 serial hops; a merged/closed PR
     // wastes the extras, but that's rare here and best-effort.
+    // One `get`, shared: it populates the PR fields and feeds the deployment preview its head sha (stable, unlike the flakier `get_status`).
+    const prGet = cachedPrRead(
+      client,
+      conn.id,
+      "pull_request_read",
+      {
+        method: "get",
+        owner: pr.repoOwner,
+        repo: pr.repoName,
+        pullNumber: pr.number,
+      },
+      `${prLabel(pr)} (get)`,
+      pending,
+    );
     const [obj, extras] = await Promise.all([
-      cachedPrRead(
-        client,
-        conn.id,
-        "pull_request_read",
-        {
-          method: "get",
-          owner: pr.repoOwner,
-          repo: pr.repoName,
-          pullNumber: pr.number,
-        },
-        `${prLabel(pr)} (get)`,
-        pending,
-      ),
-      fetchPrStatusExtras(client, conn.id, pr, pending),
+      prGet,
+      fetchPrStatusExtras(client, conn.id, pr, pending, prGet),
     ]);
     if (!obj) return NO_LIVE_STATE;
     const rawState = obj.state;

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -394,6 +394,35 @@ export function extractPreviewUrlFromComments(raw: unknown): string | null {
   return null;
 }
 
+/** Pull the preview URL out of a `GET_PREVIEW_DEPLOYMENT` result — the newest
+ *  successful GitHub Deployment status's `environmentUrl`, gated through the
+ *  same trusted-host check as the other two sources. Some hosts (VTEX FastStore
+ *  WebOps) publish the preview ONLY as a deployment — not a status `target_url`
+ *  and not a bot comment — so this is the third and last source tried. `null`
+ *  when the commit has no deployment with a published url yet (an in-flight
+ *  deploy) or the url isn't a trusted host. Exported for the pure-logic unit
+ *  test. */
+export function extractPreviewUrlFromDeployment(
+  obj: Record<string, unknown> | null,
+): string | null {
+  const url =
+    obj && typeof obj.environmentUrl === "string" ? obj.environmentUrl : null;
+  return url && isTrustedPreviewHost(url) ? url : null;
+}
+
+/** The PR head commit sha from a combined-status response (`get_status`
+ *  returns the head commit's status, which carries its `sha`). The
+ *  deployment-preview lookup keys on it. `null` when absent or not a 7–40 char
+ *  hex string, which also keeps a malformed value from reaching the GitHub
+ *  query. Exported for the pure-logic unit test. */
+export function headShaFromStatus(
+  statusObj: Record<string, unknown> | null,
+): string | null {
+  const sha =
+    statusObj && typeof statusObj.sha === "string" ? statusObj.sha : null;
+  return sha && /^[0-9a-fA-F]{7,40}$/.test(sha) ? sha : null;
+}
+
 /** Map a GitHub combined-status `state` to our three-value checks summary.
  *  A response with no statuses (`total_count === 0`) reads as "no checks",
  *  not "pending" — a PR without CI shouldn't look stuck. Exported for the
@@ -691,8 +720,24 @@ async function fetchPrStatusExtras(
     toCheckRunsStatus(runsRaw),
   );
   // Preview: a status `target_url` (rare) else the deploy bot's PR comment.
-  const previewUrl =
+  let previewUrl =
     extractPreviewUrl(statusObj) ?? extractPreviewUrlFromComments(commentsRaw);
+  if (!previewUrl) {
+    // Last resort: a GitHub Deployment env url (VTEX FastStore posts it only there), scanned only when the cheap sources missed and the head sha is known.
+    const headSha = headShaFromStatus(statusObj);
+    if (headSha) {
+      previewUrl = extractPreviewUrlFromDeployment(
+        await cachedPrRead(
+          client,
+          connectionId,
+          "GET_PREVIEW_DEPLOYMENT",
+          { owner: pr.repoOwner, repo: pr.repoName, sha: headSha },
+          `${prLabel(pr)} (deployment preview)`,
+          pending,
+        ),
+      );
+    }
+  }
   // Per-check list for the footer; pull the output markdown only for failing
   // runs (bounded, in parallel).
   const checks = await Promise.all(


### PR DESCRIPTION
## Problema

O painel de PR do task board pega o link de preview de **duas** fontes (`apps/api/src/tools/task-board/prs-get.ts`): o `target_url` de um commit-status e o comentário do bot de deploy. Alguns hosts não publicam em nenhuma das duas — a **VTEX FastStore WebOps** registra o preview **só** como `environment_url` de um GitHub Deployment. Resultado: PRs desses repos (ex.: [`agencia-e-plus/faststoretorra#70`](https://github.com/agencia-e-plus/faststoretorra/pull/70), preview em `https://sfj-b212cf4--torrafaststore.preview.vtex.app`) ficam sem botão de preview.

## Correção

Adiciona uma **terceira fonte, de último recurso**: quando nenhuma das duas fontes baratas acha o preview, resolve pela GitHub Deployments API do commit head via a nova tool `GET_PREVIEW_DEPLOYMENT` do MCP de github (mesma conexão e mesmo `cachedPrRead` que o já-existente `GET_CHECK_RUN`).

- `extractPreviewUrlFromDeployment(obj)` — lê `environmentUrl` do resultado da tool, passando pelo **mesmo** `isTrustedPreviewHost` das outras fontes (`.preview.vtex.app` **já estava** no allow-list).
- `headShaFromStatus(statusObj)` — pega o sha do head de graça da resposta do combined-status (`get_status`); valida como hex 7–40 antes de ir pra query.
- A varredura de deployment roda **só** quando o preview é desconhecido pelas fontes baratas **e** o sha é conhecido — repos com preview de Vercel/Cloudflare/deco não pagam nada.

## Testes

`apps/api/src/tools/task-board/checks-status.test.ts` (lógica pura, sem I/O — o fetch e seus modos de falha são e2e): novos casos pra `extractPreviewUrlFromDeployment` (url confiável / in-flight null / host não-confiável) e `headShaFromStatus` (sha válido / ausente / não-hex / path-injection). bun test verde (43 pass); bun run check e bun run lint limpos.

## Dependência

Requer **[decocms/mcps#535](https://github.com/decocms/mcps/pull/535)** (adiciona a tool `GET_PREVIEW_DEPLOYMENT`). Mergear o mcps primeiro / esperar o deploy do MCP; sem a tool, o cachedPrRead só retorna null e as duas fontes atuais seguem funcionando (degradação graciosa).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces deployment-based PR previews by falling back to a GitHub Deployment `environmentUrl` when no status `target_url` or deploy bot comment is present. Now derives the head SHA from `pull_request_read`’s `head.sha` (stable) and falls back to `get_status.sha`, avoiding missed previews when CI is absent or flaky.

- Keys the lookup on a validated 7–40 char hex head SHA.
- Uses `cachedPrRead` and adds the MCP tool `GET_PREVIEW_DEPLOYMENT`.
- Applies `isTrustedPreviewHost` (FastStore `.preview.vtex.app` already allow-listed).
- Threads the shared `pull_request_read get` into status extras to supply the head SHA; falls back to `get_status`.
- Adds unit tests for `extractPreviewUrlFromDeployment`, `headShaFromPrGet`, and `headShaFromStatus`.

**Rollout**
- Requires `decocms/mcps#535` (adds `GET_PREVIEW_DEPLOYMENT`); deploy the MCP first.
- If the tool is unavailable, behavior falls back to existing sources; repos with Vercel/Cloudflare/deco previews are unaffected.

<sup>Written for commit 8f318877c2db63ede5dc08926d1688092c7c257f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

