### PR TITLE
refactor(decopilot): dedupe the http(s)-only URL schema and error-body cap into browserless-fetch

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/browserless-fetch.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/browserless-fetch.ts
@@ -1,8 +1,20 @@
+import { z } from "zod";
 import { BROWSERLESS_FETCH_TIMEOUT_MS } from "./constants";
 
 export type BrowserlessFetchResult =
   | { ok: true; response: Response }
   | { ok: false; error: string };
+
+// Upstream error bodies are unbounded — cap what lands in the tool error.
+export const BROWSERLESS_ERROR_BODY_MAX_CHARS = 500;
+
+// Reject non-http(s) schemes (file:, javascript:, ...) before forwarding to Browserless.
+export const httpUrlSchema = z
+  .string()
+  .url()
+  .refine((url) => /^https?:\/\//i.test(url), {
+    message: "URL must use http or https",
+  });
 
 /**
  * Human-readable reason for a Browserless call that never produced a response.

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.ts
@@ -19,20 +19,14 @@ import type { ObjectStorageHooks } from "../../harness-deps";
 import { createOutputPreview, estimateJsonTokens } from "./read-tool-output";
 import { toStudioStorageUri } from "../studio-storage-uri";
 import { LARGE_RESULT_TOKEN_THRESHOLD } from "./constants";
-import { browserlessFetch } from "./browserless-fetch";
+import {
+  browserlessFetch,
+  BROWSERLESS_ERROR_BODY_MAX_CHARS,
+  httpUrlSchema,
+} from "./browserless-fetch";
 
-// Upstream error bodies are unbounded — cap what lands in the tool error.
-const ERROR_BODY_MAX_CHARS = 500;
-
-// Reject non-http(s) schemes (file:, javascript:, ...) before forwarding to Browserless.
 const InspectPageInputSchema = z.object({
-  url: z
-    .string()
-    .url()
-    .refine((url) => /^https?:\/\//i.test(url), {
-      message: "URL must use http or https",
-    })
-    .describe("The URL of the web page to inspect."),
+  url: httpUrlSchema.describe("The URL of the web page to inspect."),
   evaluate: z
     .string()
     .optional()
@@ -147,7 +141,7 @@ export function createInspectPageTool(
           const errorText = await response.text().catch(() => "Unknown error");
           return {
             success: false,
-            error: `Browserless function call failed (${response.status}): ${errorText.slice(0, ERROR_BODY_MAX_CHARS)}`,
+            error: `Browserless function call failed (${response.status}): ${errorText.slice(0, BROWSERLESS_ERROR_BODY_MAX_CHARS)}`,
             url: input.url,
           };
         }

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/scrape-url.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/scrape-url.ts
@@ -16,20 +16,14 @@ import type { ObjectStorageHooks } from "../../harness-deps";
 import { createOutputPreview, estimateJsonTokens } from "./read-tool-output";
 import { toStudioStorageUri } from "../studio-storage-uri";
 import { LARGE_RESULT_TOKEN_THRESHOLD } from "./constants";
-import { browserlessFetch } from "./browserless-fetch";
+import {
+  browserlessFetch,
+  BROWSERLESS_ERROR_BODY_MAX_CHARS,
+  httpUrlSchema,
+} from "./browserless-fetch";
 
-// Upstream error bodies are unbounded — cap what lands in the tool error.
-const ERROR_BODY_MAX_CHARS = 500;
-
-// Reject non-http(s) schemes (file:, javascript:, ...) before forwarding to Browserless.
 const ScrapeUrlInputSchema = z.object({
-  url: z
-    .string()
-    .url()
-    .refine((url) => /^https?:\/\//i.test(url), {
-      message: "URL must use http or https",
-    })
-    .describe("The URL of the web page to scrape."),
+  url: httpUrlSchema.describe("The URL of the web page to scrape."),
 });
 
 export type ScrapeUrlInput = z.infer<typeof ScrapeUrlInputSchema>;
@@ -79,7 +73,7 @@ export function createScrapeUrlTool(
           const errorText = await response.text().catch(() => "Unknown error");
           return {
             success: false,
-            error: `Browserless content fetch failed (${response.status}): ${errorText.slice(0, ERROR_BODY_MAX_CHARS)}`,
+            error: `Browserless content fetch failed (${response.status}): ${errorText.slice(0, BROWSERLESS_ERROR_BODY_MAX_CHARS)}`,
             url: input.url,
           };
         }


### PR DESCRIPTION
Reduction: `scrape-url.ts` and `inspect-page.ts` each hand-rolled an identical `ERROR_BODY_MAX_CHARS = 500` constant and an identical Zod URL schema (`.url().refine(/^https?:\/\//i, ...)`) with the same comment above it — copy-pasted, not shared. This mirrors the `browserlessFetch` consolidation already done in #6041 for the fetch-error-handling shape; the URL-validation and error-body-cap shape was left behind.

Moved both into `browserless-fetch.ts` (the pair's existing shared home) as exported `httpUrlSchema` and `BROWSERLESS_ERROR_BODY_MAX_CHARS`, and updated both call sites to import them instead of redefining.

Net: -26/+26 net-zero lines but removes the duplicated definitions (one shared source of truth for the http(s)-only URL check, matching a security-relevant validation that must stay in sync between the two tools). Behavior-preserving — the schema and constant values are unchanged, only relocated.

How to verify: `cd apps/api && bunx tsc --noEmit` (green), `bun test apps/api/src/harnesses/lib/decopilot/built-in-tools/browserless-fetch.test.ts` (3/3 pass, unchanged assertions), `bunx oxlint` on the three touched files (0 warnings/errors).

Locally ran: `bun run fmt`, targeted `tsc --noEmit` in apps/api, the targeted test file above, and per-file oxlint. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates Decopilot’s http(s)-only URL validation and error-body cap into `browserless-fetch`. Old: `scrape-url.ts` and `inspect-page.ts` each defined the schema and 500-char cap. New: both import `httpUrlSchema` and `BROWSERLESS_ERROR_BODY_MAX_CHARS` from `browserless-fetch.ts`. Behavior is unchanged.

- Touches three files; updates imports and adds two exports in `browserless-fetch.ts`.
- Validation still requires http/https; the error-body cap remains 500 characters.
- Centralizes a security-relevant check; future edits go in `browserless-fetch.ts`.
- Build, tests, and lint pass; no rollout or migration steps.

<sup>Written for commit 9e379cd0a880c622ec0a0bab7ad9c6764b7ab53d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

