### PR TITLE
fix(chat): dispose the orphaned thread connection on HMR teardown

### DIFF
--- a/apps/web/src/components/chat/store/thread-connection.ts
+++ b/apps/web/src/components/chat/store/thread-connection.ts
@@ -1621,6 +1621,14 @@ function readTimestamp(m: UIMessage): number {
 
 let current: ThreadConnection | null = null;
 
+// A hot-replaced module instance starts with `current: null`, orphaning the old instance's live SSE reconnect loop — dispose it on HMR teardown.
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    current?.dispose();
+    current = null;
+  });
+}
+
 /** Idempotent: same key → same instance. Different key → dispose + reopen. */
 export function getOrOpenStream(
   orgSlug: string,


### PR DESCRIPTION
Part of the chat hot-reload-resilience effort (issue #2711 — the maintainer flagged that issue as too large to land in one PR, but this is one bounded, self-contained piece of it).

`thread-connection.ts` keeps its single active `ThreadConnection` in a module-scoped `current` variable. That connection owns a persistent SSE reconnect loop with backoff. When Vite hot-replaces this module during dev (editing this file or anything it imports), the new module instance starts with `current: null` — but the *old* instance's `current` still exists in memory with its SSE loop still running, since nothing ever aborts it. The orphaned connection keeps retrying and firing its `onFinish`/`invalidateQueries` callbacks against stale closures (old `queryClient`, old React state) after every hot reload, alongside whatever connection the new module opens — so decopilot runs can appear to double-fire or desync right after a code change during local dev.

Fix: register an `import.meta.hot.dispose()` hook that calls `current?.dispose()` (aborts the SSE loop + any in-flight POST) before the module is torn down.

No test added — `import.meta.hot` doesn't exist under Bun's test runner, so there's nothing to assert against without faking Vite's HMR API; this is a `bunx tsc --noEmit`-verified dev-loop guard, not new runtime logic. Verified: `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, `bun test apps/web/src/components/chat/store/thread-connection.test.ts` (76 pass), `bunx oxlint apps/web/src/components/chat/store/thread-connection.ts` (0 warnings). Full CI validates the rest.

A reviewer can confirm by reading `getOrOpenStream`'s module-scoped-slot comment block and the new `if (import.meta.hot)` guard right below it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dispose orphaned chat thread SSE connection on Vite HMR teardown to prevent duplicate runs and stale callbacks during local development. Previously, hot-reloading `thread-connection.ts` left the old module’s `ThreadConnection` reconnect loop running; now `import.meta.hot.dispose` calls `current?.dispose()` and clears `current` so only one connection remains active.

**Review notes**
- Dev-only change; production builds without `import.meta.hot` are unaffected.
- Small addition placed under the module-scoped `current` in `apps/web/src/components/chat/store/thread-connection.ts`.
- No tests added; `import.meta.hot` is unavailable under the Bun test runner.

<sup>Written for commit d17d6361a9f554815f6cd1de54b28c2c39e9585e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

