### PR TITLE
refactor(runtime): drop unnecessary any-cast in BindingOf's literal default

### DIFF
--- a/packages/runtime/src/bindings.ts
+++ b/packages/runtime/src/bindings.ts
@@ -97,7 +97,7 @@ export const BindingOf = <
     : readonly ToolBinder[],
 ) => {
   const schema = z.object({
-    __type: z.literal(name).default(name as any),
+    __type: z.literal(name).default(name),
     value: z.string(),
   });
 


### PR DESCRIPTION
Follows the type-safety debt lane (C-DEBT: eliminate stray `as any`).

In `packages/runtime/src/bindings.ts`, `BindingOf()` built the `__type` field's literal schema with `z.literal(name).default(name as any)`. The cast was unnecessary — `name` is already typed as `TName` (the exact literal the schema is for), so `z.literal(name).default(name)` typechecks fine on its own without widening.

Why it matters: an `any` cast here would silently swallow a future type mismatch between the literal and its default (e.g. if `BindingOf` is called with a value that doesn't match `name`), so removing it restores compile-time safety for a value that flows into every binding's saved `configuration_state` / JWT.

Behavior-preserving — same runtime value, same schema. Confirmed with:
- `cd packages/runtime && bunx tsc --noEmit` — clean
- `bun test packages/runtime/src/bindings.test.ts` — 2 pass
- `bunx oxlint packages/runtime/src/bindings.ts` — 0 warnings/errors
- `bun run fmt` — no changes needed

Reviewer check: `cd packages/runtime && bunx tsc --noEmit && bun test packages/runtime/src/bindings.test.ts`. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the any-cast from `BindingOf`’s `__type` literal default. Old: `default(name as any)`; new: `default(name)`. This restores compile-time safety without changing runtime behavior or the schema.

- Scope: one-line change in `packages/runtime/src/bindings.ts`.
- Behavior: no runtime change; mismatched literals now surface as type errors.
- Validate: `cd packages/runtime && bunx tsc --noEmit && bun test packages/runtime/src/bindings.test.ts`.

<sup>Written for commit 77d872a8d298122486536066d069d0454893d577. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

