### PR TITLE
fix(oauth): reject a malformed expires_in in the refresh response

### DIFF
--- a/apps/api/src/oauth/refresh-access-token.test.ts
+++ b/apps/api/src/oauth/refresh-access-token.test.ts
@@ -145,6 +145,44 @@ describe("refreshAccessToken", () => {
     expect(result.accessToken).toBe("new");
   });
 
+  it("ignores a malformed expires_in instead of producing an Invalid Date", async () => {
+    installFetch(
+      () =>
+        new Response(
+          JSON.stringify({
+            access_token: "new",
+            token_type: "Bearer",
+            expires_in: "not-a-number",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+
+    const result = await refreshAccessToken(baseToken);
+
+    expect(result.success).toBe(true);
+    expect(result.expiresIn).toBeUndefined();
+  });
+
+  it("ignores a negative expires_in", async () => {
+    installFetch(
+      () =>
+        new Response(
+          JSON.stringify({
+            access_token: "new",
+            token_type: "Bearer",
+            expires_in: -1,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+
+    const result = await refreshAccessToken(baseToken);
+
+    expect(result.success).toBe(true);
+    expect(result.expiresIn).toBeUndefined();
+  });
+
   it("treats a 200 with no access_token as a transient failure, not success", async () => {
     installFetch(
       () =>

--- a/apps/api/src/oauth/refresh-access-token.ts
+++ b/apps/api/src/oauth/refresh-access-token.ts
@@ -151,7 +151,7 @@ export async function refreshAccessToken(
     const data = (await response.json()) as {
       access_token?: string;
       refresh_token?: string;
-      expires_in?: number;
+      expires_in?: unknown;
       token_type?: string;
       scope?: string;
     };
@@ -170,11 +170,26 @@ export async function refreshAccessToken(
       };
     }
 
+    // expires_in is untrusted server input — reject non-finite/non-positive values.
+    let expiresIn: number | undefined;
+    if (data.expires_in !== undefined) {
+      const parsed = Number(data.expires_in);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        expiresIn = parsed;
+      } else {
+        console.warn("[TokenRefresh] ignoring malformed expires_in", {
+          connectionId: token.connectionId,
+          tokenEndpoint: token.tokenEndpoint,
+          expiresIn: data.expires_in,
+        });
+      }
+    }
+
     return {
       success: true,
       accessToken: data.access_token,
       refreshToken: data.refresh_token || token.refreshToken,
-      expiresIn: data.expires_in,
+      expiresIn,
       scope: data.scope,
     };
   } catch (error) {


### PR DESCRIPTION
Hardening in the OAuth refresh flow (follows #6061/#6068 which already hardened the timeout and the missing-access_token case).

**Bug:** `refreshAccessToken` cast the token endpoint's `expires_in` straight through as `number` and `token-refresh.ts` fed it into `new Date(Date.now() + expiresIn * 1000)` with no validation. `expires_in` is untrusted input from the (often third-party) OAuth server: a non-numeric string coerces to `NaN` (`new Date(NaN)` = Invalid Date, whose `getTime()` is `NaN`), and a negative value produces a bogus already-past or already-future expiry. `DownstreamTokenStorage.isExpired` compares against `expiryTime` with plain arithmetic — any `NaN` comparison is always `false`, so a token with a corrupted expiry is silently treated as **never expiring**, i.e. it's cached and reused past its real lifetime with no further refresh check.

**Fix:** `refreshAccessToken` now validates `expires_in` is a finite, positive number before returning it; anything else (non-numeric string, negative, `NaN`) is dropped (`expiresIn: undefined`) and logged, falling back to the same "unknown lifetime" behavior already used when a server omits the field entirely.

**Regression tests:** two new cases in `refresh-access-token.test.ts` — a string `expires_in` and a negative `expires_in` — both assert `result.expiresIn` is `undefined` instead of propagating the bad value.

**To verify:** `bun test apps/api/src/oauth/refresh-access-token.test.ts`

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/api), the targeted test file above (10/10 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects malformed expires_in in OAuth refresh responses to avoid caching tokens indefinitely. Previously refreshAccessToken passed expires_in through unchecked, producing an invalid expiry and treating tokens as never expiring; now non-finite or non-positive values are dropped and we fall back to the unknown-lifetime path.

- Validates expires_in is a finite, positive number; otherwise sets expiresIn to undefined and logs a warning.
- Adds tests for string and negative expires_in to ensure we do not propagate bad values.

**Operational notes**
- Tokens from misbehaving providers will no longer be cached past their real lifetime; they use the existing unknown-lifetime behavior.
- Monitor logs for "[TokenRefresh] ignoring malformed expires_in" to identify problematic OAuth servers.

<sup>Written for commit 68e290de7cf9584a575b5abb77c7ffc862bbd7c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

