### PR TITLE
fix(cli): reject a malformed expires_in in the CLI session-refresh response

### DIFF
--- a/apps/api/src/cli/lib/refresh-session.test.ts
+++ b/apps/api/src/cli/lib/refresh-session.test.ts
@@ -69,6 +69,47 @@ describe("refreshSession", () => {
     expect(result.refreshToken).toBe("rt_xyz");
   });
 
+  it("ignores a malformed expires_in and keeps the previous expiresAt", async () => {
+    const fetchMock = mock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            access_token: "new_at",
+            expires_in: "not-a-number",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+
+    const session = makeSession({ expiresAt: 1_234 });
+    const result = await refreshSession(
+      session,
+      fetchMock as unknown as typeof fetch,
+      () => FIXED_NOW,
+    );
+
+    expect(result.expiresAt).toBe(1_234);
+  });
+
+  it("ignores a negative expires_in and keeps the previous expiresAt", async () => {
+    const fetchMock = mock(
+      async () =>
+        new Response(
+          JSON.stringify({ access_token: "new_at", expires_in: -10 }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+
+    const session = makeSession({ expiresAt: 1_234 });
+    const result = await refreshSession(
+      session,
+      fetchMock as unknown as typeof fetch,
+      () => FIXED_NOW,
+    );
+
+    expect(result.expiresAt).toBe(1_234);
+  });
+
   it("throws RefreshFailedError(invalid_grant) on 400", async () => {
     const fetchMock = mock(
       async () => new Response("invalid_grant", { status: 400 }),

--- a/apps/api/src/cli/lib/refresh-session.ts
+++ b/apps/api/src/cli/lib/refresh-session.ts
@@ -76,12 +76,17 @@ export async function refreshSession(
     );
   }
 
+  // expires_in is untrusted server input — reject non-finite/non-positive values.
+  const parsedExpiresIn = Number(data.expires_in);
+  const expiresAt =
+    Number.isFinite(parsedExpiresIn) && parsedExpiresIn > 0
+      ? Math.floor(now() / 1000) + parsedExpiresIn
+      : session.expiresAt;
+
   return {
     ...session,
     accessToken: data.access_token,
     refreshToken: data.refresh_token ?? session.refreshToken,
-    expiresAt: data.expires_in
-      ? Math.floor(now() / 1000) + data.expires_in
-      : session.expiresAt,
+    expiresAt,
   };
 }


### PR DESCRIPTION
Follows #6076, which fixed the same untrusted-`expires_in`-from-refresh-response bug in the sibling downstream-OAuth module (`apps/api/src/oauth/refresh-access-token.ts`). This PR applies the identical fix to `apps/api/src/cli/lib/refresh-session.ts`, the CLI's own Better Auth session-refresh flow, which had the same unvalidated `data.expires_in` used directly in arithmetic.

**Why a maintainer wants this**: `expires_in` is untrusted input from the auth server's token response. If it's non-numeric, NaN, or negative, `Math.floor(now()/1000) + data.expires_in` produces `NaN` (or a bogus past/negative value written as the new `expiresAt`). `get-valid-session.ts`'s expiry check (`session.expiresAt - EXPIRY_SKEW_SECONDS < nowSeconds`) is always `false` for `NaN`, so a malformed `expires_in` would make the CLI treat the session as valid forever and stop attempting refresh — a silent, hard-to-diagnose auth wedge for CLI users, the same failure class #6076 fixed on the other module.

**Fix**: validate `expires_in` is finite and positive before using it (`Number.isFinite(parsed) && parsed > 0`), matching the exact pattern already used in `refresh-access-token.ts`; on a malformed value, fall back to the session's previous `expiresAt` instead of corrupting it.

**Regression tests**: added two cases to `refresh-session.test.ts` — a non-numeric `expires_in` string and a negative `expires_in`, both asserting the previous `expiresAt` is preserved.

**To verify**: `cd apps/api && bun test src/cli/lib/refresh-session.test.ts`

**Checks run locally**: `bun run fmt`, `bunx tsc --noEmit` (apps/api), the targeted test file above, and `bunx oxlint` on both changed files — all green. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates expires_in from the CLI session-refresh response and ignores malformed values. Previously we used expires_in directly, which could set expiresAt to NaN or a past value and make the CLI treat sessions as permanently valid; now we accept only finite, positive values and otherwise keep the previous expiresAt.

- Aligns validation with `apps/api/src/oauth/refresh-access-token.ts` (finite and > 0) and computes expiresAt only when valid.
- Adds tests for non-numeric and negative expires_in in `apps/api/src/cli/lib/refresh-session.test.ts`.
- To verify: cd apps/api && bun test src/cli/lib/refresh-session.test.ts
- No migrations; impact is limited to the CLI session refresh path.

<sup>Written for commit 0fbb7c4407aa87bab4035ffee368e28adfc8050c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

