### PR TITLE
fix(task-board): stop cards parking silently in In Review, and continue re-runs instead of restarting them

### DIFF
--- a/apps/api/src/tools/task-board/conflict-reaction.ts
+++ b/apps/api/src/tools/task-board/conflict-reaction.ts
@@ -7,7 +7,7 @@ import {
   SUPER_AGENT_ASSIGNEE_ID,
 } from "@decocms/shared/task-board";
 import { recordTaskActivity } from "./activity";
-import { emitTaskBoardUpdated } from "./run-reactions";
+import { emitTaskBoardUpdated, parkOnRunsExhausted } from "./run-reactions";
 import { enqueueSuperAgentForTask } from "./enqueue-super-agent";
 
 /**
@@ -110,12 +110,6 @@ export async function reactToApprovedPrConflict(
     item.updatedBy,
   );
   if (!claimed) return false;
-  await recordTaskActivity(ctx, {
-    taskBoardItemId: item.id,
-    action: "merge_conflict_resolution",
-    actorId: null,
-    data: { prNumber: pr.number },
-  });
   emitTaskBoardUpdated(orgId, claimed);
   try {
     await enqueueSuperAgentForTask(ctx, claimed, {
@@ -123,6 +117,10 @@ export async function reactToApprovedPrConflict(
       resolveConflict: true,
     });
   } catch (err) {
+    // The per-task run cap refused it: no run is coming, so say so on the card
+    // instead of leaving it to be retried every poll until the conflict cap
+    // (which now counts only real dispatches) papers over it.
+    await parkOnRunsExhausted(ctx, claimed, err).catch(() => false);
     // Nothing was dispatched. Unlike a fresh delegation, this bounced the
     // task's STATUS to In Progress as the dispatch fence — leaving it there
     // strands the task forever: the guard above only fires on `in_review`,
@@ -138,5 +136,18 @@ export async function reactToApprovedPrConflict(
       );
     throw err;
   }
+  // AFTER the dispatch, not before: this entry is what the cap counts, so
+  // recording it up front let a dispatch that THREW spend a slot. In prod three
+  // `runs_exhausted` throws burned the all-time cap of 3 in fifty-one seconds
+  // without a single resolution run ever being created, and the PR was then
+  // "left for a human" who had no way to see why. Undercounting a dispatch that
+  // really started (if this write fails) is the safe direction: the cap is a
+  // bound on churn, and one extra attempt beats abandoning a mergeable PR.
+  await recordTaskActivity(ctx, {
+    taskBoardItemId: item.id,
+    action: "merge_conflict_resolution",
+    actorId: null,
+    data: { prNumber: pr.number },
+  });
   return true;
 }

--- a/apps/api/src/tools/task-board/enqueue-super-agent.ts
+++ b/apps/api/src/tools/task-board/enqueue-super-agent.ts
@@ -1,6 +1,9 @@
 import type { StudioContext } from "@/core/studio-context";
 import type { TaskBoardItem } from "@/storage/types";
-import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
+import {
+  outstandingReviewFeedback,
+  SUPER_AGENT_ASSIGNEE_ID,
+} from "@decocms/shared/task-board";
 import {
   claimTaskExecution,
   rollbackTaskExecution,
@@ -173,6 +176,18 @@ async function resolveRerunBranch(
   return fetchPrHeadRef(ctx, task.organizationId, pr).catch(() => null);
 }
 
+/** The reviewer feedback still outstanding on `task`, or null. Best-effort: an
+ *  unreadable activity log costs the prompt its lead, never the dispatch. */
+async function outstandingFeedback(
+  ctx: StudioContext,
+  task: TaskBoardItem,
+): Promise<string | null> {
+  const activity = await ctx.storage.taskBoard
+    .listActivity(task.id, task.organizationId)
+    .catch(() => []);
+  return outstandingReviewFeedback(activity);
+}
+
 /**
  * Whether a PR's live state is trustworthy enough to pin the branch to: it
  * isn't DEFINITIVELY closed. `null` (GitHub unreachable, the throttled queue
@@ -262,8 +277,26 @@ export async function enqueueSuperAgentForTask(
     // The prompt must name the same PR the sandbox booted on. Only widened when
     // the flag is on: naming a PR the run is NOT pinned to is the combination
     // that produced the duplicates.
+    //
+    // Same idea for the feedback: a dispatch that lands on an existing PR is a
+    // CONTINUATION, so it should carry what the last reviewer asked for. Only
+    // the reviewer bounce passed that; a human's Re-run / re-assign passed
+    // nothing and the agent restarted from the title, re-deciding an approach
+    // the reviewer had told it to keep. Scoped to `pr` — with no PR to continue
+    // there is nothing outstanding, and a fresh attempt should stay fresh.
+    // Skipped when the caller already has a lead: a reviewer bounce passes its
+    // own notes, and a conflict re-run's lead outranks feedback anyway.
+    const wantsCarry = !opts?.feedback && !opts?.resolveConflict;
+    const carried =
+      pr && wantsCarry ? await outstandingFeedback(ctx, task) : null;
     const promptOpts: SuperAgentPromptOpts | undefined =
-      pr && pr !== opts?.pr ? { ...opts, pr } : opts;
+      (pr && pr !== opts?.pr) || carried
+        ? {
+            ...opts,
+            ...(pr ? { pr } : {}),
+            ...(carried ? { feedback: carried } : {}),
+          }
+        : opts;
 
     // Sandbox-hosted claude-code takes every task that has a repo it could work
     // in — bound before dispatch when there's exactly one, otherwise chosen

--- a/apps/api/src/tools/task-board/rerun.ts
+++ b/apps/api/src/tools/task-board/rerun.ts
@@ -190,10 +190,12 @@ export const TASK_BOARD_ITEM_RERUN = defineTool({
     idempotentHint: false,
     openWorldHint: true,
   },
-  // ponytail: no `feedback` / "what to do differently" input. The only prompt
-  // lead that exists for a re-run is the reviewer's ("A reviewer requested
-  // changes on your previous work"), which would be a lie here. Add one when
-  // there is a caller for it, with its own lead.
+  // ponytail: no `feedback` / "what to do differently" input from the CALLER.
+  // A re-run on an existing PR is not blind, though: the dispatch funnel picks
+  // up the reviewer's outstanding change request by itself
+  // (`outstandingReviewFeedback`), so the run continues from there instead of
+  // restarting. Add a caller-supplied lead when someone needs to say something
+  // the reviewers did not.
   inputSchema: z.object({
     id: z.string().describe("The task board item to re-run."),
   }),

--- a/apps/api/src/tools/task-board/review-decision.ts
+++ b/apps/api/src/tools/task-board/review-decision.ts
@@ -12,7 +12,11 @@ import {
 } from "@decocms/shared/task-board";
 import { TaskBoardItemStatusSchema } from "./schema";
 import { recordTaskActivity } from "./activity";
-import { emitTaskBoardUpdated, handTaskToHuman } from "./run-reactions";
+import {
+  emitTaskBoardUpdated,
+  handTaskToHuman,
+  parkOnRunsExhausted,
+} from "./run-reactions";
 import { enqueueSuperAgentForTask } from "./enqueue-super-agent";
 import {
   allEnabledReviewersVerifiedApproved,
@@ -276,10 +280,32 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
       await enqueueSuperAgentForTask(ctx, updated, {
         feedback: `${REVIEWER_LABEL[reviewer]}: ${notes}`,
         pr: pr ? { number: pr.number, url: pr.url } : undefined,
-      }).catch((err) => {
-        // A paywall rejection is NOT best-effort — swallowing it would leave
-        // the task bounced-but-never-re-running with only a log line (same
-        // reasoning as reactToSuperAgentDelegation).
+      }).catch(async (err) => {
+        // The per-task run cap refused the re-dispatch. Nothing will run, and
+        // the bounce above already moved the card to In Progress — so put it
+        // back and hand it over, rather than rethrowing (which fails an
+        // otherwise-good reviewer decision and strands the card In Progress
+        // with nothing running).
+        if (await parkOnRunsExhausted(ctx, updated, err)) {
+          await ctx.storage.taskBoard
+            .update(
+              updated.id,
+              organizationId,
+              { status: "in_review" },
+              "system",
+            )
+            .then((reverted) => emitTaskBoardUpdated(organizationId, reverted))
+            .catch((revertErr) =>
+              console.error(
+                "[task-board] runs-exhausted status revert failed",
+                revertErr,
+              ),
+            );
+          return;
+        }
+        // Any other paywall rejection is NOT best-effort — swallowing it would
+        // leave the task bounced-but-never-re-running with only a log line
+        // (same reasoning as reactToSuperAgentDelegation).
         if (err instanceof TaskQuotaError) throw err;
         console.error("[task-board] request_changes re-enqueue failed", err);
       });

--- a/apps/api/src/tools/task-board/run-reactions.ts
+++ b/apps/api/src/tools/task-board/run-reactions.ts
@@ -19,7 +19,7 @@
  * Each transition also pushes the updated item over SSE for a real-time board.
  */
 
