### PR TITLE
feat(task-board): auto-tag Done cards whose PRs merged

### DIFF
--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -26,6 +26,10 @@ import {
   setTaskBoardArchiveSweepRuntime,
 } from "@/tools/task-board/dbos-archive-sweep";
 import {
+  registerTaskBoardMergedTagSweepWorkflow,
+  setTaskBoardMergedTagSweepRuntime,
+} from "@/tools/task-board/dbos-tag-merged-sweep";
+import {
   GITHUB_READS_QUEUE_PARAMS,
   registerTaskBoardGithubReadWorkflow,
   setTaskBoardGithubReadRuntime,
@@ -1522,6 +1526,9 @@ export async function createApp(options: CreateAppOptions = {}) {
   // Hourly auto-archive of settled Done cards, one org leg per candidate org.
   setTaskBoardArchiveSweepRuntime({ db: database.db });
 
+  // Hourly `merged` tagging of Done cards whose PRs landed.
+  setTaskBoardMergedTagSweepRuntime({ db: database.db });
+
   // The review sweep's rate-limited GitHub reads.
   setTaskBoardGithubReadRuntime({ db: database.db });
 
@@ -1789,6 +1796,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   registerPublicSetsSyncWorkflow();
   registerOrgRepoSyncWorkflow();
   registerTaskBoardArchiveSweepWorkflow();
+  registerTaskBoardMergedTagSweepWorkflow();
   registerTaskBoardGithubReadWorkflow();
 
   const automationRunner: StudioContext["automationRunner"] = async (

--- a/apps/api/src/dbos/workflow-source-guard.snapshot.json
+++ b/apps/api/src/dbos/workflow-source-guard.snapshot.json
@@ -8,5 +8,6 @@
   "harnesses/decopilot/background-tool-workflow.ts": "9febb699f45b63b418481ed998aee0ec8251c97cb5c409d54d714eb365a08fd0",
   "monitoring/dbos-retention-workflow.ts": "757e9999af900d9395c6629d4966b84c723512d0a5a8e488f70b7ba634752bd8",
   "tools/task-board/dbos-archive-sweep.ts": "fe2db3802dd291f4d9ad5369a21c28854403bd2756518d9b48c1fcda4f100000",
-  "tools/task-board/dbos-github-read.ts": "8757159d594f776d021ed28887e5ba51f7a6e007607a2dc6962efd53152b4d60"
+  "tools/task-board/dbos-github-read.ts": "8757159d594f776d021ed28887e5ba51f7a6e007607a2dc6962efd53152b4d60",
+  "tools/task-board/dbos-tag-merged-sweep.ts": "afc48f5309fd1da3196167855b52ec0074a5f24b8a96b8ef9be2e07a8abb7a0a"
 }

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -662,6 +662,58 @@ export class TaskBoardStorage {
   }
 
   /**
+   * The merged-tag sweep's work list, across EVERY org: Done cards that have at
+   * least one linked PR and do not already carry the `merged` tag.
+   *
+   * No settle window, unlike `listItemsAwaitingArchive` — the tag is a statement
+   * about the PR, not about the card being finished with, so a card gets it as
+   * soon as its PRs land. Newest first so a fresh Done card is tagged on the
+   * next tick and any pre-existing backlog drains behind it.
+   *
+   * ponytail: a Done card whose PRs never merge stays a candidate forever and
+   * costs one GitHub read per tick. If those ever outnumber the per-tick cap
+   * they starve the backlog behind them — give the table a `merged_checked_at`
+   * stamp then, not before.
+   */
+  async listItemsAwaitingMergedTag(
+    mergedTagName: string,
+    limit: number,
+  ): Promise<{ id: string; organizationId: string }[]> {
+    const rows = await this.db
+      .selectFrom("task_board_items as i")
+      .select(["i.id", "i.organization_id as organizationId"])
+      .where("i.status", "=", "done")
+      .where("i.dismissed_at", "is", null)
+      .where((eb) =>
+        eb.exists(
+          eb
+            .selectFrom("task_board_item_prs as p")
+            .select("p.url")
+            .whereRef("p.task_board_item_id", "=", "i.id"),
+        ),
+      )
+      .where((eb) =>
+        eb.not(
+          eb.exists(
+            eb
+              .selectFrom("task_board_item_tags as t")
+              .innerJoin("organization_tags as g", "g.id", "t.id")
+              .select("t.id")
+              .whereRef("t.task_board_item_id", "=", "i.id")
+              .where(sql<string>`lower(g.name)`, "=", mergedTagName),
+          ),
+        ),
+      )
+      .orderBy("i.updated_at", "desc")
+      .limit(limit)
+      .execute();
+    return rows.map((row) => ({
+      id: row.id,
+      organizationId: row.organizationId,
+    }));
+  }
+
+  /**
    * Claim the card's next sweep interval. Returns true only for the replica that
    * won it; a loser must skip the card entirely. Claimed for every card the
    * sweeper LOOKS at, not only the ones it dispatches a reviewer for — a card

--- a/apps/api/src/tools/task-board/dbos-tag-merged-sweep.ts
+++ b/apps/api/src/tools/task-board/dbos-tag-merged-sweep.ts
@@ -1,0 +1,129 @@
+/**
+ * DBOS scheduled workflow that tags Done cards whose PRs landed (see
+ * `tag-merged.ts` for the rule).
+ *
+ * Same shape as `dbos-archive-sweep.ts`: the scheduler picks ONE pod per tick
+ * (so three replicas don't triple the GitHub reads), the work list is read
+ * inside a step so a replay iterates the recorded list rather than a fresh
+ * query, and each org's leg is its own step that never throws — one org's dead
+ * GitHub connection can't skip every other org's sweep.
+ *
+ * Its own workflow rather than a second leg of the archive sweep: that one only
+ * looks at cards settled for five days, and a `merged` tag five days late is a
+ * tag nobody saw when it mattered.
+ *
+ * Runtime deps come from a module-level registry wired by app boot via
+ * `setTaskBoardMergedTagSweepRuntime` BEFORE `DBOS.launch()`.
+ */
+
+import { DBOS, SchedulerMode } from "@dbos-inc/dbos-sdk";
+import type { Kysely } from "kysely";
+import { TaskBoardStorage } from "@/storage/task-board";
+import type { Database } from "@/storage/types";
+import { groupByOrg } from "./archive-merged";
+import { buildOrgContext } from "./org-context";
+import { MERGED_TAG_NAME, tagMergedForOrg } from "./tag-merged";
+
+/** Hourly, at :41 — off the other sweeps' ticks so one pod never runs two. */
+const MERGED_TAG_SWEEP_CRONTAB = "41 * * * *";
+
+/** Ceiling on candidates per tick, across all orgs — each costs one GitHub read
+ *  per linked PR. A backlog (including every card that predates this sweep)
+ *  drains over the following hours. */
+const MAX_CANDIDATES_PER_TICK = 200;
+
+export interface TaskBoardMergedTagSweepRuntime {
+  db: Kysely<Database>;
+}
+
+let runtime: TaskBoardMergedTagSweepRuntime | null = null;
+
+/** Wire deps for the workflow body. Safe to call before `DBOS.launch()`:
+ *  it only writes a module-level pointer, no DBOS API calls. */
+export function setTaskBoardMergedTagSweepRuntime(
+  rt: TaskBoardMergedTagSweepRuntime,
+): void {
+  runtime = rt;
+}
+
+function requireRuntime(): TaskBoardMergedTagSweepRuntime {
+  if (!runtime) {
+    throw new Error(
+      "[task-board-merged-tag] runtime not initialized — setTaskBoardMergedTagSweepRuntime() must run before the workflow fires",
+    );
+  }
+  return runtime;
+}
+
+/** One org, folded to a result — the step body must never throw. */
+async function sweepOneOrg(
+  organizationId: string,
+  itemIds: string[],
+): Promise<{ organizationId: string; tagged: number; error?: string }> {
+  try {
+    const ctx = await buildOrgContext(requireRuntime().db, organizationId);
+    if (!ctx) return { organizationId, tagged: 0 };
+    const { tagged } = await tagMergedForOrg(ctx, organizationId, itemIds);
+    return { organizationId, tagged };
+  } catch (err) {
+    return {
+      organizationId,
+      tagged: 0,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+async function mergedTagSweepWorkflowFn(): Promise<void> {
+  const candidates = await DBOS.runStep(
+    () =>
+      new TaskBoardStorage(requireRuntime().db).listItemsAwaitingMergedTag(
+        MERGED_TAG_NAME,
+        MAX_CANDIDATES_PER_TICK,
+      ),
+    { name: "loadMergedTagCandidates" },
+  );
+  if (candidates.length === 0) return;
+
+  const results = await Promise.all(
+    groupByOrg(candidates).map(({ organizationId, itemIds }) =>
+      DBOS.runStep(() => sweepOneOrg(organizationId, itemIds), {
+        name: `tagMergedForOrg:${organizationId}`,
+      }),
+    ),
+  );
+  for (const result of results) {
+    if (result.error) {
+      console.warn(
+        `[task-board-merged-tag] org ${result.organizationId} failed: ${result.error}`,
+      );
+    }
+  }
+  const tagged = results.reduce((sum, r) => sum + r.tagged, 0);
+  if (tagged > 0) {
+    console.log(
+      `[task-board-merged-tag] tagged ${tagged} of ${candidates.length} candidates`,
+    );
+  }
+}
+
+let registeredWorkflow: typeof mergedTagSweepWorkflowFn | null = null;
+
+/**
+ * Must run before DBOS.launch(). Guarded so HMR repeats don't re-register.
+ *
+ * ⚠️ Durable DBOS workflow. Changing its STEP SEQUENCE (add/remove/reorder a
+ * step, or change a step's recorded I/O) requires bumping
+ * DBOS_WORKFLOW_VERSION — see apps/api/src/dbos/workflow-version.ts.
+ */
+export function registerTaskBoardMergedTagSweepWorkflow(): void {
+  if (registeredWorkflow) return;
+  registeredWorkflow = DBOS.registerWorkflow(mergedTagSweepWorkflowFn, {
+    name: "taskBoardMergedTagSweepWorkflow",
+  });
+  DBOS.registerScheduled(registeredWorkflow, {
+    name: "taskBoardMergedTagSweepWorkflow",
+    crontab: MERGED_TAG_SWEEP_CRONTAB,
+    mode: SchedulerMode.ExactlyOncePerIntervalWhenActive,
+  });
+}

--- a/apps/api/src/tools/task-board/tag-merged.integration.test.ts
+++ b/apps/api/src/tools/task-board/tag-merged.integration.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Real-Postgres coverage for the merged-tag sweep: the candidate query's four
+ * shapes (the SQL is the whole gate — the "doesn't already carry the tag" leg
+ * is a NOT EXISTS over a join an in-memory fake would happily get wrong) and
+ * the tag write path, including the activity entry and its idempotence.
+ *
+ * The PR-merged read is injected, so the sweep runs without a GitHub
+ * connection — every other part of the path is the real one.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { sql } from "kysely";
+import type { StudioContext } from "../../core/studio-context";
+import type { StudioDatabase } from "../../database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../../database/test-db-pg";
+import { TagStorage } from "../../storage/tags";
+import { TaskBoardStorage } from "../../storage/task-board";
+import type { TaskBoardItemStatus } from "../../storage/types";
+import { MERGED_TAG_NAME, tagMergedForOrg } from "./tag-merged";
+
+const ORG = "org_mergedtag_1";
+const USER = "user_m1";
+
+describe("merged-tag sweep", () => {
+  let database: StudioDatabase;
+  let taskBoard: TaskBoardStorage;
+  let tags: TagStorage;
+  let ctx: StudioContext;
+
+  const seed = async (
+    status: TaskBoardItemStatus,
+    withPr: boolean,
+  ): Promise<string> => {
+    const item = await taskBoard.create({
+      organizationId: ORG,
+      title: `${status}-${withPr}-${Math.random()}`,
+      status,
+      by: USER,
+    });
+    if (withPr) {
+      await taskBoard.linkPr({
+        taskBoardItemId: item.id,
+        organizationId: ORG,
+        url: `https://github.com/acme/repo/pull/${item.id}`,
+        prNumber: 1,
+        repoOwner: "acme",
+        repoName: "repo",
+      });
+    }
+    return item.id;
+  };
+
+  const candidateIds = async (): Promise<string[]> =>
+    (await taskBoard.listItemsAwaitingMergedTag(MERGED_TAG_NAME, 200)).map(
+      (c) => c.id,
+    );
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    const now = new Date().toISOString();
+    await database.db
+      .insertInto("organization")
+      .values({ id: ORG, name: ORG, slug: "org-mergedtag-1", createdAt: now })
+      .execute();
+    // Raw SQL: real Postgres has a BOOLEAN emailVerified the typed shape disagrees with.
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES (${USER}, ${"m1@mergedtag.test"}, false, ${USER}, ${now}, ${now})
+    `.execute(database.db);
+    taskBoard = new TaskBoardStorage(database.db);
+    tags = new TagStorage(database.db);
+    ctx = {
+      auth: { user: { id: USER, email: "m1@mergedtag.test", name: USER } },
+      organization: { id: ORG, slug: "org-mergedtag-1", name: ORG },
+      storage: { taskBoard, tags },
+    } as unknown as StudioContext;
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  it("picks up every Done card with a PR, however old, and nothing else", async () => {
+    const qualifies = await seed("done", true);
+    const noPr = await seed("done", false);
+    const notDone = await seed("in_review", true);
+
+    const ids = await candidateIds();
+    expect(ids).toContain(qualifies);
+    expect(ids).not.toContain(noPr);
+    expect(ids).not.toContain(notDone);
+  });
+
+  it("tags a merged card, logs it, and drops it from the work list", async () => {
+    const id = await seed("done", true);
+
+    const first = await tagMergedForOrg(ctx, ORG, [id], async () => true);
+    expect(first.tagged).toBe(1);
+    expect(
+      (await taskBoard.getById(id, ORG))?.tags.map((t) => t.name),
+    ).toContain(MERGED_TAG_NAME);
+
+    const activity = await taskBoard.listActivity(id, ORG);
+    expect(activity).toContainEqual(
+      expect.objectContaining({
+        action: "tags_changed",
+        actorId: null,
+        data: expect.objectContaining({ reason: "merged_pr_auto_tag" }),
+      }),
+    );
+
+    // Already tagged, so the SQL gate must not hand it back next tick.
+    expect(await candidateIds()).not.toContain(id);
+  });
+
+  it("reuses the org's one merged tag across cards", async () => {
+    const a = await seed("done", true);
+    const b = await seed("done", true);
+
+    await tagMergedForOrg(ctx, ORG, [a, b], async () => true);
+
+    const merged = (await tags.listOrgTags(ORG)).filter(
+      (t) => t.name.toLowerCase() === MERGED_TAG_NAME,
+    );
+    expect(merged).toHaveLength(1);
+  });
+
+  it("leaves a card alone when GitHub can't confirm the merge", async () => {
+    const unknown = await seed("done", true);
+    const open = await seed("done", true);
+
+    expect(
+      (await tagMergedForOrg(ctx, ORG, [unknown], async () => null)).tagged,
+    ).toBe(0);
+    expect(
+      (await tagMergedForOrg(ctx, ORG, [open], async () => false)).tagged,
+    ).toBe(0);
+    expect((await taskBoard.getById(unknown, ORG))?.tags).toEqual([]);
+    expect((await taskBoard.getById(open, ORG))?.tags).toEqual([]);
+  });
+
+  it("does not create the tag for an org with nothing merged", async () => {
+    // Runs against a second org so the earlier cases' tag can't mask it.
+    const otherOrg = "org_mergedtag_2";
+    const now = new Date().toISOString();
+    await database.db
+      .insertInto("organization")
+      .values({
+        id: otherOrg,
+        name: otherOrg,
+        slug: "org-mergedtag-2",
+        createdAt: now,
+      })
+      .execute();
+    const item = await taskBoard.create({
+      organizationId: otherOrg,
+      title: "nothing merged",
+      status: "done",
+      by: USER,
+    });
+
+    await tagMergedForOrg(ctx, otherOrg, [item.id], async () => false);
+
+    expect(await tags.listOrgTags(otherOrg)).toEqual([]);
+  });
+});

--- a/apps/api/src/tools/task-board/tag-merged.ts
+++ b/apps/api/src/tools/task-board/tag-merged.ts
@@ -1,0 +1,126 @@
+/**
+ * Auto-tag: a Done card whose linked PRs have all landed gets the org's
+ * `merged` tag, so "done" and "actually shipped" are told apart on the board
+ * without opening every card's PR link.
+ *
+ * Same shape and the same gate as `archive-merged.ts` (it reuses `allPrsMerged`
+ * and `groupByOrg`), but no settle window: the tag is a statement about the PR,
+ * not about the card being finished with. It runs unattended on the hourly
+ * `taskBoardMergedTagSweepWorkflow` (see `dbos-tag-merged-sweep.ts`) — nothing
+ * about it is a decision a human makes per task.
+ *
+ * Additive only (`addItemTags`): the sweep owns this one label and never
+ * touches the ones a human put on the card. It also never removes it — a card
+ * whose PR is somehow un-merged keeps the tag until someone takes it off by
+ * hand, which is the conservative direction for a label nobody gates on.
+ */
+
+import { nextTagColor } from "@decocms/shared/task-board";
+import type { StudioContext } from "@/core/studio-context";
+import type { TaskBoardItemPrRef } from "@/storage/types";
+import { recordTaskActivity } from "./activity";
+import { allPrsMerged } from "./archive-merged";
+import { fetchPrMerged } from "./prs-get";
+import { emitTaskBoardUpdated } from "./run-reactions";
+
+/** Lowercase — org tags are matched case-insensitively, so an existing
+ *  "Merged" is reused rather than forked into a second tag. */
+export const MERGED_TAG_NAME = "merged";
+
+/** How the sweep asks GitHub whether a PR merged — a parameter only so a
+ *  local/CI harness can drive the tag path without a GitHub connection. */
+type PrMergedReader = (
+  ctx: StudioContext,
+  orgId: string,
+  pr: TaskBoardItemPrRef,
+) => Promise<boolean | null>;
+
+/**
+ * The org's `merged` tag id, created on first use. Resolved lazily — only once
+ * a card actually qualifies — so a sweep over an org with nothing merged does
+ * not leave an unused tag in its tag picker.
+ */
+async function resolveMergedTagId(
+  ctx: StudioContext,
+  organizationId: string,
+): Promise<string> {
+  const existing = await ctx.storage.tags.listOrgTags(organizationId);
+  const found = existing.find(
+    (tag) => tag.name.toLowerCase() === MERGED_TAG_NAME,
+  );
+  if (found) return found.id;
+  const created = await ctx.storage.tags.createTag(
+    organizationId,
+    MERGED_TAG_NAME,
+    nextTagColor(existing.length),
+  );
+  return created.id;
+}
+
+/**
+ * Tag one candidate if its PRs are all merged. Returns whether it was tagged.
+ *
+ * Re-reads the card inside the org's context and re-checks `status === "done"`:
+ * the sweep's work list is a snapshot, and a card someone dragged out of Done
+ * in the meantime must not be tagged. `null` (GitHub unreachable) is never read
+ * as merged, so a bad fetch defers to the next sweep instead of tagging on a
+ * guess.
+ */
+async function tagIfMerged(
+  ctx: StudioContext,
+  organizationId: string,
+  itemId: string,
+  tagId: () => Promise<string>,
+  prMerged: PrMergedReader,
+): Promise<boolean> {
+  const item = await ctx.storage.taskBoard.getById(itemId, organizationId);
+  if (!item || item.status !== "done") return false;
+
+  const prs = await ctx.storage.taskBoard.listPrs(itemId, organizationId);
+  const merged = await Promise.all(
+    prs.map((pr) => prMerged(ctx, organizationId, pr)),
+  );
+  if (!allPrsMerged(merged)) return false;
+
+  await ctx.storage.taskBoard.addItemTags(itemId, [await tagId()], "system");
+  const updated = await ctx.storage.taskBoard.getById(itemId, organizationId);
+  if (!updated) return false;
+
+  await recordTaskActivity(ctx, {
+    taskBoardItemId: itemId,
+    action: "tags_changed",
+    actorId: null,
+    data: { from: item.tags, to: updated.tags, reason: "merged_pr_auto_tag" },
+  });
+  emitTaskBoardUpdated(organizationId, updated);
+  return true;
+}
+
+/**
+ * One org's leg of the sweep — its own candidates only, folded to a count so a
+ * single unreachable GitHub connection can't fail the whole tick.
+ *
+ * Card-at-a-time within the org: GitHub's secondary rate limit punishes bursts,
+ * and the orgs themselves already run in parallel.
+ */
+export async function tagMergedForOrg(
+  ctx: StudioContext,
+  organizationId: string,
+  itemIds: string[],
+  prMerged: PrMergedReader = fetchPrMerged,
+): Promise<{ tagged: number }> {
+  let cached: Promise<string> | null = null;
+  const tagId = () => (cached ??= resolveMergedTagId(ctx, organizationId));
+
+  let tagged = 0;
+  for (const itemId of itemIds) {
+    try {
+      if (await tagIfMerged(ctx, organizationId, itemId, tagId, prMerged)) {
+        tagged += 1;
+      }
+    } catch (err) {
+      console.error(`[task-board-merged-tag] ${itemId} failed`, err);
+    }
+  }
+  return { tagged };
+}


### PR DESCRIPTION
## Summary

Adds an hourly background sweep that attaches the org's `merged` tag to Done cards whose linked PRs have all landed — so "done" and "actually shipped" are told apart on the board without opening every card's PR link.

`taskBoardMergedTagSweepWorkflow` is a DBOS scheduled workflow at `:41`, cloned from the existing `dbos-archive-sweep.ts`: the scheduler picks one pod per tick (three replicas don't triple the GitHub reads), the work list is read inside a step so a replay iterates the recorded list, and each org's leg is its own step that never throws — one org's dead GitHub connection can't skip every other org's sweep. It reuses `allPrsMerged` and `groupByOrg` from `archive-merged.ts` rather than restating the gate.

Its own workflow rather than a second leg of the archive sweep: that one only looks at cards settled for five days, and a `merged` tag five days late is a tag nobody saw when it mattered.

**No backfill script needed.** The candidate query has no settle window, so every pre-existing Done card is already a candidate and the backlog drains unattended at up to 200 cards/hour.

## Behavior

- Additive only (`addItemTags`) — the sweep owns this one label and never touches tags a human put on the card. Idempotent.
- Never removes the tag: a card whose PR is somehow un-merged keeps it until someone takes it off by hand — conservative for a label nothing gates on.
- `null` from GitHub (unreachable) is never read as merged; a bad fetch defers to the next tick instead of tagging on a guess.
- Re-reads the card inside the org's context and re-checks `status === "done"` — the work list is a snapshot, and a card dragged out of Done meanwhile must not be tagged.
- The org's `merged` tag is resolved case-insensitively and created on first use only, so an org with nothing merged doesn't get an unused tag in its picker.
- Writes a `tags_changed` activity entry (`reason: "merged_pr_auto_tag"`) and emits `emitTaskBoardUpdated` so open boards patch live.

## Files

| File | |
|---|---|
| `apps/api/src/storage/task-board.ts` | `listItemsAwaitingMergedTag` — the SQL gate: done + not dismissed + has PR + `NOT EXISTS` the merged tag |
| `apps/api/src/tools/task-board/tag-merged.ts` | the org leg |
| `apps/api/src/tools/task-board/dbos-tag-merged-sweep.ts` | the scheduled workflow |
| `apps/api/src/api/app.ts` | runtime + registration wiring |
| `apps/api/src/tools/task-board/tag-merged.integration.test.ts` | 5 real-Postgres cases |

## Testing

Real-Postgres integration test (the SQL is the whole gate — the "doesn't already carry the tag" leg is a `NOT EXISTS` over a join an in-memory fake would happily get wrong), with the PR-merged read injected so it runs without a GitHub connection:

- candidate query picks up every Done card with a PR however old, and skips PR-less / not-Done cards
- tags a merged card, logs the activity, and drops it from the work list
- reuses the org's one `merged` tag across cards
- leaves a card alone when GitHub answers `null` or `false`
- does not create the tag for an org with nothing merged

Verified locally: `bun run check` clean, `bun run lint` 0 errors, `knip` clean, `bun run fmt` applied. 5/5 new tests plus 12/12 existing archive-sweep and DBOS-guard tests pass (against a throwaway Postgres — Docker was unavailable, so a scratch DB was migrated and dropped).

Re-baselined `workflow-source-guard.snapshot.json`. **No `DBOS_WORKFLOW_VERSION` bump** — a new workflow strands no in-flight instance, and no existing workflow's step sequence changed.

## Follow-ups / known ceilings

- A Done card whose PRs never merge stays a candidate forever and costs one GitHub read per tick. If those ever outnumber `MAX_CANDIDATES_PER_TICK` (200) they starve the backlog behind them. Marked with a `ponytail:` comment naming the fix — a `merged_checked_at` stamp on the table — to add then, not before.
- If the existing Done+PR backlog is in the thousands, raise the per-tick cap rather than waiting days for it to drain.

No frontend changes: task tags already render.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-tags Done task-board cards with the org’s `merged` tag once all linked PRs have landed, so “done” vs “actually shipped” is visible at a glance. Previously there was no auto-tag; now an hourly sweep adds the tag and never removes it.

- Scheduled workflow `taskBoardMergedTagSweepWorkflow` runs hourly at :41 (ExactlyOnce, one pod per tick). Work list is read inside a step; each org runs in its own non-throwing step.
- SQL gate `listItemsAwaitingMergedTag`: Done + not dismissed + has PR + lacks the `merged` tag; newest first; no settle window.
- Tagging is additive only via `addItemTags`; never removes the tag. Resolves/creates the org’s `merged` tag case-insensitively on first use. Re-reads the card and confirms `status === "done"` before tagging.
- Uses existing merge check (`allPrsMerged`); a GitHub `null` is not treated as merged. Caps candidates at 200 per tick to respect rate limits; no backfill needed—the backlog drains automatically.
- Emits a `tags_changed` activity with `reason: "merged_pr_auto_tag"` and calls `emitTaskBoardUpdated` for live updates.
- Wiring: `app.ts` calls `setTaskBoardMergedTagSweepRuntime` and `registerTaskBoardMergedTagSweepWorkflow`. New files: `tools/task-board/dbos-tag-merged-sweep.ts`, `tools/task-board/tag-merged.ts`, integration test. Snapshot updated; no `DBOS_WORKFLOW_VERSION` bump.

<sup>Written for commit 4bfa1471b16a72fd07cbced7b991b5a6cc9c21b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

