### PR TITLE
fix(oauth): treat a 200 refresh response missing access_token as failure

### DIFF
--- a/apps/api/src/oauth/refresh-access-token.test.ts
+++ b/apps/api/src/oauth/refresh-access-token.test.ts
@@ -144,4 +144,20 @@ describe("refreshAccessToken", () => {
     expect(result.permanent).toBeUndefined();
     expect(result.accessToken).toBe("new");
   });
+
+  it("treats a 200 with no access_token as a transient failure, not success", async () => {
+    installFetch(
+      () =>
+        new Response(JSON.stringify({ token_type: "Bearer" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    const result = await refreshAccessToken(baseToken);
+
+    expect(result.success).toBe(false);
+    expect(result.permanent).toBe(false);
+    expect(result.accessToken).toBeUndefined();
+  });
 });

--- a/apps/api/src/oauth/refresh-access-token.ts
+++ b/apps/api/src/oauth/refresh-access-token.ts
@@ -149,12 +149,26 @@ export async function refreshAccessToken(
     }
 
     const data = (await response.json()) as {
-      access_token: string;
+      access_token?: string;
       refresh_token?: string;
       expires_in?: number;
       token_type?: string;
       scope?: string;
     };
+
+    if (!data.access_token) {
+      // Spec-violating 200 (no access_token) — treat as transient, not silent success.
+      console.warn("[TokenRefresh] 200 response missing access_token", {
+        connectionId: token.connectionId,
+        tokenEndpoint: token.tokenEndpoint,
+      });
+      return {
+        success: false,
+        permanent: false,
+        status: response.status,
+        error: "Token endpoint returned no access_token",
+      };
+    }
 
     return {
       success: true,


### PR DESCRIPTION
**Source:** bug found while auditing `apps/api/src/oauth/refresh-access-token.ts` for edge-case failures (this tick's assigned focus area: OAuth token refresh hardening).

**What was wrong:** `refreshAccessToken` treated any HTTP 200 from the token endpoint as success, even if the JSON body had no `access_token` field. It returned `{ success: true, accessToken: undefined }` with no logging at all. The caller (`refreshAndStoreOnce` in `token-refresh.ts`) does check `!result.accessToken` and falls back to failure, but since `result.permanent` is unset (falsy) on the `success:true` path, this spec-violating response was silently swallowed — no warn/error log, no `error`/`status` field to diagnose it, making a misbehaving or compromised token endpoint invisible in production.

**Failure scenario:** a token endpoint returns `200 { "token_type": "Bearer" }` (no `access_token`) — due to a server bug, a proxy misconfiguration, or an unexpected response shape. The refresh silently "succeeds" with an undefined token and zero log trace, instead of being flagged as the transient failure it actually is.

**Fix:** validate `data.access_token` is present before returning success; if missing, log a warn (matching the existing warn/error convention in this file) and return `{ success: false, permanent: false, status, error }` — transient, so it doesn't evict a token that might still be valid on the next attempt.

**Regression test:** added `"treats a 200 with no access_token as a transient failure, not success"` in `refresh-access-token.test.ts`, mocking a 200 response with no `access_token` field and asserting `success: false`, `permanent: false`.

**To verify:** `bun test apps/api/src/oauth/refresh-access-token.test.ts` (8/8 pass, including the new case).

**Checks run locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint apps/api/src/oauth/refresh-access-token.ts apps/api/src/oauth/refresh-access-token.test.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats a 200 OK token refresh without access_token as a transient failure and logs it. Previously, any 200 was treated as success and returned success: true with an undefined accessToken; now it returns success: false, permanent: false, with status and error, making misbehaving token endpoints visible.

- Adds an access_token presence check in refreshAccessToken and a warn log with connectionId and tokenEndpoint.
- Preserves token retention: flags as non-permanent so future attempts can recover; happy path unchanged.
- Adds a regression test for the 200-without-access_token case.

<sup>Written for commit c615a61a6d1fa56b181d6828f759a9243c8123ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

