### PR TITLE
fix(task-board): ignore a reviewer's repeated change-request within a cycle

### DIFF
--- a/apps/api/src/tools/task-board/review-decision.test.ts
+++ b/apps/api/src/tools/task-board/review-decision.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { reviewTokenVerified } from "./review-decision";
+import type { ReviewCycleActivity } from "@decocms/shared/task-board";
+import {
+  isDuplicateChangeRequest,
+  reviewTokenVerified,
+} from "./review-decision";
 
 describe("reviewTokenVerified", () => {
   const cycleA = new Date("2026-01-01T00:00:00Z").getTime();
@@ -22,5 +26,55 @@ describe("reviewTokenVerified", () => {
 
   it("rejects a missing claim", () => {
     expect(reviewTokenVerified(null, "qa", cycleA)).toBe(false);
+  });
+});
+
+describe("isDuplicateChangeRequest", () => {
+  const cycle = (at: string): ReviewCycleActivity => ({
+    action: "status_changed",
+    data: { to: "in_review" },
+    occurredAt: at,
+  });
+  const changes = (reviewer: string, at: string): ReviewCycleActivity => ({
+    action: "review_changes_requested",
+    data: { reviewer },
+    occurredAt: at,
+  });
+
+  it("is true for the same reviewer twice in one cycle", () => {
+    const history = [
+      cycle("2026-08-13T02:39:20Z"),
+      changes("qa", "2026-08-13T02:54:59Z"),
+    ];
+    expect(isDuplicateChangeRequest(history, "qa")).toBe(true);
+  });
+
+  it("is false for the other reviewer's first verdict", () => {
+    const history = [
+      cycle("2026-08-13T02:39:20Z"),
+      changes("qa", "2026-08-13T02:54:59Z"),
+    ];
+    expect(isDuplicateChangeRequest(history, "code_review")).toBe(false);
+  });
+
+  it("is false once the card came back for a fresh cycle", () => {
+    const history = [
+      cycle("2026-08-13T02:39:20Z"),
+      changes("qa", "2026-08-13T02:54:59Z"),
+      cycle("2026-08-13T02:55:21Z"),
+    ];
+    expect(isDuplicateChangeRequest(history, "qa")).toBe(false);
+  });
+
+  it("is false when this cycle's only verdict was an approval", () => {
+    const history = [
+      cycle("2026-08-13T02:39:20Z"),
+      {
+        action: "review_approved",
+        data: { reviewer: "qa", verified: true },
+        occurredAt: "2026-08-13T02:44:00Z",
+      } as ReviewCycleActivity,
+    ];
+    expect(isDuplicateChangeRequest(history, "qa")).toBe(false);
   });
 });

--- a/apps/api/src/tools/task-board/review-decision.ts
+++ b/apps/api/src/tools/task-board/review-decision.ts
@@ -4,8 +4,11 @@ import { requireAuth } from "@/core/studio-context";
 import {
   MAX_REVIEW_BOUNCES,
   REVIEWER_LABEL,
+  type ReviewCycleActivity,
   reviewBounceLimitReached,
   reviewCycleStart,
+  reviewCycleVerdicts,
+  type ReviewerKind,
 } from "@decocms/shared/task-board";
 import { TaskBoardItemStatusSchema } from "./schema";
 import { recordTaskActivity } from "./activity";
@@ -42,6 +45,33 @@ export function reviewTokenVerified(
     claim.reviewer === reviewer &&
     claim.cycleAt.getTime() === currentCycleAt
   );
+}
+
+/**
+ * True when this reviewer already requested changes in the current review
+ * cycle — the call is a repeat, not a second verdict. Pure — unit-tested.
+ *
+ * Reviewer runs do call twice: an agent that gets a tool result it doesn't
+ * recognise as terminal calls again, and one QA run landed the same notes twice
+ * ten seconds apart on six cards in one night. The first call already bounced
+ * the card, so the repeat is *usually* absorbed by `claimReviewChangesBounce`
+ * (the card has left In Review and the claim returns null) — but only usually:
+ * if the re-run finished in between, the card is back In Review and the stale
+ * repeat bounces it a second time, spending a run and a bounce on a verdict
+ * already answered. It also charged the bounce budget a cycle early, which is
+ * how four of these cards were handed over one round sooner than the cap says.
+ *
+ * Scoped to the CYCLE, so a genuine second opinion after the Super Agent pushes
+ * a fix is a fresh verdict, not a duplicate. Only `request_changes`: it is the
+ * decision with a side effect, and a repeated approval is inert — while
+ * dropping one could discard the verified retry of an approval whose first call
+ * lost its token.
+ */
+export function isDuplicateChangeRequest(
+  history: ReviewCycleActivity[],
+  reviewer: ReviewerKind,
+): boolean {
+  return reviewCycleVerdicts(history).get(reviewer) === "changes_requested";
 }
 
 export const TASK_BOARD_REVIEW_DECISION = defineTool({
@@ -168,6 +198,9 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
         taskBoardItemId,
         organizationId,
       );
+      if (isDuplicateChangeRequest(history, reviewer)) {
+        return { status: item.status, merged: false };
+      }
       if (reviewBounceLimitReached(history)) {
         await recordTaskActivity(ctx, {
           taskBoardItemId,


### PR DESCRIPTION
## Summary

Reviewer runs call `TASK_BOARD_REVIEW_DECISION` twice. On the Studio board last night, one QA run landed the same notes twice ~10s apart on **six** cards:

```
02:54:59  review_changes_requested  qa   "Objetivo da task NÃO alcançado…"
02:55:11  review_changes_requested  qa   "Objetivo da task NÃO alcançado…"   ← same run
```

The dispatch fence is fine — that's one reviewer thread emitting two verdicts, not two dispatches.

The first call already bounced the card, so the repeat is *usually* absorbed by `claimReviewChangesBounce` returning null (the card has left In Review). Two ways it isn't harmless:

1. **It can bounce the card twice.** If the Super Agent re-run finished between the two calls, the card is back In Review and the stale repeat bounces it again — a wasted sandbox run and a wasted bounce cycle on a verdict already answered.
2. **It charges the bounce budget early.** In `board_iD7Zw9AhNI5A6SMCTgGpc` the verdict at `02:54:59` bounced normally and the duplicate at `02:55:11` is what tripped `reviewBounceLimitReached` — the card was handed to a human one round before the cap actually allows. Four cards did this.

## Changes

`isDuplicateChangeRequest(history, reviewer)` — pure, reuses the shared cycle reducer and the `listActivity` call the bounce-limit check already makes, so no extra query. Checked before the cap so the repeat can't charge it.

Scoped to the **current cycle**, so a genuine second verdict after the agent pushes a fix is a fresh bounce. **`request_changes` only** — it's the decision with a side effect, and dropping a repeated *approval* could discard the verified retry of one whose first call lost its token.

## Testing

`bun test apps/api/src/tools/task-board/review-decision.test.ts` — 4 new cases (same reviewer twice, the other reviewer, a fresh cycle, an approval-only cycle). Typecheck clean.

Not fixed here: why the agent calls twice. The tool result is already unambiguous; this is the cheap guard on the receiving end.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignores a reviewer’s repeated change request within the current review cycle to prevent double bounces and premature bounce-cap charges. Previously, a duplicate `review_changes_requested` from the same reviewer could bounce a card twice or consume the bounce budget early; now we drop repeats before the cap check.

- Adds `isDuplicateChangeRequest(history, reviewer)` using `reviewCycleVerdicts` from `@decocms/shared/task-board`; pure and unit-tested.
- Checks for duplicates before `reviewBounceLimitReached` so repeats cannot charge the cap.
- Scoped to the current cycle; only affects `request_changes`. Approvals remain unchanged.
- No extra queries; reuses the existing activity read path. Four targeted tests added.

<sup>Written for commit dc4b27feb81e0ba62a52c57d73b1bccc96c0b39a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

