### PR TITLE
fix(cli): reject a non-string refresh_token in the session-refresh response

### DIFF
--- a/apps/api/src/cli/lib/refresh-session.test.ts
+++ b/apps/api/src/cli/lib/refresh-session.test.ts
@@ -110,6 +110,28 @@ describe("refreshSession", () => {
     expect(result.expiresAt).toBe(1_234);
   });
 
+  it("keeps the previous refresh token when the server returns a non-string one", async () => {
+    const fetchMock = mock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            access_token: "new_at",
+            refresh_token: 12345,
+            expires_in: 3600,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+
+    const result = await refreshSession(
+      makeSession(),
+      fetchMock as unknown as typeof fetch,
+      () => FIXED_NOW,
+    );
+
+    expect(result.refreshToken).toBe("rt_xyz");
+  });
+
   it("throws RefreshFailedError(invalid_grant) on 400", async () => {
     const fetchMock = mock(
       async () => new Response("invalid_grant", { status: 400 }),

--- a/apps/api/src/cli/lib/refresh-session.ts
+++ b/apps/api/src/cli/lib/refresh-session.ts
@@ -11,9 +11,9 @@ export class RefreshFailedError extends Error {
 }
 
 interface TokenResponse {
-  access_token: string;
-  refresh_token?: string;
-  expires_in?: number;
+  access_token: unknown;
+  refresh_token?: unknown;
+  expires_in?: unknown;
   token_type?: string;
 }
 
@@ -69,7 +69,7 @@ export async function refreshSession(
   }
 
   const data = (await res.json()) as TokenResponse;
-  if (typeof data.access_token !== "string") {
+  if (typeof data.access_token !== "string" || !data.access_token) {
     throw new RefreshFailedError(
       "transient",
       "Token endpoint returned no access_token",
@@ -83,10 +83,16 @@ export async function refreshSession(
       ? Math.floor(now() / 1000) + parsedExpiresIn
       : session.expiresAt;
 
+  // refresh_token is untrusted server input — reject a non-string value.
+  const refreshToken =
+    typeof data.refresh_token === "string" && data.refresh_token
+      ? data.refresh_token
+      : session.refreshToken;
+
   return {
     ...session,
     accessToken: data.access_token,
-    refreshToken: data.refresh_token ?? session.refreshToken,
+    refreshToken,
     expiresAt,
   };
 }


### PR DESCRIPTION
Follows #6081 (`apps/api/src/oauth/refresh-access-token.ts`) and #6079 (this same file's `expires_in` fix), which hardened OAuth token-refresh responses against untrusted server input — but `refreshSession` (`apps/api/src/cli/lib/refresh-session.ts`) still assigned `data.refresh_token` straight through with only a JS `??` fallback, no type check.

**Why a maintainer wants this**: `refreshSession` casts the parsed JSON body to `TokenResponse` and trusts it. If the CLI's own token endpoint (or a misbehaving proxy in front of it) ever returned a non-string `refresh_token` (e.g. a number, an object, `null` from a buggy provider), the malformed value would silently become the persisted `Session.refreshToken`. The next refresh attempt would then send a garbage `refresh_token` to the OAuth server and fail with `invalid_grant`, permanently logging the CLI user out — exactly the failure class #6081 fixed on the sibling file one commit ago.

**Fix**: validate `refresh_token` is a non-empty string before using it, same as the existing `access_token` check right above it (which I also tightened to reject an empty string, matching `refresh-access-token.ts`'s equivalent check). A non-string/empty value now falls back to the session's existing refresh token instead of overwriting it.

**Regression test**: added `keeps the previous refresh token when the server returns a non-string one` to `refresh-session.test.ts`, asserting a numeric `refresh_token` in the response is rejected in favor of the session's prior token.

**To verify**: `bun test apps/api/src/cli/lib/refresh-session.test.ts` (9 pass including the new case).

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api workspace, clean), `bunx oxlint` on both changed files (0 warnings/errors), and the targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects non-string or empty `refresh_token` in CLI session refresh and tightens `access_token` validation to prevent invalid_grant lockouts from bad token endpoint responses. Previously, `refreshSession` wrote the response’s `refresh_token` through; now it keeps the existing token unless the response provides a non-empty string.

- Require `refresh_token` to be a non-empty string; otherwise keep `session.refreshToken` (old behavior overwrote it and could break subsequent refreshes).
- Require `access_token` to be a non-empty string, matching `refresh-access-token.ts`.
- Widen `TokenResponse` fields to `unknown` and validate at runtime.
- Add a unit test in `apps/api/src/cli/lib/refresh-session.test.ts` covering a numeric `refresh_token`.

<sup>Written for commit b192464fa50b3d80453d801f6e75ed4f97bc9c34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

