### PR TITLE
fix(native): bound the dev-server preview fetch/invoke with a timeout

### DIFF
--- a/apps/native/crates/local-api/src/routes/intercept/dev_server.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/dev_server.rs
@@ -5,21 +5,40 @@
 //! parts that must stay identical: the 502 `Preview unreachable` refusals and
 //! the status/`Content-Type`/body mirror.
 
+use std::time::Duration;
+
 use axum::body::Body;
 use axum::http::{header, HeaderValue, StatusCode};
 use axum::response::{IntoResponse, Response};
 
 use crate::error::ApiError;
 
+/// Both call sites build a fresh `reqwest::Client` per request with no
+/// timeout of its own, so a dev server that accepted the connection and then
+/// hung (starting up, wedged, deadlocked) would otherwise stall the native
+/// API request indefinitely — there is no daemon-side watchdog for a
+/// straight-to-dev-port call. 10s is generous for a same-machine loopback
+/// hop.
+const DEV_SERVER_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Sends `request` to the dev server and mirrors its response back: status,
 /// `Content-Type` (falling back to `default_content_type` when the dev server
 /// sent none — `None` omits the header instead), and the full body. A send or
-/// body-read failure is the family's uniform 502 `Preview unreachable`.
+/// body-read failure — including a timeout — is the family's uniform 502
+/// `Preview unreachable`.
 pub(super) async fn send_and_mirror(
     request: reqwest::RequestBuilder,
     default_content_type: Option<HeaderValue>,
 ) -> Response {
-    let Ok(response) = request.send().await else {
+    send_and_mirror_with_timeout(request, default_content_type, DEV_SERVER_TIMEOUT).await
+}
+
+async fn send_and_mirror_with_timeout(
+    request: reqwest::RequestBuilder,
+    default_content_type: Option<HeaderValue>,
+    timeout: Duration,
+) -> Response {
+    let Ok(response) = request.timeout(timeout).send().await else {
         return ApiError::new(StatusCode::BAD_GATEWAY, "Preview unreachable").into_response();
     };
     let status =
@@ -124,6 +143,32 @@ mod tests {
         let res = send_and_mirror(
             reqwest::Client::new().get(format!("http://127.0.0.1:{free_port}/x")),
             None,
+        )
+        .await;
+        assert_eq!(res.status(), StatusCode::BAD_GATEWAY);
+        let body = axum::body::to_bytes(res.into_body(), 1024).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["error"], "Preview unreachable");
+    }
+
+    /// A dev server that accepts the connection and then never answers (still
+    /// starting up, wedged) must not hang the native API request forever —
+    /// it gets the same uniform 502 as a dead port, once the timeout fires.
+    #[tokio::test]
+    async fn a_hung_dev_server_times_out_as_preview_unreachable() {
+        let app = axum::Router::new().route(
+            "/slow",
+            get(|| async {
+                tokio::time::sleep(Duration::from_secs(60)).await;
+                "too late"
+            }),
+        );
+        let port = spawn_upstream(app).await;
+
+        let res = send_and_mirror_with_timeout(
+            reqwest::Client::new().get(format!("http://127.0.0.1:{port}/slow")),
+            None,
+            Duration::from_millis(50),
         )
         .await;
         assert_eq!(res.status(), StatusCode::BAD_GATEWAY);


### PR DESCRIPTION
**Source:** bug found while auditing native local-API router hardening (`apps/native/crates/local-api/src/routes/intercept/`). Same pattern as the just-merged #6061 ("bound the downstream-token refresh fetch with a timeout").

**Payoff:** `preview-fetch` and `preview-invoke` both build a fresh `reqwest::Client::new()` per call and hand it straight to `dev_server::send_and_mirror` with no timeout. `reqwest::Client::new()` has no default request timeout, so a sandbox's dev server that accepts the TCP connection and then hangs (still booting, wedged, deadlocked mid-request) stalls the native-API request indefinitely — there's no daemon-side watchdog on this straight-to-dev-port path, unlike the guarded `/_sandbox/*` routes.

**Failure scenario:** a dev server process is alive enough to accept a connection but never responds (e.g. wedged during HMR, or still initializing a large project). Every `preview-fetch`/`preview-invoke` call against that sandbox from then on hangs forever instead of surfacing the existing uniform `502 Preview unreachable`.

**Fix + regression test:** `send_and_mirror` now applies a 10s timeout (generous for a same-machine loopback hop) via `RequestBuilder::timeout`, routed through a small internal `send_and_mirror_with_timeout` so the new test (`a_hung_dev_server_times_out_as_preview_unreachable`) can exercise the timeout path fast (50ms) without waiting out the real 10s constant. A send/timeout failure still collapses into the exact same 502 `Preview unreachable` shape as a dead port — no new error surface.

**Reviewer command:** `cd apps/native && cargo test -p local-api dev_server`

**Local checks run:** `cargo test -p local-api dev_server` (4/4 pass, including the new test) and `cargo fmt -p local-api`. Full CI (`cargo test`/clippy for the whole native workspace) validates the rest — clippy wasn't installed in this sandbox to check locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds dev-server preview requests with a timeout to prevent indefinite hangs. Previously `preview-fetch`/`preview-invoke` could stall forever if the dev server accepted the connection but never responded; now they time out after 10s and return the existing 502 “Preview unreachable.”

- Applies `RequestBuilder::timeout` via a new `send_and_mirror_with_timeout`; `send_and_mirror` now uses a 10s constant. Timeout failures map to the same 502 JSON shape; no new error surface.
- Adds `a_hung_dev_server_times_out_as_preview_unreachable` to exercise the timeout path (50ms) and assert the 502 behavior.
- To review: cd into `apps/native` and run `cargo test -p local-api dev_server`.

<sup>Written for commit 2777bf1de022537d11f12a84c410710171738365. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

