### PR TITLE
refactor(sections-editor): dedupe block write/delete error handling into throwResponseError

### DIFF
--- a/apps/web/src/components/sections-editor/decofile-api.ts
+++ b/apps/web/src/components/sections-editor/decofile-api.ts
@@ -61,7 +61,11 @@ function decofileApiUrl(params: DecofileScopeParams): string {
   return `/api/${params.orgSlug}/decofile/${encodeURIComponent(params.virtualMcpId)}/${encodeURIComponent(params.branch)}`;
 }
 
-async function throwResponseError(res: Response, verb: string): Promise<never> {
+/** Shared check-and-throw for a non-ok sandbox/decofile write response. */
+export async function throwResponseError(
+  res: Response,
+  verb: string,
+): Promise<never> {
   const body = await res.json().catch(() => ({}));
   throw new Error(
     (body as { error?: string }).error ?? `${verb} failed (${res.status})`,

--- a/apps/web/src/components/sections-editor/use-delete-block.ts
+++ b/apps/web/src/components/sections-editor/use-delete-block.ts
@@ -8,6 +8,7 @@ import {
   decofileWriteMutationKey,
   patchDecofile,
   setDecofileDraft,
+  throwResponseError,
 } from "./decofile-api";
 import { sandboxGitStatusQueryKey } from "../thread/github/sandbox-git-api";
 
@@ -66,12 +67,7 @@ export function useDeleteBlock({
           body: JSON.stringify({ path }),
         },
       );
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(
-          (body as { error?: string }).error ?? `Delete failed (${res.status})`,
-        );
-      }
+      if (!res.ok) return throwResponseError(res, "Delete");
       return res.json() as Promise<{ ok: true; existed: boolean }>;
     },
     onMutate: async ({ blockKey }) => {

--- a/apps/web/src/components/sections-editor/use-save-block.ts
+++ b/apps/web/src/components/sections-editor/use-save-block.ts
@@ -9,6 +9,7 @@ import {
   decofileWriteMutationKey,
   patchDecofile,
   setDecofileDraft,
+  throwResponseError,
 } from "./decofile-api";
 import { sandboxGitStatusQueryKey } from "../thread/github/sandbox-git-api";
 import { KEYS } from "@/lib/query-keys";
@@ -79,12 +80,7 @@ export function useSaveBlock({
           body: JSON.stringify({ path, content }),
         },
       );
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(
-          (body as { error?: string }).error ?? `Write failed (${res.status})`,
-        );
-      }
+      if (!res.ok) return throwResponseError(res, "Write");
       return res.json();
     },
     onMutate: async ({ blockKey, data }) => {


### PR DESCRIPTION
**Source:** C1 reduction — spotted while auditing `use-delete-block.ts`/`use-save-block.ts` (sections-editor block management area).

**Payoff:** `decofile-api.ts` already has a `throwResponseError(res, verb)` helper for the exact "non-ok response -> parse `{error}` body -> throw" shape, but `use-delete-block.ts` and `use-save-block.ts` each hand-rolled an identical copy of that logic for their sandbox `/unlink` and `/write` fetches instead of reusing it. This exports the existing helper and has both hooks call it.

**Net line delta:** -4 / +2 (three files). Behavior is unchanged: `throwResponseError(res, "Delete")` / `throwResponseError(res, "Write")` produce byte-identical error messages and fallback strings (`` `${verb} failed (${res.status})` ``) to what was inlined before — verified by reading both implementations side by side.

**To confirm:** open `apps/web/src/components/sections-editor/use-delete-block.ts` and `use-save-block.ts` and diff against `decofile-api.ts`'s `throwResponseError`.

**Locally verified:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint` on all three touched files (0 warnings/errors). No existing test covers this error path directly; full CI runs the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates sections editor block write/delete error handling by exporting and reusing `throwResponseError` from `decofile-api.ts`. Behavior is unchanged; error messages match the previous inlined logic.

- Exports `throwResponseError` from `decofile-api.ts` and uses it in `use-delete-block.ts` and `use-save-block.ts` on non-ok responses.
- Error text, including the fallback `${verb} failed (${res.status})`, remains identical.
- No API or behavior changes; no migrations required.

<sup>Written for commit caf906a06ab6123f620cedab7a2a09243c208840. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

