### PR TITLE
perf(threads): parallelize loadWindow's independent queries

### DIFF
--- a/apps/api/src/storage/thread-message-parts.ts
+++ b/apps/api/src/storage/thread-message-parts.ts
@@ -297,28 +297,25 @@ export class SqlThreadMessagePartStorage {
     threadId: string,
     options: { limit: number; offset?: number; includeInFlight?: boolean },
   ): Promise<{ messages: FoldedMessage[]; total: number }> {
-    const anchors = await this.db
-      .selectFrom("thread_message_parts")
-      .select(["message_id"])
-      .where("thread_id", "=", threadId)
-      .where("kind", "=", "finish")
-      .orderBy("created_at", "desc")
-      .orderBy("id", "desc")
-      .limit(options.limit)
-      .offset(options.offset ?? 0)
-      .execute();
-
-    const totalRow = await this.db
-      .selectFrom("thread_message_parts")
-      .select((eb) => eb.fn.count<string>("id").as("count"))
-      .where("thread_id", "=", threadId)
-      .where("kind", "=", "finish")
-      .executeTakeFirst();
-    const total = Number(totalRow?.count ?? 0);
-
-    const inFlight =
+    const [anchors, totalRow, inFlight] = await Promise.all([
+      this.db
+        .selectFrom("thread_message_parts")
+        .select(["message_id"])
+        .where("thread_id", "=", threadId)
+        .where("kind", "=", "finish")
+        .orderBy("created_at", "desc")
+        .orderBy("id", "desc")
+        .limit(options.limit)
+        .offset(options.offset ?? 0)
+        .execute(),
+      this.db
+        .selectFrom("thread_message_parts")
+        .select((eb) => eb.fn.count<string>("id").as("count"))
+        .where("thread_id", "=", threadId)
+        .where("kind", "=", "finish")
+        .executeTakeFirst(),
       options.includeInFlight && (options.offset ?? 0) === 0
-        ? await this.db
+        ? this.db
             .selectFrom("thread_message_parts as p")
             .select("p.message_id")
             .distinct()
@@ -336,7 +333,9 @@ export class SqlThreadMessagePartStorage {
               ),
             )
             .execute()
-        : [];
+        : Promise.resolve([]),
+    ]);
+    const total = Number(totalRow?.count ?? 0);
 
     const messageIds = [
       ...anchors.map((a) => a.message_id),


### PR DESCRIPTION
**Source:** perf finding while hunting DB-latency in the storage layer per the assigned focus area (threads/ports/automations).

**Why it matters:** `SqlThreadMessagePartStorage.loadWindow` (apps/api/src/storage/thread-message-parts.ts) backs `COLLECTION_THREAD_MESSAGES_LIST` and the decopilot memory/context read path — i.e. it runs on every load of a v2 thread's chat. It issued three separate Postgres round trips in sequence (the anchor-id page, the total count, and the in-flight-message lookup), even though none of the three reads depends on another's output. Running them concurrently with `Promise.all` removes two serialized round trips from a very hot path.

**Change:** Combined the three independent queries into a single `Promise.all`. Purely a scheduling change — same queries, same SQL, same results; `total` is still derived from `totalRow` after the array resolves.

**How I verified behavior is unchanged:** Read each of the three queries carefully — `anchors` filters/orders/paginates on `thread_id`+`kind=finish` only, `totalRow` counts the same filter with no pagination, and `inFlight` is a separate `thread_id`-scoped NOT EXISTS query — none references another's result, so parallelizing is safe. `bunx tsc --noEmit` in `apps/api` is green. The existing integration coverage in `apps/api/src/storage/thread-message-parts.integration.test.ts` already exercises `loadWindow`'s output shape (requires Postgres, not runnable in this sandbox — CI will run it).

**Reviewer command:** `cd apps/api && bun test src/storage/thread-message-parts.integration.test.ts` (needs Postgres).

**Local checks run:** `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), `bunx oxlint apps/api/src/storage/thread-message-parts.ts` (0 errors, 1 pre-existing unrelated warning). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallelizes the three independent Postgres queries in `SqlThreadMessagePartStorage.loadWindow` with `Promise.all` to cut message-list load latency on v2 threads. Before: anchors, total count, and in-flight IDs were fetched sequentially; now they run concurrently with the same SQL and results.

**Review notes**
- Semantics unchanged: same output schema; `total` comes from `totalRow.count`; `inFlight` runs only when `includeInFlight` is true and `offset === 0`, otherwise `[]`.
- Hot path impact: backs `COLLECTION_THREAD_MESSAGES_LIST` and decopilot memory/context reads.
- To verify: `cd apps/api && bun test src/storage/thread-message-parts.integration.test.ts` (requires Postgres).

<sup>Written for commit f9c05153e8aa6e083a26b7cb0743bc63a4c70f26. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

