### PR TITLE
fix(file-picker): enumerate month shards in full so busy buckets sort newest-first

### DIFF
--- a/apps/api/src/file-storage/file-config-s3.test.ts
+++ b/apps/api/src/file-storage/file-config-s3.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import {
   buildPublicUrl,
+  byLastModifiedDesc,
   isImageKey,
+  type ListedObject,
   matchScanPage,
   monthShardPrefixes,
   nextScanStep,
@@ -173,6 +175,41 @@ describe("monthShardPrefixes", () => {
     const key = buildObjectKey({ prefix: "uploads/", filename: "photo.png" });
     const [probe] = monthShardPrefixes("uploads/", new Date(), 1);
     expect(key.startsWith(probe!)).toBe(true);
+  });
+});
+
+describe("byLastModifiedDesc", () => {
+  const obj = (key: string, lastModified: string | null): ListedObject => ({
+    key,
+    size: 1,
+    lastModified,
+    publicUrl: `https://cdn/${key}`,
+  });
+
+  test("orders newest first regardless of key order", () => {
+    // A fresh upload with a lexicographically-late UUID must still sort first.
+    const items = [
+      obj("2026/08/aaa.png", "2026-08-01T00:00:00.000Z"),
+      obj("2026/08/eee.png", "2026-08-14T09:53:00.000Z"),
+      obj("2026/08/ccc.png", "2026-08-10T00:00:00.000Z"),
+    ];
+    expect(
+      items
+        .slice()
+        .sort(byLastModifiedDesc)
+        .map((i) => i.key),
+    ).toEqual(["2026/08/eee.png", "2026/08/ccc.png", "2026/08/aaa.png"]);
+  });
+
+  test("sinks null lastModified to the bottom", () => {
+    const items = [
+      obj("a", null),
+      obj("b", "2026-08-14T00:00:00.000Z"),
+      obj("c", null),
+    ];
+    const sorted = items.slice().sort(byLastModifiedDesc);
+    expect(sorted[0]?.key).toBe("b");
+    expect(sorted.slice(1).map((i) => i.lastModified)).toEqual([null, null]);
   });
 });
 

--- a/apps/api/src/file-storage/file-config-s3.ts
+++ b/apps/api/src/file-storage/file-config-s3.ts
@@ -199,12 +199,22 @@ export interface ListObjectsResult {
 }
 
 /**
- * How many month shards page 1 probes concurrently, newest first, alongside
- * the broad lexicographic fallback. Wide enough to surface recent uploads in
- * buckets that were quiet for a few months; results are merged, sorted by
- * lastModified, and truncated to the page size.
+ * How many month shards page 1 walks back, newest first, before the broad
+ * lexicographic fallback. Wide enough to surface recent uploads in buckets
+ * quiet for a few months; each is enumerated in full and the merged set is
+ * sorted by lastModified, then truncated to the page size.
  */
 const MONTH_SHARD_PROBES = 6;
