### PR TITLE
fix(task-board): don't read a 429 in a PR URL as a rate limit

### DIFF
--- a/apps/api/src/tools/task-board/checks-status.test.ts
+++ b/apps/api/src/tools/task-board/checks-status.test.ts
@@ -474,4 +474,26 @@ describe("isRateLimitError", () => {
     expect(isRateLimitError("too many requests")).toBe(true);
     expect(isRateLimitError(null)).toBe(false);
   });
+
+  // A bare 429 in the PR URL path (`…/pulls/429/merge`) is not the HTTP status.
+  it("does not treat a 429 inside the request URL as a rate limit", () => {
+    expect(
+      isRateLimitError(
+        new Error(
+          "failed to merge pull request: PUT https://api.github.com/repos/o/r/pulls/429/merge: 405 Merge commits are not allowed on this repository. []",
+        ),
+      ),
+    ).toBe(false);
+  });
+
+  // A real 429 status follows the URL after a space, so it survives the scrub.
+  it("still catches a real 429 status that follows a URL", () => {
+    expect(
+      isRateLimitError(
+        new Error(
+          "PUT https://api.github.com/repos/o/r/pulls/71/merge: 429 Too Many Requests",
+        ),
+      ),
+    ).toBe(true);
+  });
 });

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -32,7 +32,9 @@ const PR_FETCH_TIMEOUT_MS = 8000;
  */
 export function isRateLimitError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err);
-  return /too many requests|rate limit|\b429\b/i.test(message);
+  // Scrub the request URL first: a `429` in `…/pulls/429/merge` is not a status.
+  const withoutUrls = message.replace(/https?:\/\/\S+/gi, " ");
+  return /too many requests|rate limit|\b429\b/i.test(withoutUrls);
 }
 
 /**


### PR DESCRIPTION
## Summary

`isRateLimitError` (`apps/api/src/tools/task-board/prs-get.ts`) classifies a GitHub MCP refusal as rate-limited by matching `too many requests | rate limit | \b429\b` against the error message. But the message embeds the **request URL**, and a bare `429` in a PR path (`…/pulls/429/merge`) trips the `\b429\b` branch — so **any refusal on PR #429 is misread as rate-limited**.

Consequences on the merge path:
- A **forbidden-method 405** on PR #429 was read as `rate_limited`, so the merge-method fallback ladder (#6036) never advanced → the card never merged.
- A **merge conflict** on PR #429 was read as `rate_limited`, and `mayBeConflict` is `false` for `rate_limited` → conflict auto-resolution silently skipped → card stranded In Review.

This surfaced during the review of #6036; that PR reordered the classifier to check method-not-allowed first (fixing the forbidden-method sub-case), but the shared predicate is the root cause and also affects the conflict sub-case and every other caller (`dbos-github-read.ts`, the read-cache retry gate).

## Change

Scrub `https://…` from the message before matching. A real rate-limit status (`: 429 Too Many Requests`) follows the URL after a space, so it survives the scrub and still matches; a `429` **inside** the URL no longer does.

## Testing

Added two unit cases to `checks-status.test.ts`:
- a forbidden-method 405 on PR #429 → not rate-limited;
- a genuine `429 Too Many Requests` following the URL → still rate-limited.

`bun test checks-status.test.ts` — 47 pass. Typecheck + fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false rate‑limit detection when GitHub error messages include a PR URL containing “429”. Previously `isRateLimitError` treated any “429” as rate‑limited, so refusals on PR #429 blocked merge‑method fallback and skipped conflict auto‑resolution; now it strips URLs before matching so only real 429 statuses or rate‑limit phrases trigger.

**Reviewer notes**
- Scrubs `https://…` from the error message before applying `/too many requests|rate limit|\b429\b/i`; real “: 429 Too Many Requests” after the URL still matches.
- Adds two unit tests to cover a URL‑embedded 429 (not rate‑limited) and a genuine 429 status (rate‑limited).
- Affects the task‑board merge path and any other caller of `isRateLimitError`; no config or migration needed.

<sup>Written for commit 008f5d9c5c9dec4f6e14109508f9d2fcd3c8ced5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

