### PR TITLE
refactor(decopilot): dedupe scrape_url's browserless fetch into the shared helper

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/scrape-url.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/scrape-url.ts
@@ -16,12 +16,7 @@ import type { ObjectStorageHooks } from "../../harness-deps";
 import { createOutputPreview, estimateJsonTokens } from "./read-tool-output";
 import { toStudioStorageUri } from "../studio-storage-uri";
 import { LARGE_RESULT_TOKEN_THRESHOLD } from "./constants";
-
-// Browserless call itself has no bound beyond the inner page render timeout —
-// if Browserless is unresponsive the outer fetch can hang the harness run
-// forever. Give it headroom instead of leaving it unbounded (mirrors
-// inspect-page.ts's BROWSERLESS_FETCH_TIMEOUT_MS).
-const BROWSERLESS_FETCH_TIMEOUT_MS = 45_000;
+import { browserlessFetch } from "./browserless-fetch";
 
 // Upstream error bodies are unbounded — cap what lands in the tool error.
 const ERROR_BODY_MAX_CHARS = 500;
@@ -62,31 +57,23 @@ export function createScrapeUrlTool(
     execute: async (input, options) => {
       const startTime = performance.now();
       try {
-        let response: Response;
-        try {
-          response = await fetch(
-            `${browserless.baseUrl}/content?token=${encodeURIComponent(
-              browserless.token,
-            )}`,
-            {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                url: input.url,
-              }),
-              signal: AbortSignal.timeout(BROWSERLESS_FETCH_TIMEOUT_MS),
-            },
-          );
-        } catch (err) {
-          const isTimeout = err instanceof Error && err.name === "TimeoutError";
-          return {
-            success: false,
-            error: isTimeout
-              ? `Browserless content fetch timed out after ${BROWSERLESS_FETCH_TIMEOUT_MS}ms`
-              : `Browserless content fetch failed: ${err instanceof Error ? err.message : String(err)}`,
-            url: input.url,
-          };
+        const fetched = await browserlessFetch(
+          "Browserless content fetch",
+          `${browserless.baseUrl}/content?token=${encodeURIComponent(
+            browserless.token,
+          )}`,
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              url: input.url,
+            }),
+          },
+        );
+        if (!fetched.ok) {
+          return { success: false, error: fetched.error, url: input.url };
         }
+        const response = fetched.response;
 
         if (!response.ok) {
           const errorText = await response.text().catch(() => "Unknown error");


### PR DESCRIPTION
Follows #5894, which extracted `browserlessFetch()` (bounded timeout + shared error-message shaping) out of `inspect-page.ts` into `browserless-fetch.ts`, and updated `inspect-page.ts` and `portable-built-ins.ts` to use it — but left `scrape-url.ts` with its own duplicate inline copy of the exact same fetch/timeout/try-catch/error-message logic (including a second, now-redundant `BROWSERLESS_FETCH_TIMEOUT_MS` constant).

Collapsing `scrape-url.ts` onto the shared helper removes the duplication so there's one place that owns Browserless-call timeout/error behavior — the next time that timeout value or the error-message format needs to change, it changes in one file instead of two silently drifting copies.

Net: -30/+17 lines. Behavior-preserving — `browserlessFetch()` is the exact same fetch call, same `AbortSignal.timeout`, same TimeoutError → "timed out after Nms" mapping, same non-timeout → "failed: <message>" mapping that the inline code did; only the response-ok / body-size-cap / storage-offload logic below it is untouched.

Reviewer check: `bun test apps/api/src/harnesses/lib/decopilot/built-in-tools/scrape-url.test.ts` — all 5 existing tests (injected-token, timeout-signal-bound, timeout-error-message, non-http-rejection, oversized-error-body-cap) pass unchanged against the refactored implementation.

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (no new errors in this file), the targeted test file above, and `bunx oxlint` on the changed file (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates Browserless fetch/timeout/error handling in `scrape-url.ts` by replacing the inline fetch with the shared `browserlessFetch()` helper. This centralizes the timeout and error message shaping without changing behavior.

- Uses `browserlessFetch("Browserless content fetch", <same URL>)` with the same POST body and headers.
- Propagates errors via `fetched.ok`/`fetched.error`; uses `fetched.response` when successful.
- Leaves response OK checks, error body size cap, and storage/offload logic unchanged.

<sup>Written for commit dbb435576098fafb67da4bccfc7413b010834cd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6041?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

