### PR TITLE
fix(file-picker): probe month shards newest-first so fresh uploads surface

### DIFF
--- a/apps/api/src/file-storage/file-config-s3.test.ts
+++ b/apps/api/src/file-storage/file-config-s3.test.ts
@@ -3,6 +3,7 @@ import {
   buildPublicUrl,
   isImageKey,
   matchScanPage,
+  monthShardPrefixes,
   nextScanStep,
   type ScanCandidate,
   stsCredentialProvider,
@@ -105,6 +106,38 @@ describe("isImageKey", () => {
     for (const key of ["a.pdf", "b.docx", "c.png.txt", "folder/", "noext"]) {
       expect(isImageKey(key)).toBe(false);
     }
+  });
+});
+
+describe("monthShardPrefixes", () => {
+  test("lists months newest-first, crossing the year boundary", () => {
+    // 2026-02 walking back 4 months -> Feb, Jan 2026, Dec, Nov 2025.
+    expect(
+      monthShardPrefixes("uploads/", new Date("2026-02-15T00:00:00Z"), 4),
+    ).toEqual([
+      "uploads/2026/02/",
+      "uploads/2026/01/",
+      "uploads/2025/12/",
+      "uploads/2025/11/",
+    ]);
+  });
+
+  test("zero-pads the month to match buildObjectKey's yyyy/mm shard", () => {
+    expect(monthShardPrefixes("", new Date("2026-08-13T18:44:00Z"), 1)).toEqual(
+      ["2026/08/"],
+    );
+  });
+
+  test("uses UTC (keys are UTC-stamped) to derive the month", () => {
+    expect(monthShardPrefixes("", new Date("2026-09-01T00:30:00Z"), 2)).toEqual(
+      ["2026/09/", "2026/08/"],
+    );
+  });
+
+  test("count of zero yields no probes", () => {
+    expect(
+      monthShardPrefixes("p/", new Date("2026-08-13T00:00:00Z"), 0),
+    ).toEqual([]);
   });
 });
 

--- a/apps/api/src/file-storage/file-config-s3.test.ts
+++ b/apps/api/src/file-storage/file-config-s3.test.ts
@@ -9,6 +9,7 @@ import {
   stsCredentialProvider,
 } from "./file-config-s3";
 import type { FileConfigInfo } from "../storage/types";
+import { buildObjectKey } from "./upload-policy";
 
 function info(overrides: Partial<FileConfigInfo>): FileConfigInfo {
   return {
@@ -138,6 +139,40 @@ describe("monthShardPrefixes", () => {
     expect(
       monthShardPrefixes("p/", new Date("2026-08-13T00:00:00Z"), 0),
     ).toEqual([]);
+  });
+
+  test("January is followed by the previous December (immediate wrap)", () => {
+    expect(
+      monthShardPrefixes("p/", new Date("2026-01-01T00:00:00Z"), 2),
+    ).toEqual(["p/2026/01/", "p/2025/12/"]);
+  });
+
+  test("walks back across multiple years for large counts", () => {
+    // Guards the year-decrement wrap when count exceeds 12 months.
+    expect(
+      monthShardPrefixes("", new Date("2026-01-15T00:00:00Z"), 14),
+    ).toEqual([
+      "2026/01/",
+      "2025/12/",
+      "2025/11/",
+      "2025/10/",
+      "2025/09/",
+      "2025/08/",
+      "2025/07/",
+      "2025/06/",
+      "2025/05/",
+      "2025/04/",
+      "2025/03/",
+      "2025/02/",
+      "2025/01/",
+      "2024/12/",
+    ]);
+  });
+
+  test("a fresh key's shard matches its month's probe (no drift vs buildObjectKey)", () => {
+    const key = buildObjectKey({ prefix: "uploads/", filename: "photo.png" });
+    const [probe] = monthShardPrefixes("uploads/", new Date(), 1);
+    expect(key.startsWith(probe!)).toBe(true);
   });
 });
 

