### PR TITLE
fix(sandbox-env): renew claims past the idle TTL so the graceful reap wins

### DIFF
--- a/deploy/helm/sandbox-env/Chart.yaml
+++ b/deploy/helm/sandbox-env/Chart.yaml
@@ -9,6 +9,11 @@ description: |
   releases coexist in the shared `agent-sandbox-system` namespace.
   Requires the sandbox-operator chart to already be installed.
 type: application
+# 0.16.2: renewals now land at idleTtlSeconds + `housekeeper.renewSlackSeconds`
+# (default 60) instead of exactly idleTtlSeconds, so the sweep's graceful reap
+# — HTTPRoute deleted before the pod drains — stays ahead of the operator's own
+# ClaimExpired, which skips that ordering. Keep the slack >= your sweep
+# interval.
 # 0.16.0: the housekeeper now RENEWS a claim's shutdownTime (out to
 # idleTtlSeconds) whenever its daemon served traffic within
 # `housekeeper.renewActiveSeconds`. Studio only renews for its own SSE/run
@@ -149,7 +154,7 @@ type: application
 # 0.8.0: org-fs sidecar (orgFs.*) — privileged rclone mounter + main-container
 # mounts. NOTE: the publish workflow skips existing versions, so this MUST
 # stay ahead of the latest published chart (0.7.5 at time of writing).
-version: 0.16.1
+version: 0.16.2
 # appVersion tracks the studio-sandbox image version (image.tag default).
 appVersion: "1.55.1"
 kubeVersion: ">=1.30.0-0"

--- a/deploy/helm/sandbox-env/README.md
+++ b/deploy/helm/sandbox-env/README.md
@@ -286,6 +286,7 @@ See `values.yaml` for the full set. The most-tuned ones:
 | `nodePlaceholder.enabled` / `nodePlaceholder.replicas` | `false` / `2` | node "balloon": warm NODE capacity so warm-pool refill / cold claims skip the Karpenter wait; placement defaults to the sandbox `nodeSelector`/`tolerations` |
 | `previewGateway.enabled` | `false` | wildcard `*.preview.<domain>` Gateway + cert |
 | `housekeeper.enabled` | `false` | idle-claim and orphan cleanup CronJob |
+| `housekeeper.renewSlackSeconds` | `60` | how far past `idleTtlSeconds` a renewal sets the claim deadline, so the graceful reap wins the race; keep >= the sweep interval |
 | `housekeeper.renewActiveSeconds` | `120` | renew a claim's `shutdownTime` while its daemon is still serving traffic (keeps directly-opened preview URLs alive); `0` disables |
 | `mesh.namespace` | `deco-studio` | studio release namespace (this env's) |
 | `mesh.serviceAccountName` | `deco-studio` | Studio ServiceAccount that gets the RoleBinding |

--- a/deploy/helm/sandbox-env/files/housekeeper-sweep.sh
+++ b/deploy/helm/sandbox-env/files/housekeeper-sweep.sh
@@ -2,7 +2,7 @@
 # sandbox-housekeeper sweep — one CronJob run.
 #
 # Env (set by the CronJob spec):
-#   NS, TTL_MS, PROBE_TIMEOUT_SEC, RENEW_ACTIVE_MS,
+#   NS, TTL_MS, PROBE_TIMEOUT_SEC, RENEW_ACTIVE_MS, RENEW_SLACK_SEC,
 #   CLAIM_SELECTOR, POD_SELECTOR, RUN_ID.
 
 set -eu
@@ -194,12 +194,22 @@ iso_from_epoch() {
   }'
 }
 
-# Push a claim's deadline out to now + TTL because its daemon just served
+# Push a claim's deadline out past now + TTL because its daemon just served
 # traffic. Best-effort: a missed renewal costs one reprovision, and the next
 # sweep is a minute away.
+#
+# The slack matters. Renewing to exactly now + TTL puts the claim's own
+# deadline in the same instant this sweep would decide the claim is idle, and
+# whoever wins that race decides how the pod dies: `request_shutdown` deletes
+# the HTTPRoute BEFORE the operator drains the pod, so the daemon's SIGTERM
+# git-sync isn't still taking traffic. An operator-driven ClaimExpired skips
+# that ordering. Keep this >= the sweep interval so the sweep that first sees
+# the claim go idle still lands before the operator's own deadline; the default
+# fits the 1-minute cron prod runs.
+: "${RENEW_SLACK_SEC:=60}"
 renew_shutdown() {
   claim="$1"; idle="$2"
-  ts=$(iso_from_epoch "$(( $(date -u +%s) + TTL_MS / 1000 ))")
+  ts=$(iso_from_epoch "$(( $(date -u +%s) + TTL_MS / 1000 + RENEW_SLACK_SEC ))")
   case "$ts" in
     ????-??-??T??:??:??Z) ;;
     *) log "renew-skip claim=$claim reason=bad-timestamp value=\"$ts\""; return 0 ;;

