### PR TITLE
fix(sandbox): don't retry a deserialized superseded error

### DIFF
--- a/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
@@ -472,6 +472,27 @@ describe("dispatchWithContinuation", () => {
     await expect(collect(run)).rejects.toThrow("a newer dispatch took over");
     expect(attempts).toBe(1);
   });
+
+  test("a deserialized superseded error (after DBOS replay) stops without retrying", async () => {
+    // DBOS serializes errors, losing subclasses; the `superseded` property survives.
+    let attempts = 0;
+    const run = dispatchWithContinuation({
+      runId: "run_1",
+      resume: null,
+      aborted: () => false,
+      dispatchOnce: () => {
+        attempts++;
+        const err = new RunSupersededError("a newer dispatch took over");
+        const deserialized = Object.assign(
+          new Error(err.message),
+          JSON.parse(JSON.stringify({ ...err })),
+        );
+        return dispatch([chunk("start"), chunk("text-delta")], deserialized)();
+      },
+    });
+    await expect(collect(run)).rejects.toThrow("a newer dispatch took over");
+    expect(attempts).toBe(1);
+  });
 });
 
 // Which terminal code continues the turn, which drops it quietly, and which

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -494,6 +494,7 @@ export async function* dispatchWithContinuation(args: {
               .catch(() => null)) ?? null)
           : null;
       if (
+        isRunSuperseded(err) ||
         !(err instanceof SandboxUnreachableError) ||
         stalled >= maxAttempts ||
         attempt >= maxTotalAttempts


### PR DESCRIPTION
## Problem

When a `RunSupersededError` is thrown during a DBOS step execution, DBOS serializes it for the durable journal and deserializes it on replay, losing the subclass information but preserving the `superseded` property. The `dispatchWithContinuation` function uses `instanceof` checks that fail on deserialized errors, potentially allowing a displaced dispatch attempt to retry instead of stopping quietly.

## Solution

Add an explicit `isRunSuperseded(err)` check in the retry condition before checking `instanceof SandboxUnreachableError`. This ensures deserialized superseded errors are caught and thrown immediately, preventing a displaced dispatch from competing with its successor for the same run.

New test case verifies that a deserialized `RunSupersededError` (simulating DBOS replay) doesn't get retried.

## Impact

- **Lines changed**: +22 / -0
- **Files**: 2 (main code + test)
- **Behavior preserved**: All existing tests pass; new test covers the DBOS replay scenario

## Verification

Run: `bun test apps/api/src/harnesses/sandbox-dispatch-client.test.ts`

All 43 tests pass (42 existing + 1 new for DBOS replay scenario).

CI will verify: `bun run fmt`, `bunx tsc --noEmit` in apps/api, `bunx oxlint` on changed files, and full test suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop retrying displaced sandbox dispatches when a superseded error is deserialized after DBOS replay. Previously, `dispatchWithContinuation` relied on `instanceof RunSupersededError` (lost on replay) and could retry; now it short-circuits on `isRunSuperseded(err)` to avoid competing with a successor run.

**Review notes**
- Adds `isRunSuperseded(err)` check before the `SandboxUnreachableError` retry path in `dispatchWithContinuation`.
- New test simulates a DBOS-replayed superseded error; asserts a single attempt with no retry.
- Behavior for non-superseded errors is unchanged.

<sup>Written for commit 9cfb2f3d50ca073344f21255431de8e222ea8c71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

