### PR TITLE
fix(commit-suggestion): never dump raw model output into PR body

### DIFF
--- a/apps/api/src/lib/suggest-commit-message.test.ts
+++ b/apps/api/src/lib/suggest-commit-message.test.ts
@@ -22,10 +22,18 @@ describe("parseCommitSuggestionJson", () => {
     expect(result?.title).toBe("Fix bug");
   });
 
-  test("falls back to first line as title", () => {
-    const result = parseCommitSuggestionJson("Plain title\n\nMore detail");
-    expect(result?.title).toBe("Plain title");
-    expect(result?.body).toBe("More detail");
+  test("returns null for non-JSON output instead of dumping it", () => {
+    // A leaked scratchpad must fall through to the deterministic summary.
+    expect(parseCommitSuggestionJson("Plain title\n\nMore detail")).toBeNull();
+    expect(
+      parseCommitSuggestionJson(
+        "1. Analyze the Request:\n * Task: Write a commit message\n2. Drafting the Title:",
+      ),
+    ).toBeNull();
+  });
+
+  test("returns null when JSON is missing a title", () => {
+    expect(parseCommitSuggestionJson('{"body":"no title here"}')).toBeNull();
   });
 });
 

--- a/apps/api/src/lib/suggest-commit-message.ts
+++ b/apps/api/src/lib/suggest-commit-message.ts
@@ -264,13 +264,8 @@ export function parseCommitSuggestionJson(
       message: body ? `${title}\n\n${body}` : title,
     };
   } catch {
-    const firstLine = cleaned.split("\n")[0]?.trim() ?? "";
-    if (!firstLine) return null;
-    return {
-      title: firstLine.slice(0, 120),
-      body: cleaned.slice(firstLine.length).trim(),
-      message: cleaned,
-    };
+    // Non-JSON output (e.g. a leaked scratchpad) must never reach a PR body.
+    return null;
   }
 }
 


### PR DESCRIPTION
## Summary

When the auto-generated commit/PR fell back on a non-JSON model response, it dumped the model's **raw output** straight into the PR body. This is what produced the leaked chain-of-thought description in [deco-sites/miess-01#298](https://github.com/deco-sites/miess-01/pull/298) — the "fast" tier model (Haiku 4.5 / qwen-flash) emitted an `1. Analyze the Request…` scratchpad instead of JSON, `JSON.parse` threw, and the `catch` branch salvaged the first line as the title and the rest as the body.

`parseCommitSuggestionJson` now returns `null` on any non-JSON output, so `suggestCommitMessageWithLlm` falls through to the deterministic `fallbackCommitSuggestion` (built from git status). A model that ignores the JSON contract now yields a plain-but-correct description instead of leaking its reasoning.

### Why not extract JSON from mixed text
The leaked scratchpad contains a **decoy JSON** (the prompt's own `{"title":"…","body":"…"}` schema echoed back). Any "find the JSON substring" heuristic would pick up that template and emit a garbage title like *"Short imperative commit title (max 72 chars)"*. Failing clean into the deterministic fallback is the safe choice.

## Testing
- Inverted the `parseCommitSuggestionJson` test that encoded the old first-line-as-title dump; it now asserts `null` for prose and for a scratchpad-shaped input, plus a case for JSON missing a `title`.
- `bun test apps/api/src/lib/suggest-commit-message.test.ts` → 11 pass.
- `bun run fmt` clean.

## Affected areas
`apps/api/src/lib/suggest-commit-message.ts` — the auto commit/PR description path. No API or schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents raw model output from being inserted into auto-generated commit/PR descriptions when a non-JSON response is returned. Previously, on JSON parse failure we used the first line as the title and the rest as the body; now `parseCommitSuggestionJson` returns `null`, causing a fallback to the deterministic `fallbackCommitSuggestion` to avoid leaking scratchpads.

- Changes are limited to `apps/api/src/lib/suggest-commit-message.ts`; no API or schema changes.
- Tests updated to assert `null` on non-JSON and missing-title cases; all tests pass.

<sup>Written for commit 4907b32b57cbddca72f561815c3ded1625ea5d20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

