### PR TITLE
i18n(details): translate the agent-binding select placeholder in mcp-configuration-form

### DIFF
--- a/apps/web/src/components/details/connection/settings-tab/mcp-configuration-form.tsx
+++ b/apps/web/src/components/details/connection/settings-tab/mcp-configuration-form.tsx
@@ -325,7 +325,9 @@ function CustomObjectFieldTemplate(props: ObjectFieldTemplateProps) {
             selectedVirtualMcpId={currentValue || undefined}
             onVirtualMcpChange={handleBindingChange}
             variant="bordered"
-            placeholder="Select Agent"
+            placeholder={t("details.mcpConfigurationForm.selectPlaceholder", {
+              title: displayTitle.toLowerCase(),
+            })}
             className="w-[200px] shrink-0"
           />
         </div>


### PR DESCRIPTION
Sweeping the settings/connection i18n surface for missed translations (assigned focus: settings i18n consistency).

The `@deco/agent` binding branch in `mcp-configuration-form.tsx` (rendered from the connection settings tab) hardcoded `placeholder="Select Agent"` in English, while every other binding-select placeholder two branches below it in the exact same file already goes through `t("details.mcpConfigurationForm.selectPlaceholder", { title })` — so this one line silently skipped the pt-br translation (`Selecionar {title}...`) that a Portuguese user gets everywhere else in this same form.

Fix: reuse the existing `details.mcpConfigurationForm.selectPlaceholder` key (already defined in both `en/details.ts` and `pt-br/details.ts`, no new key needed) with the same `displayTitle.toLowerCase()` interpolation the sibling branch already uses. Net change: -1/+3 lines, one file, no new i18n keys.

To confirm: open a connection's settings tab that has an `@deco/agent`-bound field with pt-br selected as the UI language — the select placeholder now reads "Selecionar agent..." instead of the English "Select Agent".

Locally verified: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (no new errors touching this file), `bunx oxlint` on the changed file (0 warnings/errors). No test file exists for this component (RJSF field-template rendering, not a unit-testable trust boundary) so verification is the typecheck + lint above; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes the select placeholder for the `@deco/agent` binding in `mcp-configuration-form` to match the rest of the form. Previously it showed the hardcoded English “Select Agent”; now it uses the existing i18n key and renders per locale (e.g., pt-br “Selecionar agent...”); no behavior changes beyond the placeholder text.

**Notes for review and QA**
- Change is limited to `apps/web/src/components/details/connection/settings-tab/mcp-configuration-form.tsx`: replace the hardcoded placeholder with `t("details.mcpConfigurationForm.selectPlaceholder", { title: displayTitle.toLowerCase() })`.
- Reuses existing `details.mcpConfigurationForm.selectPlaceholder` key in `en` and `pt-br`; no new strings or side effects.
- To verify: open a connection’s settings tab with a `@deco/agent`-bound field and set UI to pt-br; the placeholder should read “Selecionar agent...” instead of “Select Agent”.

<sup>Written for commit d45ed136ac32121ead3d579839da1dca65be851b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

