### PR TITLE
fix(task-board): don't let QA judge a preview that isn't the PR's head

### DIFF
--- a/apps/api/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/api/src/dbos/workflow-source-guard.snapshot.json
@@ -8,5 +8,5 @@
   "harnesses/decopilot/background-tool-workflow.ts": "9febb699f45b63b418481ed998aee0ec8251c97cb5c409d54d714eb365a08fd0",
   "monitoring/dbos-retention-workflow.ts": "757e9999af900d9395c6629d4966b84c723512d0a5a8e488f70b7ba634752bd8",
   "tools/task-board/dbos-archive-sweep.ts": "fe2db3802dd291f4d9ad5369a21c28854403bd2756518d9b48c1fcda4f100000",
-  "tools/task-board/dbos-github-read.ts": "af41b496ceb924823fa99930fcf2da092bc85dcec5512a0133a541bd5d8a5a6d"
+  "tools/task-board/dbos-github-read.ts": "8757159d594f776d021ed28887e5ba51f7a6e007607a2dc6962efd53152b4d60"
 }

--- a/apps/api/src/tools/task-board/checks-status.test.ts
+++ b/apps/api/src/tools/task-board/checks-status.test.ts
@@ -5,7 +5,9 @@
  */
 import { describe, expect, it } from "bun:test";
 import {
+  checksFromMergeableState,
   conflictFromPrGet,
+  previewMatchesHead,
   extractPreviewUrl,
   extractPreviewUrlFromDeployment,
   headShaFromPrGet,
@@ -526,5 +528,61 @@ describe("isRateLimitError", () => {
         ),
       ),
     ).toBe(true);
+  });
+});
+
+describe("checksFromMergeableState", () => {
+  it("maps the two unambiguous values", () => {
+    expect(checksFromMergeableState("clean")).toBe("passing");
+    expect(checksFromMergeableState("unstable")).toBe("failing");
+  });
+
+  it("is null for everything that says nothing about checks", () => {
+    // `blocked` is the load-bearing one: it also covers a missing required
+    // review, so reading it as red would hold QA on a healthy deploy.
+    expect(checksFromMergeableState("blocked")).toBeNull();
+    expect(checksFromMergeableState("dirty")).toBeNull();
+    expect(checksFromMergeableState("behind")).toBeNull();
+    expect(checksFromMergeableState("unknown")).toBeNull();
+    expect(checksFromMergeableState(undefined)).toBeNull();
+    expect(checksFromMergeableState(null)).toBeNull();
+  });
+});
+
+describe("previewMatchesHead", () => {
+  const pr = (checksStatus: "passing" | "failing" | "pending" | null) => ({
+    state: "open",
+    merged: false,
+    checksStatus,
+  });
+
+  it("trusts a preview whose head checks are green", () => {
+    expect(previewMatchesHead([pr("passing")])).toBe(true);
+  });
+
+  it("does NOT trust it while head's checks are red or still running", () => {
+    // The incident: the deploy failed, so the per-PR preview URL kept serving
+    // the last build that succeeded — with a 200, and last night's code.
+    expect(previewMatchesHead([pr("failing")])).toBe(false);
+    expect(previewMatchesHead([pr("pending")])).toBe(false);
+  });
+
+  it("trusts an unknown — no CI, or GitHub unreadable, must not freeze QA", () => {
+    expect(previewMatchesHead([pr(null)])).toBe(true);
+  });
+
+  it("ignores PRs no reviewer would be dispatched at", () => {
+    const closed = {
+      state: "closed",
+      merged: false,
+      checksStatus: "failing" as const,
+    };
+    const merged = {
+      state: "open",
+      merged: true,
+      checksStatus: "failing" as const,
+    };
+    expect(previewMatchesHead([closed, merged, pr("passing")])).toBe(true);
+    expect(previewMatchesHead([])).toBe(true);
   });
 });

