### PR TITLE
fix(i18n): correct invalid pt-br plural suffix in sandbox strings

### DIFF
--- a/apps/web/src/i18n/pt-br/sandbox.ts
+++ b/apps/web/src/i18n/pt-br/sandbox.ts
@@ -61,17 +61,17 @@ export const sandbox = {
     "Esta categoria ainda não possui conteúdo. Use ⊕ para adicionar seu primeiro bloco.",
   "sandbox.categoryEditor.pickPostsTooltip":
     "Selecione posts para adicionar nesta categoria",
-  "sandbox.categoryEditor.postsInCategory": "{count} post(ns) nesta categoria",
+  "sandbox.categoryEditor.postsInCategory": "{count} post(s) nesta categoria",
   "sandbox.categoryEditor.previewTooltip":
     "Abra a visualização da categoria em uma nova aba",
   "sandbox.categoryEditor.renameActionButton": "Renomear e atualizar posts",
   "sandbox.categoryEditor.renameDialogDescription":
-    'Alterar o slug de "{oldSlug}" para "{newSlug}" atualizará {count} post(ns) que fazem referência a esta categoria.',
+    'Alterar o slug de "{oldSlug}" para "{newSlug}" atualizará {count} post(s) que fazem referência a esta categoria.',
   "sandbox.categoryEditor.renameDialogTitle": "Renomear slug da categoria?",
   "sandbox.categoryEditor.renameFailed": "Falha ao renomear",
   "sandbox.categoryEditor.renameSuccessNoPosts": "Slug renomeado",
   "sandbox.categoryEditor.renameSuccessWithPosts":
-    "Slug renomeado e {count} post(ns) atualizado(s)",
+    "Slug renomeado e {count} post(s) atualizado(s)",
   "sandbox.categoryEditor.renamingLabel": "Renomeando…",
   "sandbox.categoryEditor.seeCategoryPreview": "Ver visualização da categoria",
   "sandbox.categoryEditor.setSlugTooltip":
@@ -718,7 +718,7 @@ export const sandbox = {
   "sandbox.variantCalendar.dateMatcherInfo":
     "Variantes condicionadas a um critério de data aparecem aqui.",
   "sandbox.variantCalendar.hiddenOngoingVariants":
-    '{count} variante(ns) em andamento oculta(s) — ative "Mostrar em andamento" para visualizar.',
+    '{count} variante(s) em andamento oculta(s) — ative "Mostrar em andamento" para visualizar.',
   "sandbox.variantCalendar.next": "Próximo",
   "sandbox.variantCalendar.noDatedVariants":
     "Nenhuma variante com data à vista.",


### PR DESCRIPTION
Found while auditing the sandbox i18n area for en/pt-br mismatches (issue hint: "Sandbox i18n strings" — align en and pt-br to avoid runtime UI glitches).

Three pt-br strings in `apps/web/src/i18n/pt-br/sandbox.ts` used an invalid plural suffix `post(ns)` / `variante(ns)` — not a real Portuguese word (the correct plural of both "post" and "variante" is formed by adding just "s": `posts`, `variantes`). The rest of the same file already uses the correct `(s)` suffix consistently (e.g. `post(s)` at lines 34/48/50, `Post sem título`, `Variantes condicionadas...`), so these 4 occurrences were an isolated typo, likely a leftover from an earlier "postagem"/"postagens" wording.

Affected keys: `sandbox.categoryEditor.postsInCategory`, `sandbox.categoryEditor.renameDialogDescription`, `sandbox.categoryEditor.renameSuccessWithPosts`, `sandbox.variantCalendar.hiddenOngoingVariants`.

A pt-br user hitting these UI strings (category post-count label, category rename dialog/toast, variant-calendar hidden-count banner) would see grammatically broken text like "3 post(ns) nesta categoria" instead of "3 post(s) nesta categoria".

How to confirm: `grep -n "(ns)" apps/web/src/i18n/pt-br/sandbox.ts` returns nothing (previously returned 4 hits); the fixed strings read naturally in Portuguese.

Checks run locally: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint apps/web/src/i18n/pt-br/sandbox.ts` (0 warnings/errors). Full CI validates the rest.

No key/placeholder additions or removals — pure string-value fix, en/pt-br key sets already matched 1:1 before this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the invalid pt-br plural suffix “(ns)” in sandbox UI strings by replacing it with “(s)”. Previously pt-br users saw text like “3 post(ns) nesta categoria”; now they see the correct “3 post(s) nesta categoria”, improving grammar and aligning pt-br with en without changing keys or placeholders.

**Review notes**
- Updates four pt-br translation values: sandbox.categoryEditor.postsInCategory, sandbox.categoryEditor.renameDialogDescription, sandbox.categoryEditor.renameSuccessWithPosts, sandbox.variantCalendar.hiddenOngoingVariants.
- No key or placeholder changes; pt-br-only string fix. Optional check: grep for “(ns)” in apps/web/src/i18n/pt-br/sandbox.ts should return no matches.

<sup>Written for commit 1d8269ceddd8f939bfbe1161fd6c809ddf228168. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

