### PR TITLE
fix(sections-editor): render inline array when its schema branch is a $ref

### DIFF
--- a/apps/web/src/components/sections-editor/resolve-schema.test.ts
+++ b/apps/web/src/components/sections-editor/resolve-schema.test.ts
@@ -850,6 +850,77 @@ describe("resolveSchema – array branch hidden behind a $ref", () => {
     const children = resolveSchema("site/sections/Test.tsx", meta)?.properties
       ?.children;
     expect(children?.type).toBe("block-ref");
+    expect(children?.anyOfRefs?.map((r) => r.resolveType)).toContain(
+      "site/loaders/sections.ts",
+    );
+  });
+
+  test("full farm shape: prop behind $ref, item content is a multivariate anyOf", () => {
+    // Both layers deco emits: mediaKits is a $ref to the union; item content is anyOf[inline, multivariate].
+    const meta = metaWithSchema({
+      type: "object",
+      properties: {
+        mediaKits: { $ref: "#/definitions/MediaKits", title: "Kits" },
+      },
+    });
+    (meta.schema as { definitions?: Record<string, unknown> }).definitions = {
+      MediaKits: {
+        anyOf: [
+          { $ref: "#/definitions/MediaKitArray", title: "[MediaKit]" },
+          {
+            type: "object",
+            properties: {
+              __resolveType: {
+                type: "string",
+                enum: ["site/loaders/MediaKits.tsx"],
+                default: "site/loaders/MediaKits.tsx",
+              },
+            },
+          },
+        ],
+      },
+      MediaKitArray: {
+        type: "array",
+        items: { $ref: "#/definitions/MediaKitItem" },
+      },
+      MediaKitItem: {
+        type: "object",
+        properties: {
+          name: { type: "string", title: "Nome" },
+          content: { $ref: "#/definitions/MediaKitContent", title: "Conteúdo" },
+        },
+        required: ["name", "content"],
+      },
+      MediaKitContent: {
+        anyOf: [
+          {
+            type: "object",
+            properties: { url: { type: "string" } },
+          },
+          {
+            type: "object",
+            properties: {
+              __resolveType: {
+                type: "string",
+                enum: ["site/flags/multivariate/mediaKitContent.ts"],
+                default: "site/flags/multivariate/mediaKitContent.ts",
+              },
+              variants: { type: "array", items: { type: "object" } },
+            },
+          },
+        ],
+      },
+    };
+
+    const mediaKits = resolveSchema("site/sections/Test.tsx", meta)?.properties
+      ?.mediaKits;
+    expect(mediaKits?.type).toBe("array");
+    const content = mediaKits?.items?.properties?.content;
+    expect(content?.type).toBe("block-ref");
+    expect(content?.anyOfRefs?.[0]?.resolveType).toBe(
+      "site/flags/multivariate/mediaKitContent.ts",
+    );
+    expect(content?.plainSchema).toBeDefined();
   });
 });
 

--- a/apps/web/src/components/sections-editor/resolve-schema.test.ts
+++ b/apps/web/src/components/sections-editor/resolve-schema.test.ts
@@ -753,6 +753,106 @@ describe("resolveSchema – plainSchema on block-ref", () => {
   });
 });
 
