### PR TITLE
fix(file-storage): reject an unparseable STS refresh expiration

### DIFF
--- a/apps/api/src/file-storage/file-config-s3.test.ts
+++ b/apps/api/src/file-storage/file-config-s3.test.ts
@@ -351,6 +351,24 @@ describe("stsCredentialProvider", () => {
     );
   });
 
+  test("throws when the response's expiration is not a valid date", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response(
+          JSON.stringify({
+            accessKeyId: "AKIA",
+            secretAccessKey: "s",
+            sessionToken: "t",
+            expiration: "not-a-date",
+          }),
+          { status: 200 },
+        ),
+    ) as unknown as typeof fetch;
+    expect(stsCredentialProvider(stsInfo, "k")()).rejects.toThrow(
+      /invalid expiration/,
+    );
+  });
+
   test("throws when refreshUrl is missing", () => {
     expect(() => stsCredentialProvider(info({}), "k")).toThrow(
       /missing a refreshUrl/,

--- a/apps/api/src/file-storage/file-config-s3.ts
+++ b/apps/api/src/file-storage/file-config-s3.ts
@@ -71,11 +71,17 @@ export function stsCredentialProvider(
         `sts refresh returned incomplete credentials for file config ${info.id}`,
       );
     }
+    const expiration = data.expiration ? new Date(data.expiration) : undefined;
+    if (expiration && Number.isNaN(expiration.getTime())) {
+      throw new Error(
+        `sts refresh returned an invalid expiration for file config ${info.id}: ${data.expiration}`,
+      );
+    }
     return {
       accessKeyId: data.accessKeyId,
       secretAccessKey: data.secretAccessKey,
       sessionToken: data.sessionToken,
-      expiration: data.expiration ? new Date(data.expiration) : undefined,
+      expiration,
     };
   };
 }


### PR DESCRIPTION
**Source:** bug found while auditing `apps/api/src/file-storage/file-config-s3.ts` (`stsCredentialProvider`), the `sts-session` credential-refresh path for org file configs.

**Why it matters:** `stsCredentialProvider` fetches temporary S3 credentials from an org-configured `refreshUrl` (an external, untrusted server) and hands the `expiration` field straight to `new Date(...)` with no validation. A malformed/unparseable value silently becomes `Invalid Date`. The AWS SDK's credential memoization decides whether to refresh by comparing `expiration.getTime()` against now; `NaN` comparisons are always `false`, so the SDK never considers the credential expired and keeps reusing it past AWS's real expiry — the cached `S3Client` then starts failing every S3 call with `ExpiredToken` until the process restarts (the client is cached per config, see `buildS3Client`).

**Failure scenario:** an org's `refreshUrl` endpoint returns a non-ISO or garbage `expiration` string (bug, misconfig, or a byte flipped in transit) → `new Date("garbage")` → `Invalid Date` → SDK treats the STS session token as perpetually fresh → uploads/reads to that org's bucket fail once AWS actually expires the token, silently, until someone restarts the API.

**Fix:** validate the parsed `expiration` with `Number.isNaN(date.getTime())` and throw the same kind of descriptive error the function already throws for missing/incomplete fields, so a bad refresh response fails loud immediately instead of degrading silently later.

**Regression test:** added `apps/api/src/file-storage/file-config-s3.test.ts` case "throws when the response's expiration is not a valid date", asserting the fetch response with `expiration: "not-a-date"` rejects with `/invalid expiration/`.

**Reviewer check:** `bun test apps/api/src/file-storage/file-config-s3.test.ts`

**Verified locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test file above, and `bunx oxlint` on both changed files. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects an unparseable STS credential expiration from org refresh endpoints so the SDK does not reuse expired tokens. Previously, `stsCredentialProvider` accepted invalid dates, causing the AWS SDK to never refresh and leading to `ExpiredToken` errors until process restart.

- Valid refresh responses are unchanged; invalid `expiration` now throws immediately with a descriptive error.
- Third‑party refresh endpoints must return a parseable `expiration` value.
- Test added: apps/api/src/file-storage/file-config-s3.test.ts ("throws when the response's expiration is not a valid date"). Run: bun test apps/api/src/file-storage/file-config-s3.test.ts.

<sup>Written for commit de387de704800b3aee0a9913eb19b759564728ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

