### PR TITLE
fix(oauth): bound the downstream-token refresh fetch with a timeout

### DIFF
--- a/apps/api/src/oauth/refresh-access-token.ts
+++ b/apps/api/src/oauth/refresh-access-token.ts
@@ -22,6 +22,9 @@ const PERMANENT_REFRESH_ERROR_CODES = new Set([
   "bad_refresh_token",
 ]);
 
+/** Bound the outbound refresh call — a hanging token endpoint shouldn't hang the caller. */
+const TOKEN_REFRESH_FETCH_TIMEOUT_MS = 10_000;
+
 export interface TokenRefreshResult {
   success: boolean;
   /**
@@ -93,6 +96,7 @@ export async function refreshAccessToken(
         Accept: "application/json",
       },
       body: params.toString(),
+      signal: AbortSignal.timeout(TOKEN_REFRESH_FETCH_TIMEOUT_MS),
     });
 
     if (!response.ok) {


### PR DESCRIPTION
Follows #6056 (SSO OIDC discovery/token-exchange timeout hardening) and the same convention used by connection.ts's CONNECTION_TEST probe and discover-tools.ts's tryRawToolsList.

`refreshAccessToken()` in `apps/api/src/oauth/refresh-access-token.ts` awaited a raw `fetch()` to the connection's OAuth token endpoint with no `AbortSignal` — a slow or hanging downstream token endpoint would hang this refresh call indefinitely. This primitive is the one used by `refreshAndStore` (`token-refresh.ts`) to refresh downstream MCP connection tokens on the request path, so a hung IdP stalls whatever tool call triggered the refresh.

Bounds the fetch at 10s via `AbortSignal.timeout(10_000)`, matching the constant already used in `org-sso.ts`. A timeout throws a `DOMException`, which is already caught by the existing `catch` block and treated as a transient failure (`console.warn("[TokenRefresh] network/parse error", ...)`, `permanent: false`) — no new error-handling path needed, no test needed for a one-line addition to an already-tested code path.

Reviewer check: `cd apps/api && bunx tsc --noEmit && bun test src/oauth/refresh-access-token.test.ts` (existing 7 tests still pass unchanged).

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bun test apps/api/src/oauth/refresh-access-token.test.ts` (7 pass), `bunx oxlint apps/api/src/oauth/refresh-access-token.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the downstream OAuth token refresh fetch with a 10s timeout to prevent request-path hangs when the IdP token endpoint is slow or stuck. Previously the fetch had no timeout and could hang indefinitely; now it aborts after 10s.

- Adds `TOKEN_REFRESH_FETCH_TIMEOUT_MS = 10_000` and passes `AbortSignal.timeout(...)` to the fetch in `refreshAccessToken`.
- A timeout raises a `DOMException`; the existing catch treats it as a transient failure and logs it. No new error paths or API changes.
- Aligns with the existing SSO timeout for consistency.

<sup>Written for commit d6837f5dd2c2ccc3b625a3e556255e8c16f2f021. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6061?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

