### PR TITLE
fix(task-board): fall back merge methods when repo forbids merge commits

### DIFF
--- a/apps/api/src/tools/task-board/merge-pr.test.ts
+++ b/apps/api/src/tools/task-board/merge-pr.test.ts
@@ -11,9 +11,19 @@ import type { ReviewCycleActivity } from "@decocms/shared/task-board";
 import { approvedButUnverified } from "@decocms/shared/task-board";
 import {
   checksBlockMerge,
+  classifyMergeResult,
   isMergeMethodNotAllowed,
   mayBeConflict,
 } from "./merge-pr";
+
+/** The MCP tool-result shape `classifyMergeResult` reads: an error with a text
+ *  content array (what GitHub's refusal actually arrives as). */
+const errorResult = (text: string) => ({
+  isError: true,
+  content: [{ type: "text", text }],
+});
+const notAllowed = (method: string, pr = 71) =>
+  `failed to merge pull request: PUT https://api.github.com/repos/o/r/pulls/${pr}/merge: 405 ${method} are not allowed on this repository. []`;
 
 const BOTH = ["qa", "code_review"] as const;
 const at = "2026-08-12T00:00:00.000Z";
@@ -96,6 +106,51 @@ describe("isMergeMethodNotAllowed", () => {
       ),
     ).toBe(false);
     expect(isMergeMethodNotAllowed("")).toBe(false);
+  });
+});
+
+describe("classifyMergeResult", () => {
+  it("is 'merged' when the tool call did not error", () => {
+    expect(classifyMergeResult({}).kind).toBe("merged");
+    expect(classifyMergeResult({ isError: false }).kind).toBe("merged");
+  });
+
+  it("reads the real serialized content-array wire shape", () => {
+    const a = classifyMergeResult(errorResult(notAllowed("Merge commits")));
+    expect(a.kind).toBe("method_not_allowed");
+    if (a.kind === "method_not_allowed") {
+      expect(a.detail).toContain("not allowed on this repository");
+    }
+  });
+
+  // PR #429 puts a bare 429 in the error URL — method-not-allowed must still win.
+  it("classifies a forbidden method on PR #429 as method_not_allowed, not rate-limited", () => {
+    const a = classifyMergeResult(
+      errorResult(notAllowed("Merge commits", 429)),
+    );
+    expect(a.kind).toBe("method_not_allowed");
+  });
+
+  it("is 'rate_limited' for a genuine too-many-requests refusal", () => {
+    expect(
+      classifyMergeResult(
+        errorResult("Streamable HTTP error: too many requests"),
+      ).kind,
+    ).toBe("rate_limited");
+  });
+
+  // A conflict is a 405 without the forbidden-method phrase → stays 'refused'.
+  it("is 'refused' for a merge conflict", () => {
+    expect(
+      classifyMergeResult(errorResult("405 Pull Request is not mergeable"))
+        .kind,
+    ).toBe("refused");
+  });
+
+  it("is 'refused' with an empty detail when the error has no content", () => {
+    const a = classifyMergeResult({ isError: true });
+    expect(a.kind).toBe("refused");
+    if (a.kind === "refused") expect(a.detail).toBe("");
   });
 });
 

--- a/apps/api/src/tools/task-board/merge-pr.test.ts
+++ b/apps/api/src/tools/task-board/merge-pr.test.ts
@@ -9,7 +9,11 @@
 import { describe, expect, it } from "bun:test";
 import type { ReviewCycleActivity } from "@decocms/shared/task-board";
 import { approvedButUnverified } from "@decocms/shared/task-board";
-import { checksBlockMerge, mayBeConflict } from "./merge-pr";
+import {
+  checksBlockMerge,
+  isMergeMethodNotAllowed,
+  mayBeConflict,
+} from "./merge-pr";
 
 const BOTH = ["qa", "code_review"] as const;
 const at = "2026-08-12T00:00:00.000Z";
