### PR TITLE
fix(chat): guard orphan tool-approval-request/output-denied chunks

### DIFF
--- a/apps/web/src/components/chat/store/tool-invariant-guard.test.ts
+++ b/apps/web/src/components/chat/store/tool-invariant-guard.test.ts
@@ -121,6 +121,29 @@ describe("createToolInvariantGuard", () => {
     }
   });
 
+  it("synthesizes a tool-input-available before an orphan approval request", () => {
+    const guard = createToolInvariantGuard();
+    const out = flat(guard, [
+      { type: "tool-approval-request", toolCallId: "tc", approvalId: "a1" },
+    ] as UIMessageChunk[]);
+    expect(out.map((c) => c.type)).toEqual([
+      "tool-input-available",
+      "tool-approval-request",
+    ]);
+    expect(out[0]).toMatchObject({ toolCallId: "tc", toolName: "unknown" });
+  });
+
+  it("synthesizes a tool-input-available before an orphan output-denied", () => {
+    const guard = createToolInvariantGuard();
+    const out = flat(guard, [
+      { type: "tool-output-denied", toolCallId: "tc" },
+    ] as UIMessageChunk[]);
+    expect(out.map((c) => c.type)).toEqual([
+      "tool-input-available",
+      "tool-output-denied",
+    ]);
+  });
+
   it("leaves non-tool chunks alone", () => {
     const guard = createToolInvariantGuard();
     const out = flat(guard, [

--- a/apps/web/src/components/chat/store/tool-invariant-guard.ts
+++ b/apps/web/src/components/chat/store/tool-invariant-guard.ts
@@ -21,7 +21,12 @@ import type { UIMessage, UIMessageChunk } from "ai";
 const CREATES_PART = new Set(["tool-input-start", "tool-input-available"]);
 
 /** Chunk types that require a pre-existing part and throw without one. */
-const REQUIRES_PART = new Set(["tool-output-available", "tool-output-error"]);
+const REQUIRES_PART = new Set([
+  "tool-output-available",
+  "tool-output-error",
+  "tool-approval-request",
+  "tool-output-denied",
+]);
 
 /** Placeholder name for a tool whose input part was lost. */
 const UNKNOWN_TOOL_NAME = "unknown";


### PR DESCRIPTION
**Bug fix**, found while auditing the chat thread-connection store's tool-invariant guard (`apps/web/src/components/chat/store/tool-invariant-guard.ts`).

**Why a maintainer wants this:** `guardToolInvariant` exists specifically so an SSE tail that starts mid-run (subject purge, retention gap, pod SIGTERM'd mid-step) can't brick the chat by delivering a tool chunk whose `tool-input-start`/`tool-input-available` this client never saw. But its `REQUIRES_PART` set only covered `tool-output-available` and `tool-output-error`. The AI SDK's `readUIMessageStream` reducer (`node_modules/ai/dist/index.js`) calls the exact same throwing `getToolInvocation()` lookup for `tool-approval-request` and `tool-output-denied` too — so an orphan approval-request or denial chunk (e.g. a reconnect landing right as the server asks for tool approval, or another session's denial arriving before this client saw the call start) still threw `No tool invocation found for tool call ID "X"` and bricked the whole chat, the exact failure mode this file exists to prevent.

**Failure scenario:** client reconnects to `/stream` mid-run; the first chunk it sees for a given `toolCallId` is `tool-approval-request` (or `tool-output-denied`) instead of `tool-input-start`/`tool-input-available`. `readUIMessageStream` throws inside the fold, `onError` routes it through `failTo`, and the thread's status flips to a terminal error — the user has to reload.

**Fix:** add `tool-approval-request` and `tool-output-denied` to `REQUIRES_PART` so an orphan chunk of either type gets the same synthetic `tool-input-available` (named "unknown") the existing output-chunk cases already get, matching the AI SDK's own read order (input-available always precedes approval-request/output-denied in the source stream).

**Regression tests:** added two cases to `tool-invariant-guard.test.ts` asserting the synthetic `tool-input-available` is inserted before an orphan `tool-approval-request` and before an orphan `tool-output-denied`, mirroring the existing orphan-output tests.

**Reviewer command:** `bun test apps/web/src/components/chat/store/tool-invariant-guard.test.ts`

**Locally verified:** `bun run fmt`, `bunx tsc --noEmit` (apps/web), the targeted test file above (11 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guards orphan `tool-approval-request` and `tool-output-denied` chunks to prevent chat crashes on mid-run reconnects. Previously, these chunks threw when no prior `tool-input-start/available` existed; now the guard inserts a synthetic `tool-input-available` (toolName "unknown") before them, matching `readUIMessageStream` in `ai`.

- Changes: add `tool-approval-request` and `tool-output-denied` to `REQUIRES_PART` in `tool-invariant-guard.ts`; behavior for other chunk types is unchanged.
- Tests: new cases assert synthetic `tool-input-available` precedes orphan approval/denied chunks. Run `bun test apps/web/src/components/chat/store/tool-invariant-guard.test.ts`.

<sup>Written for commit 0b2c52b6efdd3563a99bfcb5378ce6b5ba3cb791. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

