### PR TITLE
fix(oauth): reject a non-string error/error_description in the refresh response

### DIFF
--- a/apps/api/src/oauth/refresh-access-token.test.ts
+++ b/apps/api/src/oauth/refresh-access-token.test.ts
@@ -70,6 +70,23 @@ describe("refreshAccessToken", () => {
     expect(result.permanent).toBe(true);
   });
 
+  it("ignores a non-string error/error_description instead of leaking them onto the result", async () => {
+    installFetch(
+      () =>
+        new Response(
+          JSON.stringify({ error: 400, error_description: { code: 400 } }),
+          { status: 400, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+
+    const result = await refreshAccessToken(baseToken);
+
+    expect(result.success).toBe(false);
+    expect(result.permanent).toBe(false);
+    expect(result.errorCode).toBeUndefined();
+    expect(result.error).toBe("Token refresh failed: 400");
+  });
+
   it("flags other 4xx errors as transient (could be config issue, retry-worthy)", async () => {
     installFetch(
       () =>

--- a/apps/api/src/oauth/refresh-access-token.ts
+++ b/apps/api/src/oauth/refresh-access-token.ts
@@ -104,9 +104,12 @@ export async function refreshAccessToken(
       let errorCode: string | undefined;
       let errorDescription: string | undefined;
       try {
+        // error/error_description are untrusted server input — narrow with typeof, like access_token below.
         const errorJson = JSON.parse(errorBody);
-        errorCode = errorJson.error;
-        errorDescription = errorJson.error_description;
+        if (typeof errorJson.error === "string") errorCode = errorJson.error;
+        if (typeof errorJson.error_description === "string") {
+          errorDescription = errorJson.error_description;
+        }
       } catch {
         // body wasn't JSON — fall through with undefined codes
       }


### PR DESCRIPTION
Follows the same-file hardening chain (#6061, #6068, #6076, #6081) that already narrows `access_token`/`refresh_token`/`expires_in` from the untrusted OAuth refresh response with `typeof` checks before trusting them.

`error`/`error_description` from the parsed error body were assigned straight from `JSON.parse(errorBody)` (typed `any`) with no type check, unlike every other field read off that same response. A non-compliant/broken token endpoint that echoes back a non-string `error` (e.g. `{ error: 400 }`) would silently violate `TokenRefreshResult.errorCode`'s declared `string` type — that value also feeds the `PERMANENT_REFRESH_ERROR_CODES.has(errorCode)` check that decides whether the cached token gets deleted, so keeping the type contract honest here matters for that logic staying correct as it's extended.

Failure scenario: token endpoint returns `400 { error: 400, error_description: { code: 400 } }` — before this fix, `result.errorCode` would be the number `400` instead of `string | undefined`, and `result.error` would render `[object Object]`-ish text once JS coerces it. Added a regression test (`ignores a non-string error/error_description instead of leaking them onto the result`) asserting `errorCode` stays `undefined` and `error` falls back to the generic `Token refresh failed: 400` message.

Reviewer check: `bun test apps/api/src/oauth/refresh-access-token.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects non-string `error`/`error_description` in OAuth refresh responses to keep `TokenRefreshResult` types correct and avoid misclassifying errors as permanent. Previously we copied these fields verbatim from JSON, so numbers/objects could leak into `errorCode` and `error`, skew `PERMANENT_REFRESH_ERROR_CODES` checks, and render `[object Object]`; now we ignore non-strings and fall back to "Token refresh failed: <status>."

- Narrows untrusted `error`/`error_description` with `typeof` checks; leaves `errorCode` undefined and uses the generic message when values are not strings, preventing accidental token cache deletion.
- Adds a regression test: `ignores a non-string error/error_description instead of leaking them onto the result`.
- Review: run `bun test apps/api/src/oauth/refresh-access-token.test.ts`.

<sup>Written for commit 0d20f3e3c504e5657d833f5ce22652cd1d05f342. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

