### PR TITLE
fix(task-board): bound the re-run merge guard, and surface its refusal in the UI

### DIFF
--- a/apps/api/src/tools/task-board/rerun-merge-pending.integration.test.ts
+++ b/apps/api/src/tools/task-board/rerun-merge-pending.integration.test.ts
@@ -169,4 +169,20 @@ describe("refuseIfMergePending", () => {
       /merge is retrying/,
     );
   });
+
+  // The bound on that same conservatism. A merge blocked by anything the
+  // deadlock check can't see — a failing required check, branch protection —
+  // retries every sweep forever, and the card was un-re-runnable the whole
+  // time. Aged rows rather than a fake clock: the guard reads `now()`.
+  it("allows a re-run once the merge has been retrying past the grace window", async () => {
+    const item = await cardWithVerdicts([
+      { reviewer: "qa", verified: true },
+      { reviewer: "code_review", verified: true },
+    ]);
+    await sql`
+      UPDATE task_board_activity SET occurred_at = now() - interval '30 minutes'
+      WHERE task_board_item_id = ${item.id}
+    `.execute(database.db);
+    await expect(refuseIfMergePending(ctx, item)).resolves.toBeUndefined();
+  });
 });

--- a/apps/api/src/tools/task-board/rerun.test.ts
+++ b/apps/api/src/tools/task-board/rerun.test.ts
@@ -9,7 +9,11 @@
  * wedged card stays wedged; too broad and it discards a real terminal state.
  */
 import { describe, expect, test } from "bun:test";
