### PR TITLE
refactor(decopilot): dedupe the large-result blob-offload logic across built-in tools

### DIFF
--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.ts
@@ -16,8 +16,7 @@
 import { tool, zodSchema, type UIMessageStreamWriter } from "ai";
 import { z } from "zod";
 import type { ObjectStorageHooks } from "../../harness-deps";
-import { createOutputPreview, estimateJsonTokens } from "./read-tool-output";
-import { toStudioStorageUri } from "../studio-storage-uri";
+import { estimateJsonTokens, offloadLargeResult } from "./read-tool-output";
 import { LARGE_RESULT_TOKEN_THRESHOLD } from "./constants";
 import {
   browserlessFetch,
@@ -171,28 +170,24 @@ export function createInspectPageTool(
 
         // Large results → blob storage with preview
         if (tokenCount > LARGE_RESULT_TOKEN_THRESHOLD) {
-          const key = `inspect-pages/${crypto.randomUUID()}.json`;
-          const bytes = new TextEncoder().encode(resultJson);
-          try {
-            await objectStorage.put(key, bytes, {
-              contentType: "application/json",
-            });
-            const preview = createOutputPreview(resultJson);
+          const offloaded = await offloadLargeResult(
+            objectStorage,
+            `inspect-pages/${crypto.randomUUID()}.json`,
+            resultJson,
+            "application/json",
+            "inspect-page",
+          );
+          if (offloaded) {
             return {
               success: true,
-              uri: toStudioStorageUri(key),
-              preview,
+              uri: offloaded.uri,
+              preview: offloaded.preview,
               url: input.url,
               tokenCount,
               consoleLogCount: result.consoleLogs?.length ?? 0,
               errorCount: result.errors?.length ?? 0,
               hasEvaluateResult: result.evaluateResult != null,
             };
-          } catch (err) {
-            console.error(
-              "[inspect-page] Failed to upload to storage, returning inline",
-              err,
-            );
           }
         }
 

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/read-tool-output.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/read-tool-output.ts
@@ -1,5 +1,7 @@
 import { tool, zodSchema } from "ai";
 import { z } from "zod";
+import type { ObjectStorageHooks } from "../../harness-deps";
+import { toStudioStorageUri } from "../studio-storage-uri";
 
 export interface ReadToolOutputParams {
   readonly toolOutputMap: Map<string, string>;
@@ -153,4 +155,30 @@ function estimateTokens(text: string): number {
 export function estimateJsonTokens(value: unknown): number {
   const text = typeof value === "string" ? value : JSON.stringify(value);
   return estimateTokens(text);
+}
+
+/**
+ * Upload a large tool result to blob storage and return a preview + URI, or
+ * `null` if the upload itself fails (callers should fall back to returning
+ * the result inline in that case). `logLabel` names the caller for the error
+ * log ("scrape-url", "inspect-page").
+ */
+export async function offloadLargeResult(
+  objectStorage: ObjectStorageHooks,
+  key: string,
+  text: string,
+  contentType: string,
+  logLabel: string,
+): Promise<{ uri: string; preview: string } | null> {
+  try {
+    const bytes = new TextEncoder().encode(text);
+    await objectStorage.put(key, bytes, { contentType });
+    return { uri: toStudioStorageUri(key), preview: createOutputPreview(text) };
+  } catch (err) {
+    console.error(
+      `[${logLabel}] Failed to upload to storage, returning inline`,
+      err,
+    );
+    return null;
+  }
 }

--- a/apps/api/src/harnesses/lib/decopilot/built-in-tools/scrape-url.ts
+++ b/apps/api/src/harnesses/lib/decopilot/built-in-tools/scrape-url.ts
@@ -13,8 +13,7 @@
 import { tool, zodSchema, type UIMessageStreamWriter } from "ai";
 import { z } from "zod";
 import type { ObjectStorageHooks } from "../../harness-deps";
-import { createOutputPreview, estimateJsonTokens } from "./read-tool-output";
-import { toStudioStorageUri } from "../studio-storage-uri";
+import { estimateJsonTokens, offloadLargeResult } from "./read-tool-output";
 import { LARGE_RESULT_TOKEN_THRESHOLD } from "./constants";
 import {
   browserlessFetch,
@@ -87,25 +86,21 @@ export function createScrapeUrlTool(
 
         // Large results → blob storage with preview
         if (tokenCount > LARGE_RESULT_TOKEN_THRESHOLD) {
-          const key = `scraped-pages/${crypto.randomUUID()}.html`;
-          const bytes = new TextEncoder().encode(htmlText);
-          try {
-            await objectStorage.put(key, bytes, {
-              contentType: "text/html",
-            });
-            const preview = createOutputPreview(htmlText);
+          const offloaded = await offloadLargeResult(
+            objectStorage,
+            `scraped-pages/${crypto.randomUUID()}.html`,
+            htmlText,
+            "text/html",
+            "scrape-url",
+          );
+          if (offloaded) {
             return {
               success: true,
-              uri: toStudioStorageUri(key),
-              preview,
+              uri: offloaded.uri,
+              preview: offloaded.preview,
               url: input.url,
               tokenCount,
             };
-          } catch (err) {
-            console.error(
-              "[scrape-url] Failed to upload to storage, returning inline",
-              err,
-            );
           }
         }
 


### PR DESCRIPTION
Follows #6051 (which just deduped the URL-schema/error-cap piece of these same files) — this PR dedupes the remaining copy-pasted block: `scrape_url` and `inspect_page` each had an identical "upload to blob storage, build a preview, log-and-fall-back-to-inline on failure" block, differing only in the storage key prefix/content-type and a couple of extra response fields.

Why it's worth landing: the two blocks had already drifted slightly in structure (one destructures `bytes` before the try, the try/catch shape differed) and any future third caller of this pattern (e.g. a new built-in tool that offloads large output) would otherwise copy-paste it again. Extracting `offloadLargeResult()` into `read-tool-output.ts` (which already owns `createOutputPreview`/`estimateJsonTokens`, the two helpers this logic composes) gives it one home.

Behavior is unchanged: same upload call, same preview generation, same inline-fallback-with-console.error on upload failure, same log label per caller (`[scrape-url] ...` / `[inspect-page] ...`).

How to verify: `cd apps/api && bunx tsc --noEmit` (clean) and `bun test apps/api/src/harnesses/lib/decopilot/built-in-tools/scrape-url.test.ts apps/api/src/harnesses/lib/decopilot/built-in-tools/inspect-page.test.ts` (both pass unchanged — the tests don't need updating since behavior didn't change).

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api), the two targeted test files above, and `bunx oxlint` on all three touched files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates large-result blob-offload logic for Decopilot built-in tools into a shared helper to stop drift and simplify future tools. Behavior is unchanged: same upload, same preview, and same inline fallback with the same log labels.

- Added offloadLargeResult in read-tool-output.ts. It uploads bytes, returns {uri, preview}, or null on failure while logging with the caller label.
- Replaced the inline try/catch blocks in scrape-url.ts and inspect-page.ts with offloadLargeResult, passing the same key prefixes, content types, and log labels.
- Threshold check, token estimation, preview generation, and error messaging remain identical; tests did not change.

<sup>Written for commit 44b48173286af0dba377a69b49d49ada0ad967d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