@@ -60,6 +64,38 @@ describe("mayBeConflict", () => {
     ] as const) {
       expect(mayBeConflict({ merged: false, reason })).toBe(false);
     }
+  });
+});
+
+describe("isMergeMethodNotAllowed", () => {
+  // The 405 a repo returns when it forbids the merge method just tried.
+  it("is true for the 405 that means the repo forbids this method", () => {
+    for (const detail of [
+      "PUT https://api.github.com/repos/o/r/pulls/71/merge: 405 Merge commits are not allowed on this repository. []",
+      "405 Squash merges are not allowed on this repository",
+      "405 Rebase merges are not allowed on this repository",
+    ]) {
+      expect(isMergeMethodNotAllowed(detail)).toBe(true);
+    }
+  });
+
+  // A conflict is also a 405, but no other method fixes it — must NOT advance.
+  it("is false for a 405 that is not a forbidden-method refusal", () => {
+    expect(isMergeMethodNotAllowed("405 Pull Request is not mergeable")).toBe(
+      false,
+    );
+    expect(isMergeMethodNotAllowed("405 Method Not Allowed")).toBe(false);
+  });
+
+  // Every other refusal shape is method-independent and reported as-is.
+  it("is false for non-405 refusals", () => {
+    expect(isMergeMethodNotAllowed("409 Merge conflict")).toBe(false);
+    expect(
+      isMergeMethodNotAllowed(
+        "422 At least 1 approving review is required by reviewers with write access",
+      ),
+    ).toBe(false);
+    expect(isMergeMethodNotAllowed("")).toBe(false);
   });
 });
 

--- a/apps/api/src/tools/task-board/merge-pr.ts
+++ b/apps/api/src/tools/task-board/merge-pr.ts
@@ -23,16 +23,15 @@ import { emitTaskBoardUpdated, handTaskToHuman } from "./run-reactions";
 const MERGE_TIMEOUT_MS = 15000;
 
 /**
- * Merge methods to try, best-first. A repo can forbid any subset of these in its
- * settings, and forbidding the one GitHub defaults to (a merge commit) is what
- * this ladder exists for: `merge_pull_request` with no `merge_method` asks for a
- * merge commit, and a repo with "Allow merge commits" off answers `405 Merge
- * commits are not allowed on this repository` — a card that would then sit In
- * Review forever, retried every sweep against the same refusal. Squash is first
- * to match the web "Ship to production" path (`github-pr-api.ts`) and keep a
- * linear history; the others are the fallbacks for repos that forbid squash.
+ * Merge methods to try in order, stopping at the first that succeeds. `merge` is
+ * first because it is GitHub's own default — a bare `merge_pull_request` asks for
+ * a merge commit — so keeping it first changes nothing for every repo that
+ * allows one. The fallback is the whole point: a repo with "Allow merge commits"
+ * off answers `405 Merge commits are not allowed on this repository`, which used
+ * to strand the card In Review forever, retried every sweep against the same
+ * refusal; now it advances to `squash`, then `rebase`.
  */
-const MERGE_METHODS = ["squash", "merge", "rebase"] as const;
+const MERGE_METHODS = ["merge", "squash", "rebase"] as const;
 
 /**
  * True when a merge refusal is GitHub rejecting THIS merge method (a `405 … are
@@ -132,16 +131,30 @@ type MergeAttempt =
   | { kind: "refused"; detail: string };
 
 /**
- * One `merge_pull_request` round-trip with a specific `merge_method`, classified
- * into the outcome {@link mergeLinkedPr}'s ladder branches on.
+ * Classify a raw `merge_pull_request` tool result. Pure — unit-tested.
  *
  * GitHub refuses a merge (branch protection, a required review, a forbidden
  * method, a lost race) via `isError` on an otherwise-resolved tool call — NOT a
- * throw — so the payload is parsed here, not caught. A 429 wears the refusal's
- * shape but is transient (`rate_limited`); a `405 … not allowed on this
- * repository` is the repo forbidding THIS method (`method_not_allowed`, the one
- * a different method can fix); anything else is method-independent (`refused`).
+ * throw — so the payload is parsed here. Method-not-allowed is tested BEFORE the
+ * rate-limit heuristic on purpose: that heuristic matches a bare `429` anywhere
+ * in the payload, which the error's own PR URL can carry (`pulls/429/merge`),
+ * while a forbidden-method refusal names itself unambiguously — so it wins the
+ * tie and the ladder still advances for PR #429. `detail` defaults to `""` so a
+ * refusal with no `content` (which `JSON.stringify` renders as `undefined`, not
+ * a string) can't throw downstream.
  */
