### PR TITLE
refactor(runtime): remove obsolete fetchIntegrationMetadata Omit from ClientContext

### DIFF
--- a/packages/runtime/src/bindings.ts
+++ b/packages/runtime/src/bindings.ts
@@ -5,10 +5,7 @@ import { type MCPClientFetchStub, MCPClient, type ToolBinder } from "./mcp.ts";
 import { resolveStudioUrl } from "./studio-context.ts";
 import { z } from "zod";
 
-type ClientContext = Omit<
-  RequestContext,
-  "ensureAuthenticated" | "state" | "fetchIntegrationMetadata"
->;
+type ClientContext = Omit<RequestContext, "ensureAuthenticated" | "state">;
 
 export interface Binding<TType extends string = string> {
   __type: TType;


### PR DESCRIPTION
## Summary

Removes a stale reference to `fetchIntegrationMetadata` from the `ClientContext` type's `Omit` clause. This property no longer exists in the `RequestContext` type after a prior refactor, so including it in the Omit is dead code.

## Why

The `ClientContext` type in `bindings.ts` was omitting `fetchIntegrationMetadata` from `RequestContext`, but this property was removed from `RequestContext` in an earlier refactor. Keeping the reference to a non-existent property is defensive but stale—it suggests the code wasn't reviewed after the `RequestContext` definition changed.

## Verification

- Diff: -3 / +0 (net 3-line reduction)
- TypeScript compilation: `bunx tsc --noEmit` passes in packages/runtime/
- Tests: `bun test packages/runtime/src/bindings.test.ts` — 2 pass
- Lint: `bunx oxlint packages/runtime/src/bindings.ts` — 0 errors, 0 warnings
- Behavior: The Omit continues to remove the same properties; omitting a non-existent property has no effect, so this is behavior-preserving

## To confirm

Run: `cd packages/runtime && bunx tsc --noEmit && bun test bindings.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the stale `fetchIntegrationMetadata` key from the `ClientContext` Omit in `packages/runtime/src/bindings.ts`. This key no longer exists on `RequestContext`, so the change cleans up dead code without changing behavior.

- Change is limited to `packages/runtime/src/bindings.ts`; `ClientContext` now omits only "ensureAuthenticated" and "state".
- No runtime or typing behavior change; omitting a non-existent key had no effect.
- No migrations required.

<sup>Written for commit da86a309b8a217eb3079a014419aed1b5e1beb8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