-import { releaseTaskExecution } from "@/billing/task-quota";
+import { releaseTaskExecution, TaskQuotaError } from "@/billing/task-quota";
 import { captureOrgEvent } from "@/posthog";
 import type { OrganizationBillingStorage } from "@/storage/organization-billing";
 import { TERMINAL_THREAD_STATUSES } from "@/storage/task-board";
@@ -467,6 +467,41 @@ export async function handTaskToHuman(
     console.error(`[task-board] handing ${item.id} to a human failed`, err);
     return false;
   }
+}
+
+/**
+ * The per-task run cap (`maxRunsPerTask`) refused an AUTOMATIC re-dispatch, so
+ * nothing will run on this task again on its own. Hand it to a human saying so.
+ *
+ * Without this the refusal is invisible: `runs_exhausted` throws out of
+ * `enqueueSuperAgentForTask` into a log line, and the state machine keeps
+ * cycling on a PR that never gains a commit. Four prod cards sat like that —
+ * reviewers re-reviewed an untouched PR five times over ninety minutes and the
+ * board's only explanation was "the reviewer and the Super Agent are not
+ * converging". They HAD converged; the agent was never dispatched.
+ *
+ * Narrow to `runs_exhausted` on purpose. The other quota reasons are org-wide
+ * paywalls that existing callers deliberately surface to the user; only the
+ * per-task cap is a dead end that a card can neither report nor escape (a human
+ * Re-run is exempt from it, which is exactly the action this hand-off asks for).
+ *
+ * Returns true when it handled `err` — the caller must then stop treating the
+ * dispatch as pending. False for any other error, which the caller still owns.
+ */
+export async function parkOnRunsExhausted(
+  ctx: StudioContext,
+  item: TaskBoardItem,
+  err: unknown,
+): Promise<boolean> {
+  if (!(err instanceof TaskQuotaError)) return false;
+  if (err.reason !== "runs_exhausted") return false;
+  await handTaskToHuman(
+    ctx,
+    item,
+    "per-task run limit reached — the Super Agent can no longer re-dispatch " +
+      "itself on this task. Re-run it manually to continue.",
+  );
+  return true;
 }
 
 /**

--- a/apps/api/src/tools/task-board/runs-exhausted-parking.integration.test.ts
+++ b/apps/api/src/tools/task-board/runs-exhausted-parking.integration.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Real-Postgres coverage for the two halves of the wedge that left four prod
+ * cards sitting In Review with nothing running and no reason on the card:
+ *
+ * 1. `parkOnRunsExhausted` — the per-task run cap refuses an AUTOMATIC
+ *    re-dispatch, and the card must say so instead of the refusal dying in a
+ *    log line. Real PG rather than a stub because the hand-off is a conditional
+ *    UPDATE on `assignee_id` plus an activity row, and both are exactly what an
+ *    in-memory fake gets to be lenient about (it also has to be idempotent, and
+ *    only a real conditional write proves that).
+ *
+ * 2. `outstandingReviewFeedback` over rows that made a round trip through
+ *    `recordActivity`/`listActivity`. The pure test builds its own fixtures, so
+ *    it cannot catch the failure that actually matters here: the storage row's
+ *    shape (`occurredAt` as a string the fold can order by, `data.notes`
+ *    surviving the jsonb round trip) drifting from what the fold reads. A
+ *    mismatch there degrades silently — every re-run would just quietly go back
+ *    to restarting from scratch, which is the bug this was written to fix.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { sql } from "kysely";
+import type { StudioContext } from "../../core/studio-context";
+import type { StudioDatabase } from "../../database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../../database/test-db-pg";
+import { TaskBoardStorage } from "../../storage/task-board";
+import { TaskQuotaError } from "../../billing/task-quota";
+import {
+  outstandingReviewFeedback,
+  SUPER_AGENT_ASSIGNEE_ID,
+} from "@decocms/shared/task-board";
+import { parkOnRunsExhausted } from "./run-reactions";
+
+const ORG = "org_runs_exhausted";
+const USER = "user_runs_exhausted";
+
+describe("runs-exhausted parking", () => {
+  let database: StudioDatabase;
+  let taskBoard: TaskBoardStorage;
+  let ctx: StudioContext;
+
+  /** A card delegated to the Super Agent, sitting In Review — the shape all
+   *  four prod cards were in when they stopped moving. */
+  const delegatedCard = async (title: string) => {
+    const item = await taskBoard.create({
+      organizationId: ORG,
+      title,
+      by: USER,
+      assigneeId: SUPER_AGENT_ASSIGNEE_ID,
+    });
+    return await taskBoard.update(item.id, ORG, { status: "in_review" }, USER);
+  };
+
+  const assigneeOf = async (id: string) =>
+    (await taskBoard.getById(id, ORG))?.assigneeId ?? null;
+
+  const handoffReasons = async (id: string) =>
+    (await taskBoard.listActivity(id, ORG))
+      .filter((a) => a.action === "assignee_changed")
+      .map((a) => (a.data as { reason?: string } | null)?.reason ?? null);
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    const now = new Date().toISOString();
+    await database.db
+      .insertInto("organization")
+      .values({
+        id: ORG,
+        name: ORG,
+        slug: "org-runs-exhausted",
+        createdAt: now,
+      })
+      .execute();
+    // Raw SQL: real Postgres types emailVerified BOOLEAN, the table shape TEXT.
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES (${USER}, ${"re@exhausted.test"}, false, ${USER}, ${now}, ${now})
+    `.execute(database.db);
+    taskBoard = new TaskBoardStorage(database.db);
+    ctx = { storage: { taskBoard } } as unknown as StudioContext;
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  it("hands the card to a human, with the reason, when the run cap refuses", async () => {
+    const card = await delegatedCard("cap refused me");
+
+    const handled = await parkOnRunsExhausted(
+      ctx,
+      card,
+      new TaskQuotaError("runs_exhausted"),
+    );
+
+    expect(handled).toBe(true);
+    expect(await assigneeOf(card.id)).toBeNull();
+    // The reason is the whole point: the prod cards were unassigned with no
+    // explanation a person could act on.
+    const [reason] = await handoffReasons(card.id);
+    expect(reason).toContain("per-task run limit reached");
+    expect(reason).toContain("Re-run it manually");
+  });
+
+  it("leaves the card In Review — a human picks it up where the reviewers left it", async () => {
+    const card = await delegatedCard("still in review");
+    await parkOnRunsExhausted(ctx, card, new TaskQuotaError("runs_exhausted"));
+    expect((await taskBoard.getById(card.id, ORG))?.status).toBe("in_review");
+  });
+
+  it("is idempotent — a second refusal does not log a second hand-off", async () => {
+    const card = await delegatedCard("swept twice");
+    await parkOnRunsExhausted(ctx, card, new TaskQuotaError("runs_exhausted"));
+    // The sweeper visits a card every tick, and `card` is now stale in exactly
+    // the way a re-read at the top of the next tick is not.
+    await parkOnRunsExhausted(ctx, card, new TaskQuotaError("runs_exhausted"));
+    expect(await handoffReasons(card.id)).toHaveLength(1);
+  });
+
+  it("ignores the org-wide paywall reasons and non-quota errors", async () => {
+    const paywalled = await delegatedCard("trial over");
+    expect(
+      await parkOnRunsExhausted(
+        ctx,
+        paywalled,
+        new TaskQuotaError("trial_exhausted"),
+      ),
+    ).toBe(false);
+    expect(await assigneeOf(paywalled.id)).toBe(SUPER_AGENT_ASSIGNEE_ID);
+
+    const blipped = await delegatedCard("network blip");
+    expect(
+      await parkOnRunsExhausted(ctx, blipped, new Error("ECONNRESET")),
+    ).toBe(false);
+    expect(await assigneeOf(blipped.id)).toBe(SUPER_AGENT_ASSIGNEE_ID);
+  });
+
+  it("reads the outstanding change request back off real activity rows", async () => {
+    const card = await delegatedCard("bounced then re-run");
+    await taskBoard.recordActivity({
+      taskBoardItemId: card.id,
+      action: "review_approved",
+      actorId: null,
+      data: { reviewer: "code_review", notes: "looks good to me" },
+    });
+    await taskBoard.recordActivity({
+      taskBoardItemId: card.id,
+      action: "review_changes_requested",
+      actorId: null,
+      data: {
+        reviewer: "qa",
+        notes: "the fix is right — do not redo the approach",
+      },
+    });
+
+    expect(
+      outstandingReviewFeedback(await taskBoard.listActivity(card.id, ORG)),
+    ).toBe("the fix is right — do not redo the approach");
+  });
+
+  it("carries nothing once the latest verdict is an approval", async () => {
+    const card = await delegatedCard("approved after the bounce");
+    await taskBoard.recordActivity({
+      taskBoardItemId: card.id,
+      action: "review_changes_requested",
+      actorId: null,
+      data: { reviewer: "qa", notes: "needs work" },
+    });
+    await taskBoard.recordActivity({
+      taskBoardItemId: card.id,
+      action: "review_approved",
+      actorId: null,
+      data: { reviewer: "qa", notes: "fixed" },
+    });
+
+    expect(
+      outstandingReviewFeedback(await taskBoard.listActivity(card.id, ORG)),
+    ).toBeNull();
+  });
+});

--- a/packages/shared/src/task-board.test.ts
+++ b/packages/shared/src/task-board.test.ts
@@ -4,6 +4,7 @@ import {
   enabledReviewerKinds,
   isReviewerThreadTitle,
   MAX_REVIEW_BOUNCES,
+  outstandingReviewFeedback,
   reviewBounceLimitReached,
   reviewCycleStart,
   reviewCycleVerdicts,
@@ -306,5 +307,74 @@ describe("reviewBounceLimitReached", () => {
         bounce("2026-01-01T01:00:00.000Z"),
       ]),
     ).toBe(false);
+  });
+});
+
+describe("outstandingReviewFeedback", () => {
+  const changes = (
+    occurredAt: string,
+    notes: unknown = "fix the landmark",
+  ) => ({
+    action: "review_changes_requested",
+    data: { reviewer: "qa", notes },
+    occurredAt,
+  });
+  const approved = (occurredAt: string) => ({
+    action: "review_approved",
+    data: { reviewer: "code_review", notes: "looks good" },
+    occurredAt,
+  });
+
+  it("returns the notes when the latest verdict asked for changes", () => {
+    expect(
+      outstandingReviewFeedback([
+        approved("2026-01-01T00:00:00.000Z"),
+        changes("2026-01-01T01:00:00.000Z"),
+      ]),
+    ).toBe("fix the landmark");
+  });
+
+  it("returns null when the latest verdict is an approval", () => {
+    expect(
+      outstandingReviewFeedback([
+        changes("2026-01-01T01:00:00.000Z"),
+        approved("2026-01-01T02:00:00.000Z"),
+      ]),
+    ).toBeNull();
+  });
+
+  it("is ordered by time, not array position", () => {
+    expect(
+      outstandingReviewFeedback([
+        changes("2026-01-01T03:00:00.000Z", "the newest ask"),
+        approved("2026-01-01T02:00:00.000Z"),
+        changes("2026-01-01T01:00:00.000Z", "an older ask"),
+      ]),
+    ).toBe("the newest ask");
+  });
+
+  it("carries the latest ask across review cycles, unlike the cycle helpers", () => {
+    expect(
+      outstandingReviewFeedback([
+        changes("2026-01-01T01:00:00.000Z"),
+        {
+          action: "status_changed",
+          data: { to: "in_review" },
+          occurredAt: "2026-01-01T02:00:00.000Z",
+        },
+      ]),
+    ).toBe("fix the landmark");
+  });
+
+  it("returns null with no verdicts, or with non-string notes", () => {
+    expect(outstandingReviewFeedback([])).toBeNull();
+    expect(
+      outstandingReviewFeedback([
+        { action: "created", occurredAt: "2026-01-01T00:00:00.000Z" },
+      ]),
+    ).toBeNull();
+    expect(
+      outstandingReviewFeedback([changes("2026-01-01T01:00:00.000Z", null)]),
+    ).toBeNull();
   });
 });

--- a/packages/shared/src/task-board.ts
+++ b/packages/shared/src/task-board.ts
@@ -178,6 +178,48 @@ export function approvedButUnverified(
 }
 
 /**
+ * The notes of the task's most recent review verdict, when that verdict asked
+ * for changes — i.e. the work still outstanding on its pull request.
+ *
+ * This is what makes a re-run a CONTINUATION rather than a restart. A reviewer
+ * bounce already carries its own notes into the re-run prompt; a human pressing
+ * Re-run (or re-assigning the card to the Super Agent) carried nothing, so the
+ * agent re-derived the whole task from the title and re-litigated an approach
+ * the reviewer had explicitly told it to keep. Two prod cards spent five rounds
+ * that way, one with a reviewer writing "a correção em si está CERTA — não
+ * refaça o approach" into a run that then redid it.
+ *
+ * Latest verdict wins, across cycles (a re-run's whole point is that the card
+ * left In Review). An approval as the latest verdict returns null: there is
+ * nothing outstanding to continue, so the re-run starts clean, exactly as
+ * today. Pure, so the ordering rule is unit-tested.
+ */
+export function outstandingReviewFeedback(
+  activity: ReviewCycleActivity[],
+): string | null {
+  let latest: { at: number; notes: string | null } | null = null;
+  for (const a of activity) {
+    if (
+      a.action !== "review_approved" &&
+      a.action !== "review_changes_requested"
+    ) {
+      continue;
+    }
+    const at = new Date(a.occurredAt).getTime();
+    if (latest && at <= latest.at) continue;
+    const notes = (a.data as { notes?: unknown } | null | undefined)?.notes;
+    latest = {
+      at,
+      notes:
+        a.action === "review_changes_requested" && typeof notes === "string"
+          ? notes
+          : null,
+    };
+  }
+  return latest?.notes ?? null;
+}
+
+/**
  * How many times a task may be bounced back to the Super Agent by a reviewer
  * before the loop is broken and a human takes over.
  *


### PR DESCRIPTION
## The bug

Four cards on the `deco-studio` board sat in **In Review** with nothing running and no reason visible on the card:

| Card | PR | What the board said | What actually happened |
|---|---|---|---|
| `board_iD7Zw…` | [#343](https://github.com/deco-sites/decocms-tanstack/pull/343) | "5 review bounces reached — not converging" | The PR gained no commit after 18:23. Reviewers re-reviewed the same untouched diff five times. |
| `board_8Cuy…` | [#339](https://github.com/deco-sites/decocms-tanstack/pull/339) | nothing | Both reviewers approved → merge → GitHub 405 conflict → 3 conflict-resolution "attempts" in 51s → cap → silently left for a human |
| `board__OMIC…` | [#340](https://github.com/deco-sites/decocms-tanstack/pull/340) | nothing | same |
| `board_cD2Cq…` | [#336](https://github.com/deco-sites/decocms-tanstack/pull/336) | nothing | `merge_failed { reason: "checks_failing" }` once, then silence |

All four share one root cause. `task_quota_claims.run_count` was **7, 8, 8** against `STUDIO_MAX_RUNS_PER_TASK=5`, so every *automatic* re-dispatch of the Super Agent threw `TaskQuotaError("runs_exhausted")` — and every call site handled it in a way that left the card mid-transition with no owner of the next action.

Proof that no run was dispatched: three `merge_conflict_resolution` activity rows for `board_8Cuy…` between 18:27:54 and 18:28:43, and **zero** rows in `task_board_item_threads` in that window.

## Fixes

**1. Quota exhaustion parks the card visibly instead of throwing into a log line.**
New `parkOnRunsExhausted` in `run-reactions.ts` routes a `runs_exhausted` refusal into the existing `handTaskToHuman` terminal (already used by the bounce cap and the reviewer-attempt cap): unassign, record the reason, broadcast. The bounce path in `review-decision.ts` also restores `in_review` — `claimReviewChangesBounce` had already moved the card to In Progress, and rethrowing failed an otherwise-good reviewer decision and stranded it there.

Deliberately narrow to `runs_exhausted`. The org-wide paywall reasons are still rethrown, exactly as before — only the per-task cap is a dead end a card can neither report nor escape (a human Re-run is exempt from it, which is precisely what the hand-off asks for).

**2. A failed conflict-resolution dispatch no longer burns a cap slot.**
`conflict-reaction.ts` recorded the `merge_conflict_resolution` activity *before* the enqueue, and that entry is what `conflictResolutionCapReached` counts. Moved after a dispatch that really started. Undercounting a started dispatch (if the write fails) is the safe direction: the cap bounds churn, and one extra attempt beats abandoning a mergeable PR.

## Re-run / re-assign now continues instead of restarting

Only a reviewer bounce carried its notes into the next run. A human pressing **Re-run** or re-assigning the card to the Super Agent carried nothing, so the agent re-derived the task from its title and re-litigated approaches reviewers had explicitly told it to keep — one reviewer wrote *"a correção de acessibilidade em si está CERTA e verificada — não refaça o approach"* into a run that then redid it.

New pure `outstandingReviewFeedback(activity)` in `@decocms/shared/task-board`, picked up inside `enqueueSuperAgentForTask` — the one funnel every dispatch path already shares, so both Re-run and re-assign get it with no change at either call site.

Judging the cases, as asked:

| Situation | Behavior |
|---|---|
| Open PR + latest verdict is a change request | **Continue** — carry the notes, on the pinned PR branch |
| Open PR + latest verdict is an approval | Fresh — nothing outstanding |
| No PR, or a closed/merged one | Fresh — unchanged |
| Reviewer bounce | Unchanged — it already passes its own notes |
| Conflict re-run | Unchanged — its lead outranks feedback anyway |

## Testing

- `packages/shared/src/task-board.test.ts` — 5 cases pinning the pure ordering rule (latest wins by time not array position; approval → null; carries across review cycles; non-string notes → null).
- Per `TESTING.md` this repo puts orchestration (claim fences, enqueue, real storage) in e2e, not mocked unit tests — matching `conflict-reaction.test.ts`, which pins only its bound for the same reason.
- `bun run check` ✅ · `bun run lint` 0 errors ✅ · `bun run fmt` ✅ · task-board suite 69 pass / 0 fail (the `*.integration.test.ts` failures in a full run are the usual no-Postgres ones, present on `main`).

## Follow-ups not in this PR

- `merge_failed { reason: "checks_failing" }` has **no reaction at all** — card `board_cD2Cq…`/#336 has sat on it since 18:05. Needs its own decision (dispatch a fix run? park it?).
- The four live cards still need a human Re-run to unwedge; this PR stops the next four from getting there silently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops task-board cards from stalling silently in In Review and makes Re-run/Re-assign continue with reviewer feedback. Previously, automatic re-dispatches past the per-task cap threw `runs_exhausted` and left cards mid-transition; now cards are parked with a visible reason, and re-runs continue instead of restarting.

- Quota exhaustion: `parkOnRunsExhausted` routes `runs_exhausted` to `handTaskToHuman`, and the bounce path restores `in_review` instead of failing the decision. Other paywall errors still surface unchanged.
- Conflict resolution: record `merge_conflict_resolution` activity only after a successful enqueue, and park on `runs_exhausted` so the cap counts real dispatches.
- Continuation on re-run: `enqueueSuperAgentForTask` loads `outstandingReviewFeedback` from `@decocms/shared/task-board` and carries it when dispatching onto an existing PR (unless `feedback` is already provided or `resolveConflict` is set). Approvals or no PR start fresh.
- Tests: add a real-Postgres integration test that verifies the runs-exhausted hand-off and that feedback reads correctly from stored activity; unit tests pin the ordering rule for `outstandingReviewFeedback`.
- Rollout: stuck cards still require a manual Re-run to proceed. Known gap: `merge_failed` with `reason: "checks_failing"` remains unhandled (follow-up).

<sup>Written for commit 70cd2ce2833e0bd7b1515d828e0ef8100eeffca0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

