### PR TITLE
fix(oauth): reject a non-http(s) discovered token_endpoint

### DIFF
--- a/apps/api/src/oauth/resolve-token-endpoint.test.ts
+++ b/apps/api/src/oauth/resolve-token-endpoint.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach, afterAll } from "bun:test";
+import { resolveOriginTokenEndpoint } from "./resolve-token-endpoint";
+
+const originalFetch = globalThis.fetch;
+
+const installFetch = (responder: () => Response | Promise<Response>): void => {
+  globalThis.fetch = (async () =>
+    await responder()) as unknown as typeof globalThis.fetch;
+};
+
+describe("resolveOriginTokenEndpoint", () => {
+  beforeEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns a well-formed http(s) token_endpoint", async () => {
+    installFetch(
+      () =>
+        new Response(
+          JSON.stringify({ token_endpoint: "https://idp.example.com/token" }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+    );
+
+    const result = await resolveOriginTokenEndpoint("https://mcp.example.com");
+    expect(result).toBe("https://idp.example.com/token");
+  });
+
+  it("rejects a non-http(s) token_endpoint instead of handing it back", async () => {
+    installFetch(
+      () =>
+        new Response(JSON.stringify({ token_endpoint: "file:///etc/passwd" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    const result = await resolveOriginTokenEndpoint("https://mcp.example.com");
+    expect(result).toBeNull();
+  });
+
+  it("rejects a non-string token_endpoint instead of handing it back", async () => {
+    installFetch(
+      () =>
+        new Response(JSON.stringify({ token_endpoint: 12345 }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+    );
+
+    const result = await resolveOriginTokenEndpoint("https://mcp.example.com");
+    expect(result).toBeNull();
+  });
+});

--- a/apps/api/src/oauth/resolve-token-endpoint.ts
+++ b/apps/api/src/oauth/resolve-token-endpoint.ts
@@ -49,9 +49,19 @@ export async function resolveOriginTokenEndpoint(
     const authRes = await fetchAuthorizationServerMetadata(authServerUrl);
     if (authRes.ok) {
       const data = (await authRes.json()) as {
-        token_endpoint?: string;
+        token_endpoint?: unknown;
       };
-      return data.token_endpoint ?? null;
+      // token_endpoint is untrusted input — only hand back a real http(s) URL.
+      if (typeof data.token_endpoint === "string") {
+        try {
+          const parsed = new URL(data.token_endpoint);
+          if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+            return data.token_endpoint;
+          }
+        } catch {
+          // not a valid URL — fall through to null
+        }
+      }
     }
 
     return null;


### PR DESCRIPTION
**Source:** bug found while auditing the OAuth token-refresh flow (apps/api/src/oauth/refresh-access-token.ts, token-refresh.ts, and the adjacent resolve-token-endpoint.ts that token-refresh.ts calls for re-resolution).

**Why a maintainer wants this:** `resolveOriginTokenEndpoint` discovers the auth server's `token_endpoint` via RFC 8414 metadata and hands it straight back to the caller (`token-refresh.ts`), which then POSTs the connection's `client_secret` + `refresh_token` to that URL. `token_endpoint` is untrusted response-body data with zero validation — the exact class of gap the sibling file `refresh-access-token.ts` was hardened against field-by-field in #6068/#6076/#6081/#6089 (reject non-string/malformed `access_token`, `refresh_token`, `expires_in`). This one field was missed. A malicious or compromised metadata endpoint could point `token_endpoint` at an arbitrary URL (e.g. an internal address) and our server would send the client secret + refresh token there.

**Failure scenario:** an authorization server (or a network position that can spoof its metadata response) returns `{"token_endpoint": "http://169.254.169.254/steal"}` (or a non-string, or a `file://` URL). Before this fix, that value was returned as-is and used directly in the refresh POST — credential leak / SSRF-adjacent. After: only a value that parses as an `http:`/`https:` URL is returned; anything else resolves to `null`, same as any other discovery failure (fail-closed, matching the existing fallback behavior).

**Regression test:** `apps/api/src/oauth/resolve-token-endpoint.test.ts` (new file) — mocks `globalThis.fetch` (same pattern as the existing `refresh-access-token.test.ts`) to assert: a well-formed https `token_endpoint` is returned; a `file://` URL is rejected to `null`; a non-string `token_endpoint` is rejected to `null`.

**Reviewer check:** `bun test apps/api/src/oauth/resolve-token-endpoint.test.ts`

**Locally verified:** `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), `bunx oxlint` on both changed files (0 warnings/errors), and the targeted test file above (3 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate the discovered OAuth token_endpoint and reject non-http(s) or malformed values to prevent credential leaks. Previously we returned the metadata token_endpoint as-is and posted client_secret + refresh_token to it; now we only return a string that parses as an http(s) URL, otherwise null (fail-closed).

- Reviewer notes:
  - Risk mitigation: blocks SSRF/credential exfiltration to arbitrary schemes/hosts (e.g., link-local, file://).
  - Behavior change: discovery may now return null for invalid token_endpoint values; refresh uses existing fallback/error handling. No migration required.
  - Test: run bun test apps/api/src/oauth/resolve-token-endpoint.test.ts to verify acceptance of https and rejection of file:// and non-string values.

<sup>Written for commit dde37ac8eb8c23228c6f85089301f89707b1ed2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

