### PR TITLE
fix(task-board): let a human re-run a card whose merge is deadlocked on a conflict

### DIFF
--- a/apps/api/src/tools/task-board/rerun-merge-pending.integration.test.ts
+++ b/apps/api/src/tools/task-board/rerun-merge-pending.integration.test.ts
@@ -136,6 +136,14 @@ describe("refuseIfMergePending", () => {
   // refusing. A `null` that fell through to "not deadlocked... so allow" would
   // re-open the very bug this guard was written for, on every read blip.
   it("still refuses when the PR's mergeability cannot be read", async () => {
+    // Re-arm the flag: the auto-merge-off case above mutates the shared org.
+    await organizationSettings.upsert(ORG, {
+      flags: {
+        auto_merge: true,
+        qa_agent_enabled: true,
+        code_reviewer_enabled: true,
+      },
+    });
     const item = await cardWithVerdicts([
       { reviewer: "qa", verified: true },
       { reviewer: "code_review", verified: true },

--- a/apps/api/src/tools/task-board/rerun-merge-pending.integration.test.ts
+++ b/apps/api/src/tools/task-board/rerun-merge-pending.integration.test.ts
@@ -131,4 +131,34 @@ describe("refuseIfMergePending", () => {
     });
     await expect(refuseIfMergePending(ctx, item)).resolves.toBeUndefined();
   });
+  // The deadlock escape must not open on a guess: with a PR linked but its
+  // mergeability unreadable (no GitHub connection in this org), the guard keeps
+  // refusing. A `null` that fell through to "not deadlocked... so allow" would
+  // re-open the very bug this guard was written for, on every read blip.
+  it("still refuses when the PR's mergeability cannot be read", async () => {
+    const item = await cardWithVerdicts([
+      { reviewer: "qa", verified: true },
+      { reviewer: "code_review", verified: true },
+    ]);
+    await taskBoard.linkPr({
+      taskBoardItemId: item.id,
+      organizationId: ORG,
+      url: "https://github.com/acme/widgets/pull/7",
+      prNumber: 7,
+      repoOwner: "acme",
+      repoName: "widgets",
+    });
+    // Cap already spent — so ONLY the unknown conflict signal keeps the refusal.
+    for (let i = 0; i < 3; i++) {
+      await taskBoard.recordActivity({
+        taskBoardItemId: item.id,
+        action: "merge_conflict_resolution",
+        actorId: null,
+        data: { prNumber: 7 },
+      });
+    }
+    await expect(refuseIfMergePending(ctx, item)).rejects.toThrow(
+      /merge is retrying/,
+    );
+  });
 });

--- a/apps/api/src/tools/task-board/rerun.test.ts
+++ b/apps/api/src/tools/task-board/rerun.test.ts
@@ -9,7 +9,7 @@
  * wedged card stays wedged; too broad and it discards a real terminal state.
  */
 import { describe, expect, test } from "bun:test";
-import { threadsToSupersede } from "./rerun";
+import { mergeDeadlocked, threadsToSupersede } from "./rerun";
 
 const thread = (threadId: string, status: string | null) => ({
   threadId,
@@ -67,5 +67,38 @@ describe("threadsToSupersede", () => {
   // take over, so the re-run is purely additive.
   test("a task with no open run supersedes nothing", () => {
     expect(threadsToSupersede({ threads: [] })).toEqual([]);
+  });
+});
+
+/**
+ * The half of `refuseIfMergePending` that is not "approved": whether a merge
+ * can still happen at all. Refusing when it cannot deadlocked three prod cards
+ * — an approved PR conflicting with its base, its conflict auto-resolution cap
+ * spent, so every poll re-attempted the same merge and got the same 405, while
+ * Re-run (the only escape) answered "its merge is retrying".
+ */
+describe("mergeDeadlocked", () => {
+  const resolutions = (n: number) =>
+    Array.from({ length: n }, () => ({
+      action: "merge_conflict_resolution",
+      occurredAt: "2026-08-13T18:28:00.000Z",
+    }));
+
+  test("is true only once a conflicting PR has spent the cap", () => {
+    expect(mergeDeadlocked(true, resolutions(3))).toBe(true);
+    expect(mergeDeadlocked(true, resolutions(2))).toBe(false);
+  });
+
+  test("is false for a PR that merges cleanly, however many resolutions it took", () => {
+    expect(mergeDeadlocked(false, resolutions(3))).toBe(false);
+  });
+
+  test("is false when mergeability is unknown — never break a merge that may be real", () => {
+    expect(mergeDeadlocked(null, resolutions(3))).toBe(false);
+  });
+
+  test("is false for a card that never conflicted at all", () => {
+    expect(mergeDeadlocked(false, [])).toBe(false);
+    expect(mergeDeadlocked(true, [])).toBe(false);
   });
 });

--- a/apps/api/src/tools/task-board/rerun.ts
+++ b/apps/api/src/tools/task-board/rerun.ts
@@ -37,7 +37,10 @@ import {
   requireAuth,
   type StudioContext,
 } from "@/core/studio-context";
-import { SUPER_AGENT_ASSIGNEE_ID } from "@decocms/shared/task-board";
+import {
+  type ReviewCycleActivity,
+  SUPER_AGENT_ASSIGNEE_ID,
+} from "@decocms/shared/task-board";
 import { TERMINAL_THREAD_STATUSES } from "@/storage/task-board";
 import { broadcastRunCancel } from "@/api/routes/decopilot/cancel-registry";
 import { cancelHostedHarness } from "@/dispatch-queue";
@@ -47,6 +50,8 @@ import { recordTaskActivity } from "./activity";
 import { emitTaskBoardUpdated } from "./run-reactions";
 import { enqueueSuperAgentForTask } from "./enqueue-super-agent";
 import { allEnabledReviewersVerifiedApproved } from "./merge-pr";
+import { fetchPrConflict, pickActivePr } from "./prs-get";
+import { conflictResolutionCapReached } from "./conflict-reaction";
 import {
   ensureTaskExecutionAllowed,
   userInitiatedTaskQuotaConfig,
@@ -139,6 +144,42 @@ async function stopSupersededRun(
 }
 
 /**
+ * True when an approved PR cannot merge and nothing automatic will change that:
+ * it definitively conflicts with its base AND the conflict auto-resolution cap
+ * is already spent, so no later poll can produce another attempt.
+ *
+ * `conflict` is GitHub's signal, `null` meaning unknown. Unknown answers false:
+ * the conservative direction protects a merge that might really be pending.
+ * Pure, so both halves of the AND are unit-tested.
+ */
+export function mergeDeadlocked(
+  conflict: boolean | null,
+  activity: ReviewCycleActivity[],
+): boolean {
+  return conflict === true && conflictResolutionCapReached(activity);
+}
+
+/** `mergeDeadlocked` over the card's live PR state. Best-effort at every seam:
+ *  a read that fails answers "not deadlocked" — the guard's prior behavior. */
+async function mergeIsDeadlocked(
+  ctx: StudioContext,
+  item: { id: string; organizationId: string },
+): Promise<boolean> {
+  const orgId = item.organizationId;
+  const prs = await ctx.storage.taskBoard
+    .listPrs(item.id, orgId)
+    .catch(() => []);
+  const pr = await pickActivePr(ctx, orgId, prs).catch(() => undefined);
+  if (!pr) return false;
+  const conflict = await fetchPrConflict(ctx, orgId, pr).catch(() => null);
+  if (conflict !== true) return false;
+  const activity = await ctx.storage.taskBoard
+    .listActivity(item.id, orgId)
+    .catch(() => []);
+  return mergeDeadlocked(conflict, activity);
+}
+
+/**
  * Refuse a re-run of a card whose merge is already queued and will retry.
  *
  * A re-run opens a NEW review cycle, and the auto-merge gate
@@ -151,6 +192,18 @@ async function stopSupersededRun(
  *
  * Narrow on purpose: a card sitting In Review WITHOUT that gate satisfied is
  * exactly the wedge this tool exists to clear, so it still re-runs.
+ *
+ * "Will retry" is the load-bearing half, and it is not implied by "approved".
+ * A PR that conflicts with its base merges only if the conflict auto-resolution
+ * dispatches — and that has an all-time cap of 3. Once the cap is spent on a
+ * conflicting PR the machine is out of moves: every poll re-reads the same
+ * approvals, re-attempts the same merge, and gets the same 405. Refusing there
+ * left three prod cards deadlocked — unmergeable by the machine and un-re-runnable
+ * by the human, which is the exact state this tool exists to break.
+ *
+ * So the refusal now requires that an automatic path to a merge still exists.
+ * An unknown mergeability (`null` — GitHub unreachable) keeps refusing: the
+ * conservative answer is the one that protects a merge that might be real.
  */
 export async function refuseIfMergePending(
   ctx: StudioContext,
@@ -167,6 +220,7 @@ export async function refuseIfMergePending(
     item.id,
   );
   if (!approved) return;
+  if (await mergeIsDeadlocked(ctx, item)) return;
   throw new Error(
     "Every reviewer approved this task and its merge is retrying — re-running " +
       "would throw that away and start a new review cycle. Wait for the merge, " +

--- a/packages/shared/src/task-board.test.ts
+++ b/packages/shared/src/task-board.test.ts
@@ -353,6 +353,17 @@ describe("outstandingReviewFeedback", () => {
     ).toBe("the newest ask");
   });
 
+  // Two verdicts recorded in the same millisecond compare equal (the storage
+  // row round-trips through a JS `Date`), so the append order decides. Getting
+  // this backwards made the real-Postgres test flake, not fail.
+  it("breaks a same-millisecond tie in favor of the later row", () => {
+    const at = "2026-01-01T01:00:00.000Z";
+    expect(outstandingReviewFeedback([approved(at), changes(at)])).toBe(
+      "fix the landmark",
+    );
+    expect(outstandingReviewFeedback([changes(at), approved(at)])).toBeNull();
+  });
+
   it("carries the latest ask across review cycles, unlike the cycle helpers", () => {
     expect(
       outstandingReviewFeedback([

--- a/packages/shared/src/task-board.ts
+++ b/packages/shared/src/task-board.ts
@@ -193,6 +193,10 @@ export function approvedButUnverified(
  * left In Review). An approval as the latest verdict returns null: there is
  * nothing outstanding to continue, so the re-run starts clean, exactly as
  * today. Pure, so the ordering rule is unit-tested.
+ *
+ * Ties go to the later element: `occurred_at` comes back through a JS `Date`,
+ * so two verdicts recorded in the same millisecond compare equal and only the
+ * activity list's own (append) order says which came second.
  */
 export function outstandingReviewFeedback(
   activity: ReviewCycleActivity[],
@@ -206,7 +210,7 @@ export function outstandingReviewFeedback(
       continue;
     }
     const at = new Date(a.occurredAt).getTime();
-    if (latest && at <= latest.at) continue;
+    if (latest && at < latest.at) continue;
     const notes = (a.data as { notes?: unknown } | null | undefined)?.notes;
     latest = {
       at,


### PR DESCRIPTION
Follow-up to #6070. That PR made the wedged cards reachable; this one removes the wall they hit next.

## The bug

Re-running any of the three stuck cards returns:

> Every reviewer approved this task and its merge is retrying — re-running would throw that away and start a new review cycle.

It isn't retrying. `refuseIfMergePending` refuses whenever *every reviewer approved* + *auto-merge is on*, on the premise that a merge is queued. That premise is false for a PR conflicting with its base once the conflict auto-resolution cap (3, all-time) is spent — every poll re-reads the same approvals, re-attempts the same merge, and gets the same `405 Pull Request has merge conflicts`.

Live state right now:

| PR | mergeable | conflict resolutions used |
|---|---|---|
| [#336](https://github.com/deco-sites/decocms-tanstack/pull/336) | `CONFLICTING` / DIRTY | — |
| [#339](https://github.com/deco-sites/decocms-tanstack/pull/339) | `CONFLICTING` / DIRTY | 3 / 3 |
| [#340](https://github.com/deco-sites/decocms-tanstack/pull/340) | `CONFLICTING` / DIRTY | 3 / 3 |

Unmergeable by the machine, un-re-runnable by the human. That is precisely the wedge `TASK_BOARD_ITEM_RERUN` exists to break — its own doc comment says *"a card sitting In Review WITHOUT that gate satisfied is exactly the wedge this tool exists to clear"*. The gap is that the gate being *satisfied* isn't the same as the merge being *possible*.

## The fix

The refusal now also requires that an automatic path to a merge still exists:

```ts
if (await mergeIsDeadlocked(ctx, item)) return;   // let the human through
throw new Error("…its merge is retrying…");
```

`mergeDeadlocked(conflict, activity)` is pure and exported: `conflict === true && conflictResolutionCapReached(activity)`.

The `null` case is the one that matters. An unknown mergeability (GitHub unreachable, unreadable PR) answers **false** — it keeps refusing. Opening the escape hatch on a read blip would re-introduce the exact bug this guard was written for (`board_pA_7SsIEhMmcStEcAidCs`: a rate-limited merge discarded by a re-run, then five bounces). Every seam in the async wrapper catches to "not deadlocked" for the same reason.

While the cap still has attempts left, the refusal stands — the machine really will try again.

## Testing

Run against a real Postgres on a local k3s cluster (isolated database, dropped afterwards): **350 pass / 0 fail** across the task-board suite.

- 4 pure cases on `mergeDeadlocked` (cap boundary, clean PR, unknown mergeability, never-conflicted).
- 1 real-Postgres case: a card with a linked PR whose mergeability can't be read **still refuses**, even with the cap spent — so only the unknown signal is holding the refusal up.

Mutation-tested to confirm the assertions bite:

| Mutation | Result |
|---|---|
| `conflict !== false` (treat unknown as deadlocked) | ✅ 3 cases fail |
| Drop the cap requirement | ✅ 2 cases fail |

The real DB also caught a flaw in my own first draft: the preceding case in that file flips `auto_merge` off on the shared org, so my test short-circuited before reaching the logic and passed vacuously. Fixed by re-arming the flag in the test.

## Still open

`merge_failed { reason: "checks_failing" }` has no reaction (card `board_cD2Cq…`/#336 — which is *also* conflicting, so this PR unblocks its re-run either way). Unchanged from #6070's follow-up list.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets a human re-run an approved card when its PR is deadlocked on a merge conflict, and fixes verdict ordering to resolve a rare test flake. Previously any approved card with auto-merge on refused re-run; now refusal only applies when an automatic merge path still exists. Unknown mergeability continues to refuse to protect real pending merges.

- `refuseIfMergePending` now checks for a conflict deadlock (conflict true + cap spent) and allows re-run when detected; keeps refusing when mergeability is unknown.
- Adds pure `mergeDeadlocked` and best-effort `mergeIsDeadlocked` (defaults to “not deadlocked” on read failures).
- In `@decocms/shared/task-board`, `outstandingReviewFeedback` now breaks same-millisecond verdict ties in favor of the later row.
- Tests: unit coverage for deadlock logic; integration case confirming unreadable mergeability still refuses; fixes an order-dependent case by re-arming `auto_merge` in the shared org.

No migration required; behavior only changes for conflict-deadlocked PRs and verdict tie cases.

<sup>Written for commit 2a520714d0dfd8f6faf71b9e737823d60d2f1d19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

