### PR TITLE
fix(sections-editor): keep the edited array item pinned when its label is nested

### DIFF
--- a/apps/web/ct/tests/array-nested-label-duplicate.ct.tsx
+++ b/apps/web/ct/tests/array-nested-label-duplicate.ct.tsx
@@ -1,0 +1,158 @@
+import { expect, test } from "@playwright/experimental-ct-react";
+import type { Locator } from "@playwright/test";
+import { SchemaFormHarness } from "../harness/schema-form-harness";
+import { sectionWithProps, TEST_RESOLVE_TYPE } from "../harness/fixtures";
+import {
+  openRowActionsMenu,
+  readBreadcrumb,
+  readFormValue,
+} from "../harness/ct-utils";
+
+const itemRow = (component: Locator, label: string) =>
+  component.getByRole("button").filter({ hasText: label });
+
+/**
+ * Reproduces "duplicate a SEO description, edit it, and it snaps back to the one
+ * it was duplicated from". The DescriptionSEOPLP rows read `/feminino$`, `/ab$`,
+ * … from a URL matcher nested TWO levels deep (a `matchers` array inside each
+ * item), so the item's `titleBy` reads `matcher.matchers.0.pattern`. Duplicating
+ * clones that derived label; editing the deep matcher of the copy churns it —
+ * and its crumb's re-sync races the nested trail rebuild — so resolution used to
+ * fall back to a label search and snap to the first colliding item (the
+ * original). Both must keep the editor pinned to the item being edited.
+ */
+const seoArrayProps = {
+  seoDescriptions: {
+    type: "array",
+    title: "Descrições para SEO",
+    items: {
+      type: "object",
+      title: "SEO Description",
+      titleBy: "{{{matcher.matchers.0.pattern}}}",
+      properties: {
+        matcher: {
+          type: "object",
+          title: "Configuração de exibição",
+          properties: {
+            matchers: {
+              type: "array",
+              title: "Matchers",
+              items: {
+                type: "object",
+                title: "Padrão de URL",
+                titleBy: "{{{pattern}}}",
+                properties: {
+                  pattern: { type: "string", title: "Padrão de URL" },
+                },
+              },
+            },
+          },
+        },
+        description: { type: "string", title: "Descrição" },
+      },
+    },
+  },
+};
+
+const seoItem = (pattern: string, description: string) => ({
+  matcher: { matchers: [{ pattern }] },
+  description,
+});
+
+/** Open the item row `label`, expand its matcher section, open the matcher row. */
+const drillToPattern = async (component: Locator, label: string, nth = 0) => {
+  await itemRow(component, label).nth(nth).click();
+  await itemRow(component, "Configuração de exibição").click();
+  await itemRow(component, label).click();
+};
+
+test("duplicate a deeply-labelled item, edit the copy's matcher — stays on the copy", async ({
+  mount,
+  page,
+}) => {
+  const meta = sectionWithProps(seoArrayProps);
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{ seoDescriptions: [seoItem("/feminino$", "orig")] }}
+    />,
+  );
+
+  await openRowActionsMenu(component, "/feminino$");
+  await page.getByRole("menuitem", { name: "Duplicate" }).click();
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({
+      seoDescriptions: [
+        seoItem("/feminino$", "orig"),
+        seoItem("/feminino$", "orig"),
+      ],
+    });
+
+  // Open the COPY (second row) and rename its matcher pattern.
+  await drillToPattern(component, "/feminino$", 1);
+  const patternInput = component.getByLabel("Padrão de URL");
+  await expect(patternInput).toHaveAttribute(
+    "id",
+    "seoDescriptions.1.matcher.matchers.0.pattern",
+  );
+  await patternInput.fill("/nova$");
+
+  // Editing stays on the copy (index 1), not snapped to the original (index 0).
+  await expect(component.getByLabel("Padrão de URL")).toHaveAttribute(
+    "id",
+    "seoDescriptions.1.matcher.matchers.0.pattern",
+  );
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({
+      seoDescriptions: [
+        seoItem("/feminino$", "orig"),
+        seoItem("/nova$", "orig"),
+      ],
+    });
+
+  // Item crumb tracks the edit; it must not freeze at the duplicated-from label.
+  await expect
+    .poll(() => readBreadcrumb(component))
+    .not.toContain("/feminino$");
+});
+
+test("editing a deeply-labelled item's matcher to collide with an existing item stays put", async ({
+  mount,
+}) => {
+  const meta = sectionWithProps(seoArrayProps);
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{
+        seoDescriptions: [
+          seoItem("/feminino$", "a"),
+          seoItem("/masculino$", "b"),
+        ],
+      }}
+    />,
+  );
+
+  await drillToPattern(component, "/masculino$");
+  const patternInput = component.getByLabel("Padrão de URL");
+  await expect(patternInput).toHaveAttribute(
+    "id",
+    "seoDescriptions.1.matcher.matchers.0.pattern",
+  );
+
+  await patternInput.fill("/feminino$");
+
+  // Renamed to collide with item 0 — must stay on index 1, not snap to index 0.
+  await expect(component.getByLabel("Padrão de URL")).toHaveAttribute(
+    "id",
+    "seoDescriptions.1.matcher.matchers.0.pattern",
+  );
+  await expect
+    .poll(() => readFormValue(component))
+    .toEqual({
+      seoDescriptions: [seoItem("/feminino$", "a"), seoItem("/feminino$", "b")],
+    });
+});

