### PR TITLE
fix(reports): stop the methodology popover flashing open on hover

### DIFF
--- a/apps/web/src/routes/reports/signal-deck.tsx
+++ b/apps/web/src/routes/reports/signal-deck.tsx
@@ -931,7 +931,7 @@ export default function SignalDeck({
                   </button>
                   <span
                     className={cn(
-                      "absolute bottom-full left-0 mb-3 w-72 max-w-[calc(100vw-2rem)] rounded-xl p-4 text-sm leading-relaxed shadow-sm transition-opacity duration-200 group-hover:opacity-100",
+                      "absolute bottom-full left-0 mb-3 w-72 max-w-[calc(100vw-2rem)] rounded-xl p-4 text-sm leading-relaxed shadow-sm transition-opacity duration-200",
                       methoOpen
                         ? "opacity-100"
                         : "pointer-events-none opacity-0",


### PR DESCRIPTION
Follows #6096 (deck-footer z-index fix, which made these footer popovers actually renderable above the stage) and PR #6054's split-button/CMS work in the same reactive-hunt tick — hardening in the `signal-deck.tsx` footer popovers those PRs touched.

The "Como medimos" methodology popover in the report deck footer is designed to be click-toggled: it tracks `methoOpen` state, sets `aria-expanded`, and only becomes interactive (`pointer-events-auto`... well, it never even gets that) when the button is clicked — same pattern as its sibling "A IA errou?" feedback popover right next to it.

But its className list also carried a leftover `group-hover:opacity-100`. Since the popover's wrapping `<span>` has `className="group relative"`, hovering the button (or the popover's own footprint) faded it to full opacity even while `methoOpen` is `false` and the popover is `pointer-events-none` — a purely visual glitch: it appears on hover but nothing inside it can be clicked, and it has no such behavior on its sibling popover, so the two controls sitting side by side behave inconsistently for no reason visible in the code's own intent.

**Failure scenario:** a visitor drags their cursor across the footer (e.g. moving toward "A IA errou?" or just resting near "Como medimos") and the methodology text box flashes into view unprompted, then they can't click inside it because pointer-events are still off — confusing, and out of step with the aria-expanded/click contract the component otherwise commits to.

**Fix:** drop the stray `group-hover:opacity-100` class so visibility is driven solely by `methoOpen`, matching the feedback popover.

**To confirm:** open a report deck, hover (don't click) the "Como medimos" button in the footer — the popover should stay hidden; click it to open, click again to close (unchanged from before).

**Checks run locally:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint apps/web/src/routes/reports/signal-deck.tsx` (0 warnings/errors). No test added — this is a pure CSS-class removal restoring intended click-only behavior, not new logic; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the "Como medimos" methodology popover from flashing open on hover. Previously it became fully opaque on hover while closed; now it stays hidden on hover and opens only on click, matching the adjacent "A IA errou?" popover.

- Changed `apps/web/src/routes/reports/signal-deck.tsx`: removed `group-hover:opacity-100` so visibility is driven solely by `methoOpen`/`aria-expanded`.
- Verify: hover over "Como medimos" does nothing; click toggles open/close; `aria-expanded` reflects state; no change to pointer-events behavior.
- No migrations or config changes.

<sup>Written for commit d70e31084c0f7852b90463dc43fb97e086ef287b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

