### PR TITLE
fix(sandbox): keep directly-opened preview URLs alive, and show the boot page on deep links

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,6 +9,12 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
+# 0.16.0: the housekeeper now RENEWS a claim's shutdownTime (out to
+# idleTtlSeconds) whenever its daemon served traffic within
+# `housekeeper.renewActiveSeconds`. Studio only renews for its own SSE/run
+# clients, so a preview URL opened directly in a browser used to die
+# mid-session and 502 until it was reopened from Studio. Set
+# renewActiveSeconds: 0 for the old behaviour.
 # 0.14.6: opt-in `disruptionProtection.doNotDisrupt` (default off) — annotates
 # sandbox pods with Karpenter's `do-not-disrupt` so voluntary node
 # consolidation/drift never evicts a claimed sandbox mid-session (#5815). A
@@ -143,7 +149,7 @@ type: application
 # 0.8.0: org-fs sidecar (orgFs.*) — privileged rclone mounter + main-container
 # mounts. NOTE: the publish workflow skips existing versions, so this MUST
 # stay ahead of the latest published chart (0.7.5 at time of writing).
-version: 0.15.17
+version: 0.16.0
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "1.55.0"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/README.md
+++ b/deploy/helm/sandbox-env/README.md
@@ -286,6 +286,7 @@ See `values.yaml` for the full set. The most-tuned ones:
 | `nodePlaceholder.enabled` / `nodePlaceholder.replicas` | `false` / `2` | node "balloon": warm NODE capacity so warm-pool refill / cold claims skip the Karpenter wait; placement defaults to the sandbox `nodeSelector`/`tolerations` |
 | `previewGateway.enabled` | `false` | wildcard `*.preview.<domain>` Gateway + cert |
 | `housekeeper.enabled` | `false` | idle-claim and orphan cleanup CronJob |