+describe("resolveSchema – array branch hidden behind a $ref", () => {
+  test("prefers the inline array over colliding loader/Resolvable branches", () => {
+    // Real farmrio EtcMediaKits `mediaKits`: array member is a bare $ref beside loader/named-block branches.
+    const meta = metaWithSchema({
+      type: "object",
+      properties: {
+        mediaKits: {
+          title: "Kits de mídia",
+          anyOf: [
+            { $ref: "#/definitions/MediaKitArray", title: "[MediaKit]" },
+            {
+              type: "object",
+              properties: {
+                __resolveType: {
+                  type: "string",
+                  enum: ["site/loaders/MediaKits.tsx"],
+                  default: "site/loaders/MediaKits.tsx",
+                },
+              },
+            },
+            {
+              type: "object",
+              properties: {
+                __resolveType: {
+                  type: "string",
+                  enum: ["MediaKits"],
+                  default: "MediaKits",
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+    (meta.schema as { definitions?: Record<string, unknown> }).definitions = {
+      MediaKitArray: {
+        type: "array",
+        items: { $ref: "#/definitions/MediaKitItem" },
+      },
+      MediaKitItem: {
+        type: "object",
+        properties: {
+          name: { type: "string", title: "Nome" },
+          content: { type: "string" },
+        },
+        required: ["name", "content"],
+      },
+    };
+
+    const mediaKits = resolveSchema("site/sections/Test.tsx", meta)?.properties
+      ?.mediaKits;
+    expect(mediaKits?.type).toBe("array");
+    expect(mediaKits?.title).toBe("Kits de mídia");
+    expect(mediaKits?.items?.properties?.name?.title).toBe("Nome");
+  });
+
+  test("a section array behind a $ref stays a picker (items are section refs)", () => {
+    const meta = metaWithSchema({
+      type: "object",
+      properties: {
+        children: {
+          anyOf: [
+            { $ref: "#/definitions/SectionArray" },
+            {
+              type: "object",
+              properties: {
+                __resolveType: {
+                  type: "string",
+                  enum: ["site/loaders/sections.ts"],
+                  default: "site/loaders/sections.ts",
+                },
+              },
+            },
+          ],
+        },
+      },
+    });
+    (meta.schema as { definitions?: Record<string, unknown> }).definitions = {
+      SectionArray: {
+        type: "array",
+        items: { $ref: "#/definitions/SectionItem" },
+      },
+      SectionItem: {
+        type: "object",
+        properties: {
+          __resolveType: {
+            type: "string",
+            enum: ["site/sections/Hero.tsx"],
+            default: "site/sections/Hero.tsx",
+          },
+        },
+      },
+    };
+
+    const children = resolveSchema("site/sections/Test.tsx", meta)?.properties
+      ?.children;
+    expect(children?.type).toBe("block-ref");
+  });
+});
+
 describe("resolveSchema – @hide on block-ref fields", () => {
   // Mirrors @decocms/start ≥6.10: a hidden loader/block-ref prop is emitted as
   // `{ anyOf: [Resolvable, loaderRef], hide: "true" }`. The block-ref return in

--- a/apps/web/src/components/sections-editor/resolve-schema.ts
+++ b/apps/web/src/components/sections-editor/resolve-schema.ts
@@ -567,7 +567,9 @@ export function resolveSchema(
         // page multivariate flag branch. Prefer the array (admin hides the flag UI).
         // App config arrays (e.g. flag lists) share anyOf with product-list loaders;
         // prefer the array branch when items are plain objects, not section refs.
-        const arrayBranch = nonNull.find(isArraySchemaBranch);
+        const arrayBranch = nonNull
+          .map(resolveBranchDef)
+          .find(isArraySchemaBranch);
         const hasPageMultivariateLoader = loaderBranches.some((branch) => {
           const rtEnum = (
             (branch.properties as RawSchema | undefined)?.__resolveType as

--- a/apps/web/src/components/sections-editor/resolve-schema.ts
+++ b/apps/web/src/components/sections-editor/resolve-schema.ts
@@ -568,7 +568,7 @@ export function resolveSchema(
         // App config arrays (e.g. flag lists) share anyOf with product-list loaders;
         // prefer the array branch when items are plain objects, not section refs.
         const arrayBranch = nonNull
-          .map(resolveBranchDef)
+          .map((branch) => unwrapRefAliases(branch))
           .find(isArraySchemaBranch);
         const hasPageMultivariateLoader = loaderBranches.some((branch) => {
           const rtEnum = (


### PR DESCRIPTION
## Summary

Studio's Content editor rendered a **Resolvable/loader picker with no editable fields** (only a generic `Name`) for a deco/$live loader prop that the **old deco admin** renders as an inline array/variants form.

Root cause is in `resolve-schema.ts` `buildProperty()`. In deco, any loader-return type is Resolvable, so a prop `mediaKits: EtcMediaKits[]` — where `EtcMediaKits` is also the loader's own return type — is emitted in `/live/_meta` as:

```
anyOf[ { $ref: "…@[EtcMediaKitProps]" },   // array branch: a bare $ref, no inline `type`
       <loader block>, <named block> ]
```

The array-vs-picker test used `nonNull.find(isArraySchemaBranch)`, and `isArraySchemaBranch` only checks `branch.type === "array"`. A `$ref`-wrapped array branch has no inline `type`, so it was missed; the code fell through to `loaderBranches.length > 0` and the field became a `block-ref` picker.

## Fix

Resolve `$ref` branches before the test:

```ts
const arrayBranch = nonNull.map(resolveBranchDef).find(isArraySchemaBranch);
```

`resolveBranchDef` already exists in the closure and is a no-op for inline branches. **Section** arrays behind a `$ref` still stay pickers because `isSectionLoaderArrayBranch` classifies their items as section refs (`isConfigArray` stays false).

## Testing

- Ran the real `resolveSchema` against farmrio's `/live/_meta`: `mediaKits` → inline `array` of `{ name, content }`, and each item's `content` → `block-ref` whose single ref has `variants` → `MultivariateFieldWrapper` (the "Variantes" editor), matching the old admin.
- Added regression tests in `resolve-schema.test.ts` ("array branch hidden behind a \$ref"), including a negative case (section array behind a `$ref` stays a picker). Confirmed they **fail without the fix** (`block-ref`) and pass with it.
- `bun test src/components/sections-editor/` → **625 pass, 0 fail**. `bun run fmt`, `tsc --noEmit`, and `bun run lint` (0 errors) clean.

## Follow-up

Proof so far is at the `resolveSchema` level; recommend a visual check in the dev server against a `_meta` with this shape before/after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders inline arrays in the sections editor when the array schema branch is provided via a `$ref`, including chained `$ref` aliases. Previously, these props were misclassified as a `block-ref` picker (loader dropdown only) because the `$ref` branch lacked an inline `type`.

- In `resolve-schema.ts`, the array-vs-picker check now unwraps `$ref` alias chains before testing: `nonNull.map(unwrapRefAliases).find(isArraySchemaBranch)`.
- Arrays of sections behind a `$ref` still render as pickers; `isSectionLoaderArrayBranch` continues to classify them as section refs.
- Tests in `resolve-schema.test.ts` cover the `$ref` array case, a strengthened negative case that asserts the surviving loader ref, and a full farm-shaped fixture verifying per-item multivariate `block-ref` resolution with `plainSchema`.

<sup>Written for commit db3cf4ba0c8d9b8dc64b99d437af0d02a35c4806. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

