### PR TITLE
fix(sso): exempt the org-scoped SSO mount from enforcement middleware

### DIFF
--- a/apps/api/src/api/app.test.ts
+++ b/apps/api/src/api/app.test.ts
@@ -26,6 +26,12 @@ describe("isSsoExemptPath", () => {
     expect(isSsoExemptPath("/api/_admin/orgs")).toBe(true);
   });
 
+  test("exempts the canonical org-scoped sso mount", () => {
+    expect(isSsoExemptPath("/api/acme-corp/sso/authorize")).toBe(true);
+    expect(isSsoExemptPath("/api/acme-corp/sso/callback")).toBe(true);
+    expect(isSsoExemptPath("/api/acme-corp/sso/status")).toBe(true);
+  });
+
   test("does not exempt other org-scoped routes", () => {
     expect(isSsoExemptPath("/api/acme-corp/connections")).toBe(false);
     expect(isSsoExemptPath("/api/acme-corp/mcp/conn_123")).toBe(false);

--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -310,6 +310,8 @@ function buildDecoOAuthParams(projectLocator: string | null): URLSearchParams {
 export function isSsoExemptPath(path: string): boolean {
   return (
     path.startsWith("/api/org-sso/") ||
+    // Canonical org-scoped mount — the auth/callback endpoints themselves.
+    /^\/api\/[^/]+\/sso\//.test(path) ||
     path.startsWith("/api/auth/") ||
     path.startsWith("/api/tools/management") ||
     path.startsWith("/oauth-proxy/") ||


### PR DESCRIPTION
**Bug found while auditing the org-SSO route stability (apps/api/src/api/routes/org-sso.ts) and its integration with the SSO-enforcement middleware in app.ts.**

`createSsoRoutes()` is mounted at two paths: the legacy `/api/org-sso/*` and the canonical org-scoped `/api/:org/sso/*` (wired in `org-scoped.ts:107`). The global SSO-enforcement middleware in `app.ts` (registered before the org-scoped API mount) 403s any request from a user in an org with SSO enforced who hasn't completed a valid SSO session yet — except for paths matched by `isSsoExemptPath`. That function only exempted the legacy `/api/org-sso/` prefix, not the new `/api/:org/sso/*` mount.

**Failure scenario:** an org enables SSO enforcement. A user hits the canonical `/api/acme-corp/sso/authorize` (or `/status`, `/callback`, `/config`) endpoint to start or check their SSO session. The enforcement middleware runs first, sees no valid SSO session yet, and returns 403 — on the very endpoint the user needs to complete SSO. Locked out before they can start, with no way to recover through the new route shape (only the deprecated legacy path still worked).

**Fix:** add a regex exemption for `/api/:org/sso/*` to `isSsoExemptPath`, mirroring the existing org-scoped oauth-proxy exemption pattern already in the same function. Added a regression test (`app.test.ts`) asserting `/api/acme-corp/sso/{authorize,callback,status}` are exempt.

**To verify:** `cd apps/api && bun test src/api/app.test.ts` — new test `exempts the canonical org-scoped sso mount` passes; existing exemption tests for legacy/oauth-proxy/admin paths still pass.

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), `bunx oxlint src/api/app.ts src/api/app.test.ts` (0 errors/warnings), targeted `bun test src/api/app.test.ts` (18 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents SSO lockouts by exempting the canonical org-scoped SSO routes from enforcement. Previously, `/api/:org/sso/*` returned 403 for users without a valid SSO session; now these endpoints are exempt like the legacy `/api/org-sso/*`.

- Add regex exemption in `isSsoExemptPath` for `/^\/api\/[^/]+\/sso\//`.
- Add regression test covering `/authorize`, `/callback`, and `/status` under `/api/:org/sso/`.
- Other org-scoped routes remain enforced; no config or migration changes.

<sup>Written for commit 7a7e0182df91e3c3148860b672ddb8f53f78da10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

