### PR TITLE
fix(sections-editor): reset scroll when switching editor views

### DIFF
--- a/apps/web/src/components/sections-editor/sections-editor.tsx
+++ b/apps/web/src/components/sections-editor/sections-editor.tsx
@@ -2673,7 +2673,10 @@ export function SectionsEditor({
 
       {/* Drill-down: SEO form, section form, or section list */}
       {editingSeo ? (
-        <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
+        <ScrollArea
+          key="editor-seo"
+          className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block"
+        >
           <div className="min-w-0 max-w-full overflow-x-hidden px-6 py-4">
             <div className="mx-auto max-w-2xl">
               {pageData && activePageKey ? (
@@ -2702,6 +2705,7 @@ export function SectionsEditor({
         </ScrollArea>
       ) : isEditing ? (
         <ScrollArea
+          key="editor-section-form"
           viewportRef={fieldScrollRef}
           className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block"
         >
@@ -2780,6 +2784,7 @@ export function SectionsEditor({
         </ScrollArea>
       ) : isGlobalBlockMode ? (
         <ScrollArea
+          key="editor-global-block"
           viewportRef={fieldScrollRef}
           className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block"
         >
@@ -2802,7 +2807,10 @@ export function SectionsEditor({
           />
         </ScrollArea>
       ) : (
-        <ScrollArea className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block">
+        <ScrollArea
+          key="editor-section-list"
+          className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block"
+        >
           {/* Variant selector (when page sections are multivariate) */}
           {hasMultipleVariants && activePageKey && (
             <PageVariantTabs


### PR DESCRIPTION
## Summary

Fixes a scroll bug in the page editor's section panel: scrolling the section list to the bottom and then selecting a section left the newly-opened form scrolled to the bottom instead of at the top.

**Root cause:** the editor panel body is a ternary chain where all four states (SEO form, section form, global block, section list) render `<ScrollArea>` at the same position in the tree. React's reconciler preserved the same viewport DOM node — including its `scrollTop` — when switching between branches, so the list's bottom offset bled straight into the form view. The existing scroll reset (`sections-editor.tsx`) only fires when breadcrumb *depth* changes, which stays `0` on a list→form selection, so it never triggered for this case.

**Fix:** give each branch's `ScrollArea` a distinct React `key` (`editor-seo`, `editor-section-form`, `editor-global-block`, `editor-section-list`). Distinct keys force React to mount a fresh viewport (scrollTop 0) per view, so every view starts at the top and scroll no longer bleeds between the list and the form in either direction.

## Testing notes

- `bun run fmt` — no changes
- `bun run --cwd=apps/web check` — passes

Manual: scroll the section list to the bottom, select a section → the form now opens at the top.

## Note

Because the list and form are now separate DOM nodes that remount on switch, returning to the list also resets it to the top (previously it sometimes preserved position *by accident*, via the same scroll bleed). Preserving the list's scroll position on return is possible but requires keeping the list mounted (hidden), which is more invasive — happy to follow up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resets the sections editor scroll when switching views by remounting each view’s `ScrollArea`. Previously, opening a form after scrolling the section list kept the bottom offset; now every view starts at the top, and returning to the list also resets to the top.

- Adds distinct React keys to each `ScrollArea` branch: `editor-seo`, `editor-section-form`, `editor-global-block`, `editor-section-list`, forcing a fresh viewport per view and avoiding reconciler scroll bleed.
- Manual check: scroll the section list to the bottom, select a section → the form opens at the top; navigate back → the list starts at the top.
- No API or migration changes.

<sup>Written for commit 5c48a51d5e7f897e20f933ca1875e6ed3d23cd65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