+export function classifyMergeResult(result: unknown): MergeAttempt {
+  if (!(result as { isError?: boolean })?.isError) return { kind: "merged" };
+  const detail =
+    JSON.stringify((result as { content?: unknown })?.content) ?? "";
+  if (isMergeMethodNotAllowed(detail)) {
+    return { kind: "method_not_allowed", detail };
+  }
+  if (isRateLimitError(detail)) return { kind: "rate_limited", detail };
+  return { kind: "refused", detail };
+}
+
+/** One `merge_pull_request` round-trip with a specific `merge_method`. */
 async function attemptMerge(
   client: Awaited<ReturnType<typeof clientFromConnection>>,
   pr: { repoOwner: string; repoName: string; number: number },
@@ -160,13 +173,7 @@ async function attemptMerge(
     undefined,
     { timeout: MERGE_TIMEOUT_MS },
   );
-  if (!(result as { isError?: boolean })?.isError) return { kind: "merged" };
-  const detail = JSON.stringify((result as { content?: unknown })?.content);
-  if (isRateLimitError(detail)) return { kind: "rate_limited", detail };
-  if (isMergeMethodNotAllowed(detail)) {
-    return { kind: "method_not_allowed", detail };
-  }
-  return { kind: "refused", detail };
+  return classifyMergeResult(result);
 }
 
 /**

--- a/apps/api/src/tools/task-board/merge-pr.ts
+++ b/apps/api/src/tools/task-board/merge-pr.ts
@@ -23,6 +23,32 @@ import { emitTaskBoardUpdated, handTaskToHuman } from "./run-reactions";
 const MERGE_TIMEOUT_MS = 15000;
 
 /**
+ * Merge methods to try, best-first. A repo can forbid any subset of these in its
+ * settings, and forbidding the one GitHub defaults to (a merge commit) is what
+ * this ladder exists for: `merge_pull_request` with no `merge_method` asks for a
+ * merge commit, and a repo with "Allow merge commits" off answers `405 Merge
+ * commits are not allowed on this repository` — a card that would then sit In
+ * Review forever, retried every sweep against the same refusal. Squash is first
+ * to match the web "Ship to production" path (`github-pr-api.ts`) and keep a
+ * linear history; the others are the fallbacks for repos that forbid squash.
+ */
+const MERGE_METHODS = ["squash", "merge", "rebase"] as const;
+
+/**
+ * True when a merge refusal is GitHub rejecting THIS merge method (a `405 … are
+ * not allowed on this repository`) — the one refusal a different method can fix,
+ * so the ladder advances on it. Every other refusal (branch protection, a
+ * required review, a conflict) is method-independent: no method fixes it, so the
+ * caller reports it as-is instead of burning through the ladder. Pure —
+ * unit-tested.
+ */
+export function isMergeMethodNotAllowed(content: string): boolean {
+  return (
+    /\b405\b/.test(content) && /not allowed on this repository/i.test(content)
+  );
+}
+
+/**
  * Why a merge didn't happen. `checks_pending` is the one ROUTINE outcome — CI
  * is still running and the next attempt will simply succeed — so it is the one
  * reason that never reaches the card's timeline. Everything else means a human
@@ -98,6 +124,51 @@ async function recordMergeFailure(
   });
 }
 
+/** The outcome of one `merge_pull_request` round-trip, classified. */
+type MergeAttempt =
+  | { kind: "merged" }
+  | { kind: "rate_limited"; detail: string }
+  | { kind: "method_not_allowed"; detail: string }
+  | { kind: "refused"; detail: string };
+
+/**
+ * One `merge_pull_request` round-trip with a specific `merge_method`, classified
+ * into the outcome {@link mergeLinkedPr}'s ladder branches on.
+ *
+ * GitHub refuses a merge (branch protection, a required review, a forbidden
+ * method, a lost race) via `isError` on an otherwise-resolved tool call — NOT a
+ * throw — so the payload is parsed here, not caught. A 429 wears the refusal's
+ * shape but is transient (`rate_limited`); a `405 … not allowed on this
+ * repository` is the repo forbidding THIS method (`method_not_allowed`, the one
+ * a different method can fix); anything else is method-independent (`refused`).
+ */
+async function attemptMerge(
+  client: Awaited<ReturnType<typeof clientFromConnection>>,
+  pr: { repoOwner: string; repoName: string; number: number },
+  mergeMethod: string,
+): Promise<MergeAttempt> {
+  const result = await client.callTool(
+    {
+      name: "merge_pull_request",
+      arguments: {
+        owner: pr.repoOwner,
+        repo: pr.repoName,
+        pullNumber: pr.number,
+        merge_method: mergeMethod,
+      },
+    },
+    undefined,
+    { timeout: MERGE_TIMEOUT_MS },
+  );
+  if (!(result as { isError?: boolean })?.isError) return { kind: "merged" };
+  const detail = JSON.stringify((result as { content?: unknown })?.content);
+  if (isRateLimitError(detail)) return { kind: "rate_limited", detail };
+  if (isMergeMethodNotAllowed(detail)) {
+    return { kind: "method_not_allowed", detail };
+  }
+  return { kind: "refused", detail };
+}
+
 /**
  * Merge the task's open PR via the GitHub MCP `merge_pull_request` tool. Shared
  * by the reviewer decision (auto-merge on all-approved) and the manual "promote
@@ -154,43 +225,43 @@ export async function mergeLinkedPr(
   }
   const client = await clientFromConnection(conn, ctx, true);
   try {
-    const result = await client.callTool(
-      {
-        name: "merge_pull_request",
-        arguments: {
-          owner: pr.repoOwner,
-          repo: pr.repoName,
-          pullNumber: pr.number,
-        },
-      },
-      undefined,
-      { timeout: MERGE_TIMEOUT_MS },
-    );
-    // GitHub refusing the merge (branch protection, a required review, a lost
-    // race) comes back as `isError` on an otherwise successful tool call — NOT
-    // as a throw, so the catch below never saw it. Surface the payload: this is
-    // the case that looks identical to "nothing happened" from the outside.
-    if ((result as { isError?: boolean })?.isError) {
-      const content = JSON.stringify(
-        (result as { content?: unknown })?.content,
-      );
-      // A 429 arrives in the refusal's shape; calling it one reads as terminal.
-      if (isRateLimitError(content)) {
+    // Try each allowed merge method in turn — see {@link MERGE_METHODS}.
+    let lastRefusal: string | null = null;
+    for (const mergeMethod of MERGE_METHODS) {
+      const attempt = await attemptMerge(client, pr, mergeMethod);
+      if (attempt.kind === "merged") {
+        // Drop the polled read cache so the next poll sees `merged` → Done.
+        invalidatePrReads(conn.id);
+        return { merged: true };
+      }
+      // A 429 says nothing about the method; re-asking IS the burst — stop.
+      if (attempt.kind === "rate_limited") {
         console.warn(
           `[task-board] merge rate-limited on PR #${pr.number} — sweep retries`,
         );
-        return fail("rate_limited", content?.slice(0, 500));
+        return fail("rate_limited", attempt.detail.slice(0, 500));
       }
+      // The repo forbids THIS method — remember it and try the next.
+      if (attempt.kind === "method_not_allowed") {
+        console.warn(
+          `[task-board] merge method '${mergeMethod}' not allowed on ${repo} — trying next`,
+        );
+        lastRefusal = attempt.detail;
+        continue;
+      }
+      // Method-independent refusal (branch protection, conflict) — no method fixes it.
       console.error(
         `[task-board] merge refused by GitHub on PR #${pr.number}:`,
-        content,
+        attempt.detail,
       );
-      return fail("refused", content?.slice(0, 500));
+      return fail("refused", attempt.detail.slice(0, 500));
     }
-    // The PR just changed under the polled read cache — drop it so the next
-    // poll sees `merged` and moves the card to Done immediately.
-    invalidatePrReads(conn.id);
-    return { merged: true };
+    // The repo allows none of squash/merge/rebase — report the last refusal.
+    console.error(
+      `[task-board] no merge method allowed on ${repo} (PR #${pr.number})`,
+      lastRefusal,
+    );
+    return fail("refused", lastRefusal?.slice(0, 500));
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
     // Same 429, thrown rather than returned — the transport decides which.


### PR DESCRIPTION
## Summary

Clicking **"Ship to production"** on a task failed with:

```
405 Merge commits are not allowed on this repository
```

`mergeLinkedPr` (`apps/api/src/tools/task-board/merge-pr.ts`) called GitHub's `merge_pull_request` **without a `merge_method`**, so GitHub defaulted to a **merge commit**. Repos with "Allow merge commits" off (e.g. `agencia-e-plus/faststoretorra`) reject that with a 405, and the card then sat In Review forever, retried against the same refusal every sweep. The web "Ship" flow never hit this because it already hardcodes `merge_method: "squash"` — the two paths had drifted.

## Change

Added a merge-method fallback ladder to `mergeLinkedPr`:

- Try `squash` → `merge` → `rebase` (squash first to match the web ship path and keep linear history).
- Advance to the next method **only** on a "method not allowed" 405 (new pure, unit-tested `isMergeMethodNotAllowed`).
- Any other refusal (branch protection, required review, conflict) or a 429 rate-limit is method-independent → reported immediately, no extra GitHub calls.
- If a repo allows none of the three, the last refusal is surfaced as `refused` (still lands on the card timeline, unchanged).

Extracted the single attempt-and-classify logic into an `attemptMerge` helper returning a tagged `MergeAttempt` union so the loop stays readable.

Fixes both entry points through `mergeLinkedPr`: the manual "Ship to production" button and the reviewer auto-merge path.

## Testing

- `bun test apps/api/src/tools/task-board/merge-pr.test.ts` — 14 pass (3 new cases: the real 405 refusal, a 405-conflict that must NOT advance, non-405 refusals).
- `bun run --cwd=apps/api check` — clean.
- `bun run fmt` / `bun run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes task-board merges that failed on repos disallowing merge commits by explicitly trying allowed methods and correctly classifying refusals. Previously `mergeLinkedPr` omitted `merge_method`, GitHub defaulted to a merge commit, and those repos returned 405s that left cards stuck In Review.

- Tries merge → squash → rebase, advancing only on a “405 … not allowed on this repository”; reports other refusals (conflict, required review) immediately and treats 429 as rate-limited. Classifies forbidden-method before rate-limit to avoid misreading PR #429 URLs.
- Extracts pure `classifyMergeResult` and `isMergeMethodNotAllowed` (unit-tested, reads the MCP content-array shape); defaults refusal detail to "" to avoid slice errors; `attemptMerge` uses them; invalidates PR read cache on success.
- Applies to both manual “Ship to production” and reviewer auto-merge; preserves GitHub’s default merge-commit behavior on repos that allow it; no migration required.

<sup>Written for commit 5ac165570f357235ff0faf4557651914ed0c65e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

