### PR TITLE
fix(task-board): read the mergeability field github-mcp actually sends

### DIFF
--- a/apps/api/src/tools/task-board/checks-status.test.ts
+++ b/apps/api/src/tools/task-board/checks-status.test.ts
@@ -77,6 +77,37 @@ describe("conflictFromPrGet", () => {
   it("is null for a missing response", () => {
     expect(conflictFromPrGet(null)).toBeNull();
   });
+
+  it("reads mergeable_state — github-mcp's MinimalPullRequest has no `mergeable`", () => {
+    expect(conflictFromPrGet({ state: "open", mergeable_state: "dirty" })).toBe(
+      true,
+    );
+    expect(conflictFromPrGet({ state: "open", mergeable_state: "clean" })).toBe(
+      false,
+    );
+    expect(
+      conflictFromPrGet({ state: "open", mergeable_state: "blocked" }),
+    ).toBe(false);
+  });
+
+  it("is null when mergeable_state is unknown or empty — still computing", () => {
+    expect(
+      conflictFromPrGet({ state: "open", mergeable_state: "unknown" }),
+    ).toBeNull();
+    expect(
+      conflictFromPrGet({ state: "open", mergeable_state: "" }),
+    ).toBeNull();
+  });
+
+  it("prefers the boolean when a non-minimal response carries both", () => {
+    expect(
+      conflictFromPrGet({
+        state: "open",
+        mergeable: true,
+        mergeable_state: "dirty",
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("extractPreviewUrl", () => {

--- a/apps/api/src/tools/task-board/merge-pr.test.ts
+++ b/apps/api/src/tools/task-board/merge-pr.test.ts
@@ -12,6 +12,7 @@ import { approvedButUnverified } from "@decocms/shared/task-board";
 import {
   checksBlockMerge,
   classifyMergeResult,
+  conflictSignal,
   isMergeMethodNotAllowed,
   mayBeConflict,
 } from "./merge-pr";
@@ -208,5 +209,39 @@ describe("approvedButUnverified", () => {
       },
     ];
     expect(approvedButUnverified(activity, [...BOTH])).toBe(false);
+  });
+});
+
+describe("conflictSignal", () => {
+  const refused = (detail: string) =>
+    ({ merged: false, reason: "refused", detail }) as const;
+
+  it("takes the read whenever it has an answer", () => {
+    expect(conflictSignal(true, refused("anything"))).toBe(true);
+    expect(conflictSignal(false, refused("has merge conflicts"))).toBe(false);
+  });
+
+  it("falls back to GitHub's own refusal when the read is unknown", () => {
+    expect(
+      conflictSignal(
+        null,
+        refused(
+          '[{"type":"text","text":"failed to merge pull request: PUT ' +
+            "https://api.github.com/repos/o/r/pulls/336/merge: 405 Pull " +
+            'Request has merge conflicts []"}]',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("never answers `false` from a refusal — absence is not evidence", () => {
+    expect(
+      conflictSignal(null, refused("405 Merge commits are not allowed")),
+    ).toBeNull();
+    expect(
+      conflictSignal(null, { merged: false, reason: "rate_limited" }),
+    ).toBeNull();
+    expect(conflictSignal(null, { merged: true })).toBeNull();
+    expect(conflictSignal(null, null)).toBeNull();
   });
 });

--- a/apps/api/src/tools/task-board/merge-pr.ts
+++ b/apps/api/src/tools/task-board/merge-pr.ts
@@ -347,8 +347,36 @@ async function handUnverifiedApprovalToHuman(
  * reason precisely so it lands here: it says nothing about mergeability, and
  * paying another GitHub call into a 429 is the burst that keeps the limit shut.
  */
-export function mayBeConflict(outcome: MergeOutcome): boolean {
+export function mayBeConflict(
+  outcome: MergeOutcome,
+): outcome is { merged: false; reason: MergeFailureReason; detail?: string } {
   return !outcome.merged && outcome.reason === "refused";
+}
+
+/**
+ * Whether the PR conflicts, given the `pull_request_read` answer and the merge
+ * outcome it followed. Pure — unit-tested.
+ *
+ * The read wins when it HAS an answer. When it doesn't — GitHub computes
+ * mergeability asynchronously, so `null` is routine — fall back to what the
+ * refusal said (`405 Pull Request has merge conflicts`). That is the
+ * definitive answer and we already paid for it: the merge just asked GitHub to
+ * do the thing and was told exactly why it couldn't. Without the fallback a
+ * null read silently skips the resolution run, and the card sits approved and
+ * unmergeable.
+ *
+ * Never returns `false` from the refusal alone: the phrase being absent is not
+ * evidence the PR is mergeable, and only an explicit `true` may act.
+ */
+export function conflictSignal(
+  read: boolean | null,
+  outcome: MergeOutcome | null,
+): boolean | null {
+  if (read !== null) return read;
+  if (outcome === null || !mayBeConflict(outcome)) return null;
+  return (outcome.detail ?? "").toLowerCase().includes("merge conflict")
+    ? true
+    : null;
 }
 
 /**
@@ -377,7 +405,7 @@ async function resolveConflictAfterRefusedMerge(
   if (!pr) return;
   await reactToApprovedPrConflict(ctx, orgId, item, {
     pr: { number: pr.number, url: pr.url },
-    conflict: await fetchPrConflict(ctx, orgId, pr),
+    conflict: conflictSignal(await fetchPrConflict(ctx, orgId, pr), outcome),
   }).catch((err) => {
     console.error("[task-board] sweep conflict auto-resolve failed", err);
   });

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -643,18 +643,36 @@ export async function fetchPrChecksStatus(
 }
 
 /** Map a `pull_request_read get` response to whether the PR conflicts with its
- *  base branch. `true` = conflicts (`mergeable === false`); `false` = mergeable,
- *  OR the PR is not open (a merged/closed PR reports `mergeable: null` but is
- *  never "conflicting"); `null` = GitHub hasn't computed mergeability yet (it's
- *  async) or the read gave nothing — an unknown must NEVER read as a conflict,
- *  so the caller only acts on an explicit `true`. Pure — unit-tested; the single
- *  home for the `mergeable` polarity, so the two callers can't drift. */
+ *  base branch. `true` = conflicts; `false` = mergeable, OR the PR is not open
+ *  (a merged/closed PR reports no mergeability but is never "conflicting");
+ *  `null` = GitHub hasn't computed mergeability yet (it's async) or the read
+ *  gave nothing — an unknown must NEVER read as a conflict, so the caller only
+ *  acts on an explicit `true`. Pure — unit-tested; the single home for the
+ *  mergeability polarity, so the two callers can't drift.
+ *
+ *  `mergeable_state` is the field that actually arrives: `pull_request_read`
+ *  returns github-mcp's `MinimalPullRequest`, which has no `mergeable`. Reading
+ *  only that boolean yielded `null` for every PR ever, so the conflict
+ *  auto-resolution it gates never fired once in production — zero
+ *  `merge_conflict_resolution` rows across every org, while an approved,
+ *  conflicting PR retried the same 405 every five minutes for two days. The
+ *  boolean is still read first: a non-minimal response (a direct GitHub
+ *  payload, a different MCP server) carries it and it is the richer signal.
+ *
+ *  Of the `mergeable_state` values only `dirty` means conflicts; `unknown`/`""`
+ *  is GitHub still computing, and the rest (`blocked`, `behind`, `unstable`, …)
+ *  are for the checks gate to judge, not this. */
 export function conflictFromPrGet(
   obj: Record<string, unknown> | null,
 ): boolean | null {
   if (!obj) return null;
   if (obj.state !== "open") return false;
-  return typeof obj.mergeable === "boolean" ? !obj.mergeable : null;
+  if (typeof obj.mergeable === "boolean") return !obj.mergeable;
+  const state = obj.mergeable_state;
+  if (typeof state !== "string" || state === "" || state === "unknown") {
+    return null;
+  }
+  return state === "dirty";
 }
 
 /** Whether the PR conflicts with its base branch — the definite "can't merge"
@@ -853,16 +871,15 @@ async function fetchPrLiveState(
     if (!obj) return NO_LIVE_STATE;
     const rawState = obj.state;
     const isOpen = rawState === "open";
+    const conflict = conflictFromPrGet(obj);
     return {
       title: typeof obj.title === "string" ? obj.title : null,
       body: typeof obj.body === "string" ? obj.body : null,
       state: rawState === "closed" ? "closed" : isOpen ? "open" : null,
       draft: typeof obj.draft === "boolean" ? obj.draft : null,
       merged: typeof obj.merged === "boolean" ? obj.merged : null,
-      // Mergeability only means something for an open PR (a merged/closed PR
-      // reports `mergeable: null`). Anything but a boolean is "unknown".
-      mergeable:
-        isOpen && typeof obj.mergeable === "boolean" ? obj.mergeable : null,
+      // Same reducer as the auto-resolution gate, so the two can't drift.
+      mergeable: isOpen && conflict !== null ? !conflict : null,
       // Checks/preview only mean something for an open PR.
       checksStatus: isOpen ? extras.checksStatus : null,
       checks: isOpen ? extras.checks : [],

--- a/apps/api/src/tools/task-board/review-decision.ts
+++ b/apps/api/src/tools/task-board/review-decision.ts
@@ -11,7 +11,11 @@ import { TaskBoardItemStatusSchema } from "./schema";
 import { recordTaskActivity } from "./activity";
 import { emitTaskBoardUpdated, handTaskToHuman } from "./run-reactions";
 import { enqueueSuperAgentForTask } from "./enqueue-super-agent";
-import { allEnabledReviewersVerifiedApproved, mergeLinkedPr } from "./merge-pr";
+import {
+  allEnabledReviewersVerifiedApproved,
+  conflictSignal,
+  mergeLinkedPr,
+} from "./merge-pr";
 import { fetchPrConflict, pickActivePr } from "./prs-get";
 import { verifyReviewToken } from "./review-token";
 import { reactToApprovedPrConflict } from "./conflict-reaction";
@@ -276,9 +280,10 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
 
     const settings = await ctx.storage.organizationSettings.get(organizationId);
     const autoMerge = settings?.flags?.auto_merge === true;
-    const merged = autoMerge
-      ? (await mergeLinkedPr(ctx, organizationId, taskBoardItemId)).merged
-      : false;
+    const outcome = autoMerge
+      ? await mergeLinkedPr(ctx, organizationId, taskBoardItemId)
+      : null;
+    const merged = outcome?.merged === true;
 
     // A merge ships the task → Done.
     if (merged) {
@@ -323,7 +328,10 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
       const resolving = pr
         ? await reactToApprovedPrConflict(ctx, organizationId, current, {
             pr: { number: pr.number, url: pr.url },
-            conflict: await fetchPrConflict(ctx, organizationId, pr),
+            conflict: conflictSignal(
+              await fetchPrConflict(ctx, organizationId, pr),
+              outcome,
+            ),
           }).catch((err) => {
             // Same paywall exception as above — a TaskQuotaError must
             // surface, not be swallowed as a routine auto-resolve failure.


### PR DESCRIPTION
## Summary

Conflict auto-resolution has **never fired in production**. `task_board_activity` has zero `merge_conflict_resolution` rows in the last 30 days across every org, while `board_cD2CqBdKHfmdIDLSsPi9C` (Studio org, PR deco-sites/decocms-tanstack#336) sat approved-and-unmergeable for two days, retrying the same refusal every five minutes on all three pods:

```
[task-board] merge refused by GitHub on PR #336:
  405 Pull Request has merge conflicts
```

Root cause is one field name. `conflictFromPrGet` reads `obj.mergeable`, but `pull_request_read { method: "get" }` returns github-mcp's [`MinimalPullRequest`](https://github.com/github/github-mcp-server/blob/main/pkg/github/minimal_types.go), which has **no `mergeable` field** — it carries `mergeable_state` (`"dirty"` for #336). So the reducer answered `null` for every PR ever read, and `reactToApprovedPrConflict` bailed on `conflict !== true`. Silently, because `fetchPrConflict` swallows everything.

## Changes

- **`conflictFromPrGet`** falls back to `mergeable_state` when the boolean is absent. The boolean is still read first so a non-minimal payload (direct GitHub, a different MCP server) wins. Only `dirty` is a conflict; `unknown`/`""` stays `null`.
- **`fetchPrLiveState.mergeable`** goes through the same reducer — it inlined the same missing field, so the board's conflict signal was dead too.
- **`conflictSignal(read, outcome)`** — when the read has no answer, fall back to what the merge refusal *said*. That's definitive and already paid for, and a null read is routine (GitHub computes mergeability asynchronously). Never returns `false` from the refusal alone: absence of the phrase isn't evidence of mergeability.
- Applied on **both** paths. The inline approval path (`review-decision.ts`) dropped the `MergeOutcome` and kept only `.merged` — that's where #336 lost its signal at 22:52 on 08-12.
- `mayBeConflict` is now a type guard, so reading `.detail` off the outcome is checked at compile time.

## Testing

`bun test apps/api/src/tools/task-board/` — 6 new cases (minimal-shape `mergeable_state`, unknown/empty, boolean-wins, and the four `conflictSignal` branches against the real serialized refusal payload). The 22 pre-existing failures in that directory are a local DB missing the `repo` column; identical on `main`.

Not covered by a test: the wire shape itself. It's asserted against the upstream struct in the reducer's doc comment, and it's the thing that drifted.

## Effect

`board_cD2CqBdKHfmdIDLSsPi9C` / PR #336 unblocks itself on the first sweep after deploy — the resolution run gets dispatched and rebases the branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes task-board conflict detection by reading the mergeability field `github-mcp` actually returns and by falling back to merge refusal details when the read is inconclusive. Previously we read a missing `mergeable` boolean, so all reads were null and approved conflicting PRs never triggered auto-rebase.

- `conflictFromPrGet` prefers `mergeable` when present; otherwise maps `mergeable_state` (`dirty` → conflict, `unknown`/empty → null, others → not a conflict).
- `fetchPrLiveState.mergeable` uses the same reducer, restoring the board’s conflict signal.
- Adds `conflictSignal(read, outcome)` to infer conflicts from a refusal containing “merge conflict” when the read is null; never infers “no conflict” from absence of the phrase.
- Applies the signal on both the sweep and inline approval paths by passing the merge outcome through; `mayBeConflict` is now a type guard.
- Adds focused unit tests for `mergeable_state` handling and `conflictSignal`.

<sup>Written for commit bd80916a30d4cdbfe7dcafdd32da5ae316ee817f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

