### PR TITLE
fix(chat): make the queue tray's remove button reachable by keyboard focus

### DIFF
--- a/apps/web/src/components/chat/queue-tray.tsx
+++ b/apps/web/src/components/chat/queue-tray.tsx
@@ -91,7 +91,7 @@ export function QueueTray({ taskId }: { taskId: string }) {
           <span className="min-w-0 flex-1 truncate text-sm text-foreground">
             {item.text}
           </span>
-          <div className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity group-hover/queuerow:opacity-100">
+          <div className="flex shrink-0 items-center gap-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover/queuerow:opacity-100">
             <Button
               type="button"
               variant="ghost"


### PR DESCRIPTION
Same bug class as #5727 ("make hover-only buttons reachable by keyboard focus"), found while auditing chat UI accessibility — this instance wasn't covered by that PR.

The per-row "remove from queue" button in `QueueTray` (shown when a user has multiple queued chat messages waiting behind the active run) sits in a wrapper `div` styled `opacity-0 group-hover/queuerow:opacity-100` — it only becomes visible on mouse hover. A keyboard-only user tabbing through the queue rows lands focus on the button (it's a real `<button>`, so it's in the tab order and activatable), but never sees it since it stays invisible until the row is hovered with a pointer.

Fix: add `focus-within:opacity-100` to the wrapper div, matching the exact `focus-visible:opacity-100` fix #5727 applied to the same hover-only-visibility pattern in `tag-picker.tsx` and `task-dialog.tsx`. `focus-within` (not `focus-visible`, since the class lives on the wrapper div, not the button itself) reveals the button the moment focus lands on its child button.

Failure scenario: a keyboard user queues 2+ messages, tabs to a queued row's remove button, presses Enter — the action works, but they had no visual confirmation of what they were about to activate since the button was invisible.

How to verify: `cd apps/web && bunx tsc --noEmit` (clean); `bunx oxlint apps/web/src/components/chat/queue-tray.tsx` (0 warnings/errors); manually — queue 2 chat messages, tab to a row's remove button, confirm it's now visible while focused.

Locally ran: `bun run fmt`, targeted `tsc --noEmit` in apps/web, and `oxlint` on the touched file — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the QueueTray “remove from queue” button visible when focused by keyboard. Previously it stayed invisible unless the row was pointer-hovered; now it shows on keyboard focus and on hover, giving users visual confirmation before activation.

**Review notes**
- Adds `focus-within:opacity-100` to the wrapper around the remove button in `apps/web/src/components/chat/queue-tray.tsx`; hover behavior is unchanged.
- Verify: queue 2+ messages, Tab to a row’s remove button; it becomes visible and can be activated. Static checks: `bunx tsc --noEmit` and `bunx oxlint apps/web/src/components/chat/queue-tray.tsx` are clean.

<sup>Written for commit c9b14ed8f1c00339c9331e4b7de518034e28aad5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

