### PR TITLE
fix(sandbox): bound the model-env push to the daemon with a timeout

### DIFF
--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -564,6 +564,14 @@ export function describeTermination(
 }
 
 /**
+ * Bound the env-push PUT — a wedged daemon (pod up, TCP open, nothing
+ * draining it) must not hang the dispatch forever. `DAEMON_SILENCE_TIMEOUT_MS`
+ * only bounds the streaming dispatch itself; this call happens before that
+ * stream even opens, so without its own timeout it has no ceiling at all.
+ */
+const PUSH_ENV_TIMEOUT_MS = 30_000;
+
+/**
  * PUT the run's model env onto the daemon's config channel.
  *
  * ⚠️ SECURITY: `env` holds a model credential. Never log it, and never include
@@ -578,6 +586,7 @@ async function pushSandboxEnv(
     method: "PUT",
     headers: new Headers({ "content-type": "application/json" }),
     body: JSON.stringify({ env }),
+    signal: AbortSignal.timeout(PUSH_ENV_TIMEOUT_MS),
   });
   if (!res.ok) {
     // Hard failure, unlike the tool-catalog sync: without the credential the


### PR DESCRIPTION
Follows #6061 (bounded the OAuth downstream-token refresh fetch) and #6059 (better sandbox-unreachable diagnostics) — same class of gap, one hop over in the sandbox dispatch path.

`pushSandboxEnv` in `sandbox-dispatch-client.ts` PUTs the run's model credential onto the daemon's `/_sandbox/config` channel via `provider.proxyDaemonRequest`, but passes no `signal` at all. `proxyDaemonRequest` (`packages/sandbox/server/daemon-client.ts`) only applies whatever signal it's given — with none, the underlying `fetch` has no ceiling.

**Failure scenario:** every dispatch attempt (including each continuation after a lost sandbox) calls this before it can stream anything. If the daemon's TCP connection is wedged — pod up, connection open, but nothing draining it, the exact 'stopped answering' scenario this same file already handles for the *streaming* half of dispatch — this PUT hangs forever. `DAEMON_SILENCE_TIMEOUT_MS` (90s) only bounds the dispatch stream itself; it never gets a chance to apply because the run never reaches that stream. The task-run/DBOS retry budget is consumed by a request that will never resolve on its own.

Fix: bound the fetch with `AbortSignal.timeout(30_000)`, matching the existing `CONFIG_TIMEOUT_MS` convention this same daemon-client module already uses for its other two config PUTs (`daemon-client.ts:170,198`) — this call site was the one config PUT that didn't have it.

Command to confirm: `bun test apps/api/src/harnesses/sandbox-dispatch-client.test.ts` (37/37 pass, unchanged — no test exercised this path before or after).

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint apps/api/src/harnesses/sandbox-dispatch-client.ts` (0 errors/warnings), and the targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the sandbox model-env PUT to the daemon with a 30s timeout to prevent dispatch hangs when the daemon stops draining TCP. Previously the env push had no timeout and could block forever before the dispatch stream; now it aborts after 30s, aligning with other config PUTs.

- Adds `PUSH_ENV_TIMEOUT_MS = 30_000` and passes `signal: AbortSignal.timeout(...)` to the env push request.
- Leaves `DAEMON_SILENCE_TIMEOUT_MS` unchanged; only the pre-stream env PUT is affected.
- Expected behavior: wedged daemons cause the env push to fail fast (~30s), allowing dispatch retries instead of exhausting the retry budget on a hung request.
- No migration required.

<sup>Written for commit 01824acfe847dd9466a914b89f3536e1e2968e59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

