### PR TITLE
feat(sandbox-env): carry the higher memory ceiling on a -medium SandboxTemplate

### DIFF
--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -37,7 +37,10 @@ import {
   SANDBOX_GONE_TERMINAL_CODE,
   SANDBOX_UNREACHABLE_PREFIX,
 } from "@decocms/sandbox/dispatch/error-codes";
-import type { SandboxProvider } from "@decocms/sandbox/provider";
+import type {
+  PodTermination,
+  SandboxProvider,
+} from "@decocms/sandbox/provider";
 import { isTransientStreamError } from "@/harnesses/decopilot/built-in-tools/subtask";
 import type { HarnessId, HarnessStreamInput } from "@/harnesses/lib/types";
 import {
@@ -111,12 +114,21 @@ const DAEMON_SILENCE_TIMEOUT_MS = 90_000;
  * the model.
  */
 export class SandboxUnreachableError extends Error {
-  constructor(reason: string) {
+  /**
+   * The bare reason, without the prefix — so a caller that learns WHY the pod
+   * went away can re-wrap without doubling the marker.
+   */
+  readonly reason: string;
+
+  constructor(reason: string, infra?: string) {
     // Prefixed in the CONSTRUCTOR, so the marker `isTransientRunFailure` reads
     // downstream cannot be forgotten by a new throw site. See
     // SANDBOX_UNREACHABLE_PREFIX.
-    super(`${SANDBOX_UNREACHABLE_PREFIX} ${reason}`);
+    super(
+      `${SANDBOX_UNREACHABLE_PREFIX} ${reason}${infra ? ` — ${infra}` : ""}`,
+    );
     this.name = "SandboxUnreachableError";
+    this.reason = reason;
   }
 }
 
@@ -354,10 +366,10 @@ export class SandboxDispatchClient implements SandboxClient {
             virtualMcpId,
             branch,
             sandboxProviderKind: kind,
-            // This pod runs one agent loop and returns its output. Nothing here
-            // opens a preview, so the tenant's install + dev server is pure boot
-            // latency — the harness only needs the checkout.
-            cloneOnly: true,
+            // This pod runs one agent loop and returns its output: no preview,
+            // no dev server, and a memory ceiling of its own (the agent loop is
+            // what OOMKilled 4Gi pods in prod).
+            purpose: "harness-run",
           },
           ctx,
         );
@@ -381,6 +393,13 @@ export class SandboxDispatchClient implements SandboxClient {
         resume: this.resume,
         aborted: () => input.signal?.aborted === true,
         dispatchOnce,
+        lastHandle: () => lastHandle,
+        describeTermination: async (handle) =>
+          handle === null
+            ? null
+            : describeTermination(
+                (await provider.lastTermination?.(handle)) ?? null,
+              ),
       });
     } finally {
       // The run is over — cleanly, failed, or aborted. This pod is `cloneOnly`:
@@ -415,7 +434,9 @@ export class SandboxDispatchClient implements SandboxClient {
  *  - The continuation's own `start` chunk is dropped. `start` RENAMES the message
  *    being folded (AI SDK `processUIMessageStream` assigns `state.message.id`),
  *    so forwarding a second one re-ids a message the projector has already
- *    written parts for. The first `start` of the run wins.
+ *    written parts for. The first `start` of the run wins — but if the interrupted
+ *    attempt died before sending one, the continuation's IS the first and passes,
+ *    or the run's message never opens at all.
  *
  * What it does NOT do is re-run the task: `resume` tells the harness its own
  * context is gone but the work is in the checkout, so it continues from there.
@@ -429,6 +450,18 @@ export async function* dispatchWithContinuation(args: {
   dispatchOnce: (
     resume: { reason: string } | null,
   ) => AsyncIterable<UIMessageChunk>;
+  /**
+   * Ask the infrastructure why the sandbox went away, once it has. Answers the
+   * question the broken stream cannot: an OOM kill leaves no trace in the
+   * daemon's output, so without this both the agent and the user are told only
+   * that the pod "stopped answering" — and a run that OOMs twice reads as a
+   * flaky network instead of a sandbox too small for the work.
+   *
+   * Best-effort: null (or a throw) degrades to the unqualified message.
+   */
+  describeTermination?: (handle: string | null) => Promise<string | null>;
+  /** The handle the failed attempt ran on, for `describeTermination`. */
+  lastHandle?: () => string | null;
   /** Consecutive no-progress dispatches allowed. */
   maxAttempts?: number;
   /** Dispatches allowed in total, progress or not. */
@@ -456,11 +489,21 @@ export async function* dispatchWithContinuation(args: {
     } catch (err) {
       if (args.aborted()) throw err;
       stalled = progressed ? 1 : stalled + 1;
+      const infra =
+        err instanceof SandboxUnreachableError
+          ? ((await args
+              .describeTermination?.(args.lastHandle?.() ?? null)
+              .catch(() => null)) ?? null)
+          : null;
       if (
         !(err instanceof SandboxUnreachableError) ||
         stalled >= maxAttempts ||
         attempt >= maxTotalAttempts
       ) {
+        // Out of attempts — this message is the run's error terminal, what the user reads.
+        if (infra && err instanceof SandboxUnreachableError) {
+          throw new SandboxUnreachableError(err.reason, infra);
+        }
         throw err;
       }
       console.warn("[sandbox-dispatch] sandbox lost mid-run; continuing", {
@@ -468,15 +511,56 @@ export async function* dispatchWithContinuation(args: {
         attempt,
         progressed,
         reason: err.message,
+        termination: infra,
       });
-      resume = {
-        reason: `the sandbox running the previous attempt stopped answering (${err.message})`,
-      };
-      // Whatever the interrupted attempt streamed already opened the run's
-      // message; the continuation must extend it, not re-open it.
-      forwardedStart = true;
+      resume = { reason: resumeReason(err.message, infra) };
     }
   }
+}
+
+/**
+ * What the harness is told about the sandbox it lost. `infra` is the
+ * infrastructure's verdict when we have one (an OOM kill, typically).
+ *
+ * The instructions are the point: the continuation runs in a pod that has the
+ * branch but not the transcript, so left to itself a model either re-runs the
+ * work that just died — reproducing the kill — or reports success from memory
+ * of edits that were never pushed.
+ */
+function resumeReason(errorMessage: string, infra: string | null): string {
+  const lost = `the sandbox running the previous attempt stopped answering (${errorMessage})`;
+  if (!infra) return lost;
+  return (
+    `${lost}. ${infra}. A replacement sandbox has been started from the last state pushed to the branch. ` +
+    `Tell the user this happened, re-read the files you had been editing rather than trusting your memory of them, ` +
+    `and if a step needs more memory than the sandbox has, split it instead of repeating what was killed`
+  );
+}
+
+/**
+ * The kubelet's verdict as one sentence for a prompt, a log line, and a thread
+ * error — the same text for all three, because an OOM the agent is told about
+ * and the user is not is how "it just stopped" survived in prod.
+ *
+ * Null for a stop that carries no information beyond the broken stream we
+ * already reported (a graceful shutdown, an eviction, a pod already gone).
+ */
+export function describeTermination(
+  termination: PodTermination | null,
+): string | null {
+  if (!termination) return null;
+  if (termination.oomKilled) {
+    const limit = termination.memoryLimit
+      ? ` (memory limit ${termination.memoryLimit})`
+      : "";
+    return `it was killed by the kernel for exceeding its memory limit${limit} — OOMKilled`;
+  }
+  if (termination.reason === "Completed") return null;
+  const code =
+    termination.exitCode === undefined
+      ? ""
+      : ` (exit code ${termination.exitCode})`;
+  return `the sandbox container terminated with reason ${termination.reason}${code}`;
 }
 
 /**

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -366,9 +366,7 @@ export class SandboxDispatchClient implements SandboxClient {
             virtualMcpId,
             branch,
             sandboxProviderKind: kind,
-            // This pod runs one agent loop and returns its output: no preview,
-            // no dev server, and a memory ceiling of its own (the agent loop is
-            // what OOMKilled 4Gi pods in prod).
+            // One agent loop, no preview, and a memory ceiling of its own.
             purpose: "harness-run",
           },
           ctx,

--- a/apps/api/src/sandbox/lifecycle.ts
+++ b/apps/api/src/sandbox/lifecycle.ts
@@ -90,6 +90,17 @@ function readSandboxTemplateName(): string | undefined {
   return raw && raw.trim() !== "" ? raw : undefined;
 }
 
+/**
+ * SandboxTemplate for headless agent-loop (`cloneOnly`) claims — the
+ * sandbox-env chart renders it as `<template>-medium` with a 3Gi/6Gi memory
+ * request/limit. Unset (the default) → those claims use the same template as
+ * everything else, so set it only where that chart version is deployed.
+ */
+function readMediumTemplateName(): string | undefined {
+  const raw = process.env.STUDIO_SANDBOX_MEDIUM_TEMPLATE_NAME;
+  return raw && raw.trim() !== "" ? raw : undefined;
+}
+
 function readEnvName(): string | undefined {
   const raw = process.env.STUDIO_ENV;
   return raw && raw.trim() !== "" ? raw : undefined;
@@ -161,6 +172,7 @@ async function instantiate(
         stateStore,
         previewUrlPattern,
         sandboxTemplateName: readSandboxTemplateName(),
+        mediumTemplateName: readMediumTemplateName(),
         envName: readEnvName(),
         previewGateway: readPreviewGateway(),
         sentinelToken: readSandboxSentinelToken(),

--- a/apps/api/src/sandbox/lifecycle.ts
+++ b/apps/api/src/sandbox/lifecycle.ts
@@ -90,17 +90,6 @@ function readSandboxTemplateName(): string | undefined {
   return raw && raw.trim() !== "" ? raw : undefined;
 }
 
-/**
- * SandboxTemplate for headless agent-loop (`cloneOnly`) claims — the
- * sandbox-env chart renders it as `<template>-medium` with a 3Gi/6Gi memory
- * request/limit. Unset (the default) → those claims use the same template as
- * everything else, so set it only where that chart version is deployed.
- */
-function readMediumTemplateName(): string | undefined {
-  const raw = process.env.STUDIO_SANDBOX_MEDIUM_TEMPLATE_NAME;
-  return raw && raw.trim() !== "" ? raw : undefined;
-}
-
 function readEnvName(): string | undefined {
   const raw = process.env.STUDIO_ENV;
   return raw && raw.trim() !== "" ? raw : undefined;
@@ -172,7 +161,6 @@ async function instantiate(
         stateStore,
         previewUrlPattern,
         sandboxTemplateName: readSandboxTemplateName(),
-        mediumTemplateName: readMediumTemplateName(),
         envName: readEnvName(),
         previewGateway: readPreviewGateway(),
         sentinelToken: readSandboxSentinelToken(),

--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -20,6 +20,7 @@ import {
   normalizeSandboxProviderKind,
   type SandboxProvider,
   type SandboxProviderKind,
+  type SandboxPurpose,
   type Workload,
 } from "@decocms/sandbox/provider";
 import { sleep } from "@decocms/shared/std";
@@ -234,15 +235,12 @@ export async function ensureSandbox(
     branch: string;
     sandboxProviderKind: SandboxProviderKind;
     /**
-     * Clone the repo but skip the application workload (install + dev server).
-     *
-     * For a sandbox-hosted harness the pod exists to run one agent loop and
-     * hand back its final output — nothing reads a preview URL, so booting the
-     * tenant's dev server only adds install time and a port to babysit. Drops
-     * the `application` block from the daemon config; `git` still applies, so
-     * the checkout the harness needs is there.
+     * What the sandbox is for. `harness-run` — one headless agent loop, no
+     * preview — drops the application workload (install + dev server) from the
+     * daemon config and, on the hosted runner, moves the pod onto the
+     * agent-run SandboxTemplate + warm pool. Defaults to `interactive`.
      */
-    cloneOnly?: boolean;
+    purpose?: SandboxPurpose;
   },
   ctx: StudioContext,
 ): Promise<SandboxRecord> {
@@ -329,7 +327,7 @@ export async function ensureSandbox(
     existing: null,
     providerKind,
     runner,
-    ...(input.cloneOnly ? { cloneOnly: true } : {}),
+    ...(input.purpose ? { purpose: input.purpose } : {}),
   });
   return entry;
 }
@@ -351,8 +349,8 @@ type StartParams = {
   existing: SandboxRecord | null;
   providerKind: SandboxProviderKind;
   runner: SandboxProvider;
-  /** See `ensureSandbox`'s `cloneOnly`: checkout without install + dev server. */
-  cloneOnly?: boolean;
+  /** See `ensureSandbox`'s `purpose`. `harness-run` implies checkout-only. */
+  purpose?: SandboxPurpose;
 };
 
 async function provisionSandbox(
@@ -368,8 +366,11 @@ async function provisionSandbox(
     metadata,
     existing,
     runner,
-    cloneOnly,
+    purpose,
   } = params;
+  // The workload consequence of `harness-run`: one agent loop needs the
+  // checkout, not the tenant's install + dev server.
+  const cloneOnly = purpose === "harness-run";
 
   // A recorded connectionId can dangle — deleting a connection (force-delete,
   // or another agent's delete tearing down its repo-scoped child) removes
@@ -614,7 +615,8 @@ async function provisionSandbox(
       // package manager from the lockfile when the config names none, so an
       // omitted workload still installed (404 packages, competing with the run
       // that only wanted the checkout).
-      cloneOnly: cloneOnly === true,
+      cloneOnly,
+      ...(purpose ? { purpose } : {}),
       tenant: {
         orgId,
         // The sandbox's owner, so the pod's `user_id` label/metric matches the

--- a/apps/api/src/tools/sandbox/start.ts
+++ b/apps/api/src/tools/sandbox/start.ts
@@ -368,8 +368,7 @@ async function provisionSandbox(
     runner,
     purpose,
   } = params;
-  // The workload consequence of `harness-run`: one agent loop needs the
-  // checkout, not the tenant's install + dev server.
+  // One agent loop needs the checkout, not the install + dev server.
   const cloneOnly = purpose === "harness-run";
 
   // A recorded connectionId can dangle — deleting a connection (force-delete,

--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/kubernetes.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/kubernetes.mdx
@@ -391,8 +391,9 @@ These defaults come from `deploy/helm/studio/values.yaml`:
 | --- | --- | --- |
 | `envName` | DNS-label suffix for environment resources | Required |
 | `image.repository` / `image.tag` | Sandbox daemon image ([tags](https://github.com/orgs/decocms/packages/container/package/studio%2Fstudio-sandbox-go)) | `ghcr.io/decocms/studio/studio-sandbox-go` / pinned by the chart |
-| `resources.requests` | Per-sandbox request | `500m` CPU / `1Gi` memory |
-| `resources.limits` | Per-sandbox limit | `2` CPU / `6Gi` memory / `10Gi` ephemeral storage |
+| `resources.requests` | Per-sandbox request | `500m` CPU / `2Gi` memory |
+| `resources.limits` | Per-sandbox limit | `2` CPU / `4Gi` memory / `10Gi` ephemeral storage |
+| `mediumResources` | Overrides for the second, roomier `-medium` SandboxTemplate (headless agent-loop claims) | `3Gi` request / `6Gi` limit |
 | `terminationGracePeriodSeconds` | Time for final git sync and unmount | `90` |
 | `netinit.enabled` | Install default iptables egress policy | `true` |
 | `readOnlyRootFilesystem` | Read-only sandbox root filesystem | `true` |

--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/kubernetes.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/kubernetes.mdx
@@ -392,7 +392,7 @@ These defaults come from `deploy/helm/studio/values.yaml`:
 | `envName` | DNS-label suffix for environment resources | Required |
 | `image.repository` / `image.tag` | Sandbox daemon image ([tags](https://github.com/orgs/decocms/packages/container/package/studio%2Fstudio-sandbox-go)) | `ghcr.io/decocms/studio/studio-sandbox-go` / pinned by the chart |
 | `resources.requests` | Per-sandbox request | `500m` CPU / `1Gi` memory |
-| `resources.limits` | Per-sandbox limit | `2` CPU / `4Gi` memory / `10Gi` ephemeral storage |
+| `resources.limits` | Per-sandbox limit | `2` CPU / `6Gi` memory / `10Gi` ephemeral storage |
 | `terminationGracePeriodSeconds` | Time for final git sync and unmount | `90` |
 | `netinit.enabled` | Install default iptables egress policy | `true` |
 | `readOnlyRootFilesystem` | Read-only sandbox root filesystem | `true` |

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/kubernetes.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/kubernetes.mdx
@@ -391,8 +391,9 @@ Estes padrões vêm de `deploy/helm/studio/values.yaml`:
 | --- | --- | --- |
 | `envName` | Sufixo DNS-label dos recursos do ambiente | Obrigatório |
 | `image.repository` / `image.tag` | Imagem do daemon do sandbox ([tags](https://github.com/orgs/decocms/packages/container/package/studio%2Fstudio-sandbox-go)) | `ghcr.io/decocms/studio/studio-sandbox-go` / fixada pelo chart |
-| `resources.requests` | Request por sandbox | `500m` CPU / `1Gi` memória |
-| `resources.limits` | Limite por sandbox | `2` CPU / `6Gi` memória / `10Gi` armazenamento efêmero |
+| `resources.requests` | Request por sandbox | `500m` CPU / `2Gi` memória |
+| `resources.limits` | Limite por sandbox | `2` CPU / `4Gi` memória / `10Gi` armazenamento efêmero |
+| `mediumResources` | Overrides do segundo SandboxTemplate `-medium`, mais folgado (claims de agente headless) | `3Gi` de request / `6Gi` de limite |
 | `terminationGracePeriodSeconds` | Tempo para sync final do git e unmount | `90` |
 | `netinit.enabled` | Instalar política padrão de egress no iptables | `true` |
 | `readOnlyRootFilesystem` | Root filesystem do sandbox somente leitura | `true` |

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/kubernetes.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/kubernetes.mdx
@@ -392,7 +392,7 @@ Estes padrões vêm de `deploy/helm/studio/values.yaml`:
 | `envName` | Sufixo DNS-label dos recursos do ambiente | Obrigatório |
 | `image.repository` / `image.tag` | Imagem do daemon do sandbox ([tags](https://github.com/orgs/decocms/packages/container/package/studio%2Fstudio-sandbox-go)) | `ghcr.io/decocms/studio/studio-sandbox-go` / fixada pelo chart |
 | `resources.requests` | Request por sandbox | `500m` CPU / `1Gi` memória |
-| `resources.limits` | Limite por sandbox | `2` CPU / `4Gi` memória / `10Gi` armazenamento efêmero |
+| `resources.limits` | Limite por sandbox | `2` CPU / `6Gi` memória / `10Gi` armazenamento efêmero |
 | `terminationGracePeriodSeconds` | Tempo para sync final do git e unmount | `90` |
 | `netinit.enabled` | Instalar política padrão de egress no iptables | `true` |
 | `readOnlyRootFilesystem` | Root filesystem do sandbox somente leitura | `true` |

--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,10 +9,6 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
-# 0.15.14: sandbox memory limit 4Gi → 6Gi. The request is unchanged, so the
-# scheduler packs exactly as before; this only raises what one agent loop may
-# burst to. Three prod pods hit the old ceiling on 2026-08-13, one thread twice
-# in 20 minutes. See values.yaml `resources` for the overcommit tradeoff.
 # 0.14.6: opt-in `disruptionProtection.doNotDisrupt` (default off) — annotates
 # sandbox pods with Karpenter's `do-not-disrupt` so voluntary node
 # consolidation/drift never evicts a claimed sandbox mid-session (#5815). A

--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,6 +9,10 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
+# 0.15.14: sandbox memory limit 4Gi → 6Gi. The request is unchanged, so the
+# scheduler packs exactly as before; this only raises what one agent loop may
+# burst to. Three prod pods hit the old ceiling on 2026-08-13, one thread twice
+# in 20 minutes. See values.yaml `resources` for the overcommit tradeoff.
 # 0.14.6: opt-in `disruptionProtection.doNotDisrupt` (default off) — annotates
 # sandbox pods with Karpenter's `do-not-disrupt` so voluntary node
 # consolidation/drift never evicts a claimed sandbox mid-session (#5815). A
@@ -143,7 +147,7 @@ type: application
 # 0.8.0: org-fs sidecar (orgFs.*) — privileged rclone mounter + main-container
 # mounts. NOTE: the publish workflow skips existing versions, so this MUST
 # stay ahead of the latest published chart (0.7.5 at time of writing).
-version: 0.15.13
+version: 0.15.14
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "1.54.2"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/README.md
+++ b/deploy/helm/sandbox-env/README.md
@@ -122,10 +122,6 @@ configMap:
     STUDIO_SANDBOX_PROVIDER: "agent-sandbox"
     STUDIO_ENV: "staging"
     STUDIO_SANDBOX_TEMPLATE_NAME: "studio-sandbox-staging"
-    # Optional: headless agent-loop (cloneOnly) claims get the roomier
-    # `-medium` template (mediumResources) instead. Unset → they use the
-    # template above, so this is safe to add after the chart upgrade.
-    STUDIO_SANDBOX_MEDIUM_TEMPLATE_NAME: "studio-sandbox-staging-medium"
     # The next three values are required only when previewGateway.enabled=true.
     STUDIO_SANDBOX_PREVIEW_URL_PATTERN: "https://{handle}.preview.staging.example.com"
     # Per-claim HTTPRoute attaches to this Gateway. Both required whenever
@@ -274,7 +270,7 @@ See `values.yaml` for the full set. The most-tuned ones:
 | `image.repository` | `ghcr.io/decocms/studio/studio-sandbox-go` | sandbox image (Go daemon — the implementation IS the image) |
 | `image.tag` | chart `appVersion` | bump in lockstep with packages/sandbox/package.json |
 | `resources.*` | 0.5/2 CPU, 2/4Gi RAM | per sandbox pod |
-| `mediumResources.*` | 3/6Gi RAM | deep-merged over `resources.*` into a second `<name>-medium` SandboxTemplate; Studio points `cloneOnly` (Claude Code dispatch) claims at it via `STUDIO_SANDBOX_MEDIUM_TEMPLATE_NAME` |
+| `mediumResources.*` | 3/6Gi RAM | deep-merged over `resources.*` into a second `<name>-medium` SandboxTemplate; Studio sends `cloneOnly` (Claude Code dispatch) claims to `<STUDIO_SANDBOX_TEMPLATE_NAME>-medium`, so this chart must be upgraded before the Studio release that names it |
 | `nodeSelector` / `tolerations` / `affinity` | `{}` | for sandbox isolation NodePool |
 | `topologySpreadConstraints` | `[]` | spread sandbox pods across AZs; see `values.yaml` for the recommended config |
 | `disruptionProtection.doNotDisrupt` | `false` | annotate pods with Karpenter's `do-not-disrupt` to block voluntary node consolidation/drift while a sandbox is claimed; trades cluster cost/upgrade cadence for session safety |

--- a/deploy/helm/sandbox-env/README.md
+++ b/deploy/helm/sandbox-env/README.md
@@ -7,11 +7,12 @@ is suffixed with `envName` so multiple releases coexist in the shared
 
 Renders:
 
-- `SandboxTemplate` `studio-sandbox-<envName>`
+- `SandboxTemplate` `studio-sandbox-<envName>` + `studio-sandbox-<envName>-medium`
+  (same pod spec, roomier memory — see `mediumResources`)
 - `Role` + `RoleBinding` `studio-sandbox-runner-<envName>` (for the Studio
   ServiceAccount of THIS env's studio install)
 - `Secret` `studio-sandbox-sentinel-<envName>` (initial daemon token)
-- `SandboxWarmPool` `studio-sandbox-<envName>` (optional)
+- `SandboxWarmPool` `studio-sandbox-<envName>` and `...-medium` (optional)
 - `HorizontalPodAutoscaler` for the warm pool (optional; requires explicit metrics)
 - `Deployment` `studio-sandbox-placeholder-<envName>` — node "balloon" (optional)
 - `Gateway` + `Certificate` `agent-sandbox-preview-<envName>` (optional;
@@ -121,6 +122,10 @@ configMap:
     STUDIO_SANDBOX_PROVIDER: "agent-sandbox"
     STUDIO_ENV: "staging"
     STUDIO_SANDBOX_TEMPLATE_NAME: "studio-sandbox-staging"
+    # Optional: headless agent-loop (cloneOnly) claims get the roomier
+    # `-medium` template (mediumResources) instead. Unset → they use the
+    # template above, so this is safe to add after the chart upgrade.
+    STUDIO_SANDBOX_MEDIUM_TEMPLATE_NAME: "studio-sandbox-staging-medium"
     # The next three values are required only when previewGateway.enabled=true.
     STUDIO_SANDBOX_PREVIEW_URL_PATTERN: "https://{handle}.preview.staging.example.com"
     # Per-claim HTTPRoute attaches to this Gateway. Both required whenever
@@ -268,7 +273,8 @@ See `values.yaml` for the full set. The most-tuned ones:
 | `envName` | _(required)_ | DNS-label suffix on every resource name |
 | `image.repository` | `ghcr.io/decocms/studio/studio-sandbox-go` | sandbox image (Go daemon — the implementation IS the image) |
 | `image.tag` | chart `appVersion` | bump in lockstep with packages/sandbox/package.json |
-| `resources.*` | 0.5/2 CPU, 2/6Gi RAM | per sandbox pod |
+| `resources.*` | 0.5/2 CPU, 2/4Gi RAM | per sandbox pod |
+| `mediumResources.*` | 3/6Gi RAM | deep-merged over `resources.*` into a second `<name>-medium` SandboxTemplate; Studio points `cloneOnly` (Claude Code dispatch) claims at it via `STUDIO_SANDBOX_MEDIUM_TEMPLATE_NAME` |
 | `nodeSelector` / `tolerations` / `affinity` | `{}` | for sandbox isolation NodePool |
 | `topologySpreadConstraints` | `[]` | spread sandbox pods across AZs; see `values.yaml` for the recommended config |
 | `disruptionProtection.doNotDisrupt` | `false` | annotate pods with Karpenter's `do-not-disrupt` to block voluntary node consolidation/drift while a sandbox is claimed; trades cluster cost/upgrade cadence for session safety |

--- a/deploy/helm/sandbox-env/README.md
+++ b/deploy/helm/sandbox-env/README.md
@@ -268,7 +268,7 @@ See `values.yaml` for the full set. The most-tuned ones:
 | `envName` | _(required)_ | DNS-label suffix on every resource name |
 | `image.repository` | `ghcr.io/decocms/studio/studio-sandbox-go` | sandbox image (Go daemon — the implementation IS the image) |
 | `image.tag` | chart `appVersion` | bump in lockstep with packages/sandbox/package.json |
-| `resources.*` | 0.5/2 CPU, 1/4Gi RAM | per sandbox pod |
+| `resources.*` | 0.5/2 CPU, 2/6Gi RAM | per sandbox pod |
 | `nodeSelector` / `tolerations` / `affinity` | `{}` | for sandbox isolation NodePool |
 | `topologySpreadConstraints` | `[]` | spread sandbox pods across AZs; see `values.yaml` for the recommended config |
 | `disruptionProtection.doNotDisrupt` | `false` | annotate pods with Karpenter's `do-not-disrupt` to block voluntary node consolidation/drift while a sandbox is claimed; trades cluster cost/upgrade cadence for session safety |

--- a/deploy/helm/sandbox-env/templates/_helpers.tpl
+++ b/deploy/helm/sandbox-env/templates/_helpers.tpl
@@ -190,6 +190,17 @@ worth catching at template time rather than letting the API server reject
 {{- fail "sandbox-env: warmPool.autoscaling.enabled=true requires at least one entry in warmPool.autoscaling.metrics — this chart ships no default metric. See values.yaml for an example External-metric entry." -}}
 {{- end }}
 {{- end }}
+{{/* Same two checks for the `-medium` pool's own HPA, against the metrics it
+     actually renders with (its own, else inherited from the block above). */}}
+{{- if .Values.warmPool.autoscaling.medium.enabled }}
+{{- if not .Values.warmPool.enabled }}
+{{- fail "sandbox-env: warmPool.autoscaling.medium.enabled=true requires warmPool.enabled=true (the -medium SandboxWarmPool is rendered with the pools)." -}}
+{{- end }}
+{{- $metrics := default .Values.warmPool.autoscaling.metrics .Values.warmPool.autoscaling.medium.metrics }}
+{{- if eq (len $metrics) 0 }}
+{{- fail "sandbox-env: warmPool.autoscaling.medium.enabled=true requires at least one metric — warmPool.autoscaling.medium.metrics, or warmPool.autoscaling.metrics to inherit. An HPA with no metrics sits at minReplicas forever." -}}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/deploy/helm/sandbox-env/templates/sandbox-rbac.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-rbac.yaml
@@ -55,6 +55,13 @@ rules:
   - apiGroups: ["extensions.agents.x-k8s.io"]
     resources: ["sandboxwarmpools"]
     verbs: ["get"]
+  # Studio checks that the `-medium` SandboxTemplate exists before naming it on
+  # a claim (see the runner's resolveTemplateName). A 403 here reads the same as
+  # absent, so a deploy that misses this rule silently keeps every claim on the
+  # default template rather than breaking.
+  - apiGroups: ["extensions.agents.x-k8s.io"]
+    resources: ["sandboxtemplates"]
+    verbs: ["get"]
   - apiGroups: ["agents.x-k8s.io"]
     resources: ["sandboxes"]
     verbs: ["get", "list", "watch"]

--- a/deploy/helm/sandbox-env/templates/sandbox-template.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-template.yaml
@@ -1,15 +1,20 @@
-# Shared SandboxTemplate consumed by every SandboxClaim the Studio runner
-# creates for THIS environment. Resource ceilings come from values.resources.
+# SandboxTemplates consumed by the SandboxClaims the Studio runner creates for
+# THIS environment. Rendered once per size (see the bottom of this file): the
+# default one that interactive claims use, and `-medium`, which differs ONLY in
+# `resources` — a SandboxClaim has no resource override (CRD: additionalPodMetadata,
+# env, lifecycle, sandboxTemplateRef, warmpool), so a second ceiling means a
+# second template. Studio picks it per claim; see values.yaml mediumResources.
 #
 # Hardcoded to the operator's own namespace (agent-sandbox-system) — the CRDs
 # ship with that as the install target, and the operator's RBAC watches it by
 # default. The template *name* is suffixed with envName so multiple
 # environments' SandboxTemplates coexist; Studio in this env must reference
 # the suffixed name via STUDIO_SANDBOX_TEMPLATE_NAME.
+{{ define "sandbox-env.sandboxTemplate" -}}
 apiVersion: extensions.agents.x-k8s.io/v1alpha1
 kind: SandboxTemplate
 metadata:
-  name: {{ include "sandbox-env.sandboxName" . }}
+  name: {{ include "sandbox-env.sandboxName" . }}{{ .sizeSuffix }}
   namespace: agent-sandbox-system
   labels:
     {{- include "sandbox-env.sandboxLabels" . | nindent 4 }}
@@ -308,7 +313,7 @@ spec:
               containerPort: 3000
               protocol: TCP
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{- toYaml .resources | nindent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:
@@ -409,3 +414,7 @@ spec:
           emptyDir:
             sizeLimit: 1Mi
         {{- end }}
+{{- end }}
+{{ include "sandbox-env.sandboxTemplate" (merge (dict "sizeSuffix" "" "resources" .Values.resources) .) }}
+---
+{{ include "sandbox-env.sandboxTemplate" (merge (dict "sizeSuffix" "-medium" "resources" (mergeOverwrite (deepCopy .Values.resources) .Values.mediumResources)) .) }}

--- a/deploy/helm/sandbox-env/templates/sandbox-warm-pool.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-warm-pool.yaml
@@ -26,11 +26,14 @@ spec:
   sandboxTemplateRef:
     name: {{ include "sandbox-env.sandboxName" . }}
 ---
-# Same pool for the `-medium` template. Size 0 by default and that is not a
-# footgun here: a claim must name a pool that exists, and an empty pool falls
-# back to a cold pod — so this exists to give medium claims a valid name, and
-# prewarming them is a one-value change (warmPool.mediumSize) if dispatch
-# cold-start ever shows up in a latency budget.
+# Same pool for the `-medium` template — a SandboxWarmPool binds exactly one
+# SandboxTemplate, so the second template needs its own pool to be prewarmable
+# (and its own autoscaler; see sandbox-warmpool-hpa.yaml).
+#
+# Size 0 by default, and unlike the generic pool that is not a footgun: verified
+# against operator v0.4.5, a claim whose pool is empty (or absent) is served by
+# a cold pod built from the claim's OWN template, so nothing breaks and nothing
+# idles. Prewarming medium claims is then one value (warmPool.mediumSize).
 apiVersion: extensions.agents.x-k8s.io/v1alpha1
 kind: SandboxWarmPool
 metadata:

--- a/deploy/helm/sandbox-env/templates/sandbox-warm-pool.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-warm-pool.yaml
@@ -25,4 +25,23 @@ spec:
     type: OnReplenish
   sandboxTemplateRef:
     name: {{ include "sandbox-env.sandboxName" . }}
+---
+# Same pool for the `-medium` template. Size 0 by default and that is not a
+# footgun here: a claim must name a pool that exists, and an empty pool falls
+# back to a cold pod — so this exists to give medium claims a valid name, and
+# prewarming them is a one-value change (warmPool.mediumSize) if dispatch
+# cold-start ever shows up in a latency budget.
+apiVersion: extensions.agents.x-k8s.io/v1alpha1
+kind: SandboxWarmPool
+metadata:
+  name: {{ include "sandbox-env.sandboxName" . }}-medium
+  namespace: agent-sandbox-system
+  labels:
+    {{- include "sandbox-env.sandboxLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.warmPool.mediumSize | default 0 }}
+  updateStrategy:
+    type: OnReplenish
+  sandboxTemplateRef:
+    name: {{ include "sandbox-env.sandboxName" . }}-medium
 {{- end }}

--- a/deploy/helm/sandbox-env/templates/sandbox-warmpool-hpa.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-warmpool-hpa.yaml
@@ -1,4 +1,16 @@
-{{- if and .Values.warmPool.enabled .Values.warmPool.autoscaling.enabled }}
+{{- if .Values.warmPool.enabled }}
+{{- $pools := list }}
+{{- if .Values.warmPool.autoscaling.enabled }}
+{{- $pools = append $pools (dict "suffix" "" "cfg" .Values.warmPool.autoscaling) }}
+{{- end }}
+{{- if .Values.warmPool.autoscaling.medium.enabled }}
+{{- $medium := mergeOverwrite (deepCopy .Values.warmPool.autoscaling) .Values.warmPool.autoscaling.medium }}
+{{- $pools = append $pools (dict "suffix" "-medium" "cfg" $medium) }}
+{{- end }}
+{{- range $i, $pool := $pools }}
+{{- if $i }}
+---
+{{- end }}
 # Scales the SandboxWarmPool via its native scale subresource (see
 # sandbox-operator/crds/agent-sandbox-crds.yaml: spec.versions[].subresources.scale,
 # specReplicasPath=.spec.replicas). Off by default — warmPool.size stays a
@@ -9,24 +21,29 @@
 # at whatever signals pool pressure in your cluster (e.g. a Prometheus
 # External/Object metric on claim-creation rate or pending-claim count via
 # the Prometheus adapter). See validations.yaml for the enforced minimum.
+#
+# One HPA per pool: a SandboxWarmPool binds exactly one SandboxTemplate, so the
+# default pool and the `-medium` one scale on their own claim series. Each is
+# opted in separately (warmPool.autoscaling.enabled / .medium.enabled).
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "sandbox-env.sandboxName" . }}
+  name: {{ include "sandbox-env.sandboxName" $ }}{{ $pool.suffix }}
   namespace: agent-sandbox-system
   labels:
-    {{- include "sandbox-env.sandboxLabels" . | nindent 4 }}
+    {{- include "sandbox-env.sandboxLabels" $ | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: extensions.agents.x-k8s.io/v1alpha1
     kind: SandboxWarmPool
-    name: {{ include "sandbox-env.sandboxName" . }}
-  minReplicas: {{ .Values.warmPool.autoscaling.minReplicas }}
-  maxReplicas: {{ .Values.warmPool.autoscaling.maxReplicas }}
+    name: {{ include "sandbox-env.sandboxName" $ }}{{ $pool.suffix }}
+  minReplicas: {{ $pool.cfg.minReplicas }}
+  maxReplicas: {{ $pool.cfg.maxReplicas }}
   metrics:
-    {{- toYaml .Values.warmPool.autoscaling.metrics | nindent 4 }}
-  {{- with .Values.warmPool.autoscaling.behavior }}
+    {{- toYaml $pool.cfg.metrics | nindent 4 }}
+  {{- with $pool.cfg.behavior }}
   behavior:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -590,8 +590,9 @@ warmPool:
   # the full resources.requests above.
   enabled: false
   size: 0
-  # Replicas for the `-medium` pool (see mediumResources). 0 = medium claims
-  # cold-start, which is today's behavior for the dispatch path anyway.
+  # Replicas for the `-medium` pool (see mediumResources). 0 = harness-run
+  # claims cold-start, same as the dispatch path does today. Their pods are the
+  # expensive ones (3Gi request), so warm only what you measure.
   mediumSize: 0
 
   # Optional: scale `size` dynamically via a HorizontalPodAutoscaler

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -55,16 +55,29 @@ image:
 # memory request = observed p95 of per-pod peak working-set (~2Gi over 7d;
 # 2d raw p90 2.2Gi, p95 2.4Gi). It was 1Gi — but busy pods spend ~100% of
 # their life above 1Gi, so the scheduler bin-packed on a request less than
-# half of real usage and prod nodes hit memory-pressure eviction (never
-# per-pod OOM: 0 pods reach the 4Gi limit). Sizing the request to real p95
-# stops the node-pressure evictions at the cost of lower packing density.
+# half of real usage and prod nodes hit memory-pressure eviction. Sizing the
+# request to real p95 stops those evictions at the cost of packing density.
+#
+# memory limit is the ceiling a single agent loop may burst to, and it is NOT
+# what the scheduler packs on — only the request is. It was 4Gi, chosen when no
+# pod had ever reached it; on 2026-08-13 three did, one thread twice inside 20
+# minutes (a claude-code run climbing 242MiB → 3.6Gi of RSS in three minutes,
+# then killed and reproduced on its replacement). 6Gi covers that burst without
+# costing a byte of scheduled capacity.
+#
+# The cost of raising it is overcommit: a node packed on 2Gi requests now has
+# pods that may each reach 6Gi, and node memory-pressure eviction is the failure
+# mode this file already fought once. Today's burst rate (3 pods in 24h) makes
+# that risk small — if node-pressure evictions come back, the answer is a
+# separate SandboxTemplate so only the agent-loop pods carry the higher ceiling
+# (see tenantPools[].resources for the machinery), not a blanket raise.
 resources:
   requests:
     cpu: 500m
     memory: 2Gi
   limits:
     cpu: "2"
-    memory: 4Gi
+    memory: 6Gi
     ephemeral-storage: 10Gi
 
 # ── shutdown grace period ──────────────────────────────────────────────

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -68,11 +68,10 @@ resources:
     ephemeral-storage: 10Gi
 
 # ── the `-medium` SandboxTemplate's ceilings ───────────────────────────
-# Deep-merged over `resources` above, so state only what differs. Studio
-# points headless agent-loop claims (Claude Code dispatch: cloneOnly, no dev
-# server) at the `-medium` template by setting
-# STUDIO_SANDBOX_MEDIUM_TEMPLATE_NAME=studio-sandbox-<envName>-medium; unset
-# there, nothing claims it and this template just sits unused.
+# Deep-merged over `resources` above, so state only what differs. Studio sends
+# headless agent-loop claims (Claude Code dispatch: cloneOnly, no dev server)
+# to `<STUDIO_SANDBOX_TEMPLATE_NAME>-medium` unconditionally, so this chart
+# version must be deployed before the Studio release that does.
 #
 # Why a separate template instead of raising the shared limit: prod OOMKilled
 # three pods at the 4Gi limit on 2026-08-13, all inside a claude-code loop

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -55,30 +55,38 @@ image:
 # memory request = observed p95 of per-pod peak working-set (~2Gi over 7d;
 # 2d raw p90 2.2Gi, p95 2.4Gi). It was 1Gi — but busy pods spend ~100% of
 # their life above 1Gi, so the scheduler bin-packed on a request less than
-# half of real usage and prod nodes hit memory-pressure eviction. Sizing the
-# request to real p95 stops those evictions at the cost of packing density.
-#
-# memory limit is the ceiling a single agent loop may burst to, and it is NOT
-# what the scheduler packs on — only the request is. It was 4Gi, chosen when no
-# pod had ever reached it; on 2026-08-13 three did, one thread twice inside 20
-# minutes (a claude-code run climbing 242MiB → 3.6Gi of RSS in three minutes,
-# then killed and reproduced on its replacement). 6Gi covers that burst without
-# costing a byte of scheduled capacity.
-#
-# The cost of raising it is overcommit: a node packed on 2Gi requests now has
-# pods that may each reach 6Gi, and node memory-pressure eviction is the failure
-# mode this file already fought once. Today's burst rate (3 pods in 24h) makes
-# that risk small — if node-pressure evictions come back, the answer is a
-# separate SandboxTemplate so only the agent-loop pods carry the higher ceiling
-# (see tenantPools[].resources for the machinery), not a blanket raise.
+# half of real usage and prod nodes hit memory-pressure eviction (never
+# per-pod OOM: 0 pods reach the 4Gi limit). Sizing the request to real p95
+# stops the node-pressure evictions at the cost of lower packing density.
 resources:
   requests:
     cpu: 500m
     memory: 2Gi
   limits:
     cpu: "2"
-    memory: 6Gi
+    memory: 4Gi
     ephemeral-storage: 10Gi
+
+# ── the `-medium` SandboxTemplate's ceilings ───────────────────────────
+# Deep-merged over `resources` above, so state only what differs. Studio
+# points headless agent-loop claims (Claude Code dispatch: cloneOnly, no dev
+# server) at the `-medium` template by setting
+# STUDIO_SANDBOX_MEDIUM_TEMPLATE_NAME=studio-sandbox-<envName>-medium; unset
+# there, nothing claims it and this template just sits unused.
+#
+# Why a separate template instead of raising the shared limit: prod OOMKilled
+# three pods at the 4Gi limit on 2026-08-13, all inside a claude-code loop
+# (container_memory_rss 257Mi → 3.6Gi in 9 min). Raising the shared limit to
+# 6Gi while leaving the 2Gi request would let every node pack on 2Gi and burst
+# to 6Gi — node memory-pressure eviction is exactly what drove the request from
+# 1Gi to 2Gi in 0.9.14. So the higher ceiling is carried by the pods that need
+# it, with a request that actually reserves most of it (3Gi/6Gi = 2x
+# overcommit, same ratio as the default 2Gi/4Gi).
+mediumResources:
+  requests:
+    memory: 3Gi
+  limits:
+    memory: 6Gi
 
 # ── shutdown grace period ──────────────────────────────────────────────
 # On SIGTERM (rollout, spot reclaim, idle eviction) the daemon commits and
@@ -583,6 +591,9 @@ warmPool:
   # the full resources.requests above.
   enabled: false
   size: 0
+  # Replicas for the `-medium` pool (see mediumResources). 0 = medium claims
+  # cold-start, which is today's behavior for the dispatch path anyway.
+  mediumSize: 0
 
   # Optional: scale `size` dynamically via a HorizontalPodAutoscaler
   # targeting the SandboxWarmPool's native scale subresource (kubectl scale

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -617,6 +617,22 @@ warmPool:
     # Optional autoscaling/v2 `behavior` block (scale-up/down stabilization
     # windows, policies). Left empty = cluster defaults.
     behavior: {}
+    # The `-medium` pool scales separately or not at all: a SandboxWarmPool
+    # binds exactly one SandboxTemplate, so one HPA cannot straddle both, and
+    # the two pools see different claim rates. Every key here falls back to the
+    # block above when unset — but set `minReplicas` deliberately: inheriting 1
+    # keeps one 3Gi pod idle forever.
+    #
+    # Deploys that autoscale the pools with KEDA instead (a ScaledObject on the
+    # pool's scale subresource) need a SECOND ScaledObject for `-medium` for the
+    # same reason. Leave this off there — two controllers on one scale
+    # subresource fight.
+    medium:
+      enabled: false
+      minReplicas: 1
+      maxReplicas: 10
+      metrics: []
+      behavior: {}
 
 # ── tenant warm pools ──────────────────────────────────────────────────
 # Warm pods that are already running ONE org's repo + dev server (the generic

--- a/packages/sandbox/server/provider/agent-sandbox/client.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/client.ts
@@ -324,6 +324,28 @@ async function callSwallowing404<T>(
 
 const CLAIM_PATH_PREFIX = `/apis/${K8S_CONSTANTS.CLAIM_API_GROUP}/${K8S_CONSTANTS.CLAIM_API_VERSION}/namespaces`;
 
+/**
+ * Whether a SandboxTemplate is on the cluster. `403` answers `false` alongside
+ * `404`: a claim naming a template this deploy cannot even see is a claim that
+ * sits `Ready=False TemplateNotFound` until it times out, so "absent" and
+ * "cannot confirm" have the same consequence and deserve the same answer.
+ */
+export async function sandboxTemplateExists(
+  kc: KubeConfig,
+  namespace: string,
+  name: string,
+): Promise<boolean> {
+  const path = `${CLAIM_PATH_PREFIX}/${encodeURIComponent(namespace)}/${K8S_CONSTANTS.TEMPLATE_PLURAL}/${encodeURIComponent(name)}`;
+  try {
+    const resp = await kubeFetch(kc, { method: "GET", path });
+    if (resp.status === 404 || resp.status === 403) return false;
+    await ensureOk(resp, "sandboxTemplateExists");
+    return true;
+  } catch (error) {
+    throw new SandboxError(`Failed to get SandboxTemplate: ${name}`, error);
+  }
+}
+
 export async function createSandboxClaim(
   kc: KubeConfig,
   namespace: string,

--- a/packages/sandbox/server/provider/agent-sandbox/constants.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/constants.ts
@@ -9,6 +9,7 @@ export const K8S_CONSTANTS = {
   CLAIM_API_GROUP: "extensions.agents.x-k8s.io",
   CLAIM_API_VERSION: "v1alpha1",
   CLAIM_PLURAL: "sandboxclaims",
+  TEMPLATE_PLURAL: "sandboxtemplates",
 
   SANDBOX_API_GROUP: "agents.x-k8s.io",
   SANDBOX_API_VERSION: "v1alpha1",

--- a/packages/sandbox/server/provider/agent-sandbox/runner.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.test.ts
@@ -41,6 +41,15 @@ describe("stripEnsureOpts", () => {
     const opts: EnsureOptions = { cloneOnly: false, branch: "b" };
     expect(stripEnsureOpts(opts)).toEqual({ branch: "b" });
   });
+
+  // Lose it and the resurrected claim names the default template + pool again.
+  it("retains purpose so a resurrected harness run keeps its own template", () => {
+    const opts: EnsureOptions = { purpose: "harness-run", cloneOnly: true };
+    expect(stripEnsureOpts(opts)).toEqual({
+      purpose: "harness-run",
+      cloneOnly: true,
+    });
+  });
 });
 
 describe("earlierShutdown", () => {

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -3068,8 +3068,7 @@ export function stripEnsureOpts(opts: EnsureOptions): EnsureOptions | null {
   // silently re-enabling install + dev-server for a sandbox provisioned
   // clone-only.
   if (opts.cloneOnly) out.cloneOnly = true;
-  // Same reason, one layer up: a resurrected `harness-run` claim rebuilt without
-  // this would name the default template — the 4Gi ceiling it was moved off.
+  // Lose it and a resurrected harness run names the default template again.
   if (opts.purpose) out.purpose = opts.purpose;
   // Without this, `resurrectByHandle` re-provisioning from these persisted
   // opts (no SANDBOX_START in that loop) would silently drop the org-fs

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -1255,10 +1255,10 @@ export class AgentSandboxProvider implements SandboxProvider {
     const tenantPool = resolveTenantPool(this.tenantPools, {
       orgId: opts.tenant?.orgId,
       cloneUrl: opts.repo?.cloneUrl,
-      cloneOnly: opts.cloneOnly,
+      purpose: opts.purpose,
     });
     const templateName = claimTemplateName(
-      opts.cloneOnly,
+      opts.purpose,
       this.sandboxTemplateName,
     );
     const envEntries = warmPoolMode
@@ -3034,6 +3034,9 @@ export function stripEnsureOpts(opts: EnsureOptions): EnsureOptions | null {
   // silently re-enabling install + dev-server for a sandbox provisioned
   // clone-only.
   if (opts.cloneOnly) out.cloneOnly = true;
+  // Same reason, one layer up: a resurrected `harness-run` claim rebuilt without
+  // this would name the default template — the 4Gi ceiling it was moved off.
+  if (opts.purpose) out.purpose = opts.purpose;
   // Without this, `resurrectByHandle` re-provisioning from these persisted
   // opts (no SANDBOX_START in that loop) would silently drop the org-fs
   // mounts a live sandbox had.

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -79,6 +79,7 @@ import {
   isPodUnbound,
   listWarmPoolPods,
   readPodTermination,
+  sandboxTemplateExists,
   type WarmPoolPod,
   patchSandboxClaimShutdown,
   waitForClaimAdoptedSandbox,
@@ -95,8 +96,9 @@ import {
 } from "./constants";
 import { watchClaimDeletions, watchClaimLifecycle } from "./lifecycle-watcher";
 import {
-  claimTemplateName,
   claimWarmPoolName,
+  resolveClaimTemplateName,
+  type MediumTemplateProbe,
   poolCloneUrl,
   poolsMatchingPush,
   resolveTenantPool,
@@ -136,6 +138,13 @@ export const PREVIEW_NOT_READY_HEADER = "x-sandbox-preview-not-ready";
 // names (sha256(userId:projectRef)). Per-org namespaces are deferred.
 const DEFAULT_NAMESPACE = "agent-sandbox-system";
 const DEFAULT_TEMPLATE_NAME = "studio-sandbox";
+
+/**
+ * How long a `-medium` SandboxTemplate lookup is trusted, in both directions —
+ * so a chart upgrade (or rollback) is picked up within one TTL without a GET per
+ * claim.
+ */
+const MEDIUM_TEMPLATE_PROBE_TTL_MS = 5 * 60_000;
 
 const DAEMON_CONTAINER_PORT = 9000;
 // In-pod port the daemon's reverse proxy targets. Studio never connects here
@@ -504,6 +513,8 @@ export class AgentSandboxProvider implements SandboxProvider {
     string,
     { lastConfigAt: number; lastFailureAt: number; failures: number }
   >();
+  /** Last `-medium` SandboxTemplate lookup; see `resolveTemplateName`. */
+  private mediumTemplateProbe: MediumTemplateProbe | null = null;
   /** Pool names a GitHub push says are stale; drained by the next tick. */
   private readonly dirtyPools = new Set<string>();
   private closed = false;
@@ -1239,10 +1250,36 @@ export class AgentSandboxProvider implements SandboxProvider {
     };
   }
 
+  /**
+   * SandboxTemplate for this claim, with the `-medium` one probed (cached) so a
+   * deploy whose sandbox-env chart predates it degrades to the default template
+   * instead of parking every dispatch at `TemplateNotFound`.
+   */
+  private async resolveTemplateName(
+    purpose: EnsureOptions["purpose"],
+  ): Promise<string> {
+    const { name, probe } = await resolveClaimTemplateName({
+      purpose,
+      templateName: this.sandboxTemplateName,
+      probe: this.mediumTemplateProbe,
+      now: Date.now(),
+      ttlMs: MEDIUM_TEMPLATE_PROBE_TTL_MS,
+      exists: (template) =>
+        sandboxTemplateExists(this.kubeConfig, this.namespace, template),
+      onAbsent: (template) =>
+        console.warn(
+          `[${LOG_LABEL}] SandboxTemplate ${template} not found (or not readable) — harness-run claims fall back to ${this.sandboxTemplateName}. Upgrade the sandbox-env chart to the version that renders it.`,
+        ),
+    });
+    this.mediumTemplateProbe = probe;
+    return name;
+  }
+
   private buildClaim(
     handle: string,
     opts: EnsureOptions,
     boot: { token: string; daemonBootId: string; workdir: string },
+    templateName: string,
   ): SandboxClaim {
     // Warm-pool mode: the operator rejects claim.spec.env outright when
     // warmpool != "none". Studio delivers the per-claim secret post-bind via
@@ -1257,10 +1294,6 @@ export class AgentSandboxProvider implements SandboxProvider {
       cloneUrl: opts.repo?.cloneUrl,
       purpose: opts.purpose,
     });
-    const templateName = claimTemplateName(
-      opts.purpose,
-      this.sandboxTemplateName,
-    );
     const envEntries = warmPoolMode
       ? []
       : Object.entries(this.buildEnvMap(opts, boot))
@@ -1322,11 +1355,12 @@ export class AgentSandboxProvider implements SandboxProvider {
     const token = this.tokenGenerator();
     const daemonBootId = randomUUID();
     const workdir = DEFAULT_WORKDIR;
-    const claim = this.buildClaim(handle, opts, {
-      token,
-      daemonBootId,
-      workdir,
-    });
+    const claim = this.buildClaim(
+      handle,
+      opts,
+      { token, daemonBootId, workdir },
+      await this.resolveTemplateName(opts.purpose),
+    );
     try {
       await createSandboxClaim(this.kubeConfig, this.namespace, claim);
     } catch (err) {

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -342,18 +342,6 @@ export interface AgentSandboxProviderOptions {
   /** SandboxTemplate all claims reference. */
   sandboxTemplateName?: string;
   /**
-   * SandboxTemplate for `cloneOnly` claims — the headless Claude Code dispatch
-   * path, which is where prod's 4Gi OOMKills happened (agent loop, no dev
-   * server). The sandbox-env chart renders it as `<template>-medium` with a
-   * 3Gi/6Gi memory request/limit. A SandboxClaim cannot override resources, so
-   * a second ceiling has to be a second template.
-   *
-   * Unset → cloneOnly claims use `sandboxTemplateName` like everything else,
-   * i.e. today's behavior. That's the rollout switch: the chart can ship the
-   * template before anything claims it.
-   */
-  mediumTemplateName?: string;
-  /**
    * Shared sentinel token baked into the SandboxTemplate's pod env (via the
    * sandbox-env helm chart's Secret). Presence flips the runner into
    * warm-pool mode:
@@ -477,8 +465,6 @@ export class AgentSandboxProvider implements SandboxProvider {
   private readonly portForward: PortForward;
   private readonly namespace: string;
   private readonly sandboxTemplateName: string;
-  /** See {@link AgentSandboxProviderOptions.mediumTemplateName}. */
-  private readonly mediumTemplateName: string | null;
   private readonly envName: string | null;
   private readonly tokenGenerator: () => string;
   private readonly idleTtlMs: number;
@@ -532,8 +518,6 @@ export class AgentSandboxProvider implements SandboxProvider {
     this.namespace = opts.namespace ?? DEFAULT_NAMESPACE;
     this.sandboxTemplateName =
       opts.sandboxTemplateName ?? DEFAULT_TEMPLATE_NAME;
-    const trimmedMedium = opts.mediumTemplateName?.trim() ?? "";
-    this.mediumTemplateName = trimmedMedium.length > 0 ? trimmedMedium : null;
     this.envName = normalizeEnvName(opts.envName);
     this.tokenGenerator =
       opts.tokenGenerator ??
@@ -1276,7 +1260,6 @@ export class AgentSandboxProvider implements SandboxProvider {
     const templateName = claimTemplateName(
       opts.cloneOnly,
       this.sandboxTemplateName,
-      this.mediumTemplateName,
     );
     const envEntries = warmPoolMode
       ? []

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -61,6 +61,7 @@ import {
 import type { RunnerStateStore, RunnerStateStoreOps } from "../state-store";
 import type {
   EnsureOptions,
+  PodTermination,
   ProxyRequestInit,
   Sandbox,
   SandboxId,
@@ -77,6 +78,7 @@ import {
   HTTPROUTE_CONSTANTS,
   isPodUnbound,
   listWarmPoolPods,
+  readPodTermination,
   type WarmPoolPod,
   patchSandboxClaimShutdown,
   waitForClaimAdoptedSandbox,
@@ -93,6 +95,7 @@ import {
 } from "./constants";
 import { watchClaimDeletions, watchClaimLifecycle } from "./lifecycle-watcher";
 import {
+  claimTemplateName,
   claimWarmPoolName,
   poolCloneUrl,
   poolsMatchingPush,
@@ -339,6 +342,18 @@ export interface AgentSandboxProviderOptions {
   /** SandboxTemplate all claims reference. */
   sandboxTemplateName?: string;
   /**
+   * SandboxTemplate for `cloneOnly` claims — the headless Claude Code dispatch
+   * path, which is where prod's 4Gi OOMKills happened (agent loop, no dev
+   * server). The sandbox-env chart renders it as `<template>-medium` with a
+   * 3Gi/6Gi memory request/limit. A SandboxClaim cannot override resources, so
+   * a second ceiling has to be a second template.
+   *
+   * Unset → cloneOnly claims use `sandboxTemplateName` like everything else,
+   * i.e. today's behavior. That's the rollout switch: the chart can ship the
+   * template before anything claims it.
+   */
+  mediumTemplateName?: string;
+  /**
    * Shared sentinel token baked into the SandboxTemplate's pod env (via the
    * sandbox-env helm chart's Secret). Presence flips the runner into
    * warm-pool mode:
@@ -462,6 +477,8 @@ export class AgentSandboxProvider implements SandboxProvider {
   private readonly portForward: PortForward;
   private readonly namespace: string;
   private readonly sandboxTemplateName: string;
+  /** See {@link AgentSandboxProviderOptions.mediumTemplateName}. */
+  private readonly mediumTemplateName: string | null;
   private readonly envName: string | null;
   private readonly tokenGenerator: () => string;
   private readonly idleTtlMs: number;
@@ -515,6 +532,8 @@ export class AgentSandboxProvider implements SandboxProvider {
     this.namespace = opts.namespace ?? DEFAULT_NAMESPACE;
     this.sandboxTemplateName =
       opts.sandboxTemplateName ?? DEFAULT_TEMPLATE_NAME;
+    const trimmedMedium = opts.mediumTemplateName?.trim() ?? "";
+    this.mediumTemplateName = trimmedMedium.length > 0 ? trimmedMedium : null;
     this.envName = normalizeEnvName(opts.envName);
     this.tokenGenerator =
       opts.tokenGenerator ??
@@ -616,6 +635,20 @@ export class AgentSandboxProvider implements SandboxProvider {
       if (rec) await this.stateStore.delete(rec.id, RUNNER_KIND);
       else await this.stateStore.deleteByHandle(RUNNER_KIND, handle);
     }
+  }
+
+  /**
+   * See `SandboxProvider.lastTermination`. Reads the kubelet's own verdict on
+   * the pod behind `handle` — the only place an OOM kill is recorded.
+   */
+  lastTermination(handle: string): Promise<PodTermination | null> {
+    return readPodTermination(
+      this.kubeConfig,
+      this.namespace,
+      LABEL_KEYS.sandboxHandle,
+      handle,
+      K8S_CONSTANTS.MAIN_CONTAINER_NAME,
+    );
   }
 
   async alive(handle: string): Promise<boolean> {
@@ -1240,6 +1273,11 @@ export class AgentSandboxProvider implements SandboxProvider {
       cloneUrl: opts.repo?.cloneUrl,
       cloneOnly: opts.cloneOnly,
     });
+    const templateName = claimTemplateName(
+      opts.cloneOnly,
+      this.sandboxTemplateName,
+      this.mediumTemplateName,
+    );
     const envEntries = warmPoolMode
       ? []
       : Object.entries(this.buildEnvMap(opts, boot))
@@ -1269,7 +1307,7 @@ export class AgentSandboxProvider implements SandboxProvider {
         ...(hasAnnotations ? { annotations } : {}),
       },
       spec: {
-        sandboxTemplateRef: { name: this.sandboxTemplateName },
+        sandboxTemplateRef: { name: templateName },
         // additionalPodMetadata.labels is the operator's pod-label propagation
         // hook (CRD field, not a generic patch). Tenant labels here flow to
         // the pod and become joinable in cAdvisor/kubelet metrics. `role`
@@ -1284,11 +1322,7 @@ export class AgentSandboxProvider implements SandboxProvider {
           ...(hasAnnotations ? { annotations } : {}),
         },
         env: envEntries,
-        warmpool: claimWarmPoolName(
-          tenantPool,
-          warmPoolMode,
-          this.sandboxTemplateName,
-        ),
+        warmpool: claimWarmPoolName(tenantPool, warmPoolMode, templateName),
         lifecycle: {
           shutdownPolicy: "Delete",
           shutdownTime: this.computeShutdownTime(),

--- a/packages/sandbox/server/provider/agent-sandbox/tenant-pools.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/tenant-pools.test.ts
@@ -85,22 +85,22 @@ describe("resolveTenantPool", () => {
     ).toBe("tenant-acme-site");
   });
 
-  it("a checkout-only claim never takes a tenant pod", () => {
+  it("a harness-run claim never takes a tenant pod", () => {
     // The Claude Code dispatch path. It wants no dev server, and binding a warm
     // pod would stop the one already running on it.
     expect(
       resolveTenantPool(POOLS, {
         orgId: "org-acme",
         cloneUrl: url,
-        cloneOnly: true,
+        purpose: "harness-run",
       }),
     ).toBeNull();
-    // ...but an explicit false is a normal claim.
+    // ...but an explicit `interactive` is a normal claim.
     expect(
       resolveTenantPool(POOLS, {
         orgId: "org-acme",
         cloneUrl: url,
-        cloneOnly: false,
+        purpose: "interactive",
       })?.name,
     ).toBe("tenant-acme-site");
   });
@@ -164,24 +164,43 @@ describe("claimWarmPoolName", () => {
 });
 
 describe("claimTemplateName", () => {
-  it("cloneOnly takes the -medium template", () => {
-    expect(claimTemplateName(true, "studio-sandbox")).toBe(
+  it("a harness run takes the -medium template", () => {
+    expect(claimTemplateName("harness-run", "studio-sandbox")).toBe(
       "studio-sandbox-medium",
     );
   });
 
   it("interactive claims stay on the default template", () => {
-    expect(claimTemplateName(false, "studio-sandbox")).toBe("studio-sandbox");
+    expect(claimTemplateName("interactive", "studio-sandbox")).toBe(
+      "studio-sandbox",
+    );
     expect(claimTemplateName(undefined, "studio-sandbox")).toBe(
       "studio-sandbox",
     );
   });
 
-  // Pool name == template name, so a medium claim can't bind a 4Gi pod.
+  // Pool name == template name, so a harness claim can't bind a 4Gi pod.
   it("the warm pool follows the template it picked", () => {
     expect(
-      claimWarmPoolName(null, true, claimTemplateName(true, "studio-sandbox")),
+      claimWarmPoolName(
+        null,
+        true,
+        claimTemplateName("harness-run", "studio-sandbox"),
+      ),
     ).toBe("studio-sandbox-medium");
+  });
+
+  // The generic pool is for interactive claims only; a tenant pool never
+  // reaches a harness run (resolveTenantPool above), so these two are the
+  // whole matrix of what a claim can name.
+  it("an interactive claim names the default pool, not the medium one", () => {
+    expect(
+      claimWarmPoolName(
+        null,
+        true,
+        claimTemplateName("interactive", "studio-sandbox"),
+      ),
+    ).toBe("studio-sandbox");
   });
 });
 

--- a/packages/sandbox/server/provider/agent-sandbox/tenant-pools.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/tenant-pools.test.ts
@@ -164,38 +164,24 @@ describe("claimWarmPoolName", () => {
 });
 
 describe("claimTemplateName", () => {
-  it("cloneOnly takes the medium template", () => {
-    expect(
-      claimTemplateName(true, "studio-sandbox", "studio-sandbox-medium"),
-    ).toBe("studio-sandbox-medium");
+  it("cloneOnly takes the -medium template", () => {
+    expect(claimTemplateName(true, "studio-sandbox")).toBe(
+      "studio-sandbox-medium",
+    );
   });
 
   it("interactive claims stay on the default template", () => {
-    expect(
-      claimTemplateName(false, "studio-sandbox", "studio-sandbox-medium"),
-    ).toBe("studio-sandbox");
-    expect(
-      claimTemplateName(undefined, "studio-sandbox", "studio-sandbox-medium"),
-    ).toBe("studio-sandbox");
-  });
-
-  // The rollout switch: chart deployed, Studio not configured yet.
-  it("no medium template configured → cloneOnly keeps today's template", () => {
-    expect(claimTemplateName(true, "studio-sandbox", null)).toBe(
+    expect(claimTemplateName(false, "studio-sandbox")).toBe("studio-sandbox");
+    expect(claimTemplateName(undefined, "studio-sandbox")).toBe(
       "studio-sandbox",
     );
   });
 
   // Pool name == template name, so a medium claim can't bind a 4Gi pod.
   it("the warm pool follows the template it picked", () => {
-    const template = claimTemplateName(
-      true,
-      "studio-sandbox",
-      "studio-sandbox-medium",
-    );
-    expect(claimWarmPoolName(null, true, template)).toBe(
-      "studio-sandbox-medium",
-    );
+    expect(
+      claimWarmPoolName(null, true, claimTemplateName(true, "studio-sandbox")),
+    ).toBe("studio-sandbox-medium");
   });
 });
 

--- a/packages/sandbox/server/provider/agent-sandbox/tenant-pools.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/tenant-pools.test.ts
@@ -191,9 +191,7 @@ describe("claimTemplateName", () => {
     ).toBe("studio-sandbox-medium");
   });
 
-  // The generic pool is for interactive claims only; a tenant pool never
-  // reaches a harness run (resolveTenantPool above), so these two are the
-  // whole matrix of what a claim can name.
+  // With tenant pools ruled out above, these two are the whole matrix.
   it("an interactive claim names the default pool, not the medium one", () => {
     expect(
       claimWarmPoolName(

--- a/packages/sandbox/server/provider/agent-sandbox/tenant-pools.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/tenant-pools.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 
 import {
+  claimTemplateName,
   claimWarmPoolName,
   parseTenantPools,
   poolsMatchingPush,
@@ -159,6 +160,42 @@ describe("claimWarmPoolName", () => {
 
   it("no sentinel → `none`, so the operator still accepts per-claim env", () => {
     expect(claimWarmPoolName(null, false, "studio-sandbox")).toBe("none");
+  });
+});
+
+describe("claimTemplateName", () => {
+  it("cloneOnly takes the medium template", () => {
+    expect(
+      claimTemplateName(true, "studio-sandbox", "studio-sandbox-medium"),
+    ).toBe("studio-sandbox-medium");
+  });
+
+  it("interactive claims stay on the default template", () => {
+    expect(
+      claimTemplateName(false, "studio-sandbox", "studio-sandbox-medium"),
+    ).toBe("studio-sandbox");
+    expect(
+      claimTemplateName(undefined, "studio-sandbox", "studio-sandbox-medium"),
+    ).toBe("studio-sandbox");
+  });
+
+  // The rollout switch: chart deployed, Studio not configured yet.
+  it("no medium template configured → cloneOnly keeps today's template", () => {
+    expect(claimTemplateName(true, "studio-sandbox", null)).toBe(
+      "studio-sandbox",
+    );
+  });
+
+  // Pool name == template name, so a medium claim can't bind a 4Gi pod.
+  it("the warm pool follows the template it picked", () => {
+    const template = claimTemplateName(
+      true,
+      "studio-sandbox",
+      "studio-sandbox-medium",
+    );
+    expect(claimWarmPoolName(null, true, template)).toBe(
+      "studio-sandbox-medium",
+    );
   });
 });
 

--- a/packages/sandbox/server/provider/agent-sandbox/tenant-pools.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/tenant-pools.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "bun:test";
 import {
   claimTemplateName,
   claimWarmPoolName,
+  resolveClaimTemplateName,
   parseTenantPools,
   poolsMatchingPush,
   repoKeyFromCloneUrl,
@@ -201,6 +202,100 @@ describe("claimTemplateName", () => {
         claimTemplateName("interactive", "studio-sandbox"),
       ),
     ).toBe("studio-sandbox");
+  });
+});
+
+describe("resolveClaimTemplateName", () => {
+  const base = {
+    templateName: "studio-sandbox",
+    now: 1_000_000,
+    ttlMs: 60_000,
+  };
+
+  it("never probes for an interactive claim", async () => {
+    let probes = 0;
+    const result = await resolveClaimTemplateName({
+      ...base,
+      purpose: "interactive",
+      probe: null,
+      exists: async () => {
+        probes++;
+        return true;
+      },
+    });
+    expect(result.name).toBe("studio-sandbox");
+    expect(probes).toBe(0);
+  });
+
+  it("uses -medium when the cluster has it", async () => {
+    const result = await resolveClaimTemplateName({
+      ...base,
+      purpose: "harness-run",
+      probe: null,
+      exists: async (name) => name === "studio-sandbox-medium",
+    });
+    expect(result.name).toBe("studio-sandbox-medium");
+    expect(result.probe).toEqual({ checkedAt: base.now, present: true });
+  });
+
+  // Studio ahead of the chart: that claim would park at TemplateNotFound.
+  it("falls back to the default template when -medium is absent", async () => {
+    const warned: string[] = [];
+    const result = await resolveClaimTemplateName({
+      ...base,
+      purpose: "harness-run",
+      probe: null,
+      exists: async () => false,
+      onAbsent: (name) => warned.push(name),
+    });
+    expect(result.name).toBe("studio-sandbox");
+    expect(result.probe).toEqual({ checkedAt: base.now, present: false });
+    expect(warned).toEqual(["studio-sandbox-medium"]);
+  });
+
+  it("reuses a fresh probe instead of hitting the API per claim", async () => {
+    let probes = 0;
+    const result = await resolveClaimTemplateName({
+      ...base,
+      purpose: "harness-run",
+      probe: { checkedAt: base.now - 59_999, present: true },
+      exists: async () => {
+        probes++;
+        return true;
+      },
+    });
+    expect(result.name).toBe("studio-sandbox-medium");
+    expect(probes).toBe(0);
+  });
+
+  it("re-probes once the TTL is up, so an upgrade heals on its own", async () => {
+    const result = await resolveClaimTemplateName({
+      ...base,
+      purpose: "harness-run",
+      probe: { checkedAt: base.now - 60_000, present: false },
+      exists: async () => true,
+    });
+    expect(result.name).toBe("studio-sandbox-medium");
+    expect(result.probe).toEqual({ checkedAt: base.now, present: true });
+  });
+
+  it("warns once per absence, not once per claim", async () => {
+    const warned: string[] = [];
+    const first = await resolveClaimTemplateName({
+      ...base,
+      purpose: "harness-run",
+      probe: null,
+      exists: async () => false,
+      onAbsent: (name) => warned.push(name),
+    });
+    await resolveClaimTemplateName({
+      ...base,
+      purpose: "harness-run",
+      probe: first.probe,
+      exists: async () => false,
+      onAbsent: (name) => warned.push(name),
+    });
+    expect(warned).toEqual(["studio-sandbox-medium"]);
   });
 });
 

--- a/packages/sandbox/server/provider/agent-sandbox/tenant-pools.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/tenant-pools.ts
@@ -128,11 +128,20 @@ export function resolveTenantPool(
  * 2026-08-07: claims for montecarlo and `ephemeral-*` dispatches bound
  * `tenant-electrolux-prod-*` pods.
  */
+export function claimWarmPoolName(
+  pool: TenantPool | null,
+  warmPoolMode: boolean,
+  genericPoolName: string,
+): string {
+  return pool?.name ?? (warmPoolMode ? genericPoolName : "none");
+}
+
 /**
  * The claim's `spec.sandboxTemplateRef`. `cloneOnly` (the headless Claude Code
- * dispatch path) gets the roomier `-medium` template when one is configured —
- * that's where prod's 4Gi OOMKills happened, and a claim cannot override
- * resources, so the ceiling can only come from a different template.
+ * dispatch path) gets the roomier `-medium` template the sandbox-env chart
+ * renders alongside the default one — that's where prod's 4Gi OOMKills
+ * happened, and a claim cannot override resources, so the ceiling can only
+ * come from a different template.
  *
  * The returned name is also the warm pool's name (the chart names pool after
  * template), so it feeds `claimWarmPoolName` — a claim naming the medium
@@ -141,19 +150,8 @@ export function resolveTenantPool(
 export function claimTemplateName(
   cloneOnly: boolean | undefined,
   templateName: string,
-  mediumTemplateName: string | null,
 ): string {
-  return cloneOnly === true && mediumTemplateName
-    ? mediumTemplateName
-    : templateName;
-}
-
-export function claimWarmPoolName(
-  pool: TenantPool | null,
-  warmPoolMode: boolean,
-  genericPoolName: string,
-): string {
-  return pool?.name ?? (warmPoolMode ? genericPoolName : "none");
+  return cloneOnly === true ? `${templateName}-medium` : templateName;
 }
 
 /**

--- a/packages/sandbox/server/provider/agent-sandbox/tenant-pools.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/tenant-pools.ts
@@ -128,6 +128,26 @@ export function resolveTenantPool(
  * 2026-08-07: claims for montecarlo and `ephemeral-*` dispatches bound
  * `tenant-electrolux-prod-*` pods.
  */
+/**
+ * The claim's `spec.sandboxTemplateRef`. `cloneOnly` (the headless Claude Code
+ * dispatch path) gets the roomier `-medium` template when one is configured —
+ * that's where prod's 4Gi OOMKills happened, and a claim cannot override
+ * resources, so the ceiling can only come from a different template.
+ *
+ * The returned name is also the warm pool's name (the chart names pool after
+ * template), so it feeds `claimWarmPoolName` — a claim naming the medium
+ * template must not bind a default-template pod, and vice versa.
+ */
+export function claimTemplateName(
+  cloneOnly: boolean | undefined,
+  templateName: string,
+  mediumTemplateName: string | null,
+): string {
+  return cloneOnly === true && mediumTemplateName
+    ? mediumTemplateName
+    : templateName;
+}
+
 export function claimWarmPoolName(
   pool: TenantPool | null,
   warmPoolMode: boolean,

--- a/packages/sandbox/server/provider/agent-sandbox/tenant-pools.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/tenant-pools.ts
@@ -11,6 +11,8 @@
  */
 import { z } from "zod";
 
+import type { SandboxPurpose } from "../types";
+
 const tenantPoolSchema = z.object({
   /**
    * SandboxWarmPool object name. Must match a pool rendered by the sandbox-env
@@ -90,18 +92,18 @@ export function resolveTenantPool(
     orgId: string | undefined;
     cloneUrl: string | undefined;
     /**
-     * Checkout-only claims (the Claude Code dispatch path) must never take a
-     * tenant pod. They don't want a dev server, and binding one is actively
-     * destructive: Studio posts `cloneOnly` + the thread branch, the daemon
-     * classifies `branch-change`, and its clone step stops the dev task — so a
-     * dispatch would consume a warm slot AND de-warm the pod it took. They get
-     * the generic pool instead, which is exactly what an empty pod is for.
+     * A `harness-run` claim must never take a tenant pod. It doesn't want a dev
+     * server, and binding one is actively destructive: Studio posts `cloneOnly`
+     * + the thread branch, the daemon classifies `branch-change`, and its clone
+     * step stops the dev task — so a dispatch would consume a warm slot AND
+     * de-warm the pod it took. It gets its own pool instead (see
+     * `claimTemplateName`), which is exactly what an empty pod is for.
      */
-    cloneOnly?: boolean;
+    purpose?: SandboxPurpose;
   },
 ): TenantPool | null {
   const { orgId, cloneUrl } = claim;
-  if (claim.cloneOnly === true) return null;
+  if (claim.purpose === "harness-run") return null;
   if (!orgId || !cloneUrl) return null;
   const repoKey = repoKeyFromCloneUrl(cloneUrl);
   if (!repoKey) return null;
@@ -137,21 +139,20 @@ export function claimWarmPoolName(
 }
 
 /**
- * The claim's `spec.sandboxTemplateRef`. `cloneOnly` (the headless Claude Code
- * dispatch path) gets the roomier `-medium` template the sandbox-env chart
- * renders alongside the default one — that's where prod's 4Gi OOMKills
- * happened, and a claim cannot override resources, so the ceiling can only
- * come from a different template.
+ * The claim's `spec.sandboxTemplateRef`. A `harness-run` claim gets the roomier
+ * `-medium` template the sandbox-env chart renders alongside the default one —
+ * that is where prod's 4Gi OOMKills happened, and a SandboxClaim cannot
+ * override resources, so the ceiling can only come from another template.
  *
  * The returned name is also the warm pool's name (the chart names pool after
  * template), so it feeds `claimWarmPoolName` — a claim naming the medium
  * template must not bind a default-template pod, and vice versa.
  */
 export function claimTemplateName(
-  cloneOnly: boolean | undefined,
+  purpose: SandboxPurpose | undefined,
   templateName: string,
 ): string {
-  return cloneOnly === true ? `${templateName}-medium` : templateName;
+  return purpose === "harness-run" ? `${templateName}-medium` : templateName;
 }
 
 /**

--- a/packages/sandbox/server/provider/agent-sandbox/tenant-pools.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/tenant-pools.ts
@@ -145,14 +145,56 @@ export function claimWarmPoolName(
  * override resources, so the ceiling can only come from another template.
  *
  * The returned name is also the warm pool's name (the chart names pool after
- * template), so it feeds `claimWarmPoolName` — a claim naming the medium
- * template must not bind a default-template pod, and vice versa.
+ * template), so it feeds `claimWarmPoolName`: naming the pool built from this
+ * template is what lets the claim bind a warm pod at all. It is not what keeps
+ * the ceiling right — operator v0.4.5 matches warm pods by template hash, so a
+ * mismatched pool costs a warm bind (cold pod), never a wrong-size pod.
  */
 export function claimTemplateName(
   purpose: SandboxPurpose | undefined,
   templateName: string,
 ): string {
   return purpose === "harness-run" ? `${templateName}-medium` : templateName;
+}
+
+/** Result of the last `-medium` template lookup, cached for `ttlMs`. */
+export interface MediumTemplateProbe {
+  checkedAt: number;
+  present: boolean;
+}
+
+/**
+ * `claimTemplateName`, degraded to the default template while the `-medium` one
+ * is not on the cluster.
+ *
+ * Studio and the sandbox-env chart deploy independently (the chart is pinned by
+ * targetRevision), so there is a window where Studio names a template the
+ * cluster doesn't have. The operator accepts that claim and parks it at
+ * `Ready=False TemplateNotFound` — every dispatch would burn its full readiness
+ * timeout and fail. Probing instead costs one cached GET and degrades to the
+ * ceiling we had before this feature.
+ *
+ * Both outcomes are cached for `ttlMs`, so the upgrade heals within one TTL and
+ * a chart rollback is survived just as quietly.
+ */
+export async function resolveClaimTemplateName(args: {
+  purpose: SandboxPurpose | undefined;
+  templateName: string;
+  probe: MediumTemplateProbe | null;
+  now: number;
+  ttlMs: number;
+  exists: (name: string) => Promise<boolean>;
+  onAbsent?: (name: string) => void;
+}): Promise<{ name: string; probe: MediumTemplateProbe | null }> {
+  const wanted = claimTemplateName(args.purpose, args.templateName);
+  if (wanted === args.templateName) return { name: wanted, probe: args.probe };
+  const fresh =
+    args.probe !== null && args.now - args.probe.checkedAt < args.ttlMs
+      ? args.probe
+      : { checkedAt: args.now, present: await args.exists(wanted) };
+  if (fresh.present) return { name: wanted, probe: fresh };
+  if (args.probe?.present !== false) args.onAbsent?.(wanted);
+  return { name: args.templateName, probe: fresh };
 }
 
 /**

--- a/packages/sandbox/server/provider/index.ts
+++ b/packages/sandbox/server/provider/index.ts
@@ -13,8 +13,10 @@ import {
 export type {
   EnsureOptions,
   LegacySandboxProviderKind,
+  PodTermination,
   ProxyRequestInit,
   SandboxProviderKind,
+  SandboxPurpose,
   Sandbox,
   SandboxId,
   SandboxProvider,

--- a/packages/sandbox/server/provider/types.ts
+++ b/packages/sandbox/server/provider/types.ts
@@ -40,7 +40,25 @@ export interface Workload {
   packageManagerPath?: string;
 }
 
+/**
+ * What a sandbox is for. Runners MAY size, pool, and place the two differently;
+ * a runner that treats them identically is still correct.
+ *
+ * - `interactive` (default): a person is in the loop — dev server, preview URL,
+ *   long-lived, one per (user, project).
+ * - `harness-run`: one headless agent loop (Claude Code) dispatched to the
+ *   in-pod daemon, torn down when the run settles. `cloneOnly` and the absent
+ *   preview are consequences of this, not the definition of it.
+ */
+export type SandboxPurpose = "interactive" | "harness-run";
+
 export interface EnsureOptions {
+  /**
+   * Defaults to `interactive` when absent. On the agent-sandbox runner this
+   * decides the SandboxTemplate (memory ceiling) and the warm pool, so it has
+   * to survive into the persisted opts a resurrected claim is rebuilt from.
+   */
+  purpose?: SandboxPurpose;
   /**
    * The synthetic isolation key, recorded as the claim's `git-branch`
    * ANNOTATION for operators reading `kubectl get sandboxclaim -o yaml`.
@@ -178,12 +196,37 @@ export function normalizeSandboxProviderKind(
   return kind === "cluster" ? "agent-sandbox" : kind;
 }
 
+/**
+ * How the infrastructure — not the daemon — saw a sandbox stop. An OOM kill is
+ * the case that only exists here: the kernel SIGKILLs the process at the cgroup
+ * limit, so the dying sandbox reports nothing and Studio just sees the stream
+ * break.
+ */
+export interface PodTermination {
+  /** k8s `terminated.reason`, e.g. `OOMKilled`, `Error`, `Completed`. */
+  reason: string;
+  oomKilled: boolean;
+  exitCode?: number;
+  /** The limit that was hit, as k8s spells it (`4Gi`). */
+  memoryLimit?: string;
+}
+
 export interface SandboxProvider {
   readonly kind: SandboxProviderKind;
 
   ensure(id: SandboxId, opts?: EnsureOptions): Promise<Sandbox>;
   delete(handle: string): Promise<void>;
   alive(handle: string): Promise<boolean>;
+
+  /**
+   * Why this sandbox's container last stopped, for a caller that already knows
+   * it stopped. Best-effort and racy against the pod's own deletion — null
+   * means "cannot tell", so callers must degrade to their unqualified message
+   * rather than asserting anything.
+   *
+   * Optional: callers must `?.()`.
+   */
+  lastTermination?(handle: string): Promise<PodTermination | null>;
 
   /**
    * Bring this sandbox's shutdown forward to `graceMs` from now, because the

--- a/selfhost/production/values-sandbox-env-prod.yaml
+++ b/selfhost/production/values-sandbox-env-prod.yaml
@@ -18,7 +18,7 @@ resources:
     memory: 1Gi
   limits:
     cpu: 2
-    memory: 6Gi
+    memory: 4Gi
 
 # Legacy sandbox-env values key retained for upgrade compatibility.
 mesh:

--- a/selfhost/production/values-sandbox-env-prod.yaml
+++ b/selfhost/production/values-sandbox-env-prod.yaml
@@ -18,7 +18,7 @@ resources:
     memory: 1Gi
   limits:
     cpu: 2
-    memory: 4Gi
+    memory: 6Gi
 
 # Legacy sandbox-env values key retained for upgrade compatibility.
 mesh:


### PR DESCRIPTION
## Why

The 4Gi limit was chosen when no pod had ever reached it — the 0.9.14 changelog entry says so explicitly ("0 per-pod OOMs — the 4Gi limit was never reached"). That premise expired on 2026-08-13:

| pod | org | outcome |
|---|---|---|
| `studio-sandbox-prod-xvms5` | `deco-studio` | OOMKilled 17:37Z |
| `studio-sandbox-prod-tdcps` | `deco-studio` | OOMKilled 17:57Z — same thread, same run |
| `studio-sandbox-prod-25nbs` | (other org) | OOMKilled 14:58Z |

`container_memory_rss` for the second one, per minute:

```
17:46  257 MiB   ← boot settles
17:51  242
17:52  314
17:53  667
17:54 2097
17:55 3655       ← 4Gi limit
      → OOMKill
```

RSS, not page cache — a real allocation, inside a `claude-code` agent loop (`cloneOnly` pod, no dev server). The retry path then reprovisioned and reproduced the kill on a second pod, because a limit is not something a retry can route around.

## What

`resources.limits.memory: 4Gi → 6Gi`. Nothing else changes.

**The request is untouched at 2Gi**, which is the whole reason this is a one-line change rather than a capacity decision: the scheduler packs on requests, so this buys no node capacity, makes no warm-pool pod bigger, and costs nothing per pod. It only raises the ceiling one agent loop may burst to.

### The tradeoff, stated in values.yaml

Overcommit. A node packed on 2Gi requests can now hold pods that each reach 6Gi, and node memory-pressure eviction is exactly the failure mode that drove the *request* from 1Gi to 2Gi in 0.9.14. At the observed burst rate — 3 pods in 24h — that risk is small.

If those evictions do come back, the answer is **not** a further blanket raise: it's a separate `SandboxTemplate` so only the agent-loop pods carry the higher ceiling. #5836 already built that machinery (`sandboxTemplateSpec` partial + the pool's real `sandboxTemplateRef` read back off the cluster). It is deliberately not done here, because today it would buy nothing a limit bump doesn't: limits aren't scheduled, so the split's only benefit is bounding overcommit blast radius, and it would cost agent runs their warm-pool binds (a claim naming a template its bound pod wasn't built from never binds) or a second always-on pool of 6Gi idle pods.

### Chart version

0.15.13 → **0.15.14**, deliberately not 0.16.0 — #5836 has claimed that version and is still open.

## Testing

`helm lint` clean. `helm template` with `envName=ci` renders `limits.memory: 6Gi` against an unchanged `requests.memory: 2Gi`; rendering with `selfhost/production/values-sandbox-env-prod.yaml` confirms that sample's own override moved too (it pins the limit, so without the edit it would have silently stayed at 4Gi).

The four places that documented 4Gi were updated with it: the chart README table, the self-hosting production sample, and the en + pt-br Kubernetes docs tables.

## Deploying

Merging does not raise anything by itself — prod pins the chart by `targetRevision` in `deco-apps-cd`, so that needs the bump to 0.15.14 to take effect.

## Related

#6059 makes an OOM kill legible to the user, the agent, and the log — it is what identified this one. Independent of this PR; neither blocks the other.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes harness-run sandboxes to a new `-medium` SandboxTemplate (3Gi request / 6Gi limit) to avoid 4Gi OOMKills without raising defaults. If `-medium` is missing or unreadable, Studio falls back to the default template so dispatches do not stall.

- Changes
  - Helm (`deploy/helm/sandbox-env`): renders `studio-sandbox-<envName>` and `...-medium` plus matching warm pools; adds `mediumResources`, `warmPool.mediumSize`, and `warmPool.autoscaling.medium` (own HPA with validations); grants RBAC “get” on `sandboxtemplates`; chart `version: 0.15.16`; docs updated (requests now 2Gi; `mediumResources` documented).
  - Studio/provider (`packages/sandbox` and API): introduces `SandboxPurpose` and sends `purpose: "harness-run"` for Claude Code dispatch; derives `cloneOnly` from purpose; resolves the template name via a 5‑minute cached probe and treats 403/404 as “absent” (warns once, degrades to default); persists `purpose` so resurrected claims keep their template; harness-run claims skip tenant pools and select the matching `-medium` warm pool.

- Rollout
  - Recommended: bump `deco-apps-cd` `targetRevision` to `0.15.16` before deploying Studio. Safe if reversed — Studio degrades to the default template with a warning.
  - Optional: set `warmPool.mediumSize` and/or enable `warmPool.autoscaling.medium`.

<sup>Written for commit f9c15fb72c8c59ce708a340c7b7de962d970fe11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

