### PR TITLE
fix(cli): reject an absurdly large expires_in in the session-refresh response

### DIFF
--- a/apps/api/src/cli/lib/refresh-session.test.ts
+++ b/apps/api/src/cli/lib/refresh-session.test.ts
@@ -110,6 +110,25 @@ describe("refreshSession", () => {
     expect(result.expiresAt).toBe(1_234);
   });
 
+  it("ignores an absurdly large expires_in and keeps the previous expiresAt", async () => {
+    const fetchMock = mock(
+      async () =>
+        new Response(
+          JSON.stringify({ access_token: "new_at", expires_in: 1e20 }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+
+    const session = makeSession({ expiresAt: 1_234 });
+    const result = await refreshSession(
+      session,
+      fetchMock as unknown as typeof fetch,
+      () => FIXED_NOW,
+    );
+
+    expect(result.expiresAt).toBe(1_234);
+  });
+
   it("keeps the previous refresh token when the server returns a non-string one", async () => {
     const fetchMock = mock(
       async () =>

--- a/apps/api/src/cli/lib/refresh-session.ts
+++ b/apps/api/src/cli/lib/refresh-session.ts
@@ -18,6 +18,17 @@ interface TokenResponse {
 }
 
 /**
+ * Upper bound (seconds) for `expires_in`. Without it, an absurdly large
+ * value (e.g. `1e20`, or a server returning milliseconds instead of
+ * seconds) survives `Number.isFinite`/`> 0` and gets added to `now()`,
+ * producing an `expiresAt` far enough in the future that the session is
+ * treated as valid forever — the CLI never refreshes again, even after the
+ * real upstream token has long expired. 100 years is far past any real
+ * OAuth token TTL.
+ */
+const MAX_EXPIRES_IN_SECONDS = 100 * 365 * 24 * 60 * 60;
+
+/**
  * Exchanges the session's refresh token for a fresh access token.
  *
  * Returns an updated Session object (caller is responsible for persisting it).
@@ -95,10 +106,12 @@ export async function refreshSession(
     );
   }
 
-  // expires_in is untrusted server input — reject non-finite/non-positive values.
+  // expires_in is untrusted server input — reject non-finite/non-positive/out-of-range values.
   const parsedExpiresIn = Number(data.expires_in);
   const expiresAt =
-    Number.isFinite(parsedExpiresIn) && parsedExpiresIn > 0
+    Number.isFinite(parsedExpiresIn) &&
+    parsedExpiresIn > 0 &&
+    parsedExpiresIn <= MAX_EXPIRES_IN_SECONDS
       ? Math.floor(now() / 1000) + parsedExpiresIn
       : session.expiresAt;
 


### PR DESCRIPTION
**Source:** hardening gap found while auditing my assigned focus area (OAuth token validation hardening). The sibling file `apps/api/src/oauth/refresh-access-token.ts` just got this exact fix in #6112, but the CLI's own session-refresh path (`apps/api/src/cli/lib/refresh-session.ts`) never got the equivalent cap.

**Payoff:** closes a gap in the existing `expires_in` validation that lets a misbehaving/malicious token endpoint make the CLI stop refreshing a session forever.

**Failure scenario:** the existing check only verifies `Number.isFinite(parsedExpiresIn) && parsedExpiresIn > 0`. A huge-but-finite value (e.g. `expires_in: 1e20`, or a server that returns milliseconds instead of seconds) passes that check and gets added to `now()` (in seconds) to compute `expiresAt`. `getValidSession`'s expiry check (`session.expiresAt - EXPIRY_SKEW_SECONDS < nowSeconds`) then never trips, so the CLI treats the session as valid essentially forever and never re-refreshes — even long after the real upstream access token has expired or been revoked.

**Fix:** cap `expires_in` at 100 years (`MAX_EXPIRES_IN_SECONDS`, mirroring the constant already added to `refresh-access-token.ts`), routing out-of-range values through the existing 'ignore and keep previous expiresAt' path already used for NaN/negative values. Added a regression test: `expires_in: 1e20` now keeps the session's previous `expiresAt` instead of extending it indefinitely.

**Verify:** `bun test apps/api/src/cli/lib/refresh-session.test.ts` (12 pass, up from 11).

**Checked locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bunx oxlint apps/api/src/cli/lib/refresh-session.ts apps/api/src/cli/lib/refresh-session.test.ts` (0 warnings/errors) — full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps `expires_in` in the CLI session refresh to 100 years to prevent sessions being treated as valid forever. Previously any finite positive `expires_in` was accepted; now values above the cap are ignored and the previous `expiresAt` is kept, matching the OAuth access-token refresh path.

- Enforces `Number.isFinite`, `> 0`, and `<= MAX_EXPIRES_IN_SECONDS` in `apps/api/src/cli/lib/refresh-session.ts`.
- Adds a test: absurdly large `expires_in` (1e20) keeps the previous `expiresAt`.
- Verify with: `bun test apps/api/src/cli/lib/refresh-session.test.ts`.

<sup>Written for commit 8f75f6c89017f9b32e4154b280b141992bb64537. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

