### PR TITLE
fix(settings): translate the Deco AI Gateway connect toast

### DIFF
--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -748,6 +748,10 @@ export const settings = {
     "Bring your own model server (advanced)",
   "settings.aiProviders.moreProvidersSingular": "{count} more provider",
   "settings.aiProviders.moreProvidersPlural": "{count} more providers",
+  "settings.aiProviders.decoConnectSuccess":
+    "Deco AI Gateway connected successfully",
+  "settings.aiProviders.decoConnectError":
+    "Failed to connect Deco AI Gateway: {error}",
   "settings.billing.title": "Billing",
   "settings.billing.autoTasksTitle": "Auto tasks",
   "settings.billing.unlimitedDescription":

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -792,6 +792,10 @@ export const settings = {
     "Traga seu pr\u00f3prio servidor de modelos (avan\u00e7ado)",
   "settings.aiProviders.moreProvidersSingular": "{count} provedor adicional",
   "settings.aiProviders.moreProvidersPlural": "{count} provedores adicionais",
+  "settings.aiProviders.decoConnectSuccess":
+    "Deco AI Gateway conectado com sucesso",
+  "settings.aiProviders.decoConnectError":
+    "Falha ao conectar o Deco AI Gateway: {error}",
   "settings.billing.title": "Cobrança",
   "settings.billing.autoTasksTitle": "Auto tasks",
   "settings.billing.unlimitedDescription":

--- a/apps/web/src/views/settings/ai-providers/use-deco-connect.ts
+++ b/apps/web/src/views/settings/ai-providers/use-deco-connect.ts
@@ -4,11 +4,13 @@ import { useProjectContext } from "@/sdk";
 import { KEYS } from "@/lib/query-keys";
 import { track } from "@/lib/posthog-client";
 import { useStudioTools } from "@/lib/studio-tools";
+import { useT } from "@/i18n/use-t";
 
 export function useDecoConnect() {
   const { org } = useProjectContext();
   const studio = useStudioTools();
   const queryClient = useQueryClient();
+  const t = useT();
 
   return useMutation({
     mutationFn: async () => {
@@ -18,14 +20,16 @@ export function useDecoConnect() {
       track("ai_provider_provision_succeeded", { provider_id: "deco" });
       queryClient.invalidateQueries({ queryKey: KEYS.aiProviderKeys(org.id) });
       queryClient.invalidateQueries({ queryKey: KEYS.aiProviders(org.id) });
-      toast.success("Deco AI Gateway connected successfully");
+      toast.success(t("settings.aiProviders.decoConnectSuccess"));
     },
     onError: (err) => {
       track("ai_provider_provision_failed", {
         provider_id: "deco",
         error: err.message,
       });
-      toast.error(`Failed to connect Deco AI Gateway: ${err.message}`);
+      toast.error(
+        t("settings.aiProviders.decoConnectError", { error: err.message }),
+      );
     },
   });
 }


### PR DESCRIPTION
**Source:** i18n-gap hunt in settings. `useDecoConnect` (`apps/web/src/views/settings/ai-providers/use-deco-connect.ts`) fires `toast.success("Deco AI Gateway connected successfully")` and `toast.error(`Failed to connect Deco AI Gateway: ${err.message}`)` as raw hardcoded English strings, bypassing the i18n dictionary that every other user-facing string in settings goes through per this repo's i18n convention (toasts must go through `t()`).

**Why a maintainer wants this:** a pt-BR user connecting the Deco AI Gateway from Settings → AI Providers sees an English toast while the rest of the page is localized — an inconsistency the i18n convention exists specifically to prevent.

**Fix:** added `settings.aiProviders.decoConnectSuccess` / `settings.aiProviders.decoConnectError` (with `{error}` interpolation) to both `apps/web/src/i18n/en/settings.ts` and `apps/web/src/i18n/pt-br/settings.ts`, and routed the two toasts through `useT()`.

**How a reviewer confirms:** `cd apps/web && bunx tsc --noEmit` (the `en`/`pt-br` dictionaries `satisfies Record<keyof typeof en, string>`, so a missing/mismatched key is a compile error — this passed clean, confirming both locales stay in sync). Also read the diff — it's a straight toast-string swap, no logic change.

**Checks run locally:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint` on the 3 changed files (0 warnings/errors). No unit test added — this is plain string wiring, not logic; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes the Deco AI Gateway connect toasts in Settings → AI Providers. Previously the success/error toasts were hardcoded in English; now they use `useT()` with i18n keys, keeping pt-BR and other locales consistent. No logic changes.

- Added `settings.aiProviders.decoConnectSuccess` and `settings.aiProviders.decoConnectError` (with `{error}`) to `apps/web/src/i18n/en/settings.ts` and `apps/web/src/i18n/pt-br/settings.ts`.
- Replaced raw `toast.success`/`toast.error` with `t(...)` in `apps/web/src/views/settings/ai-providers/use-deco-connect.ts`.
- Verify by connecting Deco AI Gateway and seeing localized toasts; `cd apps/web && bunx tsc --noEmit` confirms dictionary parity.
- No migration required.

<sup>Written for commit c4a7f8c318641ca72311b192d33c585cf58cd769. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

