### PR TITLE
fix(sandbox): treat a failed model-env push as a retriable unreachable sandbox

### DIFF
--- a/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
@@ -9,6 +9,7 @@ import {
   isRunSuperseded,
   isUnreachableStatus,
   ndjsonLines,
+  pushSandboxEnv,
   RunSupersededError,
   SandboxUnreachableError,
 } from "./sandbox-dispatch-client";
@@ -170,6 +171,38 @@ describe("isUnreachableStatus", () => {
     for (const status of [400, 401, 403, 409]) {
       expect(isUnreachableStatus(status)).toBe(false);
     }
+  });
+});
+
+describe("pushSandboxEnv", () => {
+  const fakeProvider = (proxyDaemonRequest: () => Promise<Response>) =>
+    ({ proxyDaemonRequest }) as unknown as Parameters<typeof pushSandboxEnv>[0];
+
+  test("a wedged/dead daemon is retriable, not a hard failure", async () => {
+    const provider = fakeProvider(() => {
+      throw new Error("The operation was aborted due to timeout");
+    });
+    let thrown: unknown;
+    try {
+      await pushSandboxEnv(provider, "handle-1", { FOO: "bar" });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(SandboxUnreachableError);
+  });
+
+  test("the daemon's own rejection of the config is a hard failure", async () => {
+    const provider = fakeProvider(
+      async () => new Response("bad env", { status: 400 }),
+    );
+    let thrown: unknown;
+    try {
+      await pushSandboxEnv(provider, "handle-1", { FOO: "bar" });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).not.toBeInstanceOf(SandboxUnreachableError);
+    expect(thrown).toBeInstanceOf(Error);
   });
 });
 

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -575,17 +575,25 @@ const PUSH_ENV_TIMEOUT_MS = 30_000;
  * ⚠️ SECURITY: `env` holds a model credential. Never log it, and never include
  * the request body in an error message.
  */
-async function pushSandboxEnv(
+export async function pushSandboxEnv(
   provider: SandboxProvider,
   handle: string,
   env: Record<string, string | null>,
 ): Promise<void> {
-  const res = await provider.proxyDaemonRequest(handle, "/_sandbox/config", {
-    method: "PUT",
-    headers: new Headers({ "content-type": "application/json" }),
-    body: JSON.stringify({ env }),
-    signal: AbortSignal.timeout(PUSH_ENV_TIMEOUT_MS),
-  });
+  let res: Response;
+  try {
+    res = await provider.proxyDaemonRequest(handle, "/_sandbox/config", {
+      method: "PUT",
+      headers: new Headers({ "content-type": "application/json" }),
+      body: JSON.stringify({ env }),
+      signal: AbortSignal.timeout(PUSH_ENV_TIMEOUT_MS),
+    });
+  } catch (err) {
+    // A wedged or dead daemon here is exactly what dispatchToDaemon's own fetch already retries on a replacement.
+    throw new SandboxUnreachableError(
+      `could not push the model env to the sandbox: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
   if (!res.ok) {
     // Hard failure, unlike the tool-catalog sync: without the credential the
     // harness cannot reach a model at all, so proceeding wastes a pod boot and


### PR DESCRIPTION
Follows #6063 (the model-env push timeout). Bug: `pushSandboxEnv` in `apps/api/src/harnesses/sandbox-dispatch-client.ts` wraps its PUT with `AbortSignal.timeout(PUSH_ENV_TIMEOUT_MS)` but never catches the fetch itself — a timeout or network failure (a wedged daemon: pod up, TCP open, nothing draining it; or a dead one) throws a plain `Error`. `dispatchWithContinuation` only retries `SandboxUnreachableError`, so this exact case — the one the whole continuation mechanism exists to handle — instead fails the run outright, on the very first dispatch attempt of a fresh sandbox.

Why a maintainer wants this: every other daemon fetch in this same file (`dispatchToDaemon`) already wraps network/timeout failures as `SandboxUnreachableError` so they're retried on a replacement pod; this closes the one path in the file that was left as a hard failure, matching the pattern the file's own docs describe.

Failure scenario: a claude-code run's sandbox has a wedged daemon before the harness even dispatches (env push happens first). Previously: run fails immediately with an opaque `Error` and burns the org's task quota with zero retry. After: it's classified as `SandboxUnreachableError` and `dispatchWithContinuation` re-provisions and continues the turn, same as a mid-stream pod loss.

Regression test added in `sandbox-dispatch-client.test.ts` (`describe("pushSandboxEnv")`): a fetch that throws on the env-push PUT now surfaces as `SandboxUnreachableError`; a real daemon 4xx rejection (bad env) still surfaces as a plain `Error` so it's not retried forever.

Reviewer check: `bun test apps/api/src/harnesses/sandbox-dispatch-client.test.ts`.

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (green), the targeted test above (39 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats timeouts or network failures during sandbox env push as `SandboxUnreachableError` so dispatch retries on a replacement pod. Previously `pushSandboxEnv` threw a plain Error on PUT timeout/failure and aborted the run; now it matches `dispatchToDaemon` and continues after re-provisioning.

- Wraps the `proxyDaemonRequest` in `pushSandboxEnv` with a try/catch and rethrows as `SandboxUnreachableError` on timeout/network failure.
- Preserves hard-fail behavior for daemon 4xx (bad env) so we do not retry invalid configs.
- Adds tests in `apps/api/src/harnesses/sandbox-dispatch-client.test.ts` covering both cases; run: bun test apps/api/src/harnesses/sandbox-dispatch-client.test.ts.

<sup>Written for commit 7e0def236bea3aaa108aac7174fa3f905979ab61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

