### PR TITLE
fix(task-board): don't read a PR number in a URL as an infra status code

### DIFF
--- a/apps/api/src/tools/task-board/transient-failure.test.ts
+++ b/apps/api/src/tools/task-board/transient-failure.test.ts
@@ -71,6 +71,24 @@ describe("isTransientRunFailure", () => {
     }
   });
 
+  // A PR number that happens to be 429/503 is not a rate-limit/capacity status.
+  test("a PR number inside a URL is not mistaken for a status code", () => {
+    expect(
+      isTransientRunFailure({
+        kind: "error",
+        errorText:
+          "Error fetching https://api.github.com/repos/o/r/pulls/429/files: 404 Not Found",
+      }),
+    ).toBe(false);
+    expect(
+      isTransientRunFailure({
+        kind: "error",
+        errorText:
+          "Error fetching https://api.github.com/repos/o/r/pulls/503/files: 404 Not Found",
+      }),
+    ).toBe(false);
+  });
+
   // The whole point of the split: retrying this would burn a run reproducing it.
   test("an error the agent produced is not retried", () => {
     expect(

--- a/apps/api/src/tools/task-board/transient-failure.ts
+++ b/apps/api/src/tools/task-board/transient-failure.ts
@@ -113,5 +113,7 @@ export function isTransientRunFailure(failure: {
   // and it matched none of the patterns, so every one of them got the
   // unknown-error budget of a single attempt.
   if (text.includes(SANDBOX_UNREACHABLE_PREFIX)) return true;
-  return TRANSIENT_ERROR_PATTERNS.some((re) => re.test(text));
+  // A `429`/`503` inside a URL path (`…/pulls/429/files`) is a PR number, not a status.
+  const withoutUrls = text.replace(/https?:\/\/\S+/gi, " ");
+  return TRANSIENT_ERROR_PATTERNS.some((re) => re.test(withoutUrls));
 }


### PR DESCRIPTION
Follows #6038, which fixed the identical bug for `isRateLimitError` in `prs-get.ts`: a `429`/`503` matched anywhere in an error message, including inside a request URL like `.../pulls/429/files`, where the number is a PR id, not an HTTP status.

This PR applies the same URL-scrub fix to `isTransientRunFailure` in `transient-failure.ts`, which classifies a task run's generic `"error"` failure kind by matching its error text against a short list of infrastructure patterns (one of which is `\b(?:429|503)\b|too many requests|service unavailable`).

**Failure scenario:** an agent's own tool-call error (e.g. a 404 on a GitHub URL that happens to contain PR number 429 or 503, like `Error fetching https://api.github.com/repos/o/r/pulls/429/files: 404 Not Found`) gets misclassified as GitHub/gateway capacity trouble. `retryBudgetFor` then grants it the full 3-attempt infrastructure retry budget (`TRANSIENT_RETRY_BUDGET`) instead of the 1-attempt benefit of the doubt for unrecognized errors (`UNKNOWN_RETRY_BUDGET`) — burning two extra sandbox runs reproducing the same agent bug before the card reaches a human in To Do.

The fix strips `https?://\S+` from the error text before running the pattern match, identical to the scrub already applied in `isRateLimitError`.

**Regression test:** added to `transient-failure.test.ts` — asserts `isTransientRunFailure` returns `false` for error text containing a GitHub URL with `/pulls/429/files` or `/pulls/503/files`.

**To verify:** `bun test apps/api/src/tools/task-board/transient-failure.test.ts` (18 pass, including the 2 new cases).

**Locally ran:** `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), `bunx oxlint` on both changed files (0 warnings/errors), and the targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes misclassification of task run failures: `isTransientRunFailure` no longer interprets 429/503 inside URLs (e.g., `/pulls/429/files`) as infra status codes. Previously it matched these numbers anywhere in the error text and granted the 3-attempt infra retry budget; now it strips URLs before matching so agent/tool errors get the 1-attempt unknown-error budget, avoiding wasted runs.

**Review notes**
- Implementation: strip `https?://\S+` from error text before testing `TRANSIENT_ERROR_PATTERNS` in `transient-failure.ts` (same scrub as `isRateLimitError`).
- Tests: add regression cases to `transient-failure.test.ts` to assert URLs with `/pulls/429/files` or `/pulls/503/files` do not trigger transient classification; verify with `bun test apps/api/src/tools/task-board/transient-failure.test.ts`.

<sup>Written for commit 221b018af788204e606ae4ccea5ba18db4827fdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

