### PR TITLE
fix(i18n): translate the sandbox state-card headlines

### DIFF
--- a/apps/web/src/components/sandbox/preview/state-card-helpers.test.ts
+++ b/apps/web/src/components/sandbox/preview/state-card-helpers.test.ts
@@ -1,11 +1,5 @@
 import { test, expect } from "bun:test";
-import { activePhaseIndex, headlineFor } from "./state-card-helpers";
-
-test("headlineFor maps each kind to its headline", () => {
-  expect(headlineFor("starting")).toBe("Starting your sandbox");
-  expect(headlineFor("suspended")).toBe("Sandbox is paused");
-  expect(headlineFor("errored")).toBe("Couldn't start the sandbox");
-});
+import { activePhaseIndex } from "./state-card-helpers";
 
 test("activePhaseIndex returns the index of the current step", () => {
   expect(activePhaseIndex({ step: "provision", status: "doing" })).toBe(0);

--- a/apps/web/src/components/sandbox/preview/state-card-helpers.ts
+++ b/apps/web/src/components/sandbox/preview/state-card-helpers.ts
@@ -1,16 +1,4 @@
 import { PHASE_ORDER, type PhaseProgress } from "./derive-phase-progress";
-import type { StateCardKind } from "./state-card-types";
-
-export function headlineFor(kind: StateCardKind): string {
-  switch (kind) {
-    case "starting":
-      return "Starting your sandbox";
-    case "suspended":
-      return "Sandbox is paused";
-    case "errored":
-      return "Couldn't start the sandbox";
-  }
-}
 
 /** The card index (0..3) the booting visual should show as active. */
 export function activePhaseIndex(progress: PhaseProgress): 0 | 1 | 2 | 3 {

--- a/apps/web/src/components/sandbox/preview/state-card-types.ts
+++ b/apps/web/src/components/sandbox/preview/state-card-types.ts
@@ -1,1 +1,0 @@
-export type StateCardKind = "starting" | "suspended" | "errored";

--- a/apps/web/src/components/sandbox/preview/state-card.tsx
+++ b/apps/web/src/components/sandbox/preview/state-card.tsx
@@ -10,7 +10,6 @@ import { BootingVisual } from "./booting-visual";
 import type { ClaimPhase } from "../hooks/sandbox-events-context";
 import type { PhaseProgress } from "./derive-phase-progress";
 import type { SandboxStartError } from "./preview-state";
-import { headlineFor } from "./state-card-helpers";
 import { useT } from "@/i18n/use-t.ts";
 
 export type SandboxStateCardProps =
@@ -51,7 +50,9 @@ export function SandboxStateCard(props: SandboxStateCardProps) {
       <div className="flex h-full w-full items-center justify-center bg-background p-6">
         <div className="flex w-full max-w-md flex-col items-center gap-4 text-center">
           <AlertTriangle className="size-12 text-destructive" />
-          <h3 className="text-lg font-medium">{headlineFor("errored")}</h3>
+          <h3 className="text-lg font-medium">
+            {t("sandbox.stateCard.erroredHeadline")}
+          </h3>
           <p className="max-w-sm text-sm text-muted-foreground">
             {connectionMissing
               ? t("sandbox.stateCard.githubConnectionMissingMessage")
@@ -85,7 +86,9 @@ export function SandboxStateCard(props: SandboxStateCardProps) {
     <div className="flex h-full w-full items-center justify-center bg-background p-6">
       <div className="flex w-full max-w-md flex-col items-center gap-4 text-center">
         <PauseCircle className="size-12 text-blue-500" />
-        <h3 className="text-lg font-medium">{headlineFor("suspended")}</h3>
+        <h3 className="text-lg font-medium">
+          {t("sandbox.stateCard.suspendedHeadline")}
+        </h3>
         <p className="max-w-sm text-sm text-muted-foreground">
           {t("sandbox.stateCard.resumeToContinue")}
         </p>

--- a/apps/web/src/i18n/en/sandbox.ts
+++ b/apps/web/src/i18n/en/sandbox.ts
@@ -617,6 +617,7 @@ export const sandbox = {
   "sandbox.sectionsRightPane.selectSectionDescription":
     "Pick a saved section to edit it, or an available one to customize and save as global.",
   "sandbox.sectionsRightPane.selectSectionTitle": "Select a section to edit",
+  "sandbox.stateCard.erroredHeadline": "Couldn't start the sandbox",
   "sandbox.stateCard.githubConnectionMissingMessage":
     "The GitHub connection this chat used was removed. Link the repository again to start the sandbox.",
   "sandbox.stateCard.linkRepoAgain": "Link repository",
@@ -624,6 +625,7 @@ export const sandbox = {
     "This agent's GitHub repo isn't authenticated. Reconnect it in Connections, then retry.",
   "sandbox.stateCard.reconnectGithub": "Reconnect GitHub",
   "sandbox.stateCard.resume": "Resume",
+  "sandbox.stateCard.suspendedHeadline": "Sandbox is paused",
   "sandbox.stateCard.resumeToContinue": "Resume to continue.",
   "sandbox.stateCard.retry": "Retry",
   "sandbox.submoduleCredentialsField.addSubmoduleCredential":

--- a/apps/web/src/i18n/pt-br/sandbox.ts
+++ b/apps/web/src/i18n/pt-br/sandbox.ts
@@ -644,6 +644,7 @@ export const sandbox = {
     "Escolha uma seção salva para editar, ou uma disponível para personalizar e salvar como global.",
   "sandbox.sectionsRightPane.selectSectionTitle":
     "Selecione uma seção para editar",
+  "sandbox.stateCard.erroredHeadline": "Não foi possível iniciar o sandbox",
   "sandbox.stateCard.githubConnectionMissingMessage":
     "A conexão do GitHub usada neste chat foi removida. Vincule o repositório novamente para iniciar o sandbox.",
   "sandbox.stateCard.linkRepoAgain": "Vincular repositório",
@@ -653,6 +654,7 @@ export const sandbox = {
   "sandbox.stateCard.resume": "Retomar",
   "sandbox.stateCard.resumeToContinue": "Retome para continuar.",
   "sandbox.stateCard.retry": "Tentar Novamente",
+  "sandbox.stateCard.suspendedHeadline": "O sandbox está pausado",
   "sandbox.submoduleCredentialsField.addSubmoduleCredential":
     "Adicionar credencial de submódulo",
   "sandbox.submoduleCredentialsField.cancel": "Cancelar",


### PR DESCRIPTION
Part of the #4468 preview-sandbox UI hardening pass.

The sandbox preview's `SandboxStateCard` (`apps/web/src/components/sandbox/preview/state-card.tsx`) already routes every other string through `t()`, but its 'errored' and 'suspended' headlines ('Couldn't start the sandbox' / 'Sandbox is paused') were hardcoded English, coming from a `headlineFor()` helper — a real gap in the repo's i18n rule (CLAUDE.md: never hardcode user-facing strings in `apps/web/src`).

Moved both headlines into `sandbox.stateCard.erroredHeadline` / `sandbox.stateCard.suspendedHeadline` (en + pt-br), and deleted `headlineFor()` and `StateCardKind` — both now fully unused (the third case, 'starting', was already dead code: `BootingVisual` renders its own headline via `pillHeadline`, so `headlineFor("starting")` was never called outside its own test).

Net: -23/+11 lines, one file deleted.

To confirm: switch language to pt-br in preferences, stop/error a sandbox, and see the card headline translate. Reviewer command: `bun test apps/web/src/components/sandbox/preview/state-card-helpers.test.ts`.

Locally verified: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean), the targeted test file above (1 pass), and `bunx oxlint` on every touched file (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localizes the sandbox state-card headlines and removes dead helper code. Previously, the "errored" and "suspended" headlines were hardcoded English via `headlineFor()`; now they use `t("sandbox.stateCard.erroredHeadline")` and `t("sandbox.stateCard.suspendedHeadline")` with translations in `en` and `pt-br`.

**Review notes**
- Verify `state-card.tsx` renders headlines via `useT()` with the new keys; confirm strings in `apps/web/src/i18n/{en,pt-br}/sandbox.ts`.
- Confirm `headlineFor()` and `StateCardKind` are fully removed (`state-card-types.ts` deleted) and have no remaining references.
- Manual check: switch to pt-br, trigger a suspended or errored sandbox, and see the translated headline.
- Run the updated test: `bun test apps/web/src/components/sandbox/preview/state-card-helpers.test.ts`.

<sup>Written for commit 17ccaa75ef9c504c84b94315ec9c1bd8feaaa2bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

