### PR TITLE
fix(sandbox): decode buildCloneInfo's error code before it reaches the publish dialog

### DIFF
--- a/apps/api/src/tools/sandbox/sync-git-credentials.test.ts
+++ b/apps/api/src/tools/sandbox/sync-git-credentials.test.ts
@@ -1,8 +1,28 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, mock, test } from "bun:test";
 import {
+  encodeSandboxStartError,
+  SANDBOX_START_ERROR_CODES,
+} from "@decocms/shared/sandbox-start-errors";
+import type { StudioContext } from "../../core/studio-context";
+import type { SandboxProvider } from "@decocms/sandbox/provider";
+
+mock.module("../../shared/github-clone-info", () => ({
+  buildCloneInfo: mock(async () => {
+    throw new Error(
+      encodeSandboxStartError(
+        SANDBOX_START_ERROR_CODES.githubConnectionMissing,
+        "GitHub connection conn_1 no longer exists. Link acme/site again.",
+      ),
+    );
+  }),
+  ensureGithubCloneToken: mock(async () => {}),
+}));
+
+const {
   GitPushAuthError,
   parseGithubRepoFromMetadata,
-} from "./sync-git-credentials";
+  refreshSandboxGitCredentials,
+} = await import("./sync-git-credentials");
 
 describe("parseGithubRepoFromMetadata", () => {
   test("returns public-clone repo without connectionId", () => {
@@ -53,5 +73,30 @@ describe("GitPushAuthError", () => {
     const err = new GitPushAuthError("nope");
     expect(err).toBeInstanceOf(Error);
     expect(err.name).toBe("GitPushAuthError");
+  });
+});
+
+describe("refreshSandboxGitCredentials", () => {
+  test("decodes buildCloneInfo's SANDBOX_START_ERROR_CODES prefix into a clean GitPushAuthError", async () => {
+    const ctx = {
+      organization: { id: "org_1" },
+      storage: { connections: { findById: async () => null } },
+      db: {},
+      vault: {},
+    } as unknown as StudioContext;
+    const runner = {} as SandboxProvider;
+
+    await expect(
+      refreshSandboxGitCredentials(ctx, runner, "handle_1", {
+        url: "https://github.com/acme/site",
+        owner: "acme",
+        name: "site",
+        connectionId: "conn_1",
+      }),
+    ).rejects.toThrow(
+      new GitPushAuthError(
+        "GitHub connection conn_1 no longer exists. Link acme/site again.",
+      ),
+    );
   });
 });

--- a/apps/api/src/tools/sandbox/sync-git-credentials.ts
+++ b/apps/api/src/tools/sandbox/sync-git-credentials.ts
@@ -4,6 +4,7 @@ import type { StudioContext } from "../../core/studio-context";
 import { RECONNECT_ERROR } from "../../oauth/token-refresh";
 import { coAuthorFromStudioContext } from "../../lib/co-author-identity";
 import { readBoundedText } from "../../lib/bounded-text";
+import { decodeSandboxStartError } from "@decocms/shared/sandbox-start-errors";
 import {
   buildCloneInfo,
   ensureGithubCloneToken,
@@ -69,7 +70,13 @@ export async function refreshSandboxGitCredentials(
     githubRepo.name,
     ctx.db,
     ctx.vault,
-  );
+  ).catch((error) => {
+    // Strip buildCloneInfo's SANDBOX_START_ERROR_CODES prefix so it doesn't leak raw into the publish-dialog UI.
+    const { code, message } = decodeSandboxStartError(
+      error instanceof Error ? error.message : String(error),
+    );
+    throw code ? new GitPushAuthError(message) : error;
+  });
 
   const operator = coAuthorFromStudioContext(ctx);
 


### PR DESCRIPTION
**Bug**: `/git/publish` (`refreshSandboxGitCredentials` in `apps/api/src/tools/sandbox/sync-git-credentials.ts`) calls `buildCloneInfo`, which throws a plain `Error` whose message is prefixed with a `SANDBOX_START_ERROR_CODES` code (e.g. `"GITHUB_CONNECTION_MISSING::GitHub connection conn_1 no longer exists. Link acme/site again."`). The `SANDBOX_START` flow already decodes this via `decodeSandboxStartError` before showing it to the user (see `sandbox-lifecycle-context.tsx`), but the publish path let it propagate raw straight into `sandbox-proxy.ts`'s generic 502 catch branch, so a user hitting Publish on a project whose GitHub connection was deleted (or is unauthenticated) saw the literal `"GITHUB_CONNECTION_MISSING::GitHub connection conn_1 no longer exists..."` string surface in the publish dialog instead of a clean, actionable message — this is the exact 'silent/confusing disconnection' failure mode the native sandbox reliability sweep is after, just on the API side of the publish path rather than in the native crate (which is fully covered by open PRs #5647/#5649 right now).

**Fix**: `buildCloneInfo`'s rejection is now decoded and rethrown as a `GitPushAuthError`, which `sandbox-proxy.ts`'s `/git/publish` handler already special-cases into a clean `403` (instead of falling through to the generic 502-with-raw-message branch). No behavior change for the happy path or for errors that aren't SANDBOX_START-coded (those still propagate as before).

**Regression test**: `sync-git-credentials.test.ts` mocks `buildCloneInfo` to throw the encoded `githubConnectionMissing` error and asserts `refreshSandboxGitCredentials` rejects with a `GitPushAuthError` carrying the decoded, human-readable message.

**To verify**: `cd apps/api && bun test src/tools/sandbox/sync-git-credentials.test.ts`

**Checks run locally**: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test file above (5 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decodes `buildCloneInfo` errors during `/git/publish` so users see a clean message. Previously, encoded `SANDBOX_START` errors surfaced as raw "CODE::message" and hit the generic 502 path; now we return a 403 with the decoded text via `GitPushAuthError`.

- Wrap the `buildCloneInfo` call in `refreshSandboxGitCredentials` with `decodeSandboxStartError` from `@decocms/shared/sandbox-start-errors` and rethrow a `GitPushAuthError`.
- Happy path unchanged; non-`SANDBOX_START` errors still propagate as before.
- Add a regression test in `sync-git-credentials.test.ts` that mocks an encoded `githubConnectionMissing` and asserts a decoded `GitPushAuthError`.

<sup>Written for commit fbc175be336efac75c85db2e935997c39f89054c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6037?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

