### PR TITLE
fix(sandbox): treat a 404/410/5xx model-env push response as retriable

### DIFF
--- a/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
@@ -204,6 +204,21 @@ describe("pushSandboxEnv", () => {
     expect(thrown).not.toBeInstanceOf(SandboxUnreachableError);
     expect(thrown).toBeInstanceOf(Error);
   });
+
+  test("a 404/410/5xx status from the daemon is retriable, not a hard failure", async () => {
+    for (const status of [404, 410, 503]) {
+      const provider = fakeProvider(
+        async () => new Response("gone", { status }),
+      );
+      let thrown: unknown;
+      try {
+        await pushSandboxEnv(provider, "handle-1", { FOO: "bar" });
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(SandboxUnreachableError);
+    }
+  });
 });
 
 describe("dispatchWithContinuation", () => {

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -595,12 +595,12 @@ export async function pushSandboxEnv(
     );
   }
   if (!res.ok) {
-    // Hard failure, unlike the tool-catalog sync: without the credential the
-    // harness cannot reach a model at all, so proceeding wastes a pod boot and
-    // reports a confusing model error instead of this one.
-    throw new Error(
-      `failed to push model env to the sandbox (${res.status} ${res.statusText})`,
-    );
+    const summary = `failed to push model env to the sandbox (${res.status} ${res.statusText})`;
+    // 404/410/5xx is the pod, not the envelope — retriable, same split as dispatchToDaemon.
+    if (isUnreachableStatus(res.status)) {
+      throw new SandboxUnreachableError(summary);
+    }
+    throw new Error(summary);
   }
 }
 


### PR DESCRIPTION
Follows #6077 (which fixed network/timeout failures on the env push). That PR left the `!res.ok` branch of `pushSandboxEnv` treating EVERY non-2xx status as a hard `Error`, including 404/410/5xx — the exact statuses `dispatchToDaemon`'s own `isUnreachableStatus()` already classifies as the pod being gone (not the envelope being rejected) and retries on a replacement sandbox for.

Why a maintainer wants this: `ensureSandbox` can hand back a handle for a pod whose daemon isn't answering yet (still booting) or has already been reclaimed — the env push then gets a 502/503 or 404/410 back and the run fails outright on its very first dispatch attempt instead of being continued on a fresh pod, exactly the case #6077 just closed for the network-exception path but not for the status-code path.

Fix: reuse the file's existing `isUnreachableStatus()` classifier in `pushSandboxEnv`'s status branch — the same split `dispatchToDaemon` already makes.

Regression test added in `sandbox-dispatch-client.test.ts`: 404/410/503 status responses from the env-push PUT now surface as `SandboxUnreachableError`; a genuine 400 (bad env) still surfaces as a plain `Error` so it isn't retried forever.

Reviewer check: `bun test apps/api/src/harnesses/sandbox-dispatch-client.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test above (40 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats 404/410/5xx responses from the model-env push as retriable by throwing `SandboxUnreachableError`, aligning `pushSandboxEnv` with `dispatchToDaemon`. Previously, any non-2xx status threw a hard `Error`, causing first-attempt failures when a pod was booting or reclaimed.

- Reuses `isUnreachableStatus` inside `pushSandboxEnv`; 400 remains a hard `Error`.
- Adds a regression test: 404/410/503 yield `SandboxUnreachableError`; 400 yields `Error`.
- Run: bun test apps/api/src/harnesses/sandbox-dispatch-client.test.ts

<sup>Written for commit 265df6e738efb857715342e7631fc324af5fa3e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

