### PR TITLE
fix(blocks): clear pending SEO-edit intent on plain page selection

### DIFF
--- a/apps/web/src/components/sandbox/blocks/blocks-preview-workspace-state.test.ts
+++ b/apps/web/src/components/sandbox/blocks/blocks-preview-workspace-state.test.ts
@@ -81,6 +81,23 @@ describe("blocksPreviewWorkspaceReducer", () => {
     });
   });
 
+  test("selecting a new target clears a pending SEO-edit intent", () => {
+    const editing = blocksPreviewWorkspaceReducer(
+      INITIAL_BLOCKS_PREVIEW_WORKSPACE,
+      {
+        type: "edit-seo",
+        target: { kind: "page", key: "pages-home", path: "/" },
+      },
+    );
+
+    const next = blocksPreviewWorkspaceReducer(editing, {
+      type: "select",
+      target: { kind: "page", key: "pages-about", path: "/about" },
+    });
+
+    expect(next.editSeoPageKey).toBeNull();
+  });
+
   test("records variant override params for the preview iframe", () => {
     const next = blocksPreviewWorkspaceReducer(
       INITIAL_BLOCKS_PREVIEW_WORKSPACE,

--- a/apps/web/src/components/sandbox/blocks/blocks-preview-workspace-state.ts
+++ b/apps/web/src/components/sandbox/blocks/blocks-preview-workspace-state.ts
@@ -35,9 +35,13 @@ export function blocksPreviewWorkspaceReducer(
 ): BlocksPreviewWorkspaceState {
   switch (action.type) {
     case "select":
-      // A new target's variant override is unknown until the editor emits it;
-      // drop the previous target's params so they don't bleed across pages.
-      return { ...state, target: action.target, variantOverride: null };
+      // Selecting away drops the stale variant override and SEO-edit intent.
+      return {
+        ...state,
+        target: action.target,
+        variantOverride: null,
+        editSeoPageKey: null,
+      };
     case "edit-seo":
       return {
         ...state,


### PR DESCRIPTION
**Bug**: `blocksPreviewWorkspaceReducer`'s `select` action already resets the stale `variantOverride` on navigation, but left `editSeoPageKey` untouched.

**Why a maintainer wants this**: `editSeoPageKey` is only cleared via the explicit `consume-edit-seo` action, dispatched from `SectionsEditor`'s `onExitSeo` when the user clicks the SEO breadcrumb to leave the SEO form. Plain navigation away from a page (clicking a different page/section in the content browser, which dispatches `select`) never calls that. So: open page A, click "Edit SEO", navigate to page B without closing the SEO form, then navigate back to page A — `blocks-panel.tsx`'s `initialEditSeo` check (`editSeoPageKey === activePageBlockKey`) is true again, silently reopening the SEO editor the user never re-requested.

**Fix**: `select` now clears `editSeoPageKey` alongside `variantOverride` — same latent-state-bleed class the variant-override case already guards against.

**Regression test**: added `"selecting a new target clears a pending SEO-edit intent"` in `blocks-preview-workspace-state.test.ts`, which fails on the old reducer (asserts `editSeoPageKey` is `null` after a `select` that follows an `edit-seo`).

**Verify**: `bun test apps/web/src/components/sandbox/blocks/blocks-preview-workspace-state.test.ts`

**Checks run locally**: `bun run fmt`, the targeted test file above (8 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears pending SEO-edit intent on plain navigation in `blocksPreviewWorkspaceReducer` to stop the SEO editor from reopening unexpectedly. Previously, `select` cleared `variantOverride` but left `editSeoPageKey`; now `select` nulls both.

- Adds a unit test covering the behavior: "selecting a new target clears a pending SEO-edit intent".
- Manual check: start SEO edit on page A, navigate to page B, return to page A — the SEO editor should not auto-open.
- No API or schema changes. No migration required.

<sup>Written for commit 00ee827fb5e0c5cfbb095b6c0aeda2274145e6aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

