### PR TITLE
fix(cli): bound the session-refresh fetch with a timeout

### DIFF
--- a/apps/api/src/cli/lib/refresh-session.test.ts
+++ b/apps/api/src/cli/lib/refresh-session.test.ts
@@ -201,6 +201,22 @@ describe("refreshSession", () => {
     await expect(promise).rejects.toMatchObject({ kind: "transient" });
   });
 
+  it("bounds the refresh call with an abort signal, so a hanging token endpoint can't hang the CLI", async () => {
+    const fetchMock = mock(async (_url: string, init?: RequestInit) => {
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+      return new Response(
+        JSON.stringify({ access_token: "new_at", expires_in: 3600 }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+    await refreshSession(
+      makeSession(),
+      fetchMock as unknown as typeof fetch,
+      () => FIXED_NOW,
+    );
+    expect(fetchMock).toHaveBeenCalled();
+  });
+
   it("throws when session has no refreshToken", async () => {
     const session = makeSession({ refreshToken: undefined });
     const fetchMock = mock(async () => new Response("", { status: 200 }));

--- a/apps/api/src/cli/lib/refresh-session.ts
+++ b/apps/api/src/cli/lib/refresh-session.ts
@@ -17,6 +17,9 @@ interface TokenResponse {
   token_type?: string;
 }
 
+/** Bound the outbound refresh call — a hanging token endpoint must not hang the CLI. */
+const TOKEN_REFRESH_FETCH_TIMEOUT_MS = 10_000;
+
 /**
  * Exchanges the session's refresh token for a fresh access token.
  *
@@ -49,6 +52,7 @@ export async function refreshSession(
       method: "POST",
       headers: { "content-type": "application/x-www-form-urlencoded" },
       body: body.toString(),
+      signal: AbortSignal.timeout(TOKEN_REFRESH_FETCH_TIMEOUT_MS),
     });
   } catch (err) {
     throw new RefreshFailedError(


### PR DESCRIPTION
Sibling `apps/api/src/oauth/refresh-access-token.ts` already caps its outbound token-refresh fetch at 10s (`TOKEN_REFRESH_FETCH_TIMEOUT_MS` + `AbortSignal.timeout`), because a wedged token endpoint must not hang the caller forever. `apps/api/src/cli/lib/refresh-session.ts` — the CLI's own session-refresh path, hit by `decocms whoami` and any authenticated CLI command via `getValidSession` — POSTs to `/api/auth/mcp/token` with no signal at all, and no caller up the chain (`ensure-session.ts`, `whoami.ts`) bounds it either. A hanging or wedged token endpoint hangs the CLI command indefinitely.

Why a maintainer wants this: it's the exact class of bug already fixed once in the sibling server-side refresh path (recent commit history), applied to the one remaining unbounded refresh call in the same feature area.

Fix: add the same 10s `AbortSignal.timeout` used by the server-side path. A timed-out fetch already rejects and is caught by the existing `catch` block, surfacing as `RefreshFailedError("transient")` — no other code path needed to change. Added a regression test asserting the outbound fetch always receives an `AbortSignal`.

Reviewer check: `cd apps/api && bun test src/cli/lib/refresh-session.test.ts`

Verified locally: `bun run fmt`, `bunx tsc --noEmit` in `apps/api`, the targeted test file (12 pass), and `bunx oxlint` on both touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the CLI session refresh to a 10s timeout to prevent hung commands. Previously the POST to `/api/auth/mcp/token` had no signal and could hang `decocms whoami` and any authenticated command; now it uses `AbortSignal.timeout(10_000)`, and timeouts surface as `RefreshFailedError("transient")`.

**Review notes**
- Adds `TOKEN_REFRESH_FETCH_TIMEOUT_MS` and passes `signal` to the fetch in `apps/api/src/cli/lib/refresh-session.ts`.
- Adds a test asserting the outbound fetch receives an `AbortSignal`.
- No behavior change beyond timing out hung token endpoints; no config or API changes.
- To verify: `cd apps/api && bun test src/cli/lib/refresh-session.test.ts`.

<sup>Written for commit 01bdc0bb13c4a33a1042285397510724c0f4a982. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

