### PR TITLE
feat(telemetry): instrument the three unmeasured steps of the PLG funnel

### DIFF
--- a/apps/web/src/hooks/use-task-board-items.ts
+++ b/apps/web/src/hooks/use-task-board-items.ts
@@ -9,6 +9,7 @@ import type {
 import { useTaskBoardEvents } from "@/hooks/use-task-board-events";
 import { useDecopilotEvents } from "@/hooks/use-decopilot-events";
 import { useT } from "@/i18n/use-t";
+import { track } from "@/lib/posthog-client";
 import { toast } from "sonner";
 
 type TaskBoardItem = ToolOutput<"TASK_BOARD_ITEM_LIST">["items"][number];
@@ -83,7 +84,7 @@ export function useTaskBoardItems() {
 }
 
 export function useTaskBoardItemActions() {
-  const { locator } = useProjectContext();
+  const { org, locator } = useProjectContext();
   const studio = useStudioTools();
   const queryClient = useQueryClient();
   const t = useT();
@@ -109,6 +110,14 @@ export function useTaskBoardItemActions() {
         ),
       );
       return { previous };
+    },
+    // A person marking done, not the agent's run finishing (task_run_completed).
+    onSuccess: (_data, input) => {
+      if (input.status === "done")
+        track("task_marked_done", {
+          organization_id: org.id,
+          task_board_item_id: input.id,
+        });
     },
     onError: (_err, _input, context) => {
       if (context?.previous)

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -129,6 +129,7 @@ import { isReportsTask, type ReviewerKind } from "@decocms/shared/task-board";
 import { useFlipLanes } from "./use-flip-lanes";
 import { Calendar as DayPickerCalendar } from "@decocms/ui/components/calendar.tsx";
 import { buildTaskChatContext } from "./build-task-chat-context";
+import { track } from "@/lib/posthog-client";
 import { useStudioTools } from "@/lib/studio-tools";
 import {
   EMPTY_FILTERS,
@@ -373,9 +374,16 @@ export function TaskBoardPage() {
     const kind = subscriptionErrorKind(err);
     if (kind) {
       setSubscriptionPaywall(kind);
+      track("task_limit_banner_shown", { organization_id: org.id, kind });
       return;
     }
     toast.error(err.message || t("taskBoard.taskBoard.actionError"));
+  };
+  // Ref, not an effect: fires once per mount, `tracked` guards a re-invoked ref.
+  const trackBoardOpenRef = (element: HTMLDivElement | null) => {
+    if (!element || element.dataset.tracked === "true") return;
+    element.dataset.tracked = "true";
+    track("task_board_opened", { organization_id: org.id });
   };
   // The task awaiting a re-run confirmation, or null. A re-run supersedes the
   // task's live run, so it is confirmed rather than fired on click.
@@ -571,7 +579,10 @@ export function TaskBoardPage() {
     // Full-width so each region's scroll container spans the whole panel — the
     // max-width lives on the *content* inside (header + lanes), so the mouse can
     // sit in the empty margins on wide monitors and still scroll the board.
-    <div className="relative flex min-h-0 flex-1 flex-col">
+    <div
+      ref={trackBoardOpenRef}
+      className="relative flex min-h-0 flex-1 flex-col"
+    >
       {/* Header — capped + centered to the same width as the board content so
           they line up; content-capped, not scroll-capped. */}
       <div className="mx-auto flex w-full max-w-[1680px] flex-col gap-4 px-4 pt-6 sm:px-8 sm:pt-8">


### PR DESCRIPTION
## Why

The PLG funnel dashboard maps 17 steps to events. Three had **no event at all**, so on the board a missing bar and a step nobody reached looked identical:

| Step | Status before |
|---|---|
| 12 · Board opened | no event |
| 14 · Task marked done | no event — `task_run_completed` is the *agent's run* finishing, not a person |
| 15 · Limit banner shown | no event — `task_quota_blocked` records the server-side block, not whether anyone saw the paywall |

## What

- **`task_board_opened`** — ref callback on the board root, not an effect (banned by `plugins/ban-use-effect.ts`). A `dataset` flag guards a re-invoked ref from double-counting, mirroring `trackGateRef` in `reports/auth-gate.tsx`.
- **`task_marked_done`** — fired inside the `update` mutation in `useTaskBoardItemActions`. That is the single choke point every status change routes through, so drag-drop, the bulk action bar and the task dialog are covered by one call site instead of ten scattered ones.
- **`task_limit_banner_shown`** — in `onDelegateError`, where the paywall dialog is actually opened. Carries `kind` so the three refusal reasons stay distinguishable.

All three carry `organization_id`, consistent with the other org-scoped events.

## Follow-up (not in this PR)

The funnel still cannot be a native PostHog funnel end to end, because the Studio server events key on `organization_id` while the engine events key on `domain`. Two things surfaced while measuring this:

1. **`$process_person_profile: false` silently drops group attachment.** `captureOrgEvent` sets that flag when there is no user, and events sent that way arrive with `$groups` populated but `$group_0` empty — so any `unique_group` math returns zero for them. `task_run_enqueued` and `task_run_completed` are affected; `task_quota_claimed` is affected only for its user-less half (67 of 84). Dashboard tiles were switched to count `organization_id` directly as a workaround.
2. **Studio does not persist an org's store domain.** `COMMERCE_DISCOVERY_BIND` takes `siteUrl` per call and the mapping lives in the engine's database. Persisting it and having `captureOrgEvent` attach `domain` would let one native funnel span the whole flow — worth its own PR, since it needs a migration and touches the shared telemetry path.

## Verification

- `bun run fmt`, `bun run check` clean.
- `bun run lint`: 0 errors (18 pre-existing warnings, none in the touched files).

No tests: these are telemetry call sites in React, which `TESTING.md`'s two-tier policy puts outside unit tests, and the e2e suite is not set up to observe a PostHog capture over the wire.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Instruments three missing PLG funnel steps so funnel gaps are measurable. Previously these steps had no events; now we emit them without changing user flows.

- `task_board_opened`: Fires once per mount via a root ref guarded by a `dataset` flag. Sends `organization_id`.
- `task_marked_done`: Fires in the `update` mutation only when a person sets status to `done`. Sends `organization_id` and `task_board_item_id`. Not the agent’s `task_run_completed`.
- `task_limit_banner_shown`: Fires when the subscription paywall dialog opens. Sends `organization_id` and refusal `kind`.
- No API or UI changes; telemetry only.

<sup>Written for commit c2f5f1e50a9fc8d7475ff284f76730fa834008a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