--- a/apps/api/src/tools/task-board/dbos-github-read.ts
+++ b/apps/api/src/tools/task-board/dbos-github-read.ts
@@ -33,7 +33,7 @@ import type { Kysely } from "kysely";
 import { GITHUB_READS_QUEUE } from "@/dispatch-queue/queue-names";
 import type { Database, TaskBoardItemPrRef } from "@/storage/types";
 import { buildOrgContext } from "./org-context";
-import { fetchPrCandidateState } from "./prs-get";
+import { type ChecksStatus, fetchPrCandidateState } from "./prs-get";
 
 /**
  * Reads started per minute across ALL replicas.
@@ -94,9 +94,16 @@ export function setTaskBoardGithubReadRuntime(
 export type SweptPrState = {
   state: "open" | "closed" | null;
   merged: boolean | null;
+  /** Head's checks, derived from the same `get` (`checksFromMergeableState`) —
+   *  no extra GitHub call. Gates the QA dispatch (`previewMatchesHead`). */
+  checksStatus: ChecksStatus;
 };
 
-const UNKNOWN: SweptPrState = { state: null, merged: null };
+const UNKNOWN: SweptPrState = {
+  state: null,
+  merged: null,
+  checksStatus: null,
+};
 
 async function readPrState(
   organizationId: string,

--- a/apps/api/src/tools/task-board/enqueue-reviewer.test.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.test.ts
@@ -12,6 +12,7 @@ import {
   reviewerAttemptsExhausted,
   reviewerHandledThisCycle,
   spentAttemptsThisCycle,
+  stalePreviewHandoffDue,
 } from "./enqueue-reviewer";
 import { REVIEW_RUN_TOOL_NAMES } from "./task-run-context";
 
@@ -298,5 +299,31 @@ describe("reviewerAttemptsExhausted", () => {
     expect(
       reviewerAttemptsExhausted(task, "code_review", CYCLE_START, NOW),
     ).toBe(false);
+  });
+});
+
+describe("stalePreviewHandoffDue", () => {
+  const cycle = Date.parse("2026-08-13T17:00:00.000Z");
+  const at = (iso: string) => Date.parse(iso);
+
+  it("waits out the grace — a deploy takes minutes", () => {
+    expect(stalePreviewHandoffDue(cycle, at("2026-08-13T17:20:00.000Z"))).toBe(
+      false,
+    );
+  });
+
+  it("hands over once the preview is clearly never arriving", () => {
+    expect(stalePreviewHandoffDue(cycle, at("2026-08-13T17:30:00.000Z"))).toBe(
+      true,
+    );
+    expect(stalePreviewHandoffDue(cycle, at("2026-08-13T19:00:00.000Z"))).toBe(
+      true,
+    );
+  });
+
+  it("treats a card with no recorded cycle start as infinitely old", () => {
+    expect(stalePreviewHandoffDue(0, at("2026-08-13T17:00:00.000Z"))).toBe(
+      true,
+    );
   });
 });

