### PR TITLE
fix(sandbox): tell the user and the agent when a sandbox was OOMKilled

### DIFF
--- a/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import type { UIMessageChunk } from "ai";
 import { harnessRunResultSchema } from "@decocms/sandbox/dispatch/schemas";
 import {
+  describeTermination,
   dispatchWithContinuation,
   errorForTerminal,
   harnessRunsInSandbox,
@@ -20,6 +21,22 @@ function bodyOf(text: string): ReadableStream<Uint8Array> {
     },
   });
 }
+
+const chunk = (type: string, extra: Record<string, unknown> = {}) =>
+  ({ type, ...extra }) as UIMessageChunk;
+
+/** A dispatch that streams `chunks`, then optionally dies. */
+const dispatch = (chunks: UIMessageChunk[], err?: Error) =>
+  async function* () {
+    for (const c of chunks) yield c;
+    if (err) throw err;
+  };
+
+const collect = async (it: AsyncIterable<UIMessageChunk>) => {
+  const out: UIMessageChunk[] = [];
+  for await (const c of it) out.push(c);
+  return out;
+};
 
 describe("harnessRunsInSandbox", () => {
   test("claude-code is sandbox-hosted", () => {
@@ -157,22 +174,6 @@ describe("isUnreachableStatus", () => {
 });
 
 describe("dispatchWithContinuation", () => {
-  const chunk = (type: string, extra: Record<string, unknown> = {}) =>
-    ({ type, ...extra }) as UIMessageChunk;
-
-  /** A dispatch that streams `chunks`, then optionally dies. */
-  const dispatch = (chunks: UIMessageChunk[], err?: Error) =>
-    async function* () {
-      for (const c of chunks) yield c;
-      if (err) throw err;
-    };
-
-  const collect = async (it: AsyncIterable<UIMessageChunk>) => {
-    const out: UIMessageChunk[] = [];
-    for await (const c of it) out.push(c);
-    return out;
-  };
-
   test("a healthy dispatch is forwarded verbatim", async () => {
     const seen: Array<{ reason: string } | null> = [];
     const chunks = await collect(
@@ -227,6 +228,28 @@ describe("dispatchWithContinuation", () => {
     // The second dispatch is told it is continuing, and why.
     expect(resumes[0]).toBeNull();
     expect(resumes[1]?.reason).toContain("pod gone");
+  });
+
+  test("an attempt that died before streaming anything lets the continuation open the message", async () => {
+    // Dropping this `start` too left the run with parts and no message: the
+    // projector never opened one, so the turn rendered empty.
+    let attempt = 0;
+    const chunks = await collect(
+      dispatchWithContinuation({
+        runId: "run_1",
+        resume: null,
+        aborted: () => false,
+        dispatchOnce: () =>
+          ++attempt === 1
+            ? dispatch([], new SandboxUnreachableError("pod never answered"))()
+            : dispatch([
+                chunk("start", { messageId: "msg_b" }),
+                chunk("finish"),
+              ])(),
+      }),
+    );
+    expect(chunks.map((c) => c.type)).toEqual(["start", "finish"]);
+    expect((chunks[0] as { messageId?: string }).messageId).toBe("msg_b");
   });
 
   test("a caller-supplied resume drops the harness's first `start` too", async () => {
@@ -416,5 +439,142 @@ describe("isRunSuperseded", () => {
     );
     expect(replayed instanceof RunSupersededError).toBe(false);
     expect(isRunSuperseded(replayed)).toBe(true);
+  });
+});
+
+describe("describeTermination", () => {
+  test("an OOM kill names the limit, because that is the actionable part", () => {
+    expect(
+      describeTermination({
+        reason: "OOMKilled",
+        oomKilled: true,
+        exitCode: 137,
+        memoryLimit: "4Gi",
+      }),
+    ).toBe(
+      "it was killed by the kernel for exceeding its memory limit (memory limit 4Gi) — OOMKilled",
+    );
+  });
+
+  test("an OOM kill still reports without a known limit", () => {
+    expect(
+      describeTermination({ reason: "OOMKilled", oomKilled: true }),
+    ).toContain("OOMKilled");
+  });
+
+  // Null is what makes the caller fall back to its unqualified message, so
+  // "nothing to add" must never render as a sentence.
+  test("nothing to add returns null, not a sentence", () => {
+    expect(describeTermination(null)).toBeNull();
+    expect(
+      describeTermination({ reason: "Completed", oomKilled: false }),
+    ).toBeNull();
+  });
+
+  test("any other termination reason is reported with its exit code", () => {
+    expect(
+      describeTermination({ reason: "Error", oomKilled: false, exitCode: 1 }),
+    ).toBe("the sandbox container terminated with reason Error (exit code 1)");
+  });
+});
+
+describe("a lost sandbox's cause reaches the agent and the thread", () => {
+  test("the continuation is told it was an OOM, and what to do about it", async () => {
+    const resumes: Array<{ reason: string } | null> = [];
+    let attempt = 0;
+    await collect(
+      dispatchWithContinuation({
+        runId: "run_1",
+        resume: null,
+        aborted: () => false,
+        lastHandle: () => "thread-abc",
+        describeTermination: async (handle) =>
+          handle === "thread-abc"
+            ? "it was OOMKilled (memory limit 4Gi)"
+            : null,
+        dispatchOnce: (resume) => {
+          resumes.push(resume);
+          return ++attempt === 1
+            ? dispatch([], new SandboxUnreachableError("stream broke"))()
+            : dispatch([chunk("start"), chunk("finish")])();
+        },
+      }),
+    );
+    expect(resumes[1]?.reason).toContain("OOMKilled");
+    expect(resumes[1]?.reason).toContain("memory limit 4Gi");
+    // Without these the model re-runs the step that was killed, or reports
+    // edits it only remembers making.
+    expect(resumes[1]?.reason).toContain("re-read the files");
+    expect(resumes[1]?.reason).toContain("split it");
+  });
+
+  test("the last attempt's failure carries the OOM into the run's error, exactly one prefix", async () => {
+    let thrown: unknown;
+    try {
+      await collect(
+        dispatchWithContinuation({
+          runId: "run_1",
+          resume: null,
+          aborted: () => false,
+          maxAttempts: 1,
+          lastHandle: () => "thread-abc",
+          describeTermination: async () =>
+            "it was OOMKilled (memory limit 4Gi)",
+          dispatchOnce: () =>
+            dispatch([], new SandboxUnreachableError("stream broke"))(),
+        }),
+      );
+    } catch (err) {
+      thrown = err;
+    }
+    const message = (thrown as Error).message;
+    expect(message).toContain("stream broke");
+    expect(message).toContain("OOMKilled");
+    // The prefix is what marks the failure transient downstream; doubling it
+    // would still match, but the user reads this string.
+    expect(message.match(/\[SANDBOX_UNREACHABLE\]/g)).toHaveLength(1);
+  });
+
+  test("an unknowable termination leaves the message it already had", async () => {
+    let thrown: unknown;
+    try {
+      await collect(
+        dispatchWithContinuation({
+          runId: "run_1",
+          resume: null,
+          aborted: () => false,
+          maxAttempts: 1,
+          lastHandle: () => "thread-abc",
+          describeTermination: async () => null,
+          dispatchOnce: () =>
+            dispatch([], new SandboxUnreachableError("stream broke"))(),
+        }),
+      );
+    } catch (err) {
+      thrown = err;
+    }
+    expect((thrown as Error).message).toBe(
+      "[SANDBOX_UNREACHABLE] stream broke",
+    );
+  });
+
+  test("a probe that throws never fails the run it was explaining", async () => {
+    let attempt = 0;
+    const chunks = await collect(
+      dispatchWithContinuation({
+        runId: "run_1",
+        resume: null,
+        aborted: () => false,
+        lastHandle: () => "thread-abc",
+        describeTermination: async () => {
+          throw new Error("kube api down");
+        },
+        dispatchOnce: () =>
+          ++attempt === 1
+            ? dispatch([], new SandboxUnreachableError("stream broke"))()
+            : dispatch([chunk("start"), chunk("finish")])(),
+      }),
+    );
+    expect(chunks.map((c) => c.type)).toEqual(["start", "finish"]);
   });
 });

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -527,10 +527,7 @@ export async function* dispatchWithContinuation(args: {
  * work that just died — reproducing the kill — or reports success from memory
  * of edits that were never pushed.
  */
-function resumeReason(
-  errorMessage: string,
-  infra: string | null,
-): string {
+function resumeReason(errorMessage: string, infra: string | null): string {
   const lost = `the sandbox running the previous attempt stopped answering (${errorMessage})`;
   if (!infra) return lost;
   return (

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -37,7 +37,10 @@ import {
   SANDBOX_GONE_TERMINAL_CODE,
   SANDBOX_UNREACHABLE_PREFIX,
 } from "@decocms/sandbox/dispatch/error-codes";
-import type { SandboxProvider } from "@decocms/sandbox/provider";
+import type {
+  PodTermination,
+  SandboxProvider,
+} from "@decocms/sandbox/provider";
 import { isTransientStreamError } from "@/harnesses/decopilot/built-in-tools/subtask";
 import type { HarnessId, HarnessStreamInput } from "@/harnesses/lib/types";
 import {
@@ -111,12 +114,21 @@ const DAEMON_SILENCE_TIMEOUT_MS = 90_000;
  * the model.
  */
 export class SandboxUnreachableError extends Error {
-  constructor(reason: string) {
+  /**
+   * The bare reason, without the prefix — so a caller that learns WHY the pod
+   * went away can re-wrap without doubling the marker.
+   */
+  readonly reason: string;
+
+  constructor(reason: string, infra?: string) {
     // Prefixed in the CONSTRUCTOR, so the marker `isTransientRunFailure` reads
     // downstream cannot be forgotten by a new throw site. See
     // SANDBOX_UNREACHABLE_PREFIX.
-    super(`${SANDBOX_UNREACHABLE_PREFIX} ${reason}`);
+    super(
+      `${SANDBOX_UNREACHABLE_PREFIX} ${reason}${infra ? ` — ${infra}` : ""}`,
+    );
     this.name = "SandboxUnreachableError";
+    this.reason = reason;
   }
 }
 
@@ -381,6 +393,13 @@ export class SandboxDispatchClient implements SandboxClient {
         resume: this.resume,
         aborted: () => input.signal?.aborted === true,
         dispatchOnce,
+        lastHandle: () => lastHandle,
+        describeTermination: async (handle) =>
+          handle === null
+            ? null
+            : describeTermination(
+                (await provider.lastTermination?.(handle)) ?? null,
+              ),
       });
     } finally {
       // The run is over — cleanly, failed, or aborted. This pod is `cloneOnly`:
@@ -415,7 +434,9 @@ export class SandboxDispatchClient implements SandboxClient {
  *  - The continuation's own `start` chunk is dropped. `start` RENAMES the message
  *    being folded (AI SDK `processUIMessageStream` assigns `state.message.id`),
  *    so forwarding a second one re-ids a message the projector has already
- *    written parts for. The first `start` of the run wins.
+ *    written parts for. The first `start` of the run wins — but if the interrupted
+ *    attempt died before sending one, the continuation's IS the first and passes,
+ *    or the run's message never opens at all.
  *
  * What it does NOT do is re-run the task: `resume` tells the harness its own
  * context is gone but the work is in the checkout, so it continues from there.
@@ -429,6 +450,18 @@ export async function* dispatchWithContinuation(args: {
   dispatchOnce: (
     resume: { reason: string } | null,
   ) => AsyncIterable<UIMessageChunk>;
+  /**
+   * Ask the infrastructure why the sandbox went away, once it has. Answers the
+   * question the broken stream cannot: an OOM kill leaves no trace in the
+   * daemon's output, so without this both the agent and the user are told only
+   * that the pod "stopped answering" — and a run that OOMs twice reads as a
+   * flaky network instead of a sandbox too small for the work.
+   *
+   * Best-effort: null (or a throw) degrades to the unqualified message.
+   */
+  describeTermination?: (handle: string | null) => Promise<string | null>;
+  /** The handle the failed attempt ran on, for `describeTermination`. */
+  lastHandle?: () => string | null;
   /** Consecutive no-progress dispatches allowed. */
   maxAttempts?: number;
   /** Dispatches allowed in total, progress or not. */
@@ -456,11 +489,21 @@ export async function* dispatchWithContinuation(args: {
     } catch (err) {
       if (args.aborted()) throw err;
       stalled = progressed ? 1 : stalled + 1;
+      const infra =
+        err instanceof SandboxUnreachableError
+          ? ((await args
+              .describeTermination?.(args.lastHandle?.() ?? null)
+              .catch(() => null)) ?? null)
+          : null;
       if (
         !(err instanceof SandboxUnreachableError) ||
         stalled >= maxAttempts ||
         attempt >= maxTotalAttempts
       ) {
+        // Out of attempts — this message is the run's error terminal, what the user reads.
+        if (infra && err instanceof SandboxUnreachableError) {
+          throw new SandboxUnreachableError(err.reason, infra);
+        }
         throw err;
       }
       console.warn("[sandbox-dispatch] sandbox lost mid-run; continuing", {
@@ -468,15 +511,59 @@ export async function* dispatchWithContinuation(args: {
         attempt,
         progressed,
         reason: err.message,
+        termination: infra,
       });
-      resume = {
-        reason: `the sandbox running the previous attempt stopped answering (${err.message})`,
-      };
-      // Whatever the interrupted attempt streamed already opened the run's
-      // message; the continuation must extend it, not re-open it.
-      forwardedStart = true;
+      resume = { reason: resumeReason(err.message, infra) };
     }
   }
+}
+
+/**
+ * What the harness is told about the sandbox it lost. `infra` is the
+ * infrastructure's verdict when we have one (an OOM kill, typically).
+ *
+ * The instructions are the point: the continuation runs in a pod that has the
+ * branch but not the transcript, so left to itself a model either re-runs the
+ * work that just died — reproducing the kill — or reports success from memory
+ * of edits that were never pushed.
+ */
+function resumeReason(
+  errorMessage: string,
+  infra: string | null,
+): string {
+  const lost = `the sandbox running the previous attempt stopped answering (${errorMessage})`;
+  if (!infra) return lost;
+  return (
+    `${lost}. ${infra}. A replacement sandbox has been started from the last state pushed to the branch. ` +
+    `Tell the user this happened, re-read the files you had been editing rather than trusting your memory of them, ` +
+    `and if a step needs more memory than the sandbox has, split it instead of repeating what was killed`
+  );
+}
+
+/**
+ * The kubelet's verdict as one sentence for a prompt, a log line, and a thread
+ * error — the same text for all three, because an OOM the agent is told about
+ * and the user is not is how "it just stopped" survived in prod.
+ *
+ * Null for a stop that carries no information beyond the broken stream we
+ * already reported (a graceful shutdown, an eviction, a pod already gone).
+ */
+export function describeTermination(
+  termination: PodTermination | null,
+): string | null {
+  if (!termination) return null;
+  if (termination.oomKilled) {
+    const limit = termination.memoryLimit
+      ? ` (memory limit ${termination.memoryLimit})`
+      : "";
+    return `it was killed by the kernel for exceeding its memory limit${limit} — OOMKilled`;
+  }
+  if (termination.reason === "Completed") return null;
+  const code =
+    termination.exitCode === undefined
+      ? ""
+      : ` (exit code ${termination.exitCode})`;
+  return `the sandbox container terminated with reason ${termination.reason}${code}`;
 }
 
 /**

--- a/packages/sandbox/server/provider/agent-sandbox/client.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/client.test.ts
@@ -8,6 +8,7 @@ import {
   applyHttpRoute,
   createSandboxClaim,
   podTermination,
+  readPodTermination,
   deleteSandboxClaim,
   ensureServicePort,
   getSandboxClaim,
@@ -727,5 +728,71 @@ describe("podTermination", () => {
       ),
     ).toBeNull();
     expect(podTermination({}, "sandbox")).toBeNull();
+  });
+});
+
+describe("readPodTermination", () => {
+  const pod = (
+    name: string,
+    creationTimestamp: string,
+    terminated?: { reason: string },
+  ) => ({
+    metadata: { name, creationTimestamp },
+    status: {
+      containerStatuses: [
+        { name: "sandbox", state: terminated ? { terminated } : {} },
+      ],
+    },
+  });
+
+  it("reads the newest pod, not an earlier attempt's corpse under the same handle", async () => {
+    fetchImpl = async () =>
+      jsonResponse(200, {
+        items: [
+          pod("old", "2026-08-13T18:00:00Z", { reason: "OOMKilled" }),
+          pod("new", "2026-08-13T18:05:00Z"),
+        ],
+      });
+    expect(
+      await readPodTermination(
+        makeKc(),
+        NS,
+        "studio.decocms.com/sandbox-handle",
+        "h1",
+        "sandbox",
+      ),
+    ).toBeNull();
+  });
+
+  it("reports the newest pod's own kill", async () => {
+    fetchImpl = async () =>
+      jsonResponse(200, {
+        items: [
+          pod("old", "2026-08-13T18:00:00Z", { reason: "Error" }),
+          pod("new", "2026-08-13T18:05:00Z", { reason: "OOMKilled" }),
+        ],
+      });
+    expect(
+      (
+        await readPodTermination(
+          makeKc(),
+          NS,
+          "studio.decocms.com/sandbox-handle",
+          "h1",
+          "sandbox",
+        )
+      )?.oomKilled,
+    ).toBe(true);
+  });
+
+  it("degrades to null when the pod is already gone or the read fails", async () => {
+    fetchImpl = async () => jsonResponse(200, { items: [] });
+    expect(
+      await readPodTermination(makeKc(), NS, "k", "h1", "sandbox"),
+    ).toBeNull();
+    fetchImpl = async () => jsonResponse(403, { message: "forbidden" });
+    expect(
+      await readPodTermination(makeKc(), NS, "k", "h1", "sandbox"),
+    ).toBeNull();
   });
 });

--- a/packages/sandbox/server/provider/agent-sandbox/client.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/client.test.ts
@@ -7,6 +7,7 @@ import {
 import {
   applyHttpRoute,
   createSandboxClaim,
+  podTermination,
   deleteSandboxClaim,
   ensureServicePort,
   getSandboxClaim,
@@ -650,5 +651,81 @@ describe("waitForSandboxReady", () => {
     await expect(p).rejects.toThrow(
       /Watch stream error while waiting for sandbox: watch channel expired/,
     );
+  });
+});
+
+describe("podTermination", () => {
+  const oomStatus = (state: "state" | "lastState") => ({
+    spec: {
+      containers: [
+        { name: "sandbox", resources: { limits: { memory: "4Gi" } } },
+        { name: "orgfs-sidecar", resources: { limits: { memory: "512Mi" } } },
+      ],
+    },
+    status: {
+      containerStatuses: [
+        {
+          name: "sandbox",
+          [state]: { terminated: { reason: "OOMKilled", exitCode: 137 } },
+        },
+      ],
+    },
+  });
+
+  it("reads an OOM kill and the limit that was hit", () => {
+    expect(podTermination(oomStatus("state"), "sandbox")).toEqual({
+      reason: "OOMKilled",
+      oomKilled: true,
+      exitCode: 137,
+      memoryLimit: "4Gi",
+    });
+  });
+
+  it("finds the same kill after the kubelet restarted the container in place", () => {
+    expect(podTermination(oomStatus("lastState"), "sandbox")?.oomKilled).toBe(
+      true,
+    );
+  });
+
+  it("reports a non-OOM termination without claiming it was one", () => {
+    const t = podTermination(
+      {
+        status: {
+          containerStatuses: [
+            { name: "sandbox", state: { terminated: { reason: "Error" } } },
+          ],
+        },
+      },
+      "sandbox",
+    );
+    expect(t).toEqual({ reason: "Error", oomKilled: false });
+  });
+
+  it("ignores a sibling container's kill — the sidecar is not the sandbox", () => {
+    expect(
+      podTermination(
+        {
+          status: {
+            containerStatuses: [
+              {
+                name: "orgfs-sidecar",
+                state: { terminated: { reason: "OOMKilled" } },
+              },
+            ],
+          },
+        },
+        "sandbox",
+      ),
+    ).toBeNull();
+  });
+
+  it("a running container has nothing to report", () => {
+    expect(
+      podTermination(
+        { status: { containerStatuses: [{ name: "sandbox", state: {} }] } },
+        "sandbox",
+      ),
+    ).toBeNull();
+    expect(podTermination({}, "sandbox")).toBeNull();
   });
 });

--- a/packages/sandbox/server/provider/agent-sandbox/client.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/client.ts
@@ -625,7 +625,7 @@ export async function isPodUnbound(
  * `lastState.terminated` once the kubelet restarted it in place — same kill.
  *
  * Best-effort by construction: the operator deletes the pod shortly after the
- * kill, so null means "no longer knowable", never "not an OOM".
+ * kill, so null means "no longer knowable", never "not an OOM". Only the newest labelled pod counts — a continuation reuses the handle, so an earlier attempt's corpse still carries it.
  */
 export async function readPodTermination(
   kc: KubeConfig,
@@ -643,11 +643,16 @@ export async function readPodTermination(
     });
     if (!resp.ok) return null;
     const body = (await resp.json()) as { items?: PodTerminationSource[] };
-    for (const pod of body.items ?? []) {
-      const termination = podTermination(pod, containerName);
-      if (termination) return termination;
-    }
-    return null;
+    const newest = (body.items ?? []).reduce<PodTerminationSource | null>(
+      (latest, pod) =>
+        latest === null ||
+        (pod.metadata?.creationTimestamp ?? "") >
+          (latest.metadata?.creationTimestamp ?? "")
+          ? pod
+          : latest,
+      null,
+    );
+    return newest ? podTermination(newest, containerName) : null;
   } catch {
     return null;
   }
@@ -659,6 +664,7 @@ interface TerminatedState {
 }
 
 interface PodTerminationSource {
+  metadata?: { creationTimestamp?: string };
   spec?: {
     containers?: Array<{
       name?: string;

--- a/packages/sandbox/server/provider/agent-sandbox/client.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/client.ts
@@ -25,6 +25,7 @@ import {
   type KubeConfig,
   type V1Status as V1StatusUpstream,
 } from "@kubernetes/client-node";
+import type { PodTermination } from "../types";
 import {
   K8S_CONSTANTS,
   SandboxAlreadyExistsError,
@@ -609,6 +610,91 @@ export async function isPodUnbound(
   } catch {
     return false;
   }
+}
+
+/**
+ * How the main container of this handle's pod last stopped, per the kubelet.
+ *
+ * The only source for an OOM kill: the cgroup limit is enforced by the kernel,
+ * the process is SIGKILLed, and the daemon gets no chance to report anything —
+ * from Studio's side the stream simply breaks. Without this, "the sandbox
+ * stopped answering" is all anyone (user, agent, on-call) ever learns.
+ *
+ * Read by label, not pod name, because a warm-pool pod keeps its generated
+ * name after binding. `state.terminated` while the container is still down,
+ * `lastState.terminated` once the kubelet restarted it in place — same kill.
+ *
+ * Best-effort by construction: the operator deletes the pod shortly after the
+ * kill, so null means "no longer knowable", never "not an OOM".
+ */
+export async function readPodTermination(
+  kc: KubeConfig,
+  namespace: string,
+  handleLabelKey: string,
+  handle: string,
+  containerName: string,
+): Promise<PodTermination | null> {
+  try {
+    const resp = await kubeFetch(kc, {
+      method: "GET",
+      path:
+        `/api/v1/namespaces/${encodeURIComponent(namespace)}/pods` +
+        `?labelSelector=${encodeURIComponent(`${handleLabelKey}=${handle}`)}`,
+    });
+    if (!resp.ok) return null;
+    const body = (await resp.json()) as { items?: PodTerminationSource[] };
+    for (const pod of body.items ?? []) {
+      const termination = podTermination(pod, containerName);
+      if (termination) return termination;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+interface TerminatedState {
+  reason?: string;
+  exitCode?: number;
+}
+
+interface PodTerminationSource {
+  spec?: {
+    containers?: Array<{
+      name?: string;
+      resources?: { limits?: { memory?: string } };
+    }>;
+  };
+  status?: {
+    containerStatuses?: Array<{
+      name?: string;
+      state?: { terminated?: TerminatedState };
+      lastState?: { terminated?: TerminatedState };
+    }>;
+  };
+}
+
+/** Exported for the unit test; the wire read above is the only caller. */
+export function podTermination(
+  pod: PodTerminationSource,
+  containerName: string,
+): PodTermination | null {
+  const status = (pod.status?.containerStatuses ?? []).find(
+    (c) => c.name === containerName,
+  );
+  const terminated = status?.state?.terminated ?? status?.lastState?.terminated;
+  if (!terminated?.reason) return null;
+  const memoryLimit = (pod.spec?.containers ?? []).find(
+    (c) => c.name === containerName,
+  )?.resources?.limits?.memory;
+  return {
+    reason: terminated.reason,
+    oomKilled: terminated.reason === "OOMKilled",
+    ...(terminated.exitCode === undefined
+      ? {}
+      : { exitCode: terminated.exitCode }),
+    ...(memoryLimit === undefined ? {} : { memoryLimit }),
+  };
 }
 
 // ---- HTTPRoute (Gateway API) ------------------------------------------------

--- a/packages/sandbox/server/provider/agent-sandbox/constants.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/constants.ts
@@ -15,6 +15,9 @@ export const K8S_CONSTANTS = {
   SANDBOX_PLURAL: "sandboxes",
 
   POD_NAME_ANNOTATION: "agents.x-k8s.io/pod-name",
+
+  /** The agent container in every sandbox pod; siblings are the org-fs sidecar and init containers. */
+  MAIN_CONTAINER_NAME: "sandbox",
 } as const;
 
 export class SandboxError extends Error {

--- a/packages/sandbox/server/provider/agent-sandbox/lifecycle-watcher.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/lifecycle-watcher.ts
@@ -50,7 +50,6 @@ export type {
 } from "./lifecycle-types";
 
 const SANDBOX_HANDLE_LABEL = "studio.decocms.com/sandbox-handle";
-const MAIN_CONTAINER_NAME = "sandbox";
 
 const DEFAULT_SCHEDULING_TIMEOUT_MS = 5 * 60 * 1000;
 
@@ -561,7 +560,7 @@ function applyPodSnapshot(pod: PodResource, state: State, _now: () => number) {
   }
 
   const main = (pod.status?.containerStatuses ?? []).find(
-    (c) => c.name === MAIN_CONTAINER_NAME,
+    (c) => c.name === K8S_CONSTANTS.MAIN_CONTAINER_NAME,
   );
   if (main) {
     state.pod.containerWaitingReason = main.state?.waiting?.reason;

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -61,6 +61,7 @@ import {
 import type { RunnerStateStore, RunnerStateStoreOps } from "../state-store";
 import type {
   EnsureOptions,
+  PodTermination,
   ProxyRequestInit,
   Sandbox,
   SandboxId,
@@ -77,6 +78,7 @@ import {
   HTTPROUTE_CONSTANTS,
   isPodUnbound,
   listWarmPoolPods,
+  readPodTermination,
   type WarmPoolPod,
   patchSandboxClaimShutdown,
   waitForClaimAdoptedSandbox,
@@ -616,6 +618,20 @@ export class AgentSandboxProvider implements SandboxProvider {
       if (rec) await this.stateStore.delete(rec.id, RUNNER_KIND);
       else await this.stateStore.deleteByHandle(RUNNER_KIND, handle);
     }
+  }
+
+  /**
+   * See `SandboxProvider.lastTermination`. Reads the kubelet's own verdict on
+   * the pod behind `handle` — the only place an OOM kill is recorded.
+   */
+  lastTermination(handle: string): Promise<PodTermination | null> {
+    return readPodTermination(
+      this.kubeConfig,
+      this.namespace,
+      LABEL_KEYS.sandboxHandle,
+      handle,
+      K8S_CONSTANTS.MAIN_CONTAINER_NAME,
+    );
   }
 
   async alive(handle: string): Promise<boolean> {

--- a/packages/sandbox/server/provider/index.ts
+++ b/packages/sandbox/server/provider/index.ts
@@ -13,6 +13,7 @@ import {
 export type {
   EnsureOptions,
   LegacySandboxProviderKind,
+  PodTermination,
   ProxyRequestInit,
   SandboxProviderKind,
   Sandbox,

--- a/packages/sandbox/server/provider/types.ts
+++ b/packages/sandbox/server/provider/types.ts
@@ -178,12 +178,37 @@ export function normalizeSandboxProviderKind(
   return kind === "cluster" ? "agent-sandbox" : kind;
 }
 
+/**
+ * How the infrastructure — not the daemon — saw a sandbox stop. An OOM kill is
+ * the case that only exists here: the kernel SIGKILLs the process at the cgroup
+ * limit, so the dying sandbox reports nothing and Studio just sees the stream
+ * break.
+ */
+export interface PodTermination {
+  /** k8s `terminated.reason`, e.g. `OOMKilled`, `Error`, `Completed`. */
+  reason: string;
+  oomKilled: boolean;
+  exitCode?: number;
+  /** The limit that was hit, as k8s spells it (`4Gi`). */
+  memoryLimit?: string;
+}
+
 export interface SandboxProvider {
   readonly kind: SandboxProviderKind;
 
   ensure(id: SandboxId, opts?: EnsureOptions): Promise<Sandbox>;
   delete(handle: string): Promise<void>;
   alive(handle: string): Promise<boolean>;
+
+  /**
+   * Why this sandbox's container last stopped, for a caller that already knows
+   * it stopped. Best-effort and racy against the pod's own deletion — null
+   * means "cannot tell", so callers must degrade to their unqualified message
+   * rather than asserting anything.
+   *
+   * Optional: callers must `?.()`.
+   */
+  lastTermination?(handle: string): Promise<PodTermination | null>;
 
   /**
    * Bring this sandbox's shutdown forward to `graceMs` from now, because the


### PR DESCRIPTION
## Why

Prod, 2026-08-13: `studio-sandbox-prod-tdcps` (org `deco-studio`, thread `thrd-gl5iorthbvj1`, `claude-code` run `thrd_gm40HXy2zVrIxIj7qfKv2`) went from a steady 242 MiB RSS to 3.6 GiB in three minutes and was OOMKilled at its 4Gi limit. Twenty minutes earlier the same thread had killed `studio-sandbox-prod-xvms5` exactly the same way.

Nobody could tell. A cgroup OOM is a kernel SIGKILL — the daemon logs nothing, and its last 90 seconds are silent. All Studio saw was:

```
[Decopilot] stream pump error for thread thrd_gm40HXy2zVrIxIj7qfKv2:
  [SANDBOX_UNREACHABLE] the sandbox stream broke mid-run: The socket connection was closed unexpectedly.
```

So the user reads "the socket closed", the agent is told the pod "stopped answering", and on-call reads a network blip. The retry path then faithfully reprovisions and reproduces the kill, because nothing in the loop knows memory was the problem.

## What

- `SandboxProvider.lastTermination?(handle)` — optional, best-effort. The agent-sandbox runner reads the kubelet's `terminated.reason` (and the limit that was hit) for the pod behind the handle, by label so a warm-pool pod's generated name doesn't matter. `null` means "no longer knowable" (the operator deletes the pod seconds later), never "not an OOM".
- `dispatchWithContinuation` folds that verdict into the three places the failure already surfaces: the `console.warn`, the resume prompt, and — when no attempts are left — the run's error terminal, which is the string the user reads in the thread. One sentence, one source.
- The resume prompt also says what to do about it. A replacement pod has the branch but not the transcript, so left to itself a model either re-runs the step that was just killed (reproducing the kill) or reports edits it only remembers making. It is now told to say what happened, re-read the files it was editing, and split the step rather than repeat it.

`SandboxUnreachableError` keeps its bare `reason` so the enriched re-wrap doesn't double the `[SANDBOX_UNREACHABLE]` prefix that marks the failure transient downstream — asserted in a test.

### Drive-by fix

The catch set `forwardedStart = true` unconditionally, so an attempt that died **before** streaming anything got the continuation's `start` dropped as well and the run's message never opened — parts with no message. The loop already sets that flag when it forwards a `start`, so the assignment was redundant where it was right and wrong where it wasn't. Deleted, with a test.

`MAIN_CONTAINER_NAME` was private to `lifecycle-watcher.ts`; it moved to `K8S_CONSTANTS` rather than being copied.

## Testing

`bun test` (71 pass in the two touched files), `bun run --cwd=apps/api check`, `bun run lint`, `bun run fmt`, knip clean.

New unit tests: OOM/non-OOM/unknown rendering; the OOM reaching the resume prompt with its instructions; exactly one prefix on the terminal error; an unknowable termination leaving the message untouched; a probe that throws never failing the run it was explaining; and the `start`-drop regression.

Not covered by unit tests: the kube read itself (`readPodTermination` is I/O — its parse is tested via `podTermination`).

## Follow-up

This makes the OOM legible; it does not stop it. The sandbox limit is 4Gi against a 2Gi request — raising the ceiling is free at scheduling time, and that is a separate PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces sandbox OOM kills to users and agents instead of generic “stopped answering” errors. Previously, OOMKilled pods looked like transient network failures; now the kubelet termination (including the memory limit) is reflected in logs, the resume prompt, and the final thread error.

- Adds `SandboxProvider.lastTermination?` returning `PodTermination` for the newest pod with the handle label (best-effort; `null` when the pod is already gone). Implements `readPodTermination`/`podTermination` for `K8S_CONSTANTS.MAIN_CONTAINER_NAME`.
- `dispatchWithContinuation` queries infra once the stream breaks, folds the verdict into `console.warn`, the resume prompt (with clear instructions to re-read files and split steps), and rewraps the final `SandboxUnreachableError` so the thread error includes exactly one `[SANDBOX_UNREACHABLE]` prefix.
- Introduces `describeTermination` to render OOM/non-OOM/unknown stops consistently; `SandboxUnreachableError` now stores the bare `reason` to avoid double-prefixing.
- Drive-by fix: allow the continuation’s `start` when the failed attempt never streamed one; move `MAIN_CONTAINER_NAME` into `K8S_CONSTANTS`.
- No migration required. `lastTermination` is optional and guarded; behavior for non-OOM terminations is unchanged. Unit tests cover OOM/non-OOM/unknown rendering, newest-pod selection, resume instructions, single-prefix error, and the `start` regression.

<sup>Written for commit f70b23b35b581fff33d4b62a4044dfdd345bdde7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6059?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