-import { mergeDeadlocked, threadsToSupersede } from "./rerun";
+import {
+  mergeDeadlocked,
+  mergeRetryExpired,
+  threadsToSupersede,
+} from "./rerun";
 
 const thread = (threadId: string, status: string | null) => ({
   threadId,
@@ -100,5 +104,61 @@ describe("mergeDeadlocked", () => {
   test("is false for a card that never conflicted at all", () => {
     expect(mergeDeadlocked(false, [])).toBe(false);
     expect(mergeDeadlocked(true, [])).toBe(false);
+  });
+});
+
+/**
+ * The bound on the same refusal, for every way a merge stays stuck that
+ * `mergeDeadlocked` cannot see (a failing required check, branch protection, a
+ * base branch that moved). Those still hit the refusal in prod after the
+ * conflict fix shipped: approved, unmergeable, and un-re-runnable.
+ */
+describe("mergeRetryExpired", () => {
+  const NOW = Date.parse("2026-08-13T18:00:00.000Z");
+  const ago = (ms: number) => new Date(NOW - ms).toISOString();
+  const MINUTE = 60 * 1000;
+  const inReview = (at: string) => ({
+    action: "status_changed",
+    data: { to: "in_review" },
+    occurredAt: at,
+  });
+  const approved = (at: string) => ({
+    action: "review_approved",
+    data: { reviewer: "qa", verified: true },
+    occurredAt: at,
+  });
+
+  test("protects a merge that is plausibly one sweep tick away", () => {
+    expect(
+      mergeRetryExpired(
+        [inReview(ago(12 * MINUTE)), approved(ago(MINUTE))],
+        NOW,
+      ),
+    ).toBe(false);
+  });
+
+  test("expires once the merge has had its sweep attempts and lost", () => {
+    expect(
+      mergeRetryExpired(
+        [inReview(ago(30 * MINUTE)), approved(ago(20 * MINUTE))],
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  // An approval from a PREVIOUS cycle is not evidence this one is shipping.
+  test("ignores approvals recorded before the current review cycle", () => {
+    expect(
+      mergeRetryExpired(
+        [approved(ago(60 * MINUTE)), inReview(ago(MINUTE))],
+        NOW,
+      ),
+    ).toBe(true);
+  });
+
+  // No approval to read at all (activity unreadable) — the human is here and
+  // the machine has shown nothing, so the re-run wins.
+  test("expires when there is no approval to read", () => {
+    expect(mergeRetryExpired([], NOW)).toBe(true);
   });
 });

--- a/apps/api/src/tools/task-board/rerun.ts
+++ b/apps/api/src/tools/task-board/rerun.ts
@@ -39,6 +39,7 @@ import {
 } from "@/core/studio-context";
 import {
   type ReviewCycleActivity,
+  reviewCycleStart,
   SUPER_AGENT_ASSIGNEE_ID,
 } from "@decocms/shared/task-board";
 import { TERMINAL_THREAD_STATUSES } from "@/storage/task-board";
@@ -164,6 +165,7 @@ export function mergeDeadlocked(
 async function mergeIsDeadlocked(
   ctx: StudioContext,
   item: { id: string; organizationId: string },
+  activity: ReviewCycleActivity[],
 ): Promise<boolean> {
   const orgId = item.organizationId;
   const prs = await ctx.storage.taskBoard
@@ -172,11 +174,48 @@ async function mergeIsDeadlocked(
   const pr = await pickActivePr(ctx, orgId, prs).catch(() => undefined);
   if (!pr) return false;
   const conflict = await fetchPrConflict(ctx, orgId, pr).catch(() => null);
-  if (conflict !== true) return false;
-  const activity = await ctx.storage.taskBoard
-    .listActivity(item.id, orgId)
-    .catch(() => []);
   return mergeDeadlocked(conflict, activity);
+}
+
+/**
+ * How long an approved card may sit unmerged before a human's Re-run outranks
+ * the merge retry. Three item-sweep ticks (`DEFAULT_ITEM_SWEEP_INTERVAL_MS` is
+ * 5 minutes), so the merge has had its attempts and lost.
+ */
+const MERGE_RETRY_GRACE_MS = 15 * 60 * 1000;
+
+/**
+ * True when the approved merge has had long enough that "it is retrying" has
+ * stopped being an explanation.
+ *
+ * `mergeDeadlocked` enumerates ONE way the retry can never succeed — a spent
+ * conflict cap. The refusal still fires on every other one, and they are not
+ * enumerable from here: a failing required check, a branch-protection rule the
+ * App can't satisfy, a draft PR, a base branch that moved. Each of those makes
+ * the sweep re-attempt the same merge every 5 minutes forever, and the human
+ * pressing Re-run is the only thing that can break it — which is exactly the
+ * wedge this tool exists to clear.
+ *
+ * So the refusal is bounded rather than made smarter: it protects the merge
+ * that is genuinely one tick from shipping, and gets out of the way once the
+ * card has been approved-and-unmerged for `MERGE_RETRY_GRACE_MS`. No approval
+ * timestamp at all (unreadable activity) reads as expired for the same reason —
+ * the human is here and the machine has shown nothing.
+ *
+ * Pure, so the boundary is unit-tested.
+ */
+export function mergeRetryExpired(
+  activity: ReviewCycleActivity[],
+  nowMs: number,
+): boolean {
+  const cycleStart = reviewCycleStart(activity);
+  let latestApproval = 0;
+  for (const a of activity) {
+    if (a.action !== "review_approved") continue;
+    const at = new Date(a.occurredAt).getTime();
+    if (at >= cycleStart) latestApproval = Math.max(latestApproval, at);
+  }
+  return nowMs - latestApproval >= MERGE_RETRY_GRACE_MS;
 }
 
 /**
@@ -203,7 +242,10 @@ async function mergeIsDeadlocked(
  *
  * So the refusal now requires that an automatic path to a merge still exists.
  * An unknown mergeability (`null` — GitHub unreachable) keeps refusing: the
- * conservative answer is the one that protects a merge that might be real.
+ * conservative answer is the one that protects a merge that might be real —
+ * but only until `mergeRetryExpired`, which is what keeps the un-enumerable
+ * ways a merge stays stuck (failing checks, branch protection) from wedging the
+ * card the same way the conflict cap did.
  */
 export async function refuseIfMergePending(
   ctx: StudioContext,
@@ -220,7 +262,11 @@ export async function refuseIfMergePending(
     item.id,
   );
   if (!approved) return;
-  if (await mergeIsDeadlocked(ctx, item)) return;
+  const activity = await ctx.storage.taskBoard
+    .listActivity(item.id, item.organizationId)
+    .catch(() => []);
+  if (mergeRetryExpired(activity, Date.now())) return;
+  if (await mergeIsDeadlocked(ctx, item, activity)) return;
   throw new Error(
     "Every reviewer approved this task and its merge is retrying — re-running " +
       "would throw that away and start a new review cycle. Wait for the merge, " +

--- a/apps/web/src/i18n/en/task-board.ts
+++ b/apps/web/src/i18n/en/task-board.ts
@@ -47,6 +47,7 @@ export const taskBoard = {
   "taskBoard.taskBoard.dueDateButton": "Due date",
   "taskBoard.taskBoard.addTagButton": "Add tag",
   "taskBoard.taskBoard.deleteSelectedButton": "Delete",
+  "taskBoard.taskBoard.actionError": "Couldn't do that. Please try again.",
   "taskBoard.taskBoard.deleteError":
     "Couldn't delete the task. Please try again.",
   "taskBoard.taskBoard.deleteBulkError":

--- a/apps/web/src/i18n/pt-br/task-board.ts
+++ b/apps/web/src/i18n/pt-br/task-board.ts
@@ -51,6 +51,8 @@ export const taskBoard = {
   "taskBoard.taskBoard.dueDateButton": "Data de entrega",
   "taskBoard.taskBoard.addTagButton": "Adicionar tag",
   "taskBoard.taskBoard.deleteSelectedButton": "Excluir",
+  "taskBoard.taskBoard.actionError":
+    "Não foi possível fazer isso. Tente novamente.",
   "taskBoard.taskBoard.deleteError":
     "Não foi possível excluir a tarefa. Tente novamente.",
   "taskBoard.taskBoard.deleteBulkError":

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -143,6 +143,7 @@ import { useThreadActions } from "@/components/chat/store/hooks";
 import { writeChatDraft } from "@/lib/chat-draft";
 import { createMentionDoc } from "@/components/chat/tiptap/mention";
 import type { TiptapDoc } from "@/components/chat/types";
+import { toast } from "sonner";
 
 // Warm the chat chunk so opening a task's activity doesn't cold-load it (flash).
 void import("../agent-shell-layout/index.tsx").catch(() => {});
@@ -364,9 +365,17 @@ export function TaskBoardPage() {
   // `actions.update`, so a single per-call `onError` here covers both.
   const [subscriptionPaywall, setSubscriptionPaywall] =
     useState<ReturnType<typeof subscriptionErrorKind>>(null);
+  // Anything that is not the paywall gets a toast: these tools refuse with a
+  // sentence written for the user (a re-run whose merge is still retrying, a
+  // card not assigned to the Super Agent), and dropping it made the button look
+  // broken — the click did nothing and the reason only reached the Network tab.
   const onDelegateError = (err: Error) => {
     const kind = subscriptionErrorKind(err);
-    if (kind) setSubscriptionPaywall(kind);
+    if (kind) {
+      setSubscriptionPaywall(kind);
+      return;
+    }
+    toast.error(err.message || t("taskBoard.taskBoard.actionError"));
   };
   // The task awaiting a re-run confirmation, or null. A re-run supersedes the
   // task's live run, so it is confirmed rather than fired on click.


### PR DESCRIPTION
Follow-up to #6071, from two things still hitting prod.

## 1. The guard still refuses cards nothing will ever merge

`refuseIfMergePending` blocks a re-run while an approved card's merge "is
retrying". #6071 carved out one way that retry can never succeed — a
conflicting PR whose conflict-resolution cap is spent. The others are not
enumerable from here: a failing required check, a branch-protection rule the
GitHub App can't satisfy, a draft PR, a base branch that moved. Each makes the
item sweep re-attempt the same merge every 5 minutes forever, and Re-run — the
only escape — answers `Every reviewer approved this task and its merge is
retrying`.

So the refusal is bounded rather than made smarter (`mergeRetryExpired`): it
still protects a merge that is plausibly one sweep tick from shipping, and gets
out of the way 15 minutes (three `DEFAULT_ITEM_SWEEP_INTERVAL_MS` ticks) after
the approval that armed it. Unreadable activity reads as expired — the human is
here and the machine has shown nothing.

Side effect: the activity list is now read once and passed into the deadlock
check instead of being fetched twice.

## 2. `TASK_BOARD_ITEM_RERUN` failures never reached the user

The board's `onDelegateError` routed `[SUBSCRIPTION_REQUIRED]` to the paywall
dialog and **dropped every other error**. Clicking Re-run on a refused card did
nothing visible — the reason only showed up in the Network tab. Non-paywall
errors now toast their message (these tools refuse with a sentence written for
the user), with a generic i18n fallback for an error that has none.

## Testing
- `mergeRetryExpired` unit tests: inside the window, past it, approvals from a
  previous cycle, no approval at all.
- Real-Postgres case in `rerun-merge-pending.integration.test.ts`: an approved
  card whose activity is aged 30 minutes re-runs; every existing refusal case
  still refuses.
- `bun run fmt`, `bun run lint`, `bun run check` pass. Integration tests were
  not run locally (no Postgres 16 available here) — `storage-integration` in CI
  covers them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the task board re-run guard and surfaces its refusal to users. Previously, Re-run refused indefinitely while a merge “was retrying”; now it protects merges for a short window and then allows Re-run, and non-paywall errors show a toast.

- Refusal window: After approval, the guard allows Re-run once the merge has been retrying for 15 minutes (three sweep ticks). It ignores approvals from a previous review cycle and treats unreadable activity as expired. Unknown mergeability keeps refusing only until this window ends; conflicts still block if the merge is genuinely one tick away.
- Single activity read: The activity list is read once and passed into the deadlock check instead of being fetched twice.
- UI feedback: The board now toasts non-paywall errors via `sonner`, with a fallback string at taskBoard.taskBoard.actionError (EN and PT-BR added).
- Tests: Unit tests cover the expiry boundary; integration verifies aged activity allows Re-run; existing refusal cases still refuse.
- Rollout: No migrations. If other locales exist, add taskBoard.taskBoard.actionError to them.

<sup>Written for commit e471161678ed21ce8e573bf60f864079d40648b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

