### PR TITLE
fix(oauth): reject an absurdly large expires_in in the refresh response

### DIFF
--- a/apps/api/src/oauth/refresh-access-token.test.ts
+++ b/apps/api/src/oauth/refresh-access-token.test.ts
@@ -200,6 +200,25 @@ describe("refreshAccessToken", () => {
     expect(result.expiresIn).toBeUndefined();
   });
 
+  it("ignores an absurdly large expires_in instead of producing an Invalid Date downstream", async () => {
+    installFetch(
+      () =>
+        new Response(
+          JSON.stringify({
+            access_token: "new",
+            token_type: "Bearer",
+            expires_in: 1e20,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+
+    const result = await refreshAccessToken(baseToken);
+
+    expect(result.success).toBe(true);
+    expect(result.expiresIn).toBeUndefined();
+  });
+
   it("treats a 200 with no access_token as a transient failure, not success", async () => {
     installFetch(
       () =>

--- a/apps/api/src/oauth/refresh-access-token.ts
+++ b/apps/api/src/oauth/refresh-access-token.ts
@@ -25,6 +25,18 @@ const PERMANENT_REFRESH_ERROR_CODES = new Set([
 /** Bound the outbound refresh call — a hanging token endpoint shouldn't hang the caller. */
 const TOKEN_REFRESH_FETCH_TIMEOUT_MS = 10_000;
 
+/**
+ * Upper bound (seconds) for `expires_in`. `Date`'s valid range is ±8.64e15ms,
+ * so a huge-but-finite `expires_in` (e.g. `1e20`, or a server that returns
+ * milliseconds instead of seconds) survives the `Number.isFinite` check but
+ * produces an Invalid Date once multiplied by 1000 downstream
+ * (`token-refresh.ts`'s `expiresAt`). `isExpired()` fails safe on that and
+ * treats the token as permanently expired, so every call re-triggers a
+ * refresh against the token endpoint instead of caching the token for its
+ * real lifetime. 100 years in seconds is far past any real OAuth token TTL.
+ */
+const MAX_EXPIRES_IN_SECONDS = 100 * 365 * 24 * 60 * 60;
+
 export interface TokenRefreshResult {
   success: boolean;
   /**
@@ -178,7 +190,11 @@ export async function refreshAccessToken(
     let expiresIn: number | undefined;
     if (data.expires_in !== undefined) {
       const parsed = Number(data.expires_in);
-      if (Number.isFinite(parsed) && parsed > 0) {
+      if (
+        Number.isFinite(parsed) &&
+        parsed > 0 &&
+        parsed <= MAX_EXPIRES_IN_SECONDS
+      ) {
         expiresIn = parsed;
       } else {
         console.warn("[TokenRefresh] ignoring malformed expires_in", {


### PR DESCRIPTION
**Source:** bug found while hardening `apps/api/src/oauth/refresh-access-token.ts` (my assigned focus area this tick — this file has had a chain of similar untrusted-response-field fixes merged recently: #6068, #6076, #6081, #6089).

**Payoff:** closes a gap in the existing `expires_in` validation that lets a misbehaving/malicious token endpoint wedge a connection's token into a permanent refresh-storm.

**Failure scenario:** the existing check only verifies `Number.isFinite(parsed) && parsed > 0`. A huge-but-finite value (e.g. `expires_in: 1e20`, or a server that returns milliseconds instead of seconds) passes that check. Downstream, `token-refresh.ts` computes `expiresAt: new Date(Date.now() + result.expiresIn * 1000)`, which overflows `Date`'s valid ±8.64e15ms range and produces an Invalid Date. `DownstreamTokenStorage.isExpired()` fails safe on an unparseable date and always reports the token as expired, so every subsequent call to `getValidDownstreamAccessToken` re-triggers a refresh against the token endpoint instead of caching the token for its real lifetime — a self-inflicted refresh storm against that connection's OAuth server.

**Fix:** cap `expires_in` at 100 years (`MAX_EXPIRES_IN_SECONDS`, far past any real OAuth token TTL) and route out-of-range values through the existing 'ignore and log' path already used for other malformed `expires_in` values (NaN, negative). Added a regression test: `expires_in: 1e20` now falls back to `expiresIn: undefined` instead of surviving to become an Invalid Date.

**Verify:** `bun test apps/api/src/oauth/refresh-access-token.test.ts` (14 pass, up from 13).

**Checked locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bunx oxlint apps/api/src/oauth/refresh-access-token.ts apps/api/src/oauth/refresh-access-token.test.ts` (0 warnings/errors) — full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects absurdly large OAuth refresh `expires_in` values to prevent Invalid Date calculations and refresh storms. Old behavior accepted any finite positive value; new behavior caps `expires_in` at 100 years and ignores/logs out-of-range values, returning `expiresIn: undefined`.

**Review notes**
- Introduces `MAX_EXPIRES_IN_SECONDS` and routes oversized values through the existing malformed `expires_in` path.
- Adds a regression test covering `expires_in: 1e20`.
- No API or caller changes; only affects misbehaving token endpoints.

<sup>Written for commit ca7475f51048cd850fbf8162dded2dc47d94c14f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6112?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