+| `housekeeper.renewActiveSeconds` | `120` | renew a claim's `shutdownTime` while its daemon is still serving traffic (keeps directly-opened preview URLs alive); `0` disables |
 | `mesh.namespace` | `deco-studio` | studio release namespace (this env's) |
 | `mesh.serviceAccountName` | `deco-studio` | Studio ServiceAccount that gets the RoleBinding |
 | `mesh.serviceName` | `deco-studio` | _deprecated, unused since per-claim HTTPRoutes_ |

--- a/deploy/helm/sandbox-env/files/housekeeper-sweep.sh
+++ b/deploy/helm/sandbox-env/files/housekeeper-sweep.sh
@@ -2,7 +2,7 @@
 # sandbox-housekeeper sweep — one CronJob run.
 #
 # Env (set by the CronJob spec):
-#   NS, TTL_MS, PROBE_TIMEOUT_SEC,
+#   NS, TTL_MS, PROBE_TIMEOUT_SEC, RENEW_ACTIVE_MS,
 #   CLAIM_SELECTOR, POD_SELECTOR, RUN_ID.
 
 set -eu
@@ -30,6 +30,20 @@ LEGACY_IDLE_PATH="/_decopilot_vm/idle"
 # its adoption wait (the "did not record an adopted Sandbox within 60s" freeze).
 # Override via the CronJob env if needed.
 : "${RECONCILER_ERROR_GRACE_SEC:=120}"
+
+# A claim's own deadline (`spec.lifecycle.shutdownTime`, 15 min) is pushed
+# forward ONLY by Studio — the preview SSE handler or a streaming run. Someone
+# who opens the preview URL straight in a browser, which is how these links get
+# shared, renews nothing: the pod is deleted under them mid-session and the
+# hostname 502s until they reopen it from Studio. The daemon counts every
+# proxied request as activity, so a small idleMs here is the live-viewer signal
+# Studio cannot see, and this is the only sweep that sees it.
+#
+# Deliberately much shorter than TTL_MS: a claim Studio released early on
+# purpose (`releaseAfter` after a headless run) goes idle the moment the run
+# ends, so it still dies on its grace deadline. Only traffic in the last couple
+# of minutes — a human actually looking at the page — buys more time.
+: "${RENEW_ACTIVE_MS:=120000}"
 RECONCILER_ERROR_SINCE_ANNOTATION="studio.decocms.com/reconciler-error-since"
 
 now_iso()   { date -u +%Y-%m-%dT%H:%M:%SZ; }
@@ -159,6 +173,43 @@ request_shutdown() {
     >/dev/null 2>&1 || true
 }
 
+# Epoch seconds → `YYYY-MM-DDTHH:MM:SSZ`. `date -u -d @<epoch>` would be one
+# line, but it's a GNU extension and this sweep runs on busybox — where the
+# failure would be a silently empty timestamp, i.e. renewals that never happen
+# and nobody notices. awk is on both. (civil-from-days; valid for epoch >= 0.)
+iso_from_epoch() {
+  awk -v t="$1" 'BEGIN {
+    days = int(t / 86400); secs = t % 86400
+    z = days + 719468
+    era = int(z / 146097)
+    doe = z - era * 146097
+    yoe = int((doe - int(doe / 1460) + int(doe / 36524) - int(doe / 146096)) / 365)
+    y = yoe + era * 400
+    doy = doe - (365 * yoe + int(yoe / 4) - int(yoe / 100))
+    mp = int((5 * doy + 2) / 153)
+    d = doy - int((153 * mp + 2) / 5) + 1
+    m = mp + (mp < 10 ? 3 : -9)
+    if (m <= 2) y = y + 1
+    printf "%04d-%02d-%02dT%02d:%02d:%02dZ", y, m, d, int(secs / 3600), int((secs % 3600) / 60), secs % 60
+  }'
+}
+
+# Push a claim's deadline out to now + TTL because its daemon just served
+# traffic. Best-effort: a missed renewal costs one reprovision, and the next
+# sweep is a minute away.
+renew_shutdown() {
+  claim="$1"; idle="$2"
+  ts=$(iso_from_epoch "$(( $(date -u +%s) + TTL_MS / 1000 ))")
+  case "$ts" in
+    ????-??-??T??:??:??Z) ;;
+    *) log "renew-skip claim=$claim reason=bad-timestamp value=\"$ts\""; return 0 ;;
+  esac
+  log "renew claim=$claim idle_ms=$idle shutdown_at=$ts"
+  kubectl patch sandboxclaim "$claim" -n "$NS" --type=merge \
+    -p "{\"spec\":{\"lifecycle\":{\"shutdownPolicy\":\"Delete\",\"shutdownTime\":\"${ts}\"}}}" \
+    >/dev/null 2>&1 || true
+}
+
 # ReconcilerError path: operator has given up, so shutdownTime is unhonored.
 force_delete_claim() {
   claim="$1"; reason="$2"; detail="$3"
@@ -175,7 +226,7 @@ force_delete_claim() {
 [ "${HOUSEKEEPER_SOURCE_ONLY:-}" = "1" ] && return 0
 
 # === main ===
-log "starting (ttl=${TTL_MS}ms probe_timeout=${PROBE_TIMEOUT_SEC}s)"
+log "starting (ttl=${TTL_MS}ms renew_active=${RENEW_ACTIVE_MS}ms probe_timeout=${PROBE_TIMEOUT_SEC}s)"
 
 CLAIMS_FILE=$(mktemp)
 PODS_FILE=$(mktemp)
@@ -208,6 +259,7 @@ kubectl get pods -n "$NS" -l "$POD_SELECTOR" \
 
 total=0
 reaped=0
+renewed=0
 skipped=0
 
 # Redirect (not pipe) so the loop stays in the parent shell — pipe-into-
@@ -276,6 +328,10 @@ while IFS='|' read -r CLAIM READY REASON ERROR_SINCE; do
       IDLE_MS="$RESULT"
       if [ "$IDLE_MS" -lt "$TTL_MS" ]; then
         log "keep claim=$CLAIM idle_ms=$IDLE_MS remaining_ms=$((TTL_MS - IDLE_MS))"
+        if [ "$IDLE_MS" -lt "$RENEW_ACTIVE_MS" ]; then
+          renew_shutdown "$CLAIM" "$IDLE_MS"
+          renewed=$((renewed + 1))
+        fi
         continue
       fi
       # Re-probe right before reap to narrow (not eliminate) the
@@ -291,6 +347,12 @@ while IFS='|' read -r CLAIM READY REASON ERROR_SINCE; do
           if [ "$RESULT2" -lt "$TTL_MS" ]; then
             log "abort-reap claim=$CLAIM reason=activity-during-decide first_idle_ms=$IDLE_MS reprobe_idle_ms=$RESULT2"
             skipped=$((skipped + 1))
+            # Sparing it from the sweep isn't enough: its own deadline is what
+            # was about to fire, and it's now imminent.
+            if [ "$RESULT2" -lt "$RENEW_ACTIVE_MS" ]; then
+              renew_shutdown "$CLAIM" "$RESULT2"
+              renewed=$((renewed + 1))
+            fi
           else
             request_shutdown "$CLAIM" "Idle" "idle_ms=$IDLE_MS reprobe_idle_ms=$RESULT2 ttl_ms=$TTL_MS"
             reaped=$((reaped + 1))
@@ -347,4 +409,4 @@ if [ "$selector_mismatch" -eq 0 ]; then
   done
 fi
 
-log "heartbeat ok claims=$total reaped=$reaped skipped=$skipped orphan_routes=$orphan_routes failed_pods=$failed_pods"
+log "heartbeat ok claims=$total reaped=$reaped renewed=$renewed skipped=$skipped orphan_routes=$orphan_routes failed_pods=$failed_pods"

--- a/deploy/helm/sandbox-env/files/housekeeper-sweep.test.ts
+++ b/deploy/helm/sandbox-env/files/housekeeper-sweep.test.ts
@@ -9,6 +9,9 @@
  * 15 minutes after Studio warms it, forever.
  */
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const SCRIPT = new URL("./housekeeper-sweep.sh", import.meta.url).pathname;
 const TTL_MS = 15 * 60 * 1000;
@@ -107,5 +110,53 @@ describe("housekeeper probe_daemon", () => {
 
   it("reports a 5xx as a server error, not idle", async () => {
     expect(await probe("boom", 500)).toBe("__server_error__");
+  });
+});
+
+/**
+ * Run one of the script's functions with a stub `kubectl` first on PATH — the
+ * developer running this has a live kube context and renew_shutdown patches.
+ */
+async function runWithFakeKubectl(snippet: string): Promise<string> {
+  const bin = await mkdtemp(join(tmpdir(), "housekeeper-bin-"));
+  await Bun.write(`${bin}/kubectl`, '#!/bin/sh\necho "kubectl $*"\n');
+  await Bun.spawn(["chmod", "+x", `${bin}/kubectl`]).exited;
+  const proc = Bun.spawn(["sh", "-c", `. "$1"; ${snippet}`, "sh", SCRIPT], {
+    env: {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH}`,
+      HOUSEKEEPER_SOURCE_ONLY: "1",
+      NS: "test",
+      TTL_MS: String(TTL_MS),
+      PROBE_TIMEOUT_SEC: "5",
+      CLAIM_SELECTOR: "x=y",
+      POD_SELECTOR: "x=y",
+      RUN_ID: "test",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return (await new Response(proc.stdout).text()).trim();
+}
+
+describe("housekeeper renew_shutdown", () => {
+  // `date -u -d @<epoch>` is a GNU extension the sweep's busybox image doesn't
+  // have, so the conversion is hand-rolled — which makes it worth proving.
+  it("converts epoch seconds to a UTC RFC-3339 stamp", async () => {
+    expect(await runWithFakeKubectl("iso_from_epoch 1776175716")).toBe(
+      new Date(1776175716 * 1000).toISOString().replace(/\.\d{3}Z$/, "Z"),
+    );
+  });
+
+  it("renews to now + TTL, not to a bad-timestamp no-op", async () => {
+    const out = await runWithFakeKubectl("renew_shutdown my-claim 1234");
+    expect(out).toContain("renew claim=my-claim idle_ms=1234");
+    expect(out).not.toContain("renew-skip");
+    const stamp = out.match(/shutdown_at=(\S+)/)?.[1];
+    expect(stamp).toBeDefined();
+    const deltaMs = new Date(stamp as string).getTime() - Date.now();
+    // Renewal is now + TTL; a couple of seconds of slack for process startup.
+    expect(deltaMs).toBeGreaterThan(TTL_MS - 5_000);
+    expect(deltaMs).toBeLessThanOrEqual(TTL_MS);
   });
 });

--- a/deploy/helm/sandbox-env/templates/sandbox-housekeeper.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-housekeeper.yaml
@@ -123,6 +123,8 @@ spec:
                   value: agent-sandbox-system
                 - name: TTL_MS
                   value: {{ mul .Values.housekeeper.idleTtlSeconds 1000 | quote }}
+                - name: RENEW_ACTIVE_MS
+                  value: {{ mul .Values.housekeeper.renewActiveSeconds 1000 | quote }}
                 - name: PROBE_TIMEOUT_SEC
                   value: {{ .Values.housekeeper.probeTimeoutSeconds | quote }}
                 - name: CLAIM_SELECTOR

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -805,8 +805,9 @@ mesh:
     app.kubernetes.io/instance: "deco-studio"
 
 # ── idle-reap housekeeper ──────────────────────────────────────────────
-# CronJob that direct-deletes ReconcilerError claims and gracefully shuts
-# down idle Ready claims. Emits a Kubernetes Event per reap.
+# CronJob that direct-deletes ReconcilerError claims, gracefully shuts down
+# idle Ready claims, and renews the ones still serving traffic. Emits a
+# Kubernetes Event per reap.
 housekeeper:
   enabled: false
 
@@ -814,6 +815,14 @@ housekeeper:
 
   # Should match (or be shorter than) DEFAULT_IDLE_TTL_MS in runner.ts.
   idleTtlSeconds: 900
+
+  # A claim whose daemon served traffic this recently gets its shutdownTime
+  # pushed back out to idleTtlSeconds. This is what keeps a sandbox alive for
+  # someone watching the preview URL directly in a browser — Studio only renews
+  # for its own SSE/run clients. Keep it well under idleTtlSeconds: a claim
+  # Studio released early is idle immediately and must still die on schedule.
+  # 0 disables renewal (pre-fix behaviour).
+  renewActiveSeconds: 120
 
   probeTimeoutSeconds: 2
 

--- a/packages/sandbox/daemon-e2e/daemon.proxy.e2e.test.ts
+++ b/packages/sandbox/daemon-e2e/daemon.proxy.e2e.test.ts
@@ -66,12 +66,24 @@ describe("daemon e2e: reverse proxy", () => {
     expect(await res.text()).toContain("Server is starting");
   });
 
-  it("dev port set but unreachable at a non-root path → 502 JSON", async () => {
+  it("dev port set but unreachable at a non-root asset request → 502 JSON", async () => {
     await startWithDeadPort();
     const res = await fetch(url(d!, "/api/thing"));
     expect(res.status).toBe(502);
     const body = (await res.json()) as { error: string };
     expect(body.error).toContain("proxy error");
+  });
+
+  it("dev port set but unreachable at a non-root navigation → 503 'Server is starting…'", async () => {
+    // Shared preview links carry a deep path. Before this, only `/` got the
+    // starting page and every other URL 502'd through the boot window.
+    await startWithDeadPort();
+    const res = await fetch(url(d!, "/2127?map=productClusterIds"), {
+      headers: { Accept: "text/html,application/xhtml+xml" },
+    });
+    expect(res.status).toBe(503);
+    expect(res.headers.get("retry-after")).toBe("1");
+    expect(await res.text()).toContain("Server is starting");
   });
 
   it("HTML upstream: injects bootstrap + strips XFO/CSP", async () => {

--- a/packages/sandbox/daemon-go/internal/proxy/proxy.go
+++ b/packages/sandbox/daemon-go/internal/proxy/proxy.go
@@ -47,6 +47,15 @@ func htmlResponse(w http.ResponseWriter, status int, body string, extra map[stri
 	io.WriteString(w, body)
 }
 
+// A page navigation, as opposed to an asset/XHR fetch. Browsers ask for
+// `text/html` when loading a document or an iframe and `*/*` (or `image/*`,
+// …) for everything a page then pulls in — so this is what decides whether a
+// human is waiting behind the request and should see a page rather than a
+// proxy error.
+func acceptsHTML(r *http.Request) bool {
+	return strings.Contains(strings.ToLower(r.Header.Get("Accept")), "text/html")
+}
+
 func isConnError(err error) bool {
 	msg := err.Error()
 	for _, pat := range []string{
@@ -176,7 +185,11 @@ func (p *Handler) proxyError(w http.ResponseWriter, r *http.Request, port int, e
 	if p.deps.Log != nil {
 		p.deps.Log(fmt.Sprintf("proxy error %s %s port=%d %s", r.Method, r.URL.Path, port, msg))
 	}
-	if r.URL.Path == "/" && isConnError(err) {
+	// Any navigation, not just `/`: a preview URL shared with a deep path
+	// (`/2127?page=1`) is the normal way these links travel, and gating the
+	// starting page on the root path turned the dev server's boot window into a
+	// bare 502 for everyone who opened one.
+	if isConnError(err) && (r.URL.Path == "/" || acceptsHTML(r)) {
 		htmlResponse(w, 503, StartingHTML, map[string]string{"Retry-After": "1"})
 		return
 	}


### PR DESCRIPTION
## What happened

A preview URL shared over WhatsApp 502'd for a customer and for us. Traced in prod (`eks-serverless`, claim `pedro-oliveira-ftfayrsm-7327321ab2e583c7`):

| Time (UTC) | Event |
|---|---|
| 13:19:18 | claim adopts a warm pod |
| **13:34:18** | `Deleting Claim because time has expired` — 15m00s later, **zero renewals** |
| 13:41:09 | reopened → new pod |
| **13:56:12** | expires again, 15m03s, again **zero renewals** |
| 13:56 → 14:08 | no claim → no HTTPRoute → Cloudflare 502 |
| 14:08:18 | reopened, adopts a warm pod, clone 4s, deps from golden L2 |
| **14:08:36.390** | daemon: `proxy error GET /2127 port=3000 … connection refused` ← the exact 502 in the report |
| 14:08:36.823 | Vite up on 5173, `starting → running` |

Two independent causes.

## 1. Preview traffic renewed nothing

`spec.lifecycle.shutdownTime` (now + `DEFAULT_IDLE_TTL_MS`, 15 min, `shutdownPolicy: Delete`) is pushed forward only by `renewTtl`, whose callers are the preview SSE handler (`sandbox-events-handler.ts`) and a streaming run (`sandbox-dispatch-client.ts`). A browser tab on the preview hostname is not in either path, so the sandbox died under its viewer — twice, on the dot.

The daemon already bumps activity on every proxied request, and the housekeeper already probes `/_sandbox/idle` on every sweep. So the sweep now **renews** a claim whose daemon served traffic within `housekeeper.renewActiveSeconds` (default 120s; `0` = old behaviour), instead of only ever shortening deadlines.

`renewActiveSeconds` is deliberately far below the TTL: a claim Studio released early on purpose (`releaseAfter` after a headless run) goes idle immediately and still dies on its grace deadline. Only traffic in the last couple of minutes — a human looking at the page — buys more time.

Known ceiling, unchanged from before: an open tab renews indefinitely, exactly as an open Studio preview panel already did. True silence still reaps at 15 minutes.

## 2. The boot page only existed at `/`

`proxyError` served `StartingHTML` only when `r.URL.Path == "/"`. Shared preview links carry a deep path, so the 18-second boot window rendered a raw 502. Now any navigation (`Accept: text/html`) gets the page; assets and XHR keep the JSON 502.

## Not covered

A hostname with **no** claim still 502s at the gateway — nothing in the request path can reprovision it, and the chart deliberately keeps Studio out of that path. Fix 1 makes that window far rarer. A wildcard fallback route needs its own always-on backend; separate change.

## Testing

- `deploy/helm/sandbox-env/files/housekeeper-sweep.test.ts`: two new cases — the hand-rolled epoch→RFC-3339 conversion (`date -d @epoch` is a GNU extension the busybox sweep image lacks, and a silent failure there would mean renewals that never happen), and `renew_shutdown` landing at now + TTL. Runs with a stub `kubectl` on PATH so a dev's live kube context is never touched. 7 pass.
- `daemon.proxy.e2e.test.ts`: new deep-link-navigation case; the existing asset-request case is kept and renamed since it still asserts the 502. 8 pass against the built Go binary.
- `go build ./... && go test ./...` green; `helm template` renders `RENEW_ACTIVE_MS`; `sh -n` on the sweep.

Chart bumped to **0.16.0** — prod pins a `targetRevision` in deco-apps-cd, so that needs bumping for this to take effect.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps directly opened preview URLs alive and shows the boot page on deep-link navigations. Previously, claims expired at 15 minutes unless Studio renewed them, and deep links returned a raw 502 while the dev server booted; now the housekeeper renews recently active claims and the proxy serves “Server is starting…” on any navigation.

- Housekeeper renews `spec.lifecycle.shutdownTime` to now + TTL when the daemon served traffic within `housekeeper.renewActiveSeconds` (default 120s; `0` restores old behavior). Open tabs can renew indefinitely; assets/XHR still return JSON 502; Studio-triggered early releases still expire on schedule.
- Proxy serves the boot page (503 with Retry-After: 1) on any navigation request (`Accept: text/html`), not only `/`; assets and XHR remain JSON 502.

**Rollout**
- Helm chart bumped to `0.16.0`; update the pinned `targetRevision` in prod to deploy.
- `housekeeper.renewActiveSeconds` is configurable in `deploy/helm/sandbox-env/values.yaml`. Set to `0` to disable renewal if needed.

<sup>Written for commit 7d0db1265327867b6feff5599794de4212cae266. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