+
+/**
+ * Safety cap on pages (1000 keys each) enumerated per month shard. A month is
+ * listed in full so sorting by lastModified yields a true newest-first order
+ * (a single capped LIST returns UUID-lexicographic order, hiding the freshest
+ * upload behind older ones). This bounds the work if a single month ever holds
+ * a pathological number of objects; realistic image buckets stay well under
+ * one page.
+ */
+const MONTH_SHARD_MAX_PAGES = 5;
 
 /**
  * Month-shard key prefixes to probe, newest first: `<bucketPrefix><yyyy>/<mm>/`
@@ -232,14 +242,50 @@ export function monthShardPrefixes(
   return prefixes;
 }
 
+/** Raw S3 object fields the listing helpers reason about. */
+type RawS3Object = { Key?: string; Size?: number; LastModified?: Date };
+
+/**
+ * Enumerate every object directly under `prefix`, paginating up to `maxPages`
+ * pages of 1000. Listing the shard in full (rather than one capped LIST) is
+ * what lets the caller sort by lastModified into a true newest-first order — a
+ * single page comes back in UUID-lexicographic order, which buries the freshest
+ * upload behind older keys in a busy month.
+ */
+async function listAllUnderPrefix(
+  client: S3Client,
+  bucket: string,
+  prefix: string,
+  maxPages: number,
+): Promise<RawS3Object[]> {
+  const out: RawS3Object[] = [];
+  let token: string | undefined;
+  let pages = 0;
+  do {
+    const res = await client.send(
+      new ListObjectsV2Command({
+        Bucket: bucket,
+        Prefix: prefix,
+        MaxKeys: 1000,
+        ContinuationToken: token,
+      }),
+    );
+    for (const obj of res.Contents ?? []) out.push(obj);
+    token = res.IsTruncated ? res.NextContinuationToken : undefined;
+    pages += 1;
+  } while (token && pages < maxPages);
+  return out;
+}
+
 /**
  * List a page of bucket objects, newest first. S3 ListObjectsV2 sorts only
- * lexicographically, so page 1 probes the month shards concurrently (see
- * `monthShardPrefixes`) plus a broad-prefix fallback for legacy keys and the
- * continuation token, then merges, de-dupes, sorts by lastModified DESC, and
- * truncates to the page size. Cursor pages walk the broad namespace in S3's
- * lexicographic key order (older objects first, NOT re-sorted by lastModified),
- * skipping the month shards page 1 already returned.
+ * lexicographically, so page 1 enumerates the newest month shard in full (see
+ * `monthShardPrefixes` / `listAllUnderPrefix`), walking back to older months
+ * only if it doesn't fill the page, plus a broad-prefix fallback for legacy
+ * keys and the continuation token; results are merged, de-duped, sorted by
+ * lastModified DESC, and truncated to the page size. Cursor pages walk the
+ * broad namespace in S3's lexicographic key order (older objects first, NOT
+ * re-sorted by lastModified), skipping the month shards page 1 already returned.
  */
 export async function listObjects(params: {
   ctx: FileConfigContext;
@@ -297,24 +343,39 @@ export async function listObjects(params: {
     );
   }
 
-  // Probe month shards concurrently — sequential round trips would each add ~1 RTT to an interactive open.
-  const monthResponses = await Promise.all(
-    monthShardPrefixesList.map((prefix) =>
-      client.send(
-        new ListObjectsV2Command({
-          Bucket: params.ctx.info.bucket,
-          Prefix: prefix,
-          MaxKeys: target,
-        }),
-      ),
-    ),
-  );
   const seen = new Map<string, ListedObject>();
-  for (const res of monthResponses) {
-    for (const obj of res.Contents ?? []) {
+  const absorb = (objs: RawS3Object[]) => {
+    for (const obj of objs) {
       if (!obj.Key || obj.Key.endsWith("/") || seen.has(obj.Key)) continue;
       seen.set(obj.Key, toListedObject(obj, params.ctx));
     }
+  };
+
+  // Newest month first; every key in it outranks any older month, so we only walk back if it doesn't fill the page.
+  const [newestMonth, ...olderMonths] = monthShardPrefixesList;
+  if (newestMonth) {
+    absorb(
+      await listAllUnderPrefix(
+        client,
+        params.ctx.info.bucket,
+        newestMonth,
+        MONTH_SHARD_MAX_PAGES,
+      ),
+    );
+  }
+  if (seen.size < target && olderMonths.length > 0) {
+    // Fan the remaining months out concurrently — we already know we need them.
+    const older = await Promise.all(
+      olderMonths.map((prefix) =>
+        listAllUnderPrefix(
+          client,
+          params.ctx.info.bucket,
+          prefix,
+          MONTH_SHARD_MAX_PAGES,
+        ),
+      ),
+    );
+    for (const objs of older) absorb(objs);
   }
 
   // Runs unconditionally to expose nextCursor and reach legacy/older keys not under the month shards.
@@ -337,7 +398,7 @@ export async function listObjects(params: {
     ? (broadRes.NextContinuationToken ?? null)
     : null;
 
-  // Concurrent probes over-fetch (up to `target` per shard), so keep only the newest page.
+  // Full-month enumeration over-fetches, so sort by recency and keep one page.
   const items = Array.from(seen.values())
     .sort(byLastModifiedDesc)
     .slice(0, target);
@@ -489,7 +550,7 @@ function toListedObject(
   };
 }
 
-function byLastModifiedDesc(a: ListedObject, b: ListedObject): number {
+export function byLastModifiedDesc(a: ListedObject, b: ListedObject): number {
   // Nulls sink to the bottom.
   if (!a.lastModified && !b.lastModified) return 0;
   if (!a.lastModified) return 1;


### PR DESCRIPTION
## Summary

Follow-up to the month-shard listing fix. That change probed each month shard with a **single `MaxKeys`-capped LIST**, but S3 `ListObjectsV2` returns keys in **UUID-lexicographic (effectively random) order**. So in a bucket with more than one page of objects in the current month, a fresh upload whose UUID happens to sort late gets **truncated off the LIST before the `lastModified` sort ever runs** — and never reaches the top of the picker.

This is exactly what an active bucket hits in practice. Real repro (casaevideo): uploading `casaevideo-tanstack/2026/08/ed2e5809-…-pos-d-logo.png` — the `ed2e5809…` UUID sorts near the end of August's keys, so with >50 objects in August the just-uploaded image doesn't appear on page 1 even with the month probe.

## Fix

Enumerate the newest month shard **in full** (paginated, bounded by `MONTH_SHARD_MAX_PAGES = 5` pages of 1000) and sort the whole set by `lastModified`, so the most recent upload is guaranteed first regardless of its UUID.

Two-phase to keep it cheap:
1. Fetch the **newest month** first. Since every key in month *M* is newer than any key in month *M-1*, if the newest month alone fills the page we're done — one shard, ~1 round trip for active buckets.
2. Only when it doesn't fill the page, fan the remaining months out **concurrently**.

Broad-prefix fallback (legacy keys + `nextCursor`), cursor paging, and search are unchanged.

## Tradeoffs / limitations

- **Bandwidth:** a busy month is fetched in full (e.g. a few hundred keys ≈ one LIST page) and then sliced to the page size. This is the price of correct ordering without a storage-side recency index; realistic image buckets stay well under one page.
- **Safety cap:** `MONTH_SHARD_MAX_PAGES = 5` bounds a pathological month at 5000 keys. Beyond that the freshest upload could theoretically still be truncated — but 5000 image objects in a single month/prefix is far past realistic use.
- **Unchanged, pre-existing:** deep paging still can't reach objects under a month shard beyond the first page (cursor pages skip the shards); the single globally-oldest object can be skipped at the page-1/page-2 seam. Both predate this PR and would need the cursor to encode the shard set (a larger pagination rework). A fully reliable order at any scale still ultimately wants a `created_at` index (the deferred "option 3").

## Testing

- `byLastModifiedDesc` is now exported and unit-tested: a lexicographically-late-UUID key still sorts first, and null `lastModified` sinks to the bottom — this pins the exact ordering contract the fix relies on.
- The `listObjects` orchestration itself hits S3 and stays untestable in the two-tier model (no S3/MinIO in the e2e stack) — pre-existing.
- `bun test apps/api/src/file-storage/{file-config-s3,upload-policy}.test.ts` — 39 pass
- `bun run --cwd=apps/api check` (tsc) — clean · `bun run lint` — 0 errors · `bun run fmt` — applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the file picker so newest uploads always appear first in busy S3 buckets. Previously, page 1 probed each month shard with a single `ListObjectsV2` page (UUID-lexicographic), which could truncate a fresh upload before the `lastModified` sort.

- Enumerates the newest month shard in full via `listAllUnderPrefix` (paginated up to `MONTH_SHARD_MAX_PAGES = 5`), merges, de-dupes, then sorts by `lastModified` and slices to the page size.
- Only walks older month shards if the newest month doesn’t fill the page; fetches remaining months concurrently. Broad-prefix fallback and cursor paging are unchanged.
- Exports `byLastModifiedDesc` and adds tests (late-UUID keys still sort first; null `lastModified` sinks).
- Tradeoff: increased listing bandwidth for active months; hard cap limits worst-case work. No API changes or migrations required.

<sup>Written for commit b358b82d5b456c0f7dd50e4eead4ded7f6aaec10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