--- a/apps/api/src/file-storage/file-config-s3.ts
+++ b/apps/api/src/file-storage/file-config-s3.ts
@@ -15,6 +15,7 @@ import type {
 import type { OrgSiteStoragePort } from "../storage/ports";
 import type { FileConfigInfo } from "../storage/types";
 import { provisionTenantS3Credentials } from "./tenant-credentials";
+import { monthShardSegment } from "./upload-policy";
 
 export interface FileConfigContext {
   info: FileConfigInfo;
@@ -198,18 +199,19 @@ export interface ListObjectsResult {
 }
 
 /**
- * How many month shards page 1 probes, newest first, before falling back to
- * the broad lexicographic walk. Active buckets fill the page in the first one
- * or two; sparse ones do a bounded handful of (usually fast/empty) probes.
+ * How many month shards page 1 probes concurrently, newest first, alongside
+ * the broad lexicographic fallback. Wide enough to surface recent uploads in
+ * buckets that were quiet for a few months; results are merged, sorted by
+ * lastModified, and truncated to the page size.
  */
 const MONTH_SHARD_PROBES = 6;
 
 /**
  * Month-shard key prefixes to probe, newest first: `<bucketPrefix><yyyy>/<mm>/`
  * for the current month walking back `count` months, crossing year boundaries
- * (`2026/01/` -> `2025/12/`). Mirrors `buildObjectKey`'s UTC `yyyy/mm` shard
- * (`upload-policy.ts`) so a fresh upload is fetched by its month's probe instead
- * of being truncated behind older months in a year-wide lexicographic listing.
+ * (`2026/01/` -> `2025/12/`). Shares `monthShardSegment` with `buildObjectKey`
+ * so a fresh upload is always fetched by its month's probe instead of being
+ * truncated behind older months in a year-wide lexicographic listing.
  */
 export function monthShardPrefixes(
   bucketPrefix: string,
@@ -220,8 +222,7 @@ export function monthShardPrefixes(
   let year = now.getUTCFullYear();
   let month = now.getUTCMonth() + 1; // 1-12
   for (let i = 0; i < count; i++) {
-    const mm = String(month).padStart(2, "0");
-    prefixes.push(`${bucketPrefix}${year}/${mm}/`);
+    prefixes.push(`${bucketPrefix}${monthShardSegment(year, month)}`);
     month -= 1;
     if (month === 0) {
       month = 12;
@@ -233,11 +234,12 @@ export function monthShardPrefixes(
 
 /**
  * List a page of bucket objects, newest first. S3 ListObjectsV2 sorts only
- * lexicographically, so page 1 probes month shards newest-first (see
- * `monthShardPrefixes`) then a broad-prefix fallback for legacy keys and the
- * continuation token; results are merged, de-duped, and sorted by lastModified
- * DESC. Cursor pages walk the broad namespace lexicographically, still sorting
- * each page newest-first and skipping the month shards page 1 already returned.
+ * lexicographically, so page 1 probes the month shards concurrently (see
+ * `monthShardPrefixes`) plus a broad-prefix fallback for legacy keys and the
+ * continuation token, then merges, de-dupes, sorts by lastModified DESC, and
+ * truncates to the page size. Cursor pages walk the broad namespace in S3's
+ * lexicographic key order (older objects first, NOT re-sorted by lastModified),
+ * skipping the month shards page 1 already returned.
  */
 export async function listObjects(params: {
   ctx: FileConfigContext;
@@ -295,16 +297,20 @@ export async function listObjects(params: {
     );
   }
 
+  // Probe month shards concurrently — sequential round trips would each add ~1 RTT to an interactive open.
+  const monthResponses = await Promise.all(
+    monthShardPrefixesList.map((prefix) =>
+      client.send(
+        new ListObjectsV2Command({
+          Bucket: params.ctx.info.bucket,
+          Prefix: prefix,
+          MaxKeys: target,
+        }),
+      ),
+    ),
+  );
   const seen = new Map<string, ListedObject>();
-  for (const prefix of monthShardPrefixesList) {
-    if (seen.size >= target) break;
-    const res = await client.send(
-      new ListObjectsV2Command({
-        Bucket: params.ctx.info.bucket,
-        Prefix: prefix,
-        MaxKeys: target - seen.size,
-      }),
-    );
+  for (const res of monthResponses) {
     for (const obj of res.Contents ?? []) {
       if (!obj.Key || obj.Key.endsWith("/") || seen.has(obj.Key)) continue;
       seen.set(obj.Key, toListedObject(obj, params.ctx));
@@ -331,7 +337,10 @@ export async function listObjects(params: {
     ? (broadRes.NextContinuationToken ?? null)
     : null;
 
-  const items = Array.from(seen.values()).sort(byLastModifiedDesc);
+  // Concurrent probes over-fetch (up to `target` per shard), so keep only the newest page.
+  const items = Array.from(seen.values())
+    .sort(byLastModifiedDesc)
+    .slice(0, target);
   return { items, nextCursor };
 }
 

--- a/apps/api/src/file-storage/file-config-s3.ts
+++ b/apps/api/src/file-storage/file-config-s3.ts
@@ -198,23 +198,46 @@ export interface ListObjectsResult {
 }
 
 /**
- * S3 ListObjectsV2 only returns keys in lexicographic order — there's no
- * "filter / sort by lastModified" server-side. Our upload key format is
- * `<configured-prefix>/<yyyy>/<mm>/<uuid>-<filename>`, so to give the
- * picker a "recent first" feel we:
- *
- *   1. List under `<prefix><currentYear>/` first — every upload from this
- *      year is captured here, no matter what historical UUID-first keys
- *      live alongside.
- *   2. If we still have room in the page, list under `<prefix><prevYear>/`.
- *   3. Finally, list under the broad prefix as a fallback for legacy
- *      objects that don't follow our date sharding.
- *
- * Results are merged, de-duped by key, sorted by lastModified DESC, and
- * truncated to `maxKeys`. Cursor pagination is only used on the broad
- * fallback list — once the user pages past the "recent" buckets we
- * iterate the whole namespace lexicographically (the only thing S3
- * offers).
+ * How many month shards page 1 probes, newest first, before falling back to
+ * the broad lexicographic walk. Active buckets fill the page in the first one
+ * or two; sparse ones do a bounded handful of (usually fast/empty) probes.
+ */
+const MONTH_SHARD_PROBES = 6;
+
+/**
+ * Month-shard key prefixes to probe, newest first: `<bucketPrefix><yyyy>/<mm>/`
+ * for the current month walking back `count` months, crossing year boundaries
+ * (`2026/01/` -> `2025/12/`). Mirrors `buildObjectKey`'s UTC `yyyy/mm` shard
+ * (`upload-policy.ts`) so a fresh upload is fetched by its month's probe instead
+ * of being truncated behind older months in a year-wide lexicographic listing.
+ */
+export function monthShardPrefixes(
+  bucketPrefix: string,
+  now: Date,
+  count: number,
+): string[] {
+  const prefixes: string[] = [];
+  let year = now.getUTCFullYear();
+  let month = now.getUTCMonth() + 1; // 1-12
+  for (let i = 0; i < count; i++) {
+    const mm = String(month).padStart(2, "0");
+    prefixes.push(`${bucketPrefix}${year}/${mm}/`);
+    month -= 1;
+    if (month === 0) {
+      month = 12;
+      year -= 1;
+    }
+  }
+  return prefixes;
+}
+
+/**
+ * List a page of bucket objects, newest first. S3 ListObjectsV2 sorts only
+ * lexicographically, so page 1 probes month shards newest-first (see
+ * `monthShardPrefixes`) then a broad-prefix fallback for legacy keys and the
+ * continuation token; results are merged, de-duped, and sorted by lastModified
+ * DESC. Cursor pages walk the broad namespace lexicographically, still sorting
+ * each page newest-first and skipping the month shards page 1 already returned.
  */
 export async function listObjects(params: {
   ctx: FileConfigContext;
@@ -244,14 +267,11 @@ export async function listObjects(params: {
     });
   }
 
-  const now = new Date();
-  const currentYear = String(now.getUTCFullYear());
-  const prevYear = String(now.getUTCFullYear() - 1);
-
-  const yearShardPrefixes = [
-    `${bucketPrefix}${currentYear}/`,
-    `${bucketPrefix}${prevYear}/`,
-  ];
+  const monthShardPrefixesList = monthShardPrefixes(
+    bucketPrefix,
+    new Date(),
+    MONTH_SHARD_PROBES,
+  );
 
   // Subsequent pages walk the broad namespace via continuation token —
   // skip the date-shard probes (already returned on page 1) and filter
@@ -266,13 +286,17 @@ export async function listObjects(params: {
         ContinuationToken: params.cursor,
       }),
     );
-    return finalize(response, params.ctx, target, false, yearShardPrefixes);
+    return finalize(
+      response,
+      params.ctx,
+      target,
+      false,
+      monthShardPrefixesList,
+    );
   }
 
-  const probes = yearShardPrefixes;
-
   const seen = new Map<string, ListedObject>();
-  for (const prefix of probes) {
+  for (const prefix of monthShardPrefixesList) {
     if (seen.size >= target) break;
     const res = await client.send(
       new ListObjectsV2Command({
@@ -287,11 +311,7 @@ export async function listObjects(params: {
     }
   }
 
-  // Broad-prefix probe runs unconditionally — even when year shards
-  // already filled `target` — so we can capture nextCursor and let the
-  // user page into legacy objects that don't follow the yyyy/mm shard
-  // convention. Without this, an active bucket with ≥ target recent
-  // uploads would have its older objects unreachable from the picker.
+  // Runs unconditionally to expose nextCursor and reach legacy/older keys not under the month shards.
   const broadMaxKeys = Math.max(1, target - seen.size);
   const broadRes = await client.send(
     new ListObjectsV2Command({
@@ -303,9 +323,8 @@ export async function listObjects(params: {
   for (const obj of broadRes.Contents ?? []) {
     if (seen.size >= target) break;
     if (!obj.Key || obj.Key.endsWith("/") || seen.has(obj.Key)) continue;
-    // Year-shard keys were already pulled via dedicated probes; skip
-    // them here so we don't dupe items inside the same page response.
-    if (yearShardPrefixes.some((p) => obj.Key!.startsWith(p))) continue;
+    // Month-shard keys were already pulled via dedicated probes; skip to avoid duping.
+    if (monthShardPrefixesList.some((p) => obj.Key!.startsWith(p))) continue;
     seen.set(obj.Key, toListedObject(obj, params.ctx));
   }
   const nextCursor = broadRes.IsTruncated

--- a/apps/api/src/file-storage/upload-policy.ts
+++ b/apps/api/src/file-storage/upload-policy.ts
@@ -114,6 +114,15 @@ export function sanitizeFilename(input: string): string {
 }
 
 /**
+ * The `<yyyy>/<mm>/` date shard a key lives under (UTC, month zero-padded).
+ * Single source of truth for the shard format: `buildObjectKey` stamps it on
+ * write and `listObjects` probes it on read, so they must never diverge.
+ */
+export function monthShardSegment(year: number, month: number): string {
+  return `${year}/${String(month).padStart(2, "0")}/`;
+}
+
+/**
  * Build the object key: `<prefix?>/<yyyy>/<mm>/<uuid>-<sanitized-filename>`.
  * The prefix (already-normalized to end with `/`) comes from the file
  * config. The uuid prevents collisions; the date shards keep S3 LIST
@@ -124,10 +133,9 @@ export function buildObjectKey(params: {
   filename: string;
 }): string {
   const now = new Date();
-  const yyyy = now.getUTCFullYear().toString();
-  const mm = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const shard = monthShardSegment(now.getUTCFullYear(), now.getUTCMonth() + 1);
   const id = randomUUID();
   const safe = sanitizeFilename(params.filename);
-  const tail = `${yyyy}/${mm}/${id}-${safe}`;
+  const tail = `${shard}${id}-${safe}`;
   return params.prefix ? `${params.prefix}${tail}` : tail;
 }


### PR DESCRIPTION
## Summary

The image picker (`FilePickerDialog` — "Escolher uma imagem") listed bucket objects "recent first" on page 1 by probing the current/previous **year** prefix (`<prefix>/<yyyy>/`) capped at `MaxKeys`. But S3 `ListObjectsV2` sorts **only lexicographically** — within a year, `01/` sorts before `12/`, so a year-wide probe returns the **oldest** months and truncates the newest ones off the end.

Result: in any active bucket (more than ~50 objects in the current year), a **just-uploaded file never appeared on page 1** — the refetch after upload re-fetched the same truncated window.

Upload keys are `<prefix>/<yyyy>/<mm>/<uuid>-<filename>` (`upload-policy.ts` `buildObjectKey`), so the fix is to shard the probe by **month** and walk backwards from the current month.

## Changes

- New pure helper `monthShardPrefixes(bucketPrefix, now, count)` — generates `<prefix><yyyy>/<mm>/` prefixes newest-first, crossing year boundaries (`2026/01/` → `2025/12/`), mirroring `buildObjectKey`'s UTC `yyyy/mm` shard.
- Page 1 probes those month shards (bounded by `MONTH_SHARD_PROBES = 6`, stops early once the page fills) instead of the two year prefixes. The newest month is fetched directly and then sorted by `lastModified` DESC.
- Broad-prefix fallback (nextCursor + legacy keys) and cursor paging unchanged, now skipping the month shards page 1 already returned.

## Known limitation

If a **single month** holds more than ~50 objects, that month's probe still truncates at `MaxKeys` in UUID-lexicographic (random) order, so a brand-new upload in a very active month could still miss page 1. Eliminating that fully requires a real index with `created_at` rather than relying on S3's lexicographic listing — out of scope here. This PR fixes the cross-month truncation, which is the reported symptom.

## Testing

- Added `describe("monthShardPrefixes")` unit tests: newest-first ordering across the year boundary, zero-padded month matching `buildObjectKey`, UTC derivation, and `count: 0`.
- `bun test apps/api/src/file-storage/file-config-s3.test.ts` — 24 pass
- `bun run --cwd=apps/api check` (tsc) — clean
- `bun run lint` — 0 errors
- `bun run fmt` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows fresh uploads on page 1 by probing month shards newest-first in parallel. Previously we listed year prefixes; S3’s lexicographic order surfaced the oldest months and hid new uploads in active buckets.

- Adds `monthShardPrefixes` and a shared `monthShardSegment` used by `buildObjectKey` to generate UTC `<yyyy>/<mm>/` shards across year boundaries; page 1 probes up to `MONTH_SHARD_PROBES` months concurrently, then merges, de-dupes, sorts by `lastModified` DESC, and slices to the page size.
- Keeps the broad-prefix fallback to expose `nextCursor`; cursor pages skip month shards and return S3’s lexicographic order (oldest-first).
- Limitation: if a single month holds more than `MaxKeys`, newest items in that month can still be truncated.
- Tests cover `monthShardPrefixes` ordering (UTC, zero-padding, year wrap, multi-year), and shard parity with `buildObjectKey`; typecheck and lint are clean.

<sup>Written for commit 8e0540d85a79067fcaec2065f328af6d41deb726. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

