### PR TITLE
fix(sandbox): decrement the active-sandbox gauge on every eviction path

### DIFF
--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -50,6 +50,7 @@ import {
   waitForDaemonReady,
 } from "../../daemon-client";
 import {
+  ActiveGaugeTracker,
   Inflight,
   applyPreviewPattern,
   buildConfigPayload,
@@ -451,6 +452,8 @@ export class AgentSandboxProvider implements SandboxProvider {
 
   private readonly records = new Map<string, K8sRecord>();
   private readonly inflight = new Inflight<string, Sandbox>();
+  /** See `ActiveGaugeTracker` doc — decides which teardown owes a gauge decrement. */
+  private readonly activeGauge = new ActiveGaugeTracker();
   private readonly stateStore: RunnerStateStore | null;
   private readonly previewUrlPattern: string | null;
   private readonly kubeConfig: KubeConfig;
@@ -595,13 +598,7 @@ export class AgentSandboxProvider implements SandboxProvider {
   async delete(handle: string): Promise<void> {
     const rec = await this.getRecord(handle);
     this.records.delete(handle);
-    if (rec) {
-      this.closeForwarder(rec.daemonForward);
-      // Decrement only when we actually held the record — getRecord can be
-      // null after restart-without-state-store, in which case the gauge
-      // was never incremented for this handle in this process.
-      this.metrics?.active.add(-1, tenantAttrs(rec.tenant));
-    }
+    if (rec) this.dropRecord(rec);
     // Drop the HTTPRoute first so traffic stops resolving immediately —
     // the operator's claim teardown can take a few seconds, and we don't
     // want browsers landing on a half-deleted Service in the interim.
@@ -1192,7 +1189,10 @@ export class AgentSandboxProvider implements SandboxProvider {
       // Only increment the active gauge on first observation to avoid
       // double-counting when the same handle is rehydrated multiple times
       // (studio-process internal cache hit; ensureLocked is invoked again).
-      if (!wasCached) this.metrics.active.add(1, attrs);
+      if (!wasCached) {
+        this.metrics.active.add(1, attrs);
+        this.activeGauge.markCounted(rec.handle);
+      }
     }
     return this.toSandbox(rec);
   }
@@ -2324,7 +2324,22 @@ export class AgentSandboxProvider implements SandboxProvider {
     const rec = this.records.get(handle);
     if (!rec) return;
     this.records.delete(handle);
+    this.dropRecord(rec);
+  }
+
+  /**
+   * Common teardown for a record leaving `this.records`: close its
+   * port-forward and decrement the active gauge, but only if this record
+   * actually owes a decrement (see `ActiveGaugeTracker`). Shared by every
+   * eviction path — explicit `delete()`, a stale/401'd cache entry, an
+   * operator-driven claim reap, and provider `close()` — so none of them can
+   * silently under- or over-count.
+   */
+  private dropRecord(rec: K8sRecord): void {
     this.closeForwarder(rec.daemonForward);
+    if (this.metrics && this.activeGauge.consume(rec.handle)) {
+      this.metrics.active.add(-1, tenantAttrs(rec.tenant));
+    }
   }
 
   // ---- Metric helpers -------------------------------------------------------
@@ -2612,7 +2627,7 @@ export class AgentSandboxProvider implements SandboxProvider {
     this.closed = true;
     this.claimWatchAbort.abort();
     for (const rec of this.records.values()) {
-      this.closeForwarder(rec.daemonForward);
+      this.dropRecord(rec);
     }
     this.records.clear();
   }

--- a/packages/sandbox/server/provider/shared/active-gauge-tracker.test.ts
+++ b/packages/sandbox/server/provider/shared/active-gauge-tracker.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+import { ActiveGaugeTracker } from "./active-gauge-tracker";
+
+describe("ActiveGaugeTracker", () => {
+  test("consume returns false for a handle that was never marked counted", () => {
+    const tracker = new ActiveGaugeTracker();
+    expect(tracker.consume("h1")).toBe(false);
+  });
+
+  test("consume returns true exactly once for a marked handle", () => {
+    const tracker = new ActiveGaugeTracker();
+    tracker.markCounted("h1");
+    expect(tracker.consume("h1")).toBe(true);
+    expect(tracker.consume("h1")).toBe(false);
+  });
+
+  test("tracks multiple handles independently", () => {
+    const tracker = new ActiveGaugeTracker();
+    tracker.markCounted("h1");
+    tracker.markCounted("h2");
+    expect(tracker.consume("h1")).toBe(true);
+    expect(tracker.consume("h2")).toBe(true);
+    expect(tracker.consume("h1")).toBe(false);
+  });
+});

--- a/packages/sandbox/server/provider/shared/active-gauge-tracker.ts
+++ b/packages/sandbox/server/provider/shared/active-gauge-tracker.ts
@@ -1,0 +1,28 @@
+/**
+ * Tracks which sandbox handles actually contributed a +1 to the "active
+ * sandboxes" gauge, so a teardown path doesn't have to guess whether it owes
+ * a decrement.
+ *
+ * The gauge is only incremented on a fresh `ensure()` observation (see
+ * `AgentSandboxProvider.finish`); a record can also enter the in-memory cache
+ * via a read-only path (`getRecord` rehydrating from the state store) that
+ * never increments it. Decrementing unconditionally on every teardown would
+ * undercount for records the gauge never counted, and — the more common case
+ * in practice — a record evicted by something other than an explicit
+ * `delete()` call (idle-TTL claim reap, a stale port-forward, a 401) would
+ * never decrement at all, since only `delete()` touched the gauge before this
+ * tracker existed. Both drift the gauge away from the cluster's real count,
+ * which is exactly the divergence this metric exists to surface.
+ */
+export class ActiveGaugeTracker {
+  private readonly counted = new Set<string>();
+
+  markCounted(handle: string): void {
+    this.counted.add(handle);
+  }
+
+  /** True (and clears the entry) iff this handle owes a decrement. */
+  consume(handle: string): boolean {
+    return this.counted.delete(handle);
+  }
+}

--- a/packages/sandbox/server/provider/shared/index.ts
+++ b/packages/sandbox/server/provider/shared/index.ts
@@ -1,3 +1,4 @@
+export { ActiveGaugeTracker } from "./active-gauge-tracker";
 export { Inflight } from "./inflight";
 export { withSandboxLock } from "./lock";
 export { computeHandle } from "./handle";


### PR DESCRIPTION
Bug found while auditing `AgentSandboxProvider` for lifecycle races/resource leaks (sandbox-runner-stability focus area).

`studio.sandbox.active` (an `UpDownCounter`, doc'd as the cross-check against the cAdvisor-derived active count — "divergence...indicates orphaned claims") was only ever decremented inside `delete()`. Every other teardown path left it untouched:

- `invalidateRecord()` — fires on a stale port-forward, a 401 (rotated token), and on `watchClaimDeletions`'s `onDelete` callback, i.e. the *normal* idle-TTL eviction path for an ephemeral sandbox. Since most sandboxes die by idle TTL rather than an explicit `SANDBOX_DELETE` call, the gauge only ever trended upward in a long-running replica.
- `close()` — same issue on provider shutdown.

A second, opposite-direction bug shares the root cause: `getRecord()` populates `this.records` straight from `rehydrate()`, bypassing `finish()` (the only place that used to increment the gauge). A record that entered the cache purely through a read path (`proxyDaemonRequest`, `getPreviewUrl`, ...) and was later torn down via `delete()` would cause a decrement the gauge was never incremented for.

Why a maintainer wants this: the gauge is the primary signal an on-call engineer reads to spot orphaned claims (studio thinks a sandbox is gone but K8s didn't reap it, or vice versa) — a metric that structurally drifts defeats its own purpose.

Fix: a tiny new pure unit, `ActiveGaugeTracker` (`packages/sandbox/server/provider/shared/active-gauge-tracker.ts`), tracks which handles actually got a `+1`. `finish()` marks a handle counted only on the same `!wasCached` branch that already gated the increment. A new `dropRecord()` helper is now the single teardown path used by `delete()`, `invalidateRecord()`, and `close()` — it consumes the tracker before deciding whether to decrement, so a never-incremented record can no longer under-count and an idle-TTL/401 eviction can no longer skip its decrement.

How to verify: `bun test packages/sandbox/server/provider/shared/active-gauge-tracker.test.ts` (new — pins the tracker's own-once/never-counted/independent-handles behavior). No behavior change to sandbox provisioning/proxying itself, only to when the metric moves — confirmed by re-running the existing pure-function suite `packages/sandbox/server/provider/agent-sandbox/runner.test.ts` (17/17 still pass) plus a typecheck of the `sandbox` workspace.

Locally ran: `bun run fmt`, `cd packages/sandbox && bunx tsc --noEmit`, the two test files above, `bunx oxlint` on every changed file (all clean). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes drift in `studio.sandbox.active` by decrementing the active gauge on every eviction path and only for handles that actually incremented it. Before: only `delete()` decremented, while idle-TTL/401/stale-forwarder/`close()` did not; rehydrated records could decrement without a prior increment.

- Introduces `ActiveGaugeTracker`; `finish()` marks counted on first observation (`!wasCached`). Adds `dropRecord()` to centralize teardown and consume the tracker before deciding to decrement.
- Routes `delete()`, `invalidateRecord()`, claim watcher `onDelete`, and `close()` through `dropRecord()` to prevent under/over-counting; still closes the forwarder in all cases.
- Behavior limited to metric accuracy; provisioning/proxy logic unchanged. Adds unit test for the tracker; existing runner tests continue to pass.

<sup>Written for commit 998fdaa3559b8769bff95706758e6b01b0328e13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

