### PR TITLE
feat(task-board): make the Super Agent verify on the preview before review

### DIFF
--- a/apps/api/src/tools/task-board/claude-code-task-run.test.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.test.ts
@@ -48,6 +48,21 @@ describe("buildClaudeCodeTaskPrompt", () => {
     expect(buildClaudeCodeTaskPrompt(task, repo)).toContain("AUTONOMOUSLY");
   });
 
+  test("requires reachability and a preview check before handing over", () => {
+    const prompt = buildClaudeCodeTaskPrompt(task, repo);
+    expect(prompt).toContain("must be REACHABLE");
+    expect(prompt).toContain("mcp__studio__TASK_BOARD_ITEM_PRS_GET");
+    expect(prompt).toContain("A green test suite is not the bar");
+  });
+
+  test("a reviewer bounce says to reproduce the check on the preview", () => {
+    const prompt = buildClaudeCodeTaskPrompt(task, repo, {
+      feedback: "view_item never fires",
+      pr: { number: 340, url: "https://github.com/acme/web/pull/340" },
+    });
+    expect(prompt).toContain("judged the DEPLOYED PREVIEW");
+  });
+
   // Inverted: this used to say "move it to review anyway so a human can close
   // it out". In Review is the reviewers' lane and reviewers are only enqueued
   // for a task that HAS a PR, so a no-PR task parked there had nobody to pick

--- a/apps/api/src/tools/task-board/claude-code-task-run.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.ts
@@ -230,6 +230,7 @@ export function buildClaudeCodeTaskPrompt(
       opts.pr
         ? `Check that branch out (\`gh pr checkout ${opts.pr.number}\`) before editing, address the feedback, then push to update the SAME pull request — do NOT open a new one.`
         : "Address this feedback.",
+      "The reviewer judged the DEPLOYED PREVIEW, not your diff. Reproduce their check there before you push again — a fix that only looks right in the code comes straight back.",
       "",
     );
   } else if (opts?.pr) {
@@ -250,6 +251,9 @@ export function buildClaudeCodeTaskPrompt(
         ? " — or push to the existing one, per the instruction above."
         : "."),
     "- Change only what the task needs. Don't refactor around it.",
+    // The two defects behind every card that burned its bounce budget.
+    "- The change must be REACHABLE from the surface the task names: edit the component that route actually renders, not one that merely looks like the right place. A change nothing imports is dead code, and it is the most common reason a task comes back rejected.",
+    `- Before handing over, VERIFY the task's outcome the way the reviewer will: get the PR's \`previewUrl\` from \`mcp__studio__TASK_BOARD_ITEM_PRS_GET\` (give the deploy a minute), open the affected route there, and confirm the behaviour actually happens. A green test suite is not the bar — the reviewer approves what it can see on the preview.`,
     // The ONLY reliable way the board learns the PR: Claude Code opens it inside
     // the pod, so no Studio-side hook sees it (see pr-link.ts). Reviewers are
     // dispatched from the linked PR, so skipping this strands the card.


### PR DESCRIPTION
## Summary

Six cards on the Studio board burned **two full 5-bounce budgets** in one night (22:31→00:04, re-delegated by hand at 01:45, exhausted again by 02:55) and were handed to a human without shipping. Roughly 10 sandbox runs and 20 reviewer runs per card.

The reviewers were right every time, and the verdicts rhyme:

> Causa raiz: o IntersectionObserver foi adicionado em `PricingToggleClient.tsx`, que não é renderizado por nenhuma rota — só é consumido por `sections/Pricing/PricingToggle.tsx`, e nada importa essa section. O código novo é dead code.

The shape repeats across #337/#339/#340/#343: **Code Reviewer approves the diff** (tests pass, the helper is well written), **QA exercises the deploy preview and finds the behaviour absent.** That gap *is* the loop — the Super Agent hands over on a green suite, and the bar it's actually held to is the preview it never opened.

## Changes

Two lines on the sandboxed task prompt (`buildClaudeCodeTaskPrompt`), aimed at exactly those two defects:

- the change must be **reachable** from the surface the task names — edit the component that route renders, not one that merely looks like the right place;
- **verify the outcome on the PR's `previewUrl`** (via `TASK_BOARD_ITEM_PRS_GET`) before handing over — a green test suite is not the bar.

And on a reviewer bounce: the reviewer judged the *deployed preview*, not your diff — reproduce their check before pushing again.

## Testing

`bun test apps/api/src/tools/task-board/claude-code-task-run.test.ts` — 2 new cases pinning that the instructions are present on a fresh run and on a bounce.

That's all a test can prove here. This is a prompt heuristic against an observed pattern, not a guarantee; the bounce cap stays the backstop. If the loop persists, the next lever is structural — gate `status: in_review` on the run having actually fetched the preview.

Only the sandboxed prompt is touched. `buildSuperAgentTaskPrompt` (the Decopilot fallback, used when the org has no importable repo) has no preview to check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Requires the Super Agent to confirm code reachability and verify the outcome on the PR’s deployed preview before requesting review. Previously it handed over on a green test suite, which let dead or un-reachable changes pass code review but fail on the preview, burning bounce budgets.

**Notes for review**
- Updates the sandboxed task prompt to: ensure the change is reachable from the routed surface, and verify behavior on the PR `previewUrl` via `mcp__studio__TASK_BOARD_ITEM_PRS_GET` before handoff; clarifies that tests alone are not the bar.
- On reviewer bounce, the prompt now states the reviewer judged the deployed preview and instructs reproducing that check before pushing to the same PR.
- Adds tests asserting these instructions appear on fresh runs and on bounces.
- Scope: only the sandboxed prompt (`buildClaudeCodeTaskPrompt`); no change to the Decopilot fallback prompt, which has no preview.
- No migrations. Low risk; intended to reduce wasted reviewer cycles.

<sup>Written for commit b7e66c46dba74006ce5d076f6b31abb89520a457. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

