### PR TITLE
fix(sso): bound the OIDC discovery and token-exchange fetches with a timeout

### DIFF
--- a/apps/api/src/api/routes/org-sso.ts
+++ b/apps/api/src/api/routes/org-sso.ts
@@ -228,6 +228,7 @@ function registerSsoRoutes(app: SsoApp) {
         client_secret: ssoConfig.clientSecret,
         code_verifier: stateData.codeVerifier,
       }),
+      signal: AbortSignal.timeout(SSO_FETCH_TIMEOUT_MS),
     });
 
     if (!tokenResponse.ok) {
@@ -471,6 +472,9 @@ interface OIDCDiscovery {
   userinfo_endpoint?: string;
 }
 
+/** Bound outbound calls to the IdP — a hanging issuer shouldn't hang the callback. */
+const SSO_FETCH_TIMEOUT_MS = 10_000;
+
 // Simple in-memory cache for OIDC discovery documents
 const discoveryCache = new Map<
   string,
@@ -545,7 +549,9 @@ async function discoverOIDC(
 
   validateOIDCUrl(url);
 
-  const response = await fetch(url);
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(SSO_FETCH_TIMEOUT_MS),
+  });
   if (!response.ok) {
     throw new Error(
       `OIDC discovery failed: ${response.status} ${response.statusText}`,


### PR DESCRIPTION
Follows #6052 — same hardening pattern applied to a sibling outbound call in `apps/api/src/api/routes/`.

**Bug:** `org-sso.ts`'s `discoverOIDC()` (fetching `<issuer>/.well-known/openid-configuration` or a custom discovery endpoint) and the callback's token-exchange `fetch(discovery.token_endpoint, ...)` both awaited a raw `fetch` with no `AbortSignal`. A slow or hanging IdP endpoint (misconfigured org SSO, network blip, IdP outage) never times out, so the `/api/org-sso/callback` request — and the user's login attempt — hangs indefinitely instead of failing fast.

**Fix:** Bound both fetches with `AbortSignal.timeout(10_000)`, the same 10s convention `connection.ts`'s `testConnection()` just adopted in #6052 and `discover-tools.ts`'s `tryRawToolsList` already uses.

**Reviewer check:** `cd apps/api && bunx tsc --noEmit` (clean), `bun test apps/api/src/api/routes/org-sso.test.ts` (4 pass, unaffected — no fetch mocking in that suite), `bunx oxlint apps/api/src/api/routes/org-sso.ts` (0 warnings/errors).

No new test added — mirrors #6052, a pure bounded-timeout fix with no behavior change on the happy path (a fast IdP is unaffected; only a hanging one now fails after 10s instead of never).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound IdP fetches in org SSO with a 10s timeout to prevent hanging login callbacks. Previously OIDC discovery and token exchange waited indefinitely; now both abort after 10s and return an error, while fast IdPs are unaffected.

**Notes**
- Adds SSO_FETCH_TIMEOUT_MS = 10_000 and applies AbortSignal.timeout to the discovery and token-exchange fetches; no configuration or migration required.

<sup>Written for commit 4a77d7976ec2dc9cd17f492f68540bf32db53dc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