--- a/deploy/helm/sandbox-env/files/housekeeper-sweep.test.ts
+++ b/deploy/helm/sandbox-env/files/housekeeper-sweep.test.ts
@@ -148,15 +148,17 @@ describe("housekeeper renew_shutdown", () => {
     );
   });
 
-  it("renews to now + TTL, not to a bad-timestamp no-op", async () => {
+  it("renews past now + TTL, not to a bad-timestamp no-op", async () => {
     const out = await runWithFakeKubectl("renew_shutdown my-claim 1234");
     expect(out).toContain("renew claim=my-claim idle_ms=1234");
     expect(out).not.toContain("renew-skip");
     const stamp = out.match(/shutdown_at=(\S+)/)?.[1];
     expect(stamp).toBeDefined();
     const deltaMs = new Date(stamp as string).getTime() - Date.now();
-    // Renewal is now + TTL; a couple of seconds of slack for process startup.
-    expect(deltaMs).toBeGreaterThan(TTL_MS - 5_000);
-    expect(deltaMs).toBeLessThanOrEqual(TTL_MS);
+    // now + TTL + RENEW_SLACK_SEC (60s), which keeps the housekeeper's own
+    // graceful reap ahead of the operator's ClaimExpired. A few seconds of
+    // tolerance for process startup.
+    expect(deltaMs).toBeGreaterThan(TTL_MS + 55_000);
+    expect(deltaMs).toBeLessThanOrEqual(TTL_MS + 60_000);
   });
 });

--- a/deploy/helm/sandbox-env/templates/sandbox-housekeeper.yaml
+++ b/deploy/helm/sandbox-env/templates/sandbox-housekeeper.yaml
@@ -125,6 +125,8 @@ spec:
                   value: {{ mul .Values.housekeeper.idleTtlSeconds 1000 | quote }}
                 - name: RENEW_ACTIVE_MS
                   value: {{ mul .Values.housekeeper.renewActiveSeconds 1000 | quote }}
+                - name: RENEW_SLACK_SEC
+                  value: {{ .Values.housekeeper.renewSlackSeconds | quote }}
                 - name: PROBE_TIMEOUT_SEC
                   value: {{ .Values.housekeeper.probeTimeoutSeconds | quote }}
                 - name: CLAIM_SELECTOR

--- a/deploy/helm/sandbox-env/values.yaml
+++ b/deploy/helm/sandbox-env/values.yaml
@@ -824,6 +824,13 @@ housekeeper:
   # 0 disables renewal (pre-fix behaviour).
   renewActiveSeconds: 120
 
+  # How far PAST idleTtlSeconds a renewal sets the claim's own deadline. Keeps
+  # the housekeeper's graceful reap (HTTPRoute deleted first, then the operator
+  # drains the pod) ahead of the operator's own ClaimExpired, which skips that
+  # ordering. Keep it >= your `schedule` interval — the default fits a 1-minute
+  # cron.
+  renewSlackSeconds: 60
+
   probeTimeoutSeconds: 2
 
   # 600s ≈ 400 sandboxes/sweep at ~1.5s/claim worst case.


### PR DESCRIPTION
Follow-up to #6098.

That PR renews an active claim's `shutdownTime` to exactly `now + idleTtlSeconds`. Which means an idle claim's own deadline lands in the same instant the next sweep would decide it is idle — and whoever wins that race decides how the pod dies:

- housekeeper wins → `request_shutdown` → `mark_for_reap` deletes the **HTTPRoute first**, then the operator drains the pod, so the daemon's SIGTERM git-sync isn't still taking traffic.
- operator wins → `ClaimExpired` deletes the claim directly and that ordering is skipped; the route lingers until the next sweep's orphan GC.

Renewals now land at `idleTtlSeconds + housekeeper.renewSlackSeconds` (default 60s, env-overridable as `RENEW_SLACK_SEC`), keeping the graceful path in front. Keep the slack >= your sweep interval — the default fits the 1-minute cron prod runs; an env on the chart's default `*/5` schedule wants 300.

Nothing else changes: renewal still only fires for a claim whose daemon served traffic within `renewActiveSeconds`, and the reap paths are untouched.

Test updated to assert the new window; `helm template` renders `RENEW_SLACK_SEC`; `sh -n` clean. Chart 0.16.2.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renewals push an active claim’s `shutdownTime` to `idleTtlSeconds + slack` so the sweep wins the idle race and performs the graceful reap. Previously we renewed to exactly `now + idleTtlSeconds`, which let the operator’s `ClaimExpired` preempt the sweep and skip deleting the HTTPRoute before draining.

- Introduces `housekeeper.renewSlackSeconds` (env `RENEW_SLACK_SEC`, default `60`). Set this to at least your sweep interval (e.g., `300` for a `*/5` CronJob) to keep the graceful path ahead of `ClaimExpired`.
- Chart bumped to `0.16.2`. Renewal trigger (`housekeeper.renewActiveSeconds`) and reap paths are unchanged; tests updated to assert the new window.

<sup>Written for commit 40410e9d09f2b187532920424592d43f4cfc5631. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

