### PR TITLE
fix(i18n): stop the automation trigger count showing a literal {plural}

### DIFF
--- a/apps/web/src/i18n/en/automations.ts
+++ b/apps/web/src/i18n/en/automations.ts
@@ -127,7 +127,7 @@ export const automations = {
   "automations.automationListRow.deleteTitle": "Delete automation?",
   "automations.automationListRow.nextRun": "Next run {date}",
   "automations.automationListRow.noTriggers": "No triggers configured",
-  "automations.automationListRow.triggers": "{count} trigger{plural}",
+  "automations.automationListRow.triggers": "{count} trigger(s)",
   "automations.automationRuns.costHeader": "Cost",
   "automations.automationRuns.costTitle": "Cost",
   "automations.automationRuns.failed": "failed",

--- a/apps/web/src/i18n/pt-br/automations.ts
+++ b/apps/web/src/i18n/pt-br/automations.ts
@@ -133,7 +133,7 @@ export const automations = {
   "automations.automationListRow.deleteTitle": "Deletar automação?",
   "automations.automationListRow.nextRun": "Próxima execução {date}",
   "automations.automationListRow.noTriggers": "Nenhum gatilho configurado",
-  "automations.automationListRow.triggers": "{count} gatilho{plural}",
+  "automations.automationListRow.triggers": "{count} gatilho(s)",
   "automations.automationRuns.costHeader": "Custo",
   "automations.automationRuns.costTitle": "Custo",
   "automations.automationRuns.failed": "falhadas",


### PR DESCRIPTION
**Source:** bug found while auditing recently-changed i18n files for the known `{count} X{plural}` anti-pattern (this bot has previously fixed the same class in `provider-grid.tsx`, `secrets-count.tsx`, `orgs.members.*`, task-board's `selectedCount`, etc.).

**Bug:** `automations.automationListRow.triggers` is defined as `"{count} trigger{plural}"` (en) / `"{count} gatilho{plural}"` (pt-br), but the only call site (`apps/web/src/views/automations/automation-list-row.tsx:201`) calls `t(...)` with just `{ count: triggerCount }` — it never passes a `plural` var. `interpolate()` (`apps/web/src/i18n/interpolate.ts`) leaves an unmatched `{name}` placeholder untouched rather than blanking it, so every automation row with configured triggers renders the literal text `"3 trigger{plural}"` to the user, in both locales — worse than the earlier English-only-`s` variant of this bug, since it's not even readable filler text.

**Fix:** replaced the ungrammatical `{plural}`-suffix form with the neutral `(s)` form already established as this repo's fix pattern for this exact bug class (see #5741, #5749, #5479, #5477) — `"{count} trigger(s)"` / `"{count} gatilho(s)"`. No call-site change needed since no `plural` var was ever supplied.

**To verify:** open a workspace with an automation that has 1+ triggers configured and no `nextRun` set; the automation list row's trigger-count badge should read "N trigger(s)" instead of "N trigger{plural}".

**Checks run locally:** `bun run fmt` (clean) and `bunx oxlint apps/web/src/i18n/en/automations.ts apps/web/src/i18n/pt-br/automations.ts` (0 warnings/errors). No test exists for this literal-string lookup (there's no logic to unit test — the `t()` call site is unchanged); the string values are covered by TypeScript's `satisfies` check between the en/pt-br dictionaries, unaffected by this change. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the automation trigger count badge rendering by replacing the `{plural}` placeholder with a neutral form. Previously it showed “N trigger{plural}” because no `plural` var was passed; now it shows “N trigger(s)” (en) and “N gatilho(s)” (pt-br). No logic or call-site changes.

- Only updates `automations.automationListRow.triggers` in `apps/web/src/i18n/en/automations.ts` and `apps/web/src/i18n/pt-br/automations.ts`.
- Verify an automation with 1+ triggers shows “N trigger(s)” / “N gatilho(s)” in the list row.
- No migration required; behavior change is limited to copy.

<sup>Written for commit 037d99042383a0332fcdb32676c976d6df7c2cc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

