### PR TITLE
fix(report): severity chips must survive a translated deck

### DIFF
--- a/apps/web/src/routes/reports/templates/paginas-variant.tsx
+++ b/apps/web/src/routes/reports/templates/paginas-variant.tsx
@@ -4,11 +4,16 @@ import { DECK } from "./tokens";
 import { useT } from "@/i18n/use-t.ts";
 import type { TableProps } from "@decocms/shared/reports/deck-types";
 
-// Severity chips are graded by the engine's pt-BR badge label — the badge tone
-// alone can't tell "Atenção" from "Menor" (both arrive `neutral`).
+// Severity chips are graded by the engine's badge LABEL — the badge tone alone
+// can't tell "Atenção" from "Menor" (both arrive `neutral`). The label is
+// client copy, so it arrives translated on a non-pt deck: key both languages.
+const CRITICAL = { color: "#ef4444", tint: "rgba(239,68,68,0.12)" };
+const WARNING = { color: "#d98324", tint: "rgba(217,131,36,0.12)" };
 const SEVERITY_STYLE: Record<string, { color: string; tint: string }> = {
-  Crítico: { color: "#ef4444", tint: "rgba(239,68,68,0.12)" },
-  Atenção: { color: "#d98324", tint: "rgba(217,131,36,0.12)" },
+  Crítico: CRITICAL,
+  Critical: CRITICAL,
+  Atenção: WARNING,
+  Warning: WARNING,
 };
 const SEVERITY_FALLBACK = { color: DECK.muted, tint: "rgba(13,9,6,0.06)" };
 


### PR DESCRIPTION
`paginas-variant.tsx` colors its severity chips by the engine's badge **label**, not its tone — the comment explains why: tone alone can't tell `Atenção` from `Menor`, both arrive `neutral`.

But the label is client copy, so on a non-pt deck it arrives translated (`Critical`, `Warning`) and every chip falls through to `SEVERITY_FALLBACK` grey. Keying both languages restores the color.

Worth doing now because the reports engine is about to produce an English deck for every diagnostic rather than only for non-pt sites (decocms/reports#361), so this goes from affecting a handful of decks to affecting every EN view.

If a third language shows up, the durable fix is for the engine to ship a stable severity key next to the display label — this map is the cheap version until then.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores severity chip colors on translated decks by matching both pt-BR and EN badge labels. Previously EN labels did not match the pt-BR keys, so all chips fell back to grey; now both labels map to the intended styles.

- Maps `Crítico`/`Critical` to the same CRITICAL style and `Atenção`/`Warning` to the same WARNING style.
- Keeps the existing fallback for unknown labels; no API or engine changes.
- Short-term fix until the engine exposes a stable severity key alongside the display label.

<sup>Written for commit 25305051304b4778fcf8c8652d9e9858530d8bc3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

