### PR TITLE
fix(cli): reject a non-object JSON body in the session-refresh response

### DIFF
--- a/apps/api/src/cli/lib/refresh-session.test.ts
+++ b/apps/api/src/cli/lib/refresh-session.test.ts
@@ -149,6 +149,23 @@ describe("refreshSession", () => {
     await expect(promise).rejects.toMatchObject({ kind: "transient" });
   });
 
+  it("throws RefreshFailedError(transient) on a valid-JSON non-object 200 body", async () => {
+    const fetchMock = mock(
+      async () =>
+        new Response("null", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    const promise = refreshSession(
+      makeSession(),
+      fetchMock as unknown as typeof fetch,
+      () => FIXED_NOW,
+    );
+    await expect(promise).rejects.toBeInstanceOf(RefreshFailedError);
+    await expect(promise).rejects.toMatchObject({ kind: "transient" });
+  });
+
   it("throws RefreshFailedError(invalid_grant) on 400", async () => {
     const fetchMock = mock(
       async () => new Response("invalid_grant", { status: 400 }),

--- a/apps/api/src/cli/lib/refresh-session.ts
+++ b/apps/api/src/cli/lib/refresh-session.ts
@@ -80,6 +80,14 @@ export async function refreshSession(
     );
   }
 
+  // Valid JSON (e.g. `null`) can still be a non-object — reject before property access.
+  if (typeof data !== "object" || data === null) {
+    throw new RefreshFailedError(
+      "transient",
+      "Token endpoint returned a non-object JSON body",
+    );
+  }
+
   if (typeof data.access_token !== "string" || !data.access_token) {
     throw new RefreshFailedError(
       "transient",


### PR DESCRIPTION
Continues the session-refresh hardening chain (#6079, #6083, #6085) that already rejects non-string `refresh_token`, malformed `expires_in`, and non-JSON 200 bodies.

**Bug**: the token endpoint's body is untrusted input. `res.json()` accepts any valid JSON, including a bare `null`, a number, or a string — none of those throw during parsing. `data.access_token` was then read unconditionally; on `data === null` this throws an uncaught `TypeError` that propagates out of `refreshSession` instead of the documented `RefreshFailedError`, crashing the CLI session-refresh flow ungracefully rather than falling back to the transient-failure path callers already handle.

**Fix**: after parsing, reject when `data` isn't a non-null object, throwing `RefreshFailedError("transient")` — same failure class as the sibling non-JSON-body check.

**Test**: added `throws RefreshFailedError(transient) on a valid-JSON non-object 200 body` — a 200 response with body `"null"` (valid JSON, parses to `null`) now yields the graceful error the sibling non-JSON-body test already exercises, where before this fix it would throw an uncaught TypeError.

**To verify**: `bun test apps/api/src/cli/lib/refresh-session.test.ts`

**Checks run locally**: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bun test apps/api/src/cli/lib/refresh-session.test.ts` (11 pass), `bunx oxlint` on both touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects non-object JSON bodies from the token endpoint in CLI session refresh. Previously, a 200 with valid JSON like null caused an uncaught TypeError when reading access_token; now it throws `RefreshFailedError('transient')`, consistent with other malformed-body cases.

**Review and verification**
- Adds a guard in `refreshSession` to require `data` is a non-null object before accessing fields; otherwise throws `RefreshFailedError('transient')`.
- Adds a test for a 200 response with JSON `"null"`; run: `bun test apps/api/src/cli/lib/refresh-session.test.ts`.
- No change to successful refresh; callers that handle transient errors need no changes.

<sup>Written for commit c4c6b17bf7a260f2353aa4ee92fcd810ef889c0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

