### PR TITLE
fix(task-board): claim the sweep interval instead of stamping it

### DIFF
--- a/apps/api/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/api/src/dbos/workflow-source-guard.snapshot.json
@@ -8,5 +8,5 @@
   "harnesses/decopilot/background-tool-workflow.ts": "9febb699f45b63b418481ed998aee0ec8251c97cb5c409d54d714eb365a08fd0",
   "monitoring/dbos-retention-workflow.ts": "757e9999af900d9395c6629d4966b84c723512d0a5a8e488f70b7ba634752bd8",
   "tools/task-board/dbos-archive-sweep.ts": "fe2db3802dd291f4d9ad5369a21c28854403bd2756518d9b48c1fcda4f100000",
-  "tools/task-board/dbos-github-read.ts": "bc498f9d45d1470e08efb1992434d07148e1bd444d2c19fc2bfcb2d2d096aa49"
+  "tools/task-board/dbos-github-read.ts": "af41b496ceb924823fa99930fcf2da092bc85dcec5512a0133a541bd5d8a5a6d"
 }

--- a/apps/api/src/storage/task-board-pending-review.integration.test.ts
+++ b/apps/api/src/storage/task-board-pending-review.integration.test.ts
@@ -262,6 +262,9 @@ describe("listItemsPendingReview (real Postgres)", () => {
   // whole mechanism is one NULL-aware SQL predicate plus one narrow UPDATE.
   describe("due filter (last_swept_at)", () => {
     const ORG_DUE = "org_pending_due";
+    /** The cutoff a live tick passes: one interval ago. It must be in the PAST
+     *  — a future cutoff re-claims a card this same tick already stamped. */
+    const dueNow = () => new Date(Date.now() - 5 * 60_000);
 
     beforeAll(async () => {
       await database.db
@@ -315,7 +318,7 @@ describe("listItemsPendingReview (real Postgres)", () => {
     // costs. Also asserts the stamp does NOT move `updated_at` — that column is
     // the keyset cursor and the UI's "edited" signal, and churning it on every
     // sweep would reorder the backlog under the cursor.
-    it("markSwept claims the interval without touching updated_at", async () => {
+    it("claimSweep claims the interval without touching updated_at", async () => {
       const item = await card({ org: ORG_DUE, title: "claimed" });
       const before = await database.db
         .selectFrom("task_board_items")
@@ -324,7 +327,7 @@ describe("listItemsPendingReview (real Postgres)", () => {
         .executeTakeFirstOrThrow();
       expect(before.last_swept_at).toBeNull();
 
-      await taskBoard.markSwept(item.id, ORG_DUE);
+      expect(await taskBoard.claimSweep(item.id, ORG_DUE, dueNow())).toBe(true);
 
       const after = await database.db
         .selectFrom("task_board_items")
@@ -343,9 +346,9 @@ describe("listItemsPendingReview (real Postgres)", () => {
 
     // Org-scoped like every other write here: a task id alone must not let one
     // org's sweep stamp another org's card.
-    it("markSwept will not stamp a card from another org", async () => {
+    it("claimSweep will not stamp a card from another org", async () => {
       const item = await card({ org: ORG_DUE, title: "other org" });
-      await taskBoard.markSwept(item.id, ORG_A);
+      expect(await taskBoard.claimSweep(item.id, ORG_A, dueNow())).toBe(false);
 
       const row = await database.db
         .selectFrom("task_board_items")
@@ -353,6 +356,41 @@ describe("listItemsPendingReview (real Postgres)", () => {
         .where("id", "=", item.id)
         .executeTakeFirstOrThrow();
       expect(row.last_swept_at).toBeNull();
+    });
+
+    // The reason this is a claim and not a stamp. Every replica reads the same
+    // work list in the same second, and an unconditional write let all of them
+    // through to the GitHub calls that follow: two `merge_pull_request` calls
+    // landed on one PR inside a second, the loser answered "405 Merge already
+    // in progress" and recorded as a merge failure on the card's timeline.
+    it("a second replica in the same round loses the claim", async () => {
+      const item = await card({ org: ORG_DUE, title: "contended" });
+
+      const cutoff = dueNow();
+      expect(await taskBoard.claimSweep(item.id, ORG_DUE, cutoff)).toBe(true);
+      expect(await taskBoard.claimSweep(item.id, ORG_DUE, cutoff)).toBe(false);
+    });
+
+    it("the card is claimable again once its interval has passed", async () => {
+      const item = await card({ org: ORG_DUE, title: "next round" });
+      await sweptAt(item.id, "2026-01-01T00:05:00.000Z");
+
+      // Same boundary the work list uses: swept at :05, so a tick whose cutoff
+      // is :00 must not re-claim it, and one at :10 must.
+      expect(
+        await taskBoard.claimSweep(
+          item.id,
+          ORG_DUE,
+          new Date("2026-01-01T00:00:00.000Z"),
+        ),
+      ).toBe(false);
+      expect(
+        await taskBoard.claimSweep(
+          item.id,
+          ORG_DUE,
+          new Date("2026-01-01T00:10:00.000Z"),
+        ),
+      ).toBe(true);
     });
   });
 });

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -662,23 +662,42 @@ export class TaskBoardStorage {
   }
 
   /**
-   * Stamp a card as swept. Claims the card's next interval for whichever replica
-   * got there first, so the stamp must be written for every card the sweeper
-   * LOOKS at, not only the ones it dispatches a reviewer for — a card that has no
-   * PR, or whose checks are still pending, is exactly the card that otherwise
-   * comes back on every tick forever.
+   * Claim the card's next sweep interval. Returns true only for the replica that
+   * won it; a loser must skip the card entirely. Claimed for every card the
+   * sweeper LOOKS at, not only the ones it dispatches a reviewer for — a card
+   * that has no PR, or whose checks are still pending, is exactly the card that
+   * otherwise comes back on every tick forever.
+   *
+   * `dueBefore` is the same cutoff the work list was read with, and it is what
+   * makes this a claim rather than a stamp. An unconditional write was not one:
+   * three replicas that all read the card as due all passed it, and all three
+   * went on to call GitHub — two `merge_pull_request` calls on the same PR
+   * inside one second, the loser answered `405 Merge already in progress` and
+   * written to the card's timeline as a failure. The per-card interval bounded
+   * the number of ROUNDS but never the pods within one.
    *
    * Writes `last_swept_at` alone, on purpose: it does not go through `update()`
    * (whose column whitelist is for user edits) and it must not touch
    * `updated_at`, which is this table's keyset cursor and its UI "edited" signal.
    */
-  async markSwept(id: string, organizationId: string): Promise<void> {
-    await this.db
+  async claimSweep(
+    id: string,
+    organizationId: string,
+    dueBefore: Date,
+  ): Promise<boolean> {
+    const rows = await this.db
       .updateTable("task_board_items")
       .set({ last_swept_at: new Date() })
       .where("id", "=", id)
       .where("organization_id", "=", organizationId)
-      .execute();
+      .where((eb) =>
+        eb.or([
+          eb("last_swept_at", "is", null),
+          eb("last_swept_at", "<", dueBefore),
+        ]),
+      )
+      .executeTakeFirst();
+    return Number(rows.numUpdatedRows ?? 0) > 0;
   }
 
   /**
@@ -971,7 +990,7 @@ export class TaskBoardStorage {
    * bound GitHub calls on a card that keeps coming back unchanged; a PR landing
    * on it is new information, so it earns one immediate look instead of waiting
    * out a budget claimed while there was nothing to see. Same narrow write as
-   * `markSwept` — never `updated_at`.
+   * `claimSweep` — never `updated_at`.
    */
   async clearSweepBudget(id: string, organizationId: string): Promise<void> {
     await this.db

--- a/apps/api/src/tools/task-board/dbos-github-read.ts
+++ b/apps/api/src/tools/task-board/dbos-github-read.ts
@@ -23,7 +23,7 @@
  *
  * Throttling makes the sweep SLOWER, deliberately. It is the floor, not the
  * fast path: the dialog's poll and the run's terminal hook still react
- * immediately, `markSwept` claims a card's interval before this call so a slow
+ * immediately, `claimSweep` claims a card's interval before this call so a slow
  * tick simply visits fewer cards, and the sweeper's `running` flag stops ticks
  * overlapping. A card waits on CI for minutes anyway.
  */

--- a/apps/api/src/tools/task-board/review-sweeper.ts
+++ b/apps/api/src/tools/task-board/review-sweeper.ts
@@ -44,7 +44,7 @@
  * happened to restart. So the sweep budget now lives on the CARD
  * (`task_board_items.last_swept_at`, migration 166): replicas share it, and a
  * parked card costs one sweep per `DEFAULT_ITEM_SWEEP_INTERVAL_MS` instead of one
- * per tick. `DEFAULT_BATCH_SIZE` remains the ceiling on any single tick.
+ * per tick, CLAIMED not stamped (`claimSweep`) so replicas can't race it.
  *
  * It later grew a third job for the same reason — **retrying a failed merge**.
  * A card whose reviewers all approved but whose merge was refused (GitHub down,
@@ -188,10 +188,11 @@ export class TaskBoardReviewSweeper {
       const batchSize = this.options.batchSize ?? DEFAULT_BATCH_SIZE;
       const itemInterval =
         this.options.itemIntervalMs ?? DEFAULT_ITEM_SWEEP_INTERVAL_MS;
+      const dueBefore = new Date(Date.now() - itemInterval);
       const pending = await this.taskBoard.listItemsPendingReview(
         batchSize,
         this.cursor,
-        new Date(Date.now() - itemInterval),
+        dueBefore,
       );
       // A short page means the backlog is exhausted — wrap around so cards that
       // moved back into In Review behind the cursor get picked up again.
@@ -204,7 +205,9 @@ export class TaskBoardReviewSweeper {
         // Best-effort per item: one card's failure must not stop the batch, or a
         // single wedged org would starve every other org's cards behind it.
         try {
-          if (await this.reconcileItem(id, organizationId)) dispatched++;
+          if (await this.reconcileItem(id, organizationId, dueBefore)) {
+            dispatched++;
+          }
         } catch (err) {
           console.error(`[task-board-review-sweeper] ${id} failed`, err);
         }
@@ -453,7 +456,12 @@ export class TaskBoardReviewSweeper {
   private async reconcileItem(
     id: string,
     organizationId: string,
+    dueBefore: Date,
   ): Promise<boolean> {
+    // Lost the claim: another replica owns this card's interval (`claimSweep`).
+    if (!(await this.taskBoard.claimSweep(id, organizationId, dueBefore))) {
+      return false;
+    }
     const item = await this.taskBoard.getById(id, organizationId);
     if (!item) return false;
     // Re-check against the fresh row: `listItemsPendingReview` scanned a
@@ -465,12 +473,6 @@ export class TaskBoardReviewSweeper {
     // `enqueueEnabledReviewers` call. A handed-off card burns no agent runs, but
     // its approvals stay valid, so it stays eligible to merge.
     const owned = item.assigneeId === SUPER_AGENT_ASSIGNEE_ID;
-
-    // Claim the interval BEFORE the GitHub work, not after: that is what makes a
-    // second replica skip this card, and what stops a card that comes back
-    // rate-limited from being retried on the very next tick. A pod crashing
-    // mid-sweep costs one interval of delay — the right trade for a slow floor.
-    await this.taskBoard.markSwept(id, organizationId);
 
     const prs = await this.taskBoard.listPrs(id, organizationId);
 


### PR DESCRIPTION
## Summary

Observed in prod ~15 min after #6044 deployed:

```
17:22:57  board_cD2CqBdKHfmdIDLSsPi9C  merge_conflict_resolution  {"prNumber": 336}
17:22:58  board_cD2CqBdKHfmdIDLSsPi9C  merge_failed  refused
          "405 Merge already in progress"
```

Two pods attempted `merge_pull_request` on the same PR inside one second. The loser's refusal was written to the card's timeline as a merge failure — on a card that, at that instant, was being correctly handed to a conflict-resolution run by the winner.

The per-card sweep budget (`last_swept_at`, migration 166) bounded how many **rounds** a parked card costs, not how many **pods take part in one round**. All three replicas read the same work list in the same second; `markSwept` was an unconditional `UPDATE`, so all three passed it and all three went on to the GitHub calls.

## Changes

`markSwept(id, org)` → `claimSweep(id, org, dueBefore)`: the same narrow write (still never touches `updated_at`, the keyset cursor), now conditional on the card still being due by the cutoff its work list was read with, returning whether this replica won.

The sweeper threads its existing cutoff through and **skips a card it didn't claim** — so the claim also moves ahead of the row read, instead of sitting between it and the GitHub work.

## Why not DBOS?

Fair question, and the durable machinery is already carrying the part that matters: the reviewer and Super Agent dispatches this sweep ends in are `DBOS.startWorkflow` calls fenced on a deterministic id derived from `(task, reviewer, cycle, attempt)`. Duplicate *runs* were never possible. What raced is the un-fenced GitHub I/O the sweeper does inline on the way there.

Wrapping each card's reconcile in a workflow keyed `sweep:<id>:<bucket>` would work, but the bucket has to come from the wall clock, so two pods either side of a boundary still both run — the very race this closes — and it puts a workflow row per parked card per five minutes through the DBOS tables for a reconciler that usually does nothing. Durable resume is also the wrong shape here: a pod dying mid-sweep should be re-swept from scratch next tick, not resumed. A conditional update on the column that already exists for this budget is atomic in one round-trip and has no clock-skew gap.

## Testing

`apps/api/src/storage/task-board-pending-review.integration.test.ts` (real Postgres) — 2 new cases: a second replica in the same round loses the claim, and the card is claimable again once its interval passes. Existing `markSwept` cases updated.

Worth noting: my first draft of the race test passed a cutoff in the *future*, which re-claims a card the same tick just stamped and made the test go green against the *unfixed* code path. Real Postgres caught it. The fixture now passes the cutoff a live tick passes.

Full run: 260 storage tests green against a migrated Postgres; typecheck and lint clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents multi-pod races in the task-board sweeper by replacing an unconditional stamp with an atomic claim. Old behavior: `markSwept` let all replicas proceed; new behavior: `claimSweep` lets only the winner proceed and makes losers skip, avoiding duplicate GitHub calls and spurious merge failures.

- API: replace `markSwept(id, org)` with `claimSweep(id, org, dueBefore): boolean`. Writes `last_swept_at` only and succeeds only when `last_swept_at` is NULL or earlier than `dueBefore`. Never touches `updated_at`.
- Sweeper: compute one `dueBefore`, pass it to `listItemsPendingReview`, and call `claimSweep` before reading the row or touching GitHub. Remove the post-GitHub stamp.
- Tests: add losing-replica and re-claim-after-interval cases; update existing tests; ensure cutoff is in the past.
- Workflow snapshot: re-baseline to reflect a doc change in `tools/task-board/dbos-github-read.ts`; no step changes and no `DBOS_WORKFLOW_VERSION` bump.
- Side effects: stops duplicate `merge_pull_request` calls and false "merge_failed" timeline entries; reduces GitHub traffic. No schema or config changes.

<sup>Written for commit 5f60d7a8fdaaee90aaadee8fc6ed6d77d3875f70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

