### PR TITLE
fix(ui): make a disabled split-button menu item's tooltip keyboard-reachable

### DIFF
--- a/packages/ui/src/components/split-button.stories.tsx
+++ b/packages/ui/src/components/split-button.stories.tsx
@@ -65,6 +65,21 @@ export const DisabledPrimaryWithMenu: Story = {
   },
 };
 
+/** A disabled item with a tooltip stays reachable and explainable by keyboard. */
+export const DisabledMenuItemTooltip: Story = {
+  args: {
+    items: [
+      {
+        key: "force",
+        label: "Force publish",
+        disabled: true,
+        tooltip: "Only maintainers can force publish",
+        onSelect: () => {},
+      },
+    ],
+  },
+};
+
 export const Loading: Story = {
   args: { label: "Publishing", loading: true },
 };

--- a/packages/ui/src/components/split-button.tsx
+++ b/packages/ui/src/components/split-button.tsx
@@ -71,9 +71,11 @@ function SplitButtonMenuEntry({ item }: { item: SplitButtonMenuItem }) {
 
   return (
     <Tooltip>
-      {/* Wrapper is the trigger: a disabled item is pointer-events-none. */}
+      {/* Wrapper is the trigger, tabbable when disabled so it's reachable. */}
       <TooltipTrigger asChild>
-        <span className="block">{entry}</span>
+        <span className="block" tabIndex={item.disabled ? 0 : undefined}>
+          {entry}
+        </span>
       </TooltipTrigger>
       <TooltipContent side="right">{item.tooltip}</TooltipContent>
     </Tooltip>


### PR DESCRIPTION
The `SplitButton` component already makes its disabled primary button's tooltip keyboard-reachable by putting `tabIndex={0}` on the tooltip's wrapper span when disabled (see the existing comment at the primary-button tooltip). `SplitButtonMenuEntry` — the wrapper around a disabled `DropdownMenuItem` with a `tooltip` — has the identical shape (a `pointer-events-none` disabled item wrapped in a span as the `TooltipTrigger`) but was missing that `tabIndex`, so a keyboard-only user tabbing through the menu skips straight past a disabled item and never sees why it's disabled (e.g. "Only maintainers can force publish" in the existing `DisabledPrimaryWithMenu`/force-publish fixture).

Fix: add `tabIndex={item.disabled ? 0 : undefined}` to the same wrapper span, mirroring the pattern already used for the primary button a few lines below. Also added a `DisabledMenuItemTooltip` story exercising this exact case.

How to verify: open Storybook's `Components/SplitButton` → `Disabled Menu Item Tooltip` story, tab through the menu with the keyboard, and confirm the disabled "Force publish" item receives focus and shows its tooltip.

Checked locally: `bun run fmt`, `bunx tsc --noEmit` in `packages/ui` (pre-existing unrelated TS4023 errors in other story files, none touching split-button), and `bunx oxlint` on both changed files (0 warnings/errors). No test file exists for this component (it's story-driven); full CI will run the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make disabled `SplitButton` menu item tooltips reachable via keyboard. Previously, tabbing skipped disabled dropdown items, hiding why they were disabled; now disabled items are tabbable and show their tooltip, matching the primary button behavior. Tab order now includes disabled menu items; activation remains blocked.

- Set `tabIndex={item.disabled ? 0 : undefined}` on the `TooltipTrigger` wrapper span for menu entries; no other behavior changes.
- Add Storybook story `Components/SplitButton → Disabled Menu Item Tooltip` to verify: tab to the disabled “Force publish” item and see its tooltip.
- No API changes or migrations.

<sup>Written for commit 9aca9d74aa3041dc751fb266032f2621b461d8f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

