### PR TITLE
fix(reports): raise deck footer above the stage so its popovers work

### DIFF
--- a/apps/web/src/routes/reports/signal-deck.tsx
+++ b/apps/web/src/routes/reports/signal-deck.tsx
@@ -794,7 +794,8 @@ export default function SignalDeck({
           as a seamless extension of the full-bleed card. Desktop is always light. */}
       <footer
         className={cn(
-          "relative flex shrink-0 items-center gap-2 px-4 py-4 sm:px-6",
+          // z-20: footer popovers open upward over the stage (`relative z-10`).
+          "relative z-20 flex shrink-0 items-center gap-2 px-4 py-4 sm:px-6",
           isCoverSlide && !isCtaSlide && "backdrop-blur-md",
         )}
         style={


### PR DESCRIPTION
## Summary

On a report deck (`/report/<domain>`), the two footer popovers were unusable:

- **"How we measure"** rendered behind the slide cards.
- **"A IA errou?" / report-an-error** appeared to do nothing on click.

Same root cause: the stage is `<main className="relative z-10">` while the
footer had no z-index, so the footer (and the popovers it anchors, which open
upward over the stage) painted underneath it — and the stage also swallowed the
click. One class on the footer: `z-20`.

## Testing

Manual, on a report deck: both footer popovers open, sit above the slide cards,
and the feedback textarea + submit are clickable. Header dropdown (`z-[60]`
inside the `z-20` header) is unaffected — it does not overlap the footer.

## Affected areas

`apps/web/src/routes/reports/signal-deck.tsx` only (one Tailwind class).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the report deck footer above the stage so its popovers render and accept clicks. Before: footer popovers appeared under slide cards and clicks were intercepted by the stage; after: footer uses `z-20` over a `z-10` stage, so popovers open above and work.

**Review notes**
- Single change: add `z-20` to the footer container in `apps/web/src/routes/reports/signal-deck.tsx`. Header dropdown (higher z-index) is unaffected.

**Verification**
- On `/report/<domain>`, open “How we measure” and the error-report popover; both render above slides and are clickable (textarea and submit).

<sup>Written for commit 3a378019da79b44b5ae7a8455c31cfcadf726e7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

