### PR TITLE
fix(oauth): clear the refresh backoff window when a dead token is deleted

### DIFF
--- a/apps/api/src/oauth/token-refresh.integration.test.ts
+++ b/apps/api/src/oauth/token-refresh.integration.test.ts
@@ -269,6 +269,43 @@ describe("refreshAndStore", () => {
     expect(await refreshAndStore(after!, tokenStorage)).toBeNull();
     expect(mockRefreshAccessToken).toHaveBeenCalledTimes(3);
   });
+
+  it("does not let a dead token's backoff throttle a freshly reconnected one", async () => {
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      success: false,
+      permanent: true,
+      status: 400,
+      errorCode: "invalid_grant",
+      error: "refresh token revoked",
+    });
+
+    const token = await tokenStorage.get(connectionId);
+    expect(await refreshAndStore(token!, tokenStorage)).toBeNull();
+    expect(await tokenStorage.get(connectionId)).toBeNull();
+
+    // Manual reconnect stores a brand new token for the same connection.
+    await tokenStorage.upsert({
+      connectionId,
+      accessToken: "reconnected",
+      refreshToken: "rt-new",
+      scope: "repo",
+      expiresAt: new Date(Date.now() - 1000),
+      clientId: "cid",
+      clientSecret: null,
+      tokenEndpoint: "https://example.com/token",
+    });
+
+    mockRefreshAccessToken.mockResolvedValueOnce({
+      success: true,
+      accessToken: "fresh",
+      refreshToken: "rt-new",
+      expiresIn: 3600,
+      scope: "repo",
+    });
+    const reconnected = await tokenStorage.get(connectionId);
+    expect(await refreshAndStore(reconnected!, tokenStorage)).toBe("fresh");
+    expect(mockRefreshAccessToken).toHaveBeenCalledTimes(2);
+  });
 });
 
 const { getValidDownstreamAccessToken } = await import("./token-refresh");

--- a/apps/api/src/oauth/token-refresh.ts
+++ b/apps/api/src/oauth/token-refresh.ts
@@ -90,7 +90,7 @@ export function clearRefreshBackoff(connectionId?: string): void {
 async function refreshAndStoreOnce(
   token: DownstreamToken,
   tokenStorage: DownstreamTokenStorage,
-): Promise<string | null> {
+): Promise<{ accessToken: string | null; permanent: boolean }> {
   const result = await refreshAccessToken(token);
   if (!result.success || !result.accessToken) {
     // Only delete the cached row when the OAuth server told us the
@@ -100,10 +100,8 @@ async function refreshAndStoreOnce(
     // OAuth server into a forced manual reconnect.
     if (result.permanent === true) {
       await tokenStorage.delete(token.connectionId);
-      // Don't let a dead token's backoff throttle a freshly reconnected one.
-      refreshBackoff.delete(token.connectionId);
     }
-    return null;
+    return { accessToken: null, permanent: result.permanent === true };
   }
   await tokenStorage.upsert({
     connectionId: token.connectionId,
@@ -117,7 +115,7 @@ async function refreshAndStoreOnce(
     clientSecret: token.clientSecret,
     tokenEndpoint: token.tokenEndpoint,
   });
-  return result.accessToken;
+  return { accessToken: result.accessToken, permanent: false };
 }
 
 export function refreshAndStore(
@@ -135,8 +133,9 @@ export function refreshAndStore(
   }
 
   const refresh = refreshAndStoreOnce(token, tokenStorage)
-    .then((accessToken) => {
-      if (accessToken) {
+    .then(({ accessToken, permanent }) => {
+      if (accessToken || permanent) {
+        // Permanent failure already deleted the token row — no backoff to arm.
         refreshBackoff.delete(token.connectionId);
       } else {
         const attempt = refreshBackoff.get(token.connectionId)?.attempt ?? 0;

--- a/apps/api/src/oauth/token-refresh.ts
+++ b/apps/api/src/oauth/token-refresh.ts
@@ -100,6 +100,8 @@ async function refreshAndStoreOnce(
     // OAuth server into a forced manual reconnect.
     if (result.permanent === true) {
       await tokenStorage.delete(token.connectionId);
+      // Don't let a dead token's backoff throttle a freshly reconnected one.
+      refreshBackoff.delete(token.connectionId);
     }
     return null;
   }


### PR DESCRIPTION
Follows the recent refresh-access-token hardening (#6089 and neighbors) in this area.

`refreshAndStore` keeps a per-connection exponential-backoff window (`refreshBackoff`, in `apps/api/src/oauth/token-refresh.ts`) that suppresses re-attempts after a failed refresh, up to a 5-minute cap. On a permanent failure (400 `invalid_grant`/`bad_refresh_token`) the dead token row is deleted, but the backoff entry for that `connectionId` was left in the map. `clearRefreshBackoff` exists and is exercised in tests, but nothing in production code ever calls it.

**Failure scenario:** a connection's refresh_token dies, gets deleted, and the backoff window opens (and grows on each subsequent failed attempt while the token is missing). The user then manually reconnects the same connection (same `connectionId`), storing a fresh token. The stale backoff window is still active, so the very first legitimate refresh of the new token is silently skipped (`refreshAndStore` returns `null` without even calling the OAuth endpoint) until the old window expires — up to 5 minutes of unnecessary refresh failures right after a reconnect. The map entry also never gets cleaned up otherwise, so it accumulates one entry per connection that ever hit a permanent failure.

Fix: clear the backoff entry for a connection at the same point its dead token row is deleted, since a future upsert for that `connectionId` represents a fresh reconnect, not the token the backoff was measuring.

Added a regression test in `apps/api/src/oauth/token-refresh.integration.test.ts` (`does not let a dead token's backoff throttle a freshly reconnected one`) that fails without the fix — a reconnected token would return `null` from the second `refreshAndStore` call instead of hitting the mocked endpoint.

Reviewer check: `bun test apps/api/src/oauth/token-refresh.integration.test.ts` (needs Postgres, as the existing tests in that file do).

Locally verified: `bun run fmt`, `bunx tsc --noEmit` in `apps/api` (clean), `bunx oxlint` on both changed files (0 warnings/errors). Could not run the integration test itself locally (no Postgres in this environment) — full CI covers it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears the OAuth refresh backoff as soon as a token is deleted on a permanent failure, so reconnects for the same `connectionId` are not throttled and the backoff map does not grow. Previously the token row was removed but the backoff window remained (and could be re-armed), causing the first refresh after a reconnect to be skipped for up to 5 minutes.

- On permanent refresh failure, delete the token and immediately clear its backoff entry before any retry logic can re-arm it.
- Internal change: `refreshAndStoreOnce` now returns `{ accessToken, permanent }`; `refreshAndStore` clears backoff when a refresh succeeds or fails permanently. External behavior is unchanged aside from removing stale throttling.
- Adds an integration test covering the reconnect scenario. Run: bun test apps/api/src/oauth/token-refresh.integration.test.ts (requires Postgres).

<sup>Written for commit 6af1589cb449e8423c4d0804495343afb1a30945. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

