### PR TITLE
fix(decopilot): key vm-tool output stash by the real tool call id

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/vm-tools/common.test.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/vm-tools/common.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "bun:test";
+import { maybeTruncate } from "./common";
+
+describe("maybeTruncate", () => {
+  it("keys the stash by the caller-supplied tool call id, not a self-minted one", () => {
+    const big = "x".repeat(200_000);
+    const toolOutputMap = new Map<string, string>();
+
+    const first = maybeTruncate(big, toolOutputMap, "call_1") as {
+      truncated: boolean;
+      message: string;
+    };
+    const second = maybeTruncate(big, toolOutputMap, "call_2") as {
+      truncated: boolean;
+      message: string;
+    };
+
+    expect(first.truncated).toBe(true);
+    expect(second.truncated).toBe(true);
+    expect(first.message).toContain("call_1");
+    expect(second.message).toContain("call_2");
+    // Two concurrent truncations never collide on the same map key.
+    expect(toolOutputMap.has("call_1")).toBe(true);
+    expect(toolOutputMap.has("call_2")).toBe(true);
+    expect(toolOutputMap.size).toBe(2);
+  });
+});

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/vm-tools/common.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/vm-tools/common.ts
@@ -11,6 +11,7 @@ import {
 export function maybeTruncate(
   result: unknown,
   toolOutputMap: Map<string, string>,
+  toolCallId: string,
 ): unknown {
   let serialized: string;
   try {
@@ -21,7 +22,6 @@ export function maybeTruncate(
   }
   const tokenCount = estimateJsonTokens(serialized);
   if (tokenCount > MAX_RESULT_TOKENS) {
-    const toolCallId = `vm_${Date.now()}`;
     toolOutputMap.set(toolCallId, serialized);
     const preview = createOutputPreview(serialized);
     return {

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/vm-tools/index.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/vm-tools/index.ts
@@ -87,7 +87,7 @@ export function createVmTools(params: VmToolsParams) {
           message: "Image attached below.",
         };
       }
-      return maybeTruncate(result, toolOutputMap);
+      return maybeTruncate(result, toolOutputMap, options.toolCallId);
     },
   });
 
@@ -137,7 +137,7 @@ export function createVmTools(params: VmToolsParams) {
     inputSchema: zodSchema(GrepInputSchema),
     execute: async (input, options) => {
       const result = await call("/_sandbox/grep", input, options.abortSignal);
-      return maybeTruncate(result, toolOutputMap);
+      return maybeTruncate(result, toolOutputMap, options.toolCallId);
     },
   });
 
@@ -147,7 +147,7 @@ export function createVmTools(params: VmToolsParams) {
     inputSchema: zodSchema(GlobInputSchema),
     execute: async (input, options) => {
       const result = await call("/_sandbox/glob", input, options.abortSignal);
-      return maybeTruncate(result, toolOutputMap);
+      return maybeTruncate(result, toolOutputMap, options.toolCallId);
     },
   });
 
@@ -157,7 +157,7 @@ export function createVmTools(params: VmToolsParams) {
     inputSchema: zodSchema(BashInputSchema),
     execute: async (input, options) => {
       const result = await call("/_sandbox/bash", input, options.abortSignal);
-      return maybeTruncate(result, toolOutputMap);
+      return maybeTruncate(result, toolOutputMap, options.toolCallId);
     },
   });
 
@@ -181,7 +181,7 @@ export function createVmTools(params: VmToolsParams) {
           { path },
           options.abortSignal,
         );
-        return maybeTruncate(result, toolOutputMap);
+        return maybeTruncate(result, toolOutputMap, options.toolCallId);
       } catch {
         return {
           error: `Skill "${id}" not found. Use an id from <available-skills>.`,


### PR DESCRIPTION
Bug found while hunting the assigned focus area (pluggable filesystem abstraction for decopilot's vm-tools); the abstraction itself (`SandboxFsHooks`) is already in place and well-documented, and issue #2884 describing a broader FS abstraction is too large/speculative for one PR, so instead this fixes a concrete correctness bug in the same file set.

`maybeTruncate` (apps/api/src/harnesses/lib/decopilot/built-in-tools/vm-tools/common.ts) minted its own key `vm_${Date.now()}` for stashing oversized tool output, instead of using the AI SDK's `options.toolCallId` — the pattern every other built-in tool (scrape-url.ts, inspect-page.ts, web-search.ts, mcp-tools.ts) already follows.

Failure scenario: the agent frequently fires several vm-tools (e.g. grep + glob) within one step. If two of those calls both produce oversized output in the same millisecond, they collide on the same `vm_<timestamp>` map key. The second write silently overwrites the first in `toolOutputMap`, so when the agent later calls `read_tool_output` with the id it was told for the *first* truncated result, it gets the *second* tool's content instead — silent misattribution of tool output.

Fix: `maybeTruncate` now takes the caller's real `toolCallId` (from the AI SDK's `execute(input, options)` — `options.toolCallId`) instead of generating one, eliminating the collision entirely (tool-call ids are unique per call).

Regression test: `vm-tools/common.test.ts` — two truncated calls with distinct ids never collide in the map (fails on old code once the key generation is timestamp-based, since it exercises the stash-and-retrieve contract `read_tool_output` depends on).

Reviewer check: `cd apps/api && bunx tsc --noEmit` (clean) and `bun test apps/api/src/harnesses/lib/decopilot/built-in-tools/vm-tools/common.test.ts` (1 pass).

Locally verified: `bun run fmt`, targeted `tsc --noEmit` in apps/api, the one new test file, and `bunx oxlint` on all three changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates vm-tools output collisions by keying the stash with the real tool call id. Before, `maybeTruncate` used a `vm_<timestamp>` key; concurrent truncations in the same millisecond overwrote each other, misattributing outputs. Now it uses `options.toolCallId`, ensuring correct retrieval.

- Updates `maybeTruncate` to accept `toolCallId` and all vm tools to pass `options.toolCallId`.
- Adds a regression test verifying two truncated calls with distinct ids store separate entries in `toolOutputMap`.
- No migration required; external behavior is unchanged except that `read_tool_output` now consistently returns the correct content.

<sup>Written for commit 66ac0ea1c5f7f9d34679a41313d197d6c33bea43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6034?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

