### PR TITLE
refactor(dispatch): remove unused error codes

### DIFF
--- a/packages/sandbox/dispatch/error-codes.ts
+++ b/packages/sandbox/dispatch/error-codes.ts
@@ -1,18 +1,3 @@
-/** Terminal error codes carried in link `{type:"error", code}` frames /
- *  dispatch SSE error events. A thin shared vocabulary — each transport maps
- *  INTO these where meaningful. NOT a unified cancel model. */
-export const LINK_ERROR_CODES = [
-  "publish_failed",
-  "ws_closed",
-  "harness_crashed",
-  "bad_input",
-  "unknown_harness",
-  "tombstoned",
-  "offload_fetch_failed",
-] as const;
-
-export type LinkErrorCode = (typeof LINK_ERROR_CODES)[number];
-
 /**
  * The daemon's terminal code for a run its pod could not finish: the daemon is
  * shutting down (SIGTERM → `CancelAll`, i.e. the pod was evicted or scaled in)


### PR DESCRIPTION
## Summary

Removed unused `LINK_ERROR_CODES` constant and `LinkErrorCode` type from the dispatch error-codes module. These were never imported or used anywhere in the codebase.

## Why

Dead code adds noise to the module contract and signals outdated design. The error codes were likely intended for a link transport that has since been phased out.

## Changes

- Deleted 15 lines: `LINK_ERROR_CODES` constant (7 unused error codes) and its derived `LinkErrorCode` type
- Kept the actively used codes: `SANDBOX_GONE_TERMINAL_CODE` and `SANDBOX_UNREACHABLE_PREFIX`

## Verification

- `rg LINK_ERROR_CODES | wc -l` = 0 (no references in codebase)
- `bun run fmt` — no changes needed
- `cd packages/sandbox && bunx tsc --noEmit` — ✓ passed
- `bunx oxlint packages/sandbox/dispatch/error-codes.ts` — ✓ 0 errors
- Type check in apps/api, packages/harness-runner — ✓ passed

## Net delta

-15 lines / +0 lines

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes unused link error codes from dispatch to reduce dead surface area. Previously the module exported `LINK_ERROR_CODES` and `LinkErrorCode`; now both are deleted. No runtime behavior changes.

**Review and migration**
- Public API shrink in `packages/sandbox/dispatch/error-codes.ts`: removed `LINK_ERROR_CODES` and `LinkErrorCode`. `SANDBOX_GONE_TERMINAL_CODE` and `SANDBOX_UNREACHABLE_PREFIX` remain.
- If you imported the removed symbols, delete those imports and any dependent types; no replacements are provided.

<sup>Written for commit efa5d2287db7f3bd61791a9c9f1c8cb3f9520786. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