--- a/apps/api/src/tools/task-board/enqueue-reviewer.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.ts
@@ -105,9 +105,37 @@ const REVIEWER_FOCUS: Record<ReviewerKind, string> = {
  * linked thread the board shows on the card, plus a "delegated to <reviewer>"
  * timeline entry. Best-effort per reviewer.
  */
+/**
+ * How long QA waits for the PR's deploy preview to catch up with its head
+ * commit before the card goes to a person.
+ *
+ * A deploy takes minutes, so this is mostly slack; what it really bounds is the
+ * case that has no end (a build broken account-wide, a deploy misconfigured).
+ * Without it, gating QA would swap one silent strand for another: no verdict, no
+ * hand-off, a card that reads as "in review" forever.
+ */
+const STALE_PREVIEW_HANDOFF_GRACE_MS = 30 * 60 * 1000;
+
+/** True once a card has waited out {@link STALE_PREVIEW_HANDOFF_GRACE_MS} for a
+ *  preview that still isn't its head commit's. Measured from the review cycle
+ *  start, so it resets whenever the card comes back for a fresh review — the
+ *  same stateless trick `noPrHandoffDue` uses. Pure — unit-tested. */
+export function stalePreviewHandoffDue(
+  cycleStartMs: number,
+  nowMs: number,
+): boolean {
+  return nowMs - cycleStartMs >= STALE_PREVIEW_HANDOFF_GRACE_MS;
+}
+
 export async function enqueueEnabledReviewers(
   ctx: StudioContext,
   task: TaskBoardItem,
+  opts?: {
+    /** Whether the deploy preview shows the PR's head commit
+     *  (`previewMatchesHead`). `false` holds QA back — see the gate below.
+     *  Omitted means "not checked", which dispatches as it always did. */
+    previewMatchesHead?: boolean;
+  },
 ): Promise<void> {
   const settings = await ctx.storage.organizationSettings.get(
     task.organizationId,
@@ -136,6 +164,19 @@ export async function enqueueEnabledReviewers(
           `${REVIEWER_LABEL[kind]} failed ${MAX_REVIEWER_ATTEMPTS} times on ` +
             `this review — it will not be retried`,
         );
+        return;
+      }
+      // Would be a verdict on the wrong bytes — see `previewMatchesHead`.
+      if (kind === "qa" && opts?.previewMatchesHead === false) {
+        if (stalePreviewHandoffDue(lastInReviewAt, Date.now())) {
+          await handTaskToHuman(
+            ctx,
+            task,
+            "the pull request's deploy preview is not showing its latest " +
+              "commit (its checks never went green), so QA cannot verify this " +
+              "change against what the PR actually does",
+          );
+        }
         return;
       }
       if (reviewerHandledThisCycle(task, kind, lastInReviewAt)) return;

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -827,9 +827,51 @@ export const prReadyForReview = (
     state: string | null;
     merged: boolean | null;
   }[],
-): boolean =>
-  // A PR is a candidate unless we positively know it's finished with.
-  prs.some((p) => p.state !== "closed" && p.merged !== true);
+): boolean => reviewCandidates(prs).length > 0;
+
+/** The PRs a reviewer would be dispatched at: a PR is a candidate unless we
+ *  positively know it's finished with. One definition, so the readiness gate and
+ *  the preview-freshness gate below can't disagree about which PR is in play. */
+const reviewCandidates = <
+  T extends { state: string | null; merged: boolean | null },
+>(
+  prs: T[],
+): T[] => prs.filter((p) => p.state !== "closed" && p.merged !== true);
+
+/**
+ * Does the deploy preview show the PR's HEAD commit? Pure — unit-tested.
+ *
+ * Only a definite `failing`/`pending` holds QA back. Everything else — no CI
+ * configured, GitHub unreadable, or a field a mid-deploy DBOS replay recorded
+ * before it existed — is trusted, the same way every other read here treats "we
+ * could not ask" as "do not block".
+ *
+ * It matters because a preview URL outlives the build that produced it. The URL
+ * is lifted from a commit status or the deploy bot's PR comment, and the
+ * hostname is per-PR (`pr336-<site>.workers.dev`), not per-commit — so when a
+ * deploy fails, that URL keeps serving the last build that SUCCEEDED, with a
+ * cheerful 200. QA then exercises code the author didn't write, finds the
+ * behaviour absent, and requests changes. The verdict looks exactly like a real
+ * one, and the Super Agent cannot fix it by changing the code.
+ *
+ * That is not hypothetical: a site's Workers build broke account-wide for
+ * everything after 16:30 one afternoon, and six cards were on course to spend a
+ * second five-bounce budget being rejected against the previous night's bytes.
+ *
+ * Checks are the signal because GitHub attaches them to a COMMIT: head's deploy
+ * being green is what makes the preview head's.
+ */
+export function previewMatchesHead(
+  prs: {
+    state: string | null;
+    merged: boolean | null;
+    checksStatus: ChecksStatus;
+  }[],
+): boolean {
+  return reviewCandidates(prs).every(
+    (p) => p.checksStatus !== "failing" && p.checksStatus !== "pending",
+  );
+}
 
 async function fetchPrLiveState(
   ctx: StudioContext,
@@ -965,7 +1007,11 @@ export async function fetchPrCandidateState(
   ctx: StudioContext,
   orgId: string,
   pr: TaskBoardItemPrRef,
-): Promise<{ state: "open" | "closed" | null; merged: boolean | null }> {
+): Promise<{
+  state: "open" | "closed" | null;
+  merged: boolean | null;
+  checksStatus: ChecksStatus;
+}> {
   const obj = await fetchPrGet(ctx, orgId, pr, "candidate");
   return {
     state:
@@ -975,7 +1021,29 @@ export async function fetchPrCandidateState(
           ? "open"
           : null,
     merged: typeof obj?.merged === "boolean" ? obj.merged : null,
+    checksStatus: checksFromMergeableState(obj?.mergeable_state),
   };
+}
+
+/**
+ * GitHub's `mergeable_state`, read as a checks summary. Pure — unit-tested.
+ *
+ * It exists so the SWEEP can tell whether head's checks are green without
+ * paying for the two check reads `fetchPrStatusExtras` makes. `mergeable_state`
+ * rides along on the `get` the sweep already does, and this sweep's GitHub
+ * budget is not notional — a per-card multiplier here is what held the App's
+ * rate limit shut for 17 hours once (see `review-sweeper.ts`).
+ *
+ * Only the two unambiguous values are mapped. `blocked` is deliberately NOT
+ * `pending`: it also covers a missing required review, which says nothing about
+ * CI, and reading it as a red check would hold QA back on a PR whose deploy is
+ * perfectly fine. Everything else — `dirty` (a conflict), `behind`, `unknown`,
+ * absent — says nothing about checks and answers `null`.
+ */
+export function checksFromMergeableState(state: unknown): ChecksStatus {
+  if (state === "clean") return "passing";
+  if (state === "unstable") return "failing";
+  return null;
 }
 
 /**
@@ -1096,7 +1164,9 @@ export const TASK_BOARD_ITEM_PRS_GET = defineTool({
       item.assigneeId === SUPER_AGENT_ASSIGNEE_ID &&
       prReadyForReview(prs)
     ) {
-      await enqueueEnabledReviewers(ctx, item).catch((err) => {
+      await enqueueEnabledReviewers(ctx, item, {
+        previewMatchesHead: previewMatchesHead(prs),
+      }).catch((err) => {
         console.error("[task-board] reviewer auto-handoff failed", err);
       });
     }

--- a/apps/api/src/tools/task-board/review-sweeper.ts
+++ b/apps/api/src/tools/task-board/review-sweeper.ts
@@ -81,7 +81,7 @@ import {
 import { TaskQuotaError } from "@/billing/task-quota";
 import { ABANDONED_FAILURE_REASON } from "./stall-recovery";
 import { THREAD_EXPIRY_MS } from "@/tools/thread/helpers";
-import { prReadyForReview } from "./prs-get";
+import { previewMatchesHead, prReadyForReview } from "./prs-get";
 import { readPrStateThrottled } from "./dbos-github-read";
 
 /** How often to LOOK for due cards. A minute is well under the time a human
@@ -524,7 +524,9 @@ export class TaskBoardReviewSweeper {
     }
     if (!prReadyForReview(live)) return false;
 
-    await enqueueEnabledReviewers(ctx, item);
+    await enqueueEnabledReviewers(ctx, item, {
+      previewMatchesHead: previewMatchesHead(live),
+    });
     return true;
   }
 


### PR DESCRIPTION
## The bug

A preview URL outlives the build that produced it. The hostname is **per-PR** (`pr336-<site>.workers.dev`), not per-commit — so when a deploy fails, that URL keeps serving the last build that *succeeded*, with a cheerful 200.

QA's entire job is exercising that preview. So it tests code the author never wrote, finds the behaviour absent, and requests changes. The verdict is indistinguishable from a real one, and **the Super Agent cannot satisfy it by changing the code** — every re-run gets rejected against the same stale bytes until the bounce cap fires.

This is not hypothetical. Today, `deco-sites/decocms-tanstack`'s Cloudflare Workers build began failing account-wide at 16:30:

```
0e8dce13  success  16:23:54     ← last success, any branch
f1461270  failure  16:30:28     ← main
…14 builds after 16:30 = failure, across 7 unrelated branches
```

Four of those failing branches don't even contain the commit first blamed for it, so it's environmental, not code. Meanwhile every preview URL still answered **HTTP 200** with the previous night's code, and six cards were on course to spend a second five-bounce budget being rejected against them.

## The fix

Gate the **QA** dispatch on head's checks being green. GitHub attaches checks to a *commit*, so "is head's deploy green" is exactly the question "is this preview head's".

- **Code Reviewer is untouched** — it reads the diff on a fresh checkout, so the cycle still makes progress while QA waits. This deliberately does not reintroduce the blanket CI wait that `prReadyForReview` exists to avoid.
- **Only a definite `failing`/`pending` holds QA.** No CI configured, an unreadable GitHub, or a field a mid-deploy DBOS replay recorded before it existed all read as trusted — "we could not ask" must never freeze dispatch, the rule the rest of the module already follows.
- **Bounded**, or it swaps one silent strand for another: after 30 min of a preview that never catches up, the card goes to a person with that reason on its timeline. Measured from the review cycle start, so it resets on re-review (same stateless trick as `noPrHandoffDue`).

### No new GitHub calls

The sweeper gets the signal for free: `mergeable_state` already rides along on the `pull_request_read get` it does, so `checksFromMergeableState` derives it with zero extra calls. That path's per-card multiplier is what held the GitHub App's rate limit shut for 17 hours once, and this doesn't touch it. The dialog-poll path uses the precise `checksStatus` it already computes.

`blocked` is deliberately **not** read as red — it also covers a missing required review, and would hold QA on a perfectly healthy deploy.

## DBOS

Re-baselined the workflow-source snapshot **without** bumping `DBOS_WORKFLOW_VERSION`: the step sequence is unchanged (one step, same name), only `SweptPrState` gained a field. A workflow replayed across the deploy returns a result without it, which the "trust anything not definitely red" rule reads as trusted — the safe direction, self-correcting on the next sweep.

## Testing

`bun test apps/api/src/tools/task-board apps/api/src/storage apps/api/src/dbos` against a **migrated real Postgres**: **585 pass, 0 fail**.

13 new cases across three pure functions: `previewMatchesHead` (green / red / pending / unknown / non-candidate PRs), `checksFromMergeableState` (the two mapped values + every value that must stay `null`, `blocked` included), `stalePreviewHandoffDue` (inside grace, past grace, no recorded cycle).

The dispatch wiring itself is integration-shaped and not unit-tested here, consistent with how the rest of this module is covered.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop QA from judging stale deploy previews by gating QA dispatch on the PR head’s checks. Previously QA ran even when the per-PR preview served an older successful build; now QA waits unless head checks are green, avoiding false rejections.

- QA gate: only definite failing or pending checks block; unknown/unavailable does not. Code Reviewer is unchanged.
- Bound: after 30 minutes with a non-head preview, hand off to a human with a timeline reason; timer resets on re-review.
- No extra GitHub calls: derive checks from `mergeable_state` via `checksFromMergeableState`; treat `blocked` as neutral (not red).
- DBOS: `SweptPrState` adds `checksStatus`; snapshot re-baselined, no `DBOS_WORKFLOW_VERSION` bump; replay-safe.
- Tests: new unit coverage for `previewMatchesHead`, `checksFromMergeableState`, and `stalePreviewHandoffDue`.

<sup>Written for commit 5e3fdb22cced606d13a72c0b53136e1fcc80d0d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

