### PR TITLE
fix(cli): treat a non-JSON 200 session-refresh body as a transient failure

### DIFF
--- a/apps/api/src/cli/lib/refresh-session.test.ts
+++ b/apps/api/src/cli/lib/refresh-session.test.ts
@@ -132,6 +132,23 @@ describe("refreshSession", () => {
     expect(result.refreshToken).toBe("rt_xyz");
   });
 
+  it("throws RefreshFailedError(transient) on a non-JSON 200 body", async () => {
+    const fetchMock = mock(
+      async () =>
+        new Response("<html>not json</html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        }),
+    );
+    const promise = refreshSession(
+      makeSession(),
+      fetchMock as unknown as typeof fetch,
+      () => FIXED_NOW,
+    );
+    await expect(promise).rejects.toBeInstanceOf(RefreshFailedError);
+    await expect(promise).rejects.toMatchObject({ kind: "transient" });
+  });
+
   it("throws RefreshFailedError(invalid_grant) on 400", async () => {
     const fetchMock = mock(
       async () => new Response("invalid_grant", { status: 400 }),

--- a/apps/api/src/cli/lib/refresh-session.ts
+++ b/apps/api/src/cli/lib/refresh-session.ts
@@ -68,7 +68,18 @@ export async function refreshSession(
     throw new RefreshFailedError("transient", `HTTP ${res.status} ${text}`);
   }
 
-  const data = (await res.json()) as TokenResponse;
+  let data: TokenResponse;
+  try {
+    data = (await res.json()) as TokenResponse;
+  } catch (err) {
+    throw new RefreshFailedError(
+      "transient",
+      `Token endpoint returned a non-JSON body: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
   if (typeof data.access_token !== "string" || !data.access_token) {
     throw new RefreshFailedError(
       "transient",


### PR DESCRIPTION
Follows #6083 hardening of the CLI session-refresh flow.

`refreshSession`'s doc comment promises callers it only ever throws `RefreshFailedError` — `getValidSession` relies on that, catching `RefreshFailedError` and re-throwing anything else. But `res.json()` on the 200-success path was called outside any try/catch: a token endpoint that returns a malformed body on 200 (an HTML error page from a misconfigured proxy, a truncated response, an empty body) throws a raw, unclassified `SyntaxError` that breaks that contract and propagates as an unhandled exception instead of the intended `transient` classification.

Failure scenario: the CLI's silent background refresh hits a token endpoint returning `200` with a non-JSON body — `getValidSession` crashes with a bare `SyntaxError: Unexpected token '<'...` instead of surfacing a `RefreshFailedError("transient")` the caller already knows how to handle (retry / surface to user).

Fix: wrap `res.json()` in a try/catch and translate a parse failure into `RefreshFailedError("transient", ...)`, consistent with how every other failure mode in this function is already classified. Added a regression test (`throws RefreshFailedError(transient) on a non-JSON 200 body`) that fails on the old code (raw `SyntaxError`) and passes now.

Reviewer command: `cd apps/api && bun test src/cli/lib/refresh-session.test.ts`

Locally verified: `bun run fmt`, `bunx tsc --noEmit` (apps/api), targeted test file above, `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats a non-JSON 200 response from the token endpoint during CLI session refresh as a transient failure. Previously a malformed 200 body caused a bare `SyntaxError` to escape; now it throws `RefreshFailedError('transient')`, so callers like `getValidSession` can retry or surface the error.

**Review notes**
- Wraps `res.json()` in try/catch and maps parse failures to `RefreshFailedError('transient', ...)`.
- Adds a regression test: non-JSON 200 body triggers `RefreshFailedError('transient')`.
- No API or config changes; only error classification aligns with existing contract.

<sup>Written for commit 9009f31ebb8e02995f173db907919480c899824b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

