### PR TITLE
fix(sandbox): default and cap the Go daemon's await-mode exec timeout

### DIFF
--- a/packages/sandbox/daemon-go/internal/routes/exec.go
+++ b/packages/sandbox/daemon-go/internal/routes/exec.go
@@ -21,6 +21,23 @@ type ExecDeps struct {
 	SetStatus   func(events.DaemonStatus)
 }
 
+// resolveAwaitTimeoutMs bounds an await-mode exec's TimeoutMs. An await
+// caller blocks on TaskManager.Finished, which waits on the task's done
+// channel with no server-side deadline (ReadHeaderTimeout only covers
+// reading the request). A script that never exits — or a caller who forgets
+// timeoutMs — would otherwise hang the handler goroutine and the HTTP
+// connection forever, so mirror bash.go's default+ceiling instead of
+// trusting an unbounded/absent value.
+func resolveAwaitTimeoutMs(timeoutMs int) int {
+	if timeoutMs <= 0 {
+		return bashDefaultTimeoutMs
+	}
+	if timeoutMs > bashAwaitCeilingMs {
+		return bashAwaitCeilingMs
+	}
+	return timeoutMs
+}
+
 func Exec(deps ExecDeps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// The router unescapes the {name} wildcard for us.
@@ -71,6 +88,9 @@ func Exec(deps ExecDeps) http.HandlerFunc {
 		mode := "background"
 		if body.Mode == "await" {
 			mode = "await"
+		}
+		if mode == "await" {
+			body.TimeoutMs = resolveAwaitTimeoutMs(body.TimeoutMs)
 		}
 
 		overrides := map[string]string{}

--- a/packages/sandbox/daemon-go/internal/routes/exec_test.go
+++ b/packages/sandbox/daemon-go/internal/routes/exec_test.go
@@ -1,0 +1,27 @@
+package routes
+
+import "testing"
+
+// Before this fix, an await-mode exec with no timeoutMs left spec.TimeoutMs
+// at 0, which armTimeout treats as "no timeout" — the handler would block on
+// TaskManager.Finished forever if the script never exits.
+func TestResolveAwaitTimeoutMsDefaultsWhenUnset(t *testing.T) {
+	if got := resolveAwaitTimeoutMs(0); got != bashDefaultTimeoutMs {
+		t.Fatalf("got %d, want default %d", got, bashDefaultTimeoutMs)
+	}
+	if got := resolveAwaitTimeoutMs(-1); got != bashDefaultTimeoutMs {
+		t.Fatalf("got %d, want default %d", got, bashDefaultTimeoutMs)
+	}
+}
+
+func TestResolveAwaitTimeoutMsCapsAtCeiling(t *testing.T) {
+	if got := resolveAwaitTimeoutMs(bashAwaitCeilingMs * 10); got != bashAwaitCeilingMs {
+		t.Fatalf("got %d, want ceiling %d", got, bashAwaitCeilingMs)
+	}
+}
+
+func TestResolveAwaitTimeoutMsPassesThroughValidValue(t *testing.T) {
+	if got := resolveAwaitTimeoutMs(5000); got != 5000 {
+		t.Fatalf("got %d, want 5000", got)
+	}
+}


### PR DESCRIPTION
Source: real bug found while hunting issue #5789 (agent reliability findings — race conditions, resource leaks, graceful shutdown in the sandbox daemon).

The `/exec/:name` route's `mode="await"` path blocks the HTTP handler on `TaskManager.Finished`, which waits on the task's `done` channel with no server-side deadline (`ReadHeaderTimeout` on the daemon's `http.Server` only covers reading the request, there is no `WriteTimeout`). `armTimeout` treats `TimeoutMs <= 0` as "no timeout" — and `body.TimeoutMs` is left at its zero value whenever a caller omits it. So an await-mode exec of a script that never exits (or one a caller forgot to pass `timeoutMs` for) hangs the handler goroutine and its HTTP connection indefinitely. The daemon's own `bash.go` route already guards this exact path with a default + await ceiling (`bashDefaultTimeoutMs` / `bashAwaitCeilingMs`); `exec.go` never got the same treatment.

Fix: extract that bound into `resolveAwaitTimeoutMs` and apply it to `exec.go`'s await mode too, so a missing or absurd `timeoutMs` can no longer leave the goroutine parked forever.

Regression test: `packages/sandbox/daemon-go/internal/routes/exec_test.go` exercises `resolveAwaitTimeoutMs` directly — asserts a zero/negative input defaults, an oversized input is capped at the ceiling, and a valid value passes through unchanged. This is a pure function (no process spawn needed), which is why the test runs fast without a live daemon.

To confirm: `cd packages/sandbox/daemon-go && go test ./internal/routes/... -run TestResolveAwaitTimeoutMs -v`

Locally ran: `go build ./...`, `go vet ./internal/routes/...`, `gofmt -l` (clean), and the targeted test above. Full CI (daemon-e2e, etc.) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents indefinite hangs in await-mode execs by defaulting and capping `timeoutMs`. Previously, `/exec/:name?mode=await` treated missing/non-positive `timeoutMs` as no timeout; now it defaults to `bashDefaultTimeoutMs` and caps at `bashAwaitCeilingMs`.

- Adds `resolveAwaitTimeoutMs` in `packages/sandbox/daemon-go/internal/routes/exec.go` and applies it only for `mode="await"`, mirroring `bash.go`.
- Adds `packages/sandbox/daemon-go/internal/routes/exec_test.go` covering defaulting, capping, and pass-through.
- Behavior change: await-mode execs without a `timeoutMs` or with an oversized value will now time out instead of hanging; non-await paths are unchanged.
- Migration: none. If a client relied on indefinite waits, send an explicit `timeoutMs` within the ceiling.

<sup>Written for commit 8a6653c37d02cdcee10573f819a29865399f8dd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

