### PR TITLE
fix(connection): bound the CONNECTION_TEST health-check fetch with a timeout

### DIFF
--- a/apps/api/src/storage/connection.ts
+++ b/apps/api/src/storage/connection.ts
@@ -479,10 +479,14 @@ export class ConnectionStorage implements ConnectionStoragePort {
         headers?: Record<string, string>;
       } | null;
 
-      const response = await createNoRedirectFetch()(
-        connection.connection_url,
-        {
+      // Bound the probe — a hanging remote server shouldn't hang this call.
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 10_000);
+      let response: Response;
+      try {
+        response = await createNoRedirectFetch()(connection.connection_url, {
           method: "POST",
+          signal: controller.signal,
           headers: {
             "Content-Type": "application/json",
             ...(connection.connection_token && {
@@ -496,8 +500,10 @@ export class ConnectionStorage implements ConnectionStoragePort {
             method: "ping",
             id: 1,
           }),
-        },
-      );
+        });
+      } finally {
+        clearTimeout(timer);
+      }
 
       return {
         healthy: response.ok || response.status === 404,


### PR DESCRIPTION
**Source:** bug found while hardening `apps/api/src/storage/connection.ts` post-merge (no linked issue).

**Why:** `ConnectionStorage.testConnection()` awaits `createNoRedirectFetch()(connection.connection_url, ...)` with no `AbortSignal`. A slow or hanging remote MCP server means the health check — and the `CONNECTION_TEST` tool call awaiting it — never returns, tying up the request indefinitely. The sibling outbound probe in `discover-tools.ts`'s `tryRawToolsList` already bounds itself with an `AbortController` + `setTimeout`; this connection test had no equivalent.

**Fix:** wrap the fetch with an `AbortController` that aborts after 10s (matching the existing 10s bound used elsewhere in this file's neighbor, `discover-tools.ts`), clearing the timer in a `finally`. Behavior on a normal, responsive connection is unchanged — the abort only fires if the remote server doesn't respond in time, in which case the existing `catch` block already returns `{ healthy: false }`.

**How to verify:** call `COLLECTION_CONNECTIONS_TEST` (or `ConnectionStorage.testConnection`) against a connection URL that never responds (e.g. a TCP listener that accepts but never replies) and confirm it resolves `{ healthy: false }` within ~10s instead of hanging.

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bunx oxlint apps/api/src/storage/connection.ts` — all clean. Did not run `connection.integration.test.ts` locally since it needs a real Postgres instance not available in this sandbox; CI's existing integration suite (including the two `testConnection` cases for unreachable/private-network URLs) exercises this method and should still pass unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the connection health check in `ConnectionStorage.testConnection()` with a 10s timeout to prevent hangs. Previously the fetch had no `AbortSignal` and could block indefinitely on a slow or nonresponsive MCP server; now it aborts after 10s and the method returns `{ healthy: false }` via the existing error path. Normal responsive connections are unchanged.

- Uses `AbortController` + `setTimeout`, passes `signal` to `createNoRedirectFetch`, and clears the timer in `finally`.
- Timeout matches the 10s bound already used in `discover-tools.ts`’s `tryRawToolsList`.
- To verify: run `COLLECTION_CONNECTIONS_TEST` against a nonresponsive URL and confirm it resolves in ~10s with `{ healthy: false }`.

<sup>Written for commit 3b21e4e690abdad4ae4ec975ab41e34446f5e8a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

