### PR TITLE
fix(sandbox): reset the full consecutive-failure budget on progress

### DIFF
--- a/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
@@ -408,6 +408,30 @@ describe("dispatchWithContinuation", () => {
     ]);
   });
 
+  // Progress must reset the consecutive no-progress budget to zero, not one.
+  test("progress grants the full consecutive-failure budget again, not one less", async () => {
+    let attempts = 0;
+    const run = dispatchWithContinuation({
+      runId: "run_1",
+      resume: null,
+      aborted: () => false,
+      maxAttempts: 2,
+      dispatchOnce: () => {
+        attempts++;
+        if (attempts === 1) {
+          return dispatch(
+            [chunk("start"), chunk("text-delta")],
+            new SandboxUnreachableError("pod gone"),
+          )();
+        }
+        return dispatch([], new SandboxUnreachableError("pod gone again"))();
+      },
+    });
+    await expect(collect(run)).rejects.toThrow("pod gone again");
+    // attempt 1 progresses; attempts 2-3 spend the full maxAttempts budget again.
+    expect(attempts).toBe(3);
+  });
+
   test("the total ceiling stops a pod that dies after every chunk", async () => {
     let attempts = 0;
     const run = dispatchWithContinuation({

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -486,7 +486,7 @@ export async function* dispatchWithContinuation(args: {
       return;
     } catch (err) {
       if (args.aborted()) throw err;
-      stalled = progressed ? 1 : stalled + 1;
+      stalled = progressed ? 0 : stalled + 1;
       const infra =
         err instanceof SandboxUnreachableError
           ? ((await args


### PR DESCRIPTION
Bug found while reading `apps/api/src/harnesses/sandbox-dispatch-client.ts` (this tick's focus area).

`dispatchWithContinuation`'s off-by-one: on a progressed attempt it sets `stalled = progressed ? 1 : stalled + 1` instead of resetting to `0`. The docstring on `MAX_DISPATCH_ATTEMPTS` explicitly promises "Any chunk from the replacement pod proves the continuation worked, so it resets the count" — but resetting to `1` instead of `0` means a run that streamed chunks and then failed only tolerates `maxAttempts - 1` further consecutive no-progress failures (1, with the default `maxAttempts=2`) instead of the full budget a fresh run gets. Concretely: a run streams 30 tool calls, the apiserver hangs up the port-forward once (no progress), continues, streams a few more chunks, then a second unrelated hang up happens with no progress — that second failure alone now exhausts the budget and permanently fails the run (burning the org's task quota), where the design intent was to tolerate two such failures after any progress, same as a fresh run.

Failure scenario: consecutive `SandboxUnreachableError`s where the first carries progress and the second doesn't — the run gives up one failure earlier than the documented budget.

Fix: reset `stalled` to `0` (not `1`) when an attempt progressed.

Added a regression test (`progress grants the full consecutive-failure budget again, not one less`) that encodes the correct behavior: 1 progressed+failed attempt, then 2 more consecutive no-progress failures (the full `maxAttempts` budget) before giving up — this test fails against the old code (it would stop one attempt earlier).

Command to verify: `bun test apps/api/src/harnesses/sandbox-dispatch-client.test.ts` (42 pass).

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint` on both changed files (0 warnings/errors), and the targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resets the consecutive no-progress counter to 0 after any progress in `dispatchWithContinuation`, restoring the full retry budget. Previously, progress set `stalled` to 1, so runs allowed only `maxAttempts - 1` further no-progress failures and could fail early.

- Old behavior: progress → `stalled = 1`; second no-progress failure could terminate the run (e.g., consecutive `SandboxUnreachableError`s).
- New behavior: progress → `stalled = 0`; run gets the full `maxAttempts` budget again; reduces premature failures and wasted task quota.
- Adds a regression test that fails on the old logic and passes now.
- Verify: bun test apps/api/src/harnesses/sandbox-dispatch-client.test.ts

<sup>Written for commit 0c19ef3bada2ecd87420e585b85df49ef4fee05e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

