### PR TITLE
fix(oauth): reject a non-string access_token/refresh_token in the refresh response

### DIFF
--- a/apps/api/src/oauth/refresh-access-token.test.ts
+++ b/apps/api/src/oauth/refresh-access-token.test.ts
@@ -198,4 +198,35 @@ describe("refreshAccessToken", () => {
     expect(result.permanent).toBe(false);
     expect(result.accessToken).toBeUndefined();
   });
+
+  it("treats a non-string access_token as a transient failure, not success", async () => {
+    installFetch(
+      () =>
+        new Response(JSON.stringify({ access_token: 12345 }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    const result = await refreshAccessToken(baseToken);
+
+    expect(result.success).toBe(false);
+    expect(result.permanent).toBe(false);
+    expect(result.accessToken).toBeUndefined();
+  });
+
+  it("falls back to the prior refresh token when the response's refresh_token isn't a string", async () => {
+    installFetch(
+      () =>
+        new Response(
+          JSON.stringify({ access_token: "new", refresh_token: 987 }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+
+    const result = await refreshAccessToken(baseToken);
+
+    expect(result.success).toBe(true);
+    expect(result.refreshToken).toBe("rt");
+  });
 });

--- a/apps/api/src/oauth/refresh-access-token.ts
+++ b/apps/api/src/oauth/refresh-access-token.ts
@@ -149,15 +149,16 @@ export async function refreshAccessToken(
     }
 
     const data = (await response.json()) as {
-      access_token?: string;
-      refresh_token?: string;
+      access_token?: unknown;
+      refresh_token?: unknown;
       expires_in?: unknown;
       token_type?: string;
-      scope?: string;
+      scope?: unknown;
     };
 
-    if (!data.access_token) {
-      // Spec-violating 200 (no access_token) — treat as transient, not silent success.
+    // access_token is untrusted server input — narrow with typeof, not the cast above.
+    if (typeof data.access_token !== "string" || !data.access_token) {
+      // Spec-violating 200 (no/non-string access_token) — treat as transient, not silent success.
       console.warn("[TokenRefresh] 200 response missing access_token", {
         connectionId: token.connectionId,
         tokenEndpoint: token.tokenEndpoint,
@@ -188,9 +189,12 @@ export async function refreshAccessToken(
     return {
       success: true,
       accessToken: data.access_token,
-      refreshToken: data.refresh_token || token.refreshToken,
+      refreshToken:
+        typeof data.refresh_token === "string" && data.refresh_token
+          ? data.refresh_token
+          : token.refreshToken,
       expiresIn,
-      scope: data.scope,
+      scope: typeof data.scope === "string" ? data.scope : undefined,
     };
   } catch (error) {
     // Network/parse errors are transient upstream failures → warn (see above).


### PR DESCRIPTION
**Source**: bug found while auditing the recently-hardened `refresh-access-token.ts` flow (assigned focus area: OAuth refresh token robustness). Three prior PRs (#6061, #6068, #6076) hardened this same file for timeout/missing-access_token/malformed-expires_in — this closes a related gap they left open.

**Bug**: the refresh response body is cast (`as { access_token?: string; ... }`) but that cast is a lie at runtime — it's an untrusted OAuth-server response. If a server returns a non-string value for `access_token` (e.g. a number), the old `!data.access_token` truthy check let it through, and it was returned as a real credential string. That value then flows into the token vault (`storage/downstream-token.ts`) and later gets used as a literal `Authorization: Bearer <token>` header — a non-string sneaking through a field typed `string` can crash or misbehave anywhere downstream that assumes string semantics. Same issue existed for `refresh_token` (falls back silently vs. storing garbage) and `scope`.

**Fix**: narrow every field read off the parsed JSON with `typeof` instead of trusting the cast — `access_token` fails the same way a missing one already does, `refresh_token` falls back to the prior refresh token when malformed, `scope` is dropped when malformed. Behavior-preserving for well-formed responses (the common case); only changes handling of a spec-violating body.

**Verify**: `cd apps/api && bunx tsc --noEmit` (green) and `bun test apps/api/src/oauth/refresh-access-token.test.ts` (12 pass, including 2 new tests: non-string `access_token` treated as transient failure, non-string `refresh_token` falls back to the prior token).

**Checks run locally**: `bun run fmt`, targeted `tsc --noEmit` in `apps/api`, the single test file above, and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects non-string OAuth `access_token`, `refresh_token`, and `scope` in the refresh response to prevent invalid credentials from entering the token vault and Authorization headers. Previously, a truthy non-string value passed through; now we narrow with `typeof` and handle invalid fields safely.

- Non-string or empty `access_token` now triggers a transient failure (no token returned).
- Non-string `refresh_token` now falls back to the prior refresh token.
- Non-string `scope` is dropped.
- Adds two tests for non-string `access_token` and `refresh_token`; no behavior change for well-formed responses and no migration required.

<sup>Written for commit 42da895415857870968017433a210aa1060a6a84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

