### PR TITLE
fix(settings): i18n the 'Connect to clients' nav label

### DIFF
--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -2,6 +2,7 @@ export const settings = {
   "settings.title": "Profile & Preferences",
   "settings.nav.organization": "Organization",
   "settings.nav.general": "General",
+  "settings.nav.connect": "Connect to clients",
   "settings.nav.brandContext": "Brand Context",
   "settings.nav.aiProviders": "AI Providers",
   "settings.nav.secrets": "Secrets",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -4,6 +4,7 @@ export const settings = {
   "settings.title": "Perfil e preferências",
   "settings.nav.organization": "Organização",
   "settings.nav.general": "Geral",
+  "settings.nav.connect": "Conectar a clientes",
   "settings.nav.brandContext": "Contexto da marca",
   "settings.nav.aiProviders": "Provedores de IA",
   "settings.nav.secrets": "Segredos",

--- a/apps/web/src/layouts/settings-layout.tsx
+++ b/apps/web/src/layouts/settings-layout.tsx
@@ -107,7 +107,7 @@ function useSettingsSidebarGroups(): SettingsNavGroup[] {
         },
         {
           key: "connect",
-          label: "Connect to clients",
+          label: t("settings.nav.connect"),
           icon: <LinkExternal01 size={14} />,
           to: "/$org/settings/connect",
         },


### PR DESCRIPTION
Settings sidebar's "Connect" nav item (`apps/web/src/layouts/settings-layout.tsx`) was hardcoded as `label: "Connect to clients"` while every other nav item routes through `t(...)`. This means it never gets translated for pt-br users and would silently stay English forever if left as-is, unlike the rest of the settings nav.

Fix: add `settings.nav.connect` to both `en/settings.ts` ("Connect to clients") and `pt-br/settings.ts` ("Conectar a clientes"), and swap the hardcoded string in `settings-layout.tsx` for `t("settings.nav.connect")`.

To confirm: switch the app language to Portuguese and open Settings — the "Connect to clients" sidebar item now renders "Conectar a clientes" instead of staying in English.

Verified locally: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean — `TranslationKey` derivation proves both dictionaries stay in sync), `bunx oxlint` on all 3 changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes the Settings sidebar "Connect to clients" nav label. Previously hardcoded in English; now uses i18n so it renders per locale (added for `en` and `pt-br`).

- Adds `settings.nav.connect` to `apps/web/src/i18n/en/settings.ts` and `apps/web/src/i18n/pt-br/settings.ts`; replaces the hardcoded label with `t("settings.nav.connect")` in `apps/web/src/layouts/settings-layout.tsx`.
- No migration required; if you maintain other locales, add `settings.nav.connect`.
- Verify by switching the app to Portuguese and opening Settings—the label should read "Conectar a clientes".

<sup>Written for commit 3745807cab47fe824a157ec1273de5cae2ea6564. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

