### PR TITLE
fix(cli): clear the stale session file when refresh hits invalid_grant

### DIFF
--- a/apps/api/src/cli/lib/get-valid-session.test.ts
+++ b/apps/api/src/cli/lib/get-valid-session.test.ts
@@ -117,7 +117,7 @@ describe("getValidSession", () => {
     expect(result).toBeNull();
   });
 
-  it("returns null when refresh fails with invalid_grant", async () => {
+  it("returns null and clears the stale file when refresh fails with invalid_grant", async () => {
     await writeSession(dir, makeSession({ expiresAt: NOW_S - 60 }));
     const fetchMock = mock(
       async () => new Response("invalid_grant", { status: 400 }),
@@ -128,6 +128,7 @@ describe("getValidSession", () => {
       now: () => FIXED_NOW_MS,
     });
     expect(result).toBeNull();
+    expect(await readSession(dir)).toBeNull();
   });
 
   it("rethrows when refresh fails with a transient error", async () => {

--- a/apps/api/src/cli/lib/get-valid-session.ts
+++ b/apps/api/src/cli/lib/get-valid-session.ts
@@ -1,5 +1,10 @@
 import { RefreshFailedError, refreshSession } from "./refresh-session";
-import { readSession, type Session, writeSession } from "./session";
+import {
+  clearSession,
+  readSession,
+  type Session,
+  writeSession,
+} from "./session";
 
 /** Treat a session as expired this many seconds before its declared expiry, to avoid races. */
 const EXPIRY_SKEW_SECONDS = 60;
@@ -42,6 +47,8 @@ export async function getValidSession(
     return refreshed;
   } catch (err) {
     if (err instanceof RefreshFailedError && err.kind === "invalid_grant") {
+      // Dead refresh token — drop the stale file instead of re-rejecting it forever.
+      await clearSession(opts.dataDir, session.target);
       return null;
     }
     throw err;


### PR DESCRIPTION
Follows the `apps/api/src/cli/lib/refresh-session.ts` hardening chain (#6079, #6083, #6085, #6090) that made the CLI session-refresh response parsing bulletproof against a malformed OAuth server response. This PR closes the one lifecycle gap left in the caller: `getValidSession()` in `get-valid-session.ts` catches an `invalid_grant` refresh failure and returns `null`, but never deletes the now-dead session file on disk (unlike `token-refresh.ts`, which deletes the stored downstream token on the same permanent-failure signal). A non-interactive CLI invocation (e.g. CI, a script) re-reads that same rejected refresh token and re-sends it to the OAuth server on every single subsequent command, hammering the server with a request that can never succeed.

Fix: on `invalid_grant`, call the existing `clearSession(dataDir, session.target)` before returning `null`, so the stale file is gone and later commands short-circuit to "No session found" instead of re-hitting the server.

Regression test (inverted the existing test that encoded the old behavior): `apps/api/src/cli/lib/get-valid-session.test.ts` — "returns null and clears the stale file when refresh fails with invalid_grant" now also asserts `readSession(dir)` returns `null` after the call; it failed before the fix (file was still on disk) and passes after.

Reviewer command: `cd apps/api && bun test src/cli/lib/get-valid-session.test.ts`

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api), `bunx oxlint` on both changed files, and the targeted test above — all clean. Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears the stale CLI session file when a refresh fails with invalid_grant to stop endless retry loops. Previously, `getValidSession()` returned null but left the dead session on disk; now it deletes the file so later commands short-circuit to “No session found” instead of re-hitting the OAuth server.

- On `RefreshFailedError` with `invalid_grant`, `getValidSession()` calls `clearSession(dataDir, session.target)` and returns null; transient refresh errors are unchanged and still throw.
- Test updated to assert the file is removed. Run: cd apps/api && bun test src/cli/lib/get-valid-session.test.ts

<sup>Written for commit cdf0b9735f6e681746d2b56678491f86efb03684. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