--- a/apps/web/ct/tests/array-nested-label-duplicate.ct.tsx
+++ b/apps/web/ct/tests/array-nested-label-duplicate.ct.tsx
@@ -113,10 +113,9 @@ test("duplicate a deeply-labelled item, edit the copy's matcher — stays on the
       ],
     });
 
-  // Item crumb tracks the edit; it must not freeze at the duplicated-from label.
-  await expect
-    .poll(() => readBreadcrumb(component))
-    .not.toContain("/feminino$");
+  // Item crumb re-syncs to the edit (positive check: an empty trail passes .not).
+  await expect.poll(() => readBreadcrumb(component)).toContain("/nova$");
+  expect(await readBreadcrumb(component)).not.toContain("/feminino$");
 });
 
 test("editing a deeply-labelled item's matcher to collide with an existing item stays put", async ({

--- a/apps/web/src/components/sections-editor/fields/array-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/array-field.tsx
@@ -36,7 +36,6 @@ import {
 import { isEmbeddedUnionResolveType } from "../block-type-utils";
 import {
   buildArrayDrillDownBreadcrumb,
-  findBreadcrumbLabelIndex,
   resolveArrayItemSelection,
 } from "../schema-form-breadcrumb";
 import { isSectionArrayField } from "../section-array-field";
@@ -181,6 +180,16 @@ export function ArrayField({
   const [prevListKey, setPrevListKey] = useState(path);
   const [prevItemCount, setPrevItemCount] = useState(items.length);
   const suppressClickRef = useRef(false);
+  /**
+   * The open item's freshest display label, stashed by `updateItem` so the
+   * nested-field breadcrumb rebuild (`arrayItemPrefix`) can carry it before the
+   * edited value re-renders this array — otherwise the item crumb keeps the
+   * label it had at drill-in time (the duplicated-from value the user saw stuck
+   * in the breadcrumb). Scoped by index so it's ignored once selection moves.
+   */
+  const openItemLabelRef = useRef<{ index: number; label: string } | null>(
+    null,
+  );
 
   if (prevListKey !== path) {
     setPrevListKey(path);
@@ -329,6 +338,7 @@ export function ArrayField({
     if (index === selectedIndex && selection) {
       const oldLabel = itemLabel(items[index], index);
       const newLabel = itemLabel(next[index], index);
+      openItemLabelRef.current = { index, label: newLabel };
       if (oldLabel !== newLabel) {
         const updatedBreadcrumb = [...breadcrumbPath];
         const existing = breadcrumbPath[selection.crumbIndex];
@@ -403,20 +413,40 @@ export function ArrayField({
       containerResolveType,
       arrayFieldKey,
     );
+    /**
+     * Trail prefix through the open item's own crumb — the base that nested
+     * fields prepend their breadcrumb changes onto.
+     *
+     * Locate that crumb by INDEX (`selection.crumbIndex`), never by a label
+     * lookup: a churning or duplicate label matches the wrong crumb — a
+     * colliding sibling, or a same-labelled nested crumb — and strands the
+     * prefix, snapping the editor back to the item the open one was duplicated
+     * from. Refresh its label from `openItemLabelRef` (the fresh value stashed
+     * by `updateItem` this same edit, before the new value re-renders here) so
+     * the crumb tracks the item instead of freezing at its drill-in label.
+     */
     const arrayItemPrefix = () => {
-      const itemName = itemLabel(item, selectedIndex);
-      const trail = buildArrayDrillDownBreadcrumb(
-        breadcrumbPath,
-        label,
-        itemName,
-        selectedIndex,
-        drillDownOpts,
-      );
-      const itemIndex = findBreadcrumbLabelIndex(trail, itemName);
-      if (itemIndex >= 0) {
-        return trail.slice(0, itemIndex + 1);
+      if (!selection) {
+        return buildArrayDrillDownBreadcrumb(
+          breadcrumbPath,
+          label,
+          itemLabel(item, selectedIndex),
+          selectedIndex,
+          drillDownOpts,
+        );
       }
-      return trail;
+      const prefix = breadcrumbPath.slice(0, selection.crumbIndex + 1);
+      const stashed = openItemLabelRef.current;
+      const freshLabel =
+        stashed?.index === selectedIndex
+          ? stashed.label
+          : itemLabel(item, selectedIndex);
+      const crumb = prefix[selection.crumbIndex];
+      prefix[selection.crumbIndex] =
+        crumb != null && typeof crumb === "object"
+          ? { ...crumb, label: freshLabel, itemIndex: selectedIndex }
+          : { label: freshLabel, itemIndex: selectedIndex };
+      return prefix;
     };
 
     return (

--- a/apps/web/src/components/sections-editor/fields/array-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/array-field.tsx
@@ -37,6 +37,7 @@ import { isEmbeddedUnionResolveType } from "../block-type-utils";
 import {
   buildArrayDrillDownBreadcrumb,
   resolveArrayItemSelection,
+  withItemCrumbLabel,
 } from "../schema-form-breadcrumb";
 import { isSectionArrayField } from "../section-array-field";
 import {
@@ -185,11 +186,14 @@ export function ArrayField({
    * nested-field breadcrumb rebuild (`arrayItemPrefix`) can carry it before the
    * edited value re-renders this array — otherwise the item crumb keeps the
    * label it had at drill-in time (the duplicated-from value the user saw stuck
-   * in the breadcrumb). Scoped by index so it's ignored once selection moves.
+   * in the breadcrumb). Keyed by `path` + `index` so a reused instance driving a
+   * different array (or a different open row) never serves a foreign label.
    */
-  const openItemLabelRef = useRef<{ index: number; label: string } | null>(
-    null,
-  );
+  const openItemLabelRef = useRef<{
+    path: string;
+    index: number;
+    label: string;
+  } | null>(null);
 
   if (prevListKey !== path) {
     setPrevListKey(path);
@@ -338,16 +342,14 @@ export function ArrayField({
     if (index === selectedIndex && selection) {
       const oldLabel = itemLabel(items[index], index);
       const newLabel = itemLabel(next[index], index);
-      openItemLabelRef.current = { index, label: newLabel };
+      openItemLabelRef.current = { path, index, label: newLabel };
       if (oldLabel !== newLabel) {
         const updatedBreadcrumb = [...breadcrumbPath];
-        const existing = breadcrumbPath[selection.crumbIndex];
-        // Preserve the crumb's `arrayLabel` disambiguator (if any) — only the
-        // display label changed, not which array this item belongs to.
-        updatedBreadcrumb[selection.crumbIndex] =
-          existing != null && typeof existing === "object"
-            ? { ...existing, label: newLabel, itemIndex: index }
-            : { label: newLabel, itemIndex: index };
+        updatedBreadcrumb[selection.crumbIndex] = withItemCrumbLabel(
+          breadcrumbPath[selection.crumbIndex],
+          newLabel,
+          index,
+        );
         onBreadcrumbChange?.(updatedBreadcrumb);
       }
     }
@@ -438,14 +440,14 @@ export function ArrayField({
       const prefix = breadcrumbPath.slice(0, selection.crumbIndex + 1);
       const stashed = openItemLabelRef.current;
       const freshLabel =
-        stashed?.index === selectedIndex
+        stashed?.path === path && stashed.index === selectedIndex
           ? stashed.label
           : itemLabel(item, selectedIndex);
-      const crumb = prefix[selection.crumbIndex];
-      prefix[selection.crumbIndex] =
-        crumb != null && typeof crumb === "object"
-          ? { ...crumb, label: freshLabel, itemIndex: selectedIndex }
-          : { label: freshLabel, itemIndex: selectedIndex };
+      prefix[selection.crumbIndex] = withItemCrumbLabel(
+        prefix[selection.crumbIndex],
+        freshLabel,
+        selectedIndex,
+      );
       return prefix;
     };
 

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -9,7 +9,6 @@ import {
   crumbLabel,
   headerBackTargetIndex,
   fieldDisplayLabel,
-  findBreadcrumbLabelIndex,
   isArrayDrillDownField,
   normalizeBreadcrumbLabel,
   objectSiblingsNeedingAncestorCrumb,
@@ -65,14 +64,6 @@ describe("headerBackTargetIndex", () => {
     expect(headerBackTargetIndex(3, { isMultivariateSectionTop: true })).toBe(
       0,
     );
-  });
-});
-
-describe("findBreadcrumbLabelIndex", () => {
-  test("matches labels with NFC normalization", () => {
-    const nfd = "cafe\u0301";
-    const nfc = "caf\u00e9";
-    expect(findBreadcrumbLabelIndex(["Flag", nfd], nfc)).toBe(1);
   });
 });
 
@@ -1214,6 +1205,60 @@ describe("resolveArrayItemSelection", () => {
           5,
         ),
       ).toEqual({ index: 1, innerPath: [], crumbIndex: 0 });
+    });
+
+    test("open-row pin: a stale crumb label sticks to the open row, not a colliding sibling", () => {
+      /**
+       * The crumb carries the OLD label ("Men's") because a deep re-sync hasn't
+       * reached it, but items[1] already holds the edited value. A label search
+       * would snap to the colliding sibling at index 0 (the bug); the open-row
+       * pin (preferredIndex === itemIndex) keeps selection on 1.
+       */
+      const edited = [{ title: "Men's" }, { title: "Men's edited" }];
+      expect(
+        resolveArrayItemSelection(
+          "Cards",
+          [{ label: "Men's", itemIndex: 1 }],
+          edited,
+          itemSchema,
+          1,
+        ),
+      ).toEqual({ index: 1, innerPath: [], crumbIndex: 0 });
+    });
+
+    test("open-row pin holds the last of three colliding items (label search would pick the first)", () => {
+      /**
+       * With three identical labels the last-resort search always returns 0, so
+       * the index pin is the ONLY thing keeping selection on the edited row.
+       */
+      const triple = [{ title: "x" }, { title: "x" }, { title: "edited" }];
+      expect(
+        resolveArrayItemSelection(
+          "Cards",
+          [{ label: "x", itemIndex: 2 }],
+          triple,
+          itemSchema,
+          2,
+        ),
+      ).toEqual({ index: 2, innerPath: [], crumbIndex: 0 });
+    });
+
+    test("open-row pin does NOT fire when preferredIndex differs from the crumb index", () => {
+      /**
+       * A genuine shift: the crumb's stale label still matches item 0, and the
+       * open row (0) is not the crumb's index (1). The label match must win, so
+       * selection lands on the real owner rather than blindly on the crumb index.
+       */
+      const shifted = [{ title: "A" }, { title: "B" }];
+      expect(
+        resolveArrayItemSelection(
+          "Cards",
+          [{ label: "A", itemIndex: 1 }],
+          shifted,
+          itemSchema,
+          0,
+        ),
+      ).toEqual({ index: 0, innerPath: [], crumbIndex: 0 });
     });
   });
 });

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -38,6 +38,23 @@ function crumbArrayLabel(crumb: Crumb): string | undefined {
   return isItemCrumb(crumb) ? crumb.arrayLabel : undefined;
 }
 
+/**
+ * Rewrite an array-item crumb's display label at `itemIndex`, preserving any
+ * `arrayLabel` disambiguator on the existing crumb. `existing` may be undefined
+ * or (defensively) a plain string; either way a fresh item crumb is returned.
+ * The single place crumb shape is (re)built for a label change — used by both
+ * `ArrayField.updateItem` (label edit) and `ArrayField.arrayItemPrefix`.
+ */
+export function withItemCrumbLabel(
+  existing: Crumb | undefined,
+  label: string,
+  itemIndex: number,
+): Crumb {
+  return existing != null && typeof existing === "object"
+    ? { ...existing, label, itemIndex }
+    : { label, itemIndex };
+}
+
 function humanize(key: string): string {
   return key
     .replace(/([a-z])([A-Z])/g, "$1 $2")
@@ -261,16 +278,6 @@ export function breadcrumbsForHeaderClick(
 ): Crumb[] {
   if (headerIndex <= 0) return [];
   return breadcrumbs.slice(0, headerIndex);
-}
-
-export function findBreadcrumbLabelIndex(
-  path: Crumb[],
-  targetLabel: string,
-): number {
-  const normalized = normalizeBreadcrumbLabel(targetLabel);
-  return path.findIndex(
-    (crumb) => normalizeBreadcrumbLabel(crumbLabel(crumb)) === normalized,
-  );
 }
 
 /** Breadcrumb drill-down applies to array fields only (not nested objects). */

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -709,7 +709,24 @@ function findItemIndexForCrumb(
   ) {
     return crumb.itemIndex;
   }
-  // Churn-window fallback: keep the open row while its label is mid-edit.
+  /**
+   * Open-row pin: the crumb still addresses the row the user has open, but its
+   * label lags `items[itemIndex]` mid-edit — e.g. a titleBy driven by a field
+   * being typed, or a value edited deep in a nested array whose label re-sync
+   * races the nested trail rebuild. The index is the source of truth (the label
+   * is display-only), so trust it rather than fall through to the label search
+   * below, which would snap to a colliding sibling (the duplicated-item
+   * "original").
+   */
+  if (
+    preferredIndex != null &&
+    preferredIndex === crumb.itemIndex &&
+    preferredIndex >= 0 &&
+    preferredIndex < items.length
+  ) {
+    return preferredIndex;
+  }
+  // Churn-window fallback: the item shifted but its label still matches the open row.
   const preferred = preferredIndex != null ? labels[preferredIndex] : undefined;
   if (preferred !== undefined && labelsMatch(preferred, crumb.label)) {
     return preferredIndex!;


### PR DESCRIPTION
## Summary

Fixes the reported DescriptionSEOPLP bug: duplicating a SEO description, opening the copy, and editing its URL matcher snapped the editor back to the item it was duplicated from — and left the item's breadcrumb crumb frozen at the duplicated-from label (`/feminino$`) while the matcher already showed the new value.

The row's label is derived from a matcher nested **two levels deep** (a `matchers` array inside each item), so editing it churns the item's derived label, and its crumb re-sync races the nested-field trail rebuild. Two label lookups the earlier #5853 fix left untouched caused it:

- **`arrayItemPrefix`** (array-field.tsx) rebuilt the open item's crumb via `findBreadcrumbLabelIndex` — a label lookup reading a lagging closure — so a churning/duplicate label matched the wrong crumb and clobbered `updateItem`'s fresh re-sync. Now it locates the crumb **by index** (`selection.crumbIndex`) and refreshes its label from a ref stashed by `updateItem` the same edit, so the crumb tracks the item instead of freezing at its drill-in label.
- **`findItemIndexForCrumb`** (schema-form-breadcrumb.ts) then failed its label-gated exact-pin and fell through to a label search that returns the **first** colliding item (the original). Added an **open-row pin**: trust the crumb's `itemIndex` when it equals the open row — the index is the source of truth, the label is display-only.

Same index-over-label move as #5853, applied to the two sites it missed.

## Testing

- New `apps/web/ct/tests/array-nested-label-duplicate.ct.tsx` drives the real `ArrayField` through duplicate → open copy → edit nested matcher. Both cases **fail without the fix** (confirmed via stash) and assert the editor stays on the copy and the crumb tracks the edited label.
- `bun run test:ct` — 198 pass (incl. the existing `array-object-drilldown` suite).
- `bun test apps/web/src/components/sections-editor/` — 623 pass.
- `bunx tsc --noEmit`, `oxlint`, `knip`, `bun run fmt` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the Sections Editor pinned to the edited array item when its label is nested. Previously, after duplicating a SEO description and editing the copy’s URL matcher, the editor jumped to the original and the breadcrumb froze at the old label; now it stays on the copy and the crumb updates.

**Reviewer notes**
- ArrayField: address the open item’s crumb by index (`selection.crumbIndex`) and refresh its label from a ref keyed by `path`+`index` set during `updateItem`; build the nested trail prefix by index and drop the label lookup path. Deduplicate crumb-label writes via `withItemCrumbLabel`.
- schema-form-breadcrumb: add an open-row pin in `findItemIndexForCrumb` that trusts `crumb.itemIndex` when it matches the preferred index; remove `findBreadcrumbLabelIndex`. Export `withItemCrumbLabel` for single-owner crumb shape updates.
- Tests: add `apps/web/ct/tests/array-nested-label-duplicate.ct.tsx` and strengthen its breadcrumb assertion to a positive check; add three unit tests covering the index pin and collision cases in `schema-form-breadcrumb.test.ts`.

<sup>Written for commit 651cb485e69200b18e0f93d30e2bf701929d88f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

