### PR TITLE
fix(file-storage): validate S3 config before passing to AWS SDK

### DIFF
--- a/apps/api/src/file-storage/file-config-s3.test.ts
+++ b/apps/api/src/file-storage/file-config-s3.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import {
   buildPublicUrl,
+  buildS3Client,
   byLastModifiedDesc,
   isImageKey,
   type ListedObject,
@@ -373,5 +374,68 @@ describe("stsCredentialProvider", () => {
     expect(() => stsCredentialProvider(info({}), "k")).toThrow(
       /missing a refreshUrl/,
     );
+  });
+});
+
+describe("buildS3Client", () => {
+  test("throws when region is empty", () => {
+    expect(() =>
+      buildS3Client({
+        info: info({ region: "" }),
+        credentials: {
+          type: "static",
+          accessKeyId: "AKIA",
+          secretAccessKey: "secret",
+        },
+      }),
+    ).toThrow(/missing or empty region/);
+  });
+
+  test("throws when bucket is empty", () => {
+    expect(() =>
+      buildS3Client({
+        info: info({ bucket: "" }),
+        credentials: {
+          type: "static",
+          accessKeyId: "AKIA",
+          secretAccessKey: "secret",
+        },
+      }),
+    ).toThrow(/missing or empty bucket/);
+  });
+
+  test("throws when static credentials lack accessKeyId", () => {
+    expect(() =>
+      buildS3Client({
+        info: info({}),
+        credentials: {
+          type: "static",
+          accessKeyId: "",
+          secretAccessKey: "secret",
+        },
+      }),
+    ).toThrow(/missing or empty accessKeyId/);
+  });
+
+  test("throws when static credentials lack secretAccessKey", () => {
+    expect(() =>
+      buildS3Client({
+        info: info({}),
+        credentials: {
+          type: "static",
+          accessKeyId: "AKIA",
+          secretAccessKey: "",
+        },
+      }),
+    ).toThrow(/missing or empty secretAccessKey/);
+  });
+
+  test("throws when managed config lacks siteSlug", () => {
+    expect(() =>
+      buildS3Client({
+        info: info({ siteSlug: null }),
+        credentials: { type: "managed" },
+      }),
+    ).toThrow(/missing siteSlug/);
   });
 });

--- a/apps/api/src/file-storage/file-config-s3.ts
+++ b/apps/api/src/file-storage/file-config-s3.ts
@@ -99,17 +99,45 @@ export function buildS3Client(ctx: FileConfigContext): S3Client {
   const cached = clientCache.get(cacheKey);
   if (cached) return cached;
 
+  // Validate required configuration fields before passing to AWS SDK
+  if (!ctx.info.region) {
+    throw new Error(`File config ${ctx.info.id} missing or empty region`);
+  }
+  if (!ctx.info.bucket) {
+    throw new Error(`File config ${ctx.info.id} missing or empty bucket`);
+  }
+
   const credentials =
     ctx.credentials.type === "sts-session"
       ? stsCredentialProvider(ctx.info, ctx.credentials.apiKey)
       : ctx.credentials.type === "managed"
-        ? // Mint prefix-scoped STS creds in-process for the config's slug. The
-          // SDK memoizes/refreshes by expiration, same as the sts-session path.
-          () => provisionTenantS3Credentials(ctx.info.siteSlug ?? "")
-        : {
-            accessKeyId: ctx.credentials.accessKeyId,
-            secretAccessKey: ctx.credentials.secretAccessKey,
-          };
+        ? (() => {
+            // Validate siteSlug for managed credentials
+            const slug = ctx.info.siteSlug;
+            if (!slug) {
+              throw new Error(
+                `Managed file config ${ctx.info.id} missing siteSlug`,
+              );
+            }
+            return () => provisionTenantS3Credentials(slug);
+          })()
+        : (() => {
+            // Validate static credentials before passing to AWS SDK
+            if (!ctx.credentials.accessKeyId) {
+              throw new Error(
+                `File config ${ctx.info.id} missing or empty accessKeyId`,
+              );
+            }
+            if (!ctx.credentials.secretAccessKey) {
+              throw new Error(
+                `File config ${ctx.info.id} missing or empty secretAccessKey`,
+              );
+            }
+            return {
+              accessKeyId: ctx.credentials.accessKeyId,
+              secretAccessKey: ctx.credentials.secretAccessKey,
+            };
+          })();
 
   const client = new S3Client({
     region: ctx.info.region,


### PR DESCRIPTION
Adds validation of S3 file config at the trust boundary where config values cross into AWS SDK calls, preventing cryptic downstream errors.

**What was fixed:**
- Static credentials (accessKeyId, secretAccessKey) now validated for presence before passing to S3Client
- Required fields (region, bucket) now validated to prevent invalid S3 requests
- Managed config's siteSlug now validated to prevent silent fallback to empty string

**Why it matters:**
 Missing field validation at the boundary between config storage and external AWS SDK calls leads to confusing errors from the SDK itself. Early validation provides clear, actionable error messages showing which file config is misconfigured.

**Verification:**
- All 35 tests pass (5 new tests verify validation errors)
- No lint errors or formatting issues
- Zero-length diff summary: +99 / -7 (adds validation + tests, removes fallback logic)

Run `bun test apps/api/src/file-storage/file-config-s3.test.ts` to verify.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate S3 file config at the trust boundary to fail fast with clear errors instead of cryptic `@aws-sdk/client-s3` failures. Previously, empty or missing fields reached the SDK; now `buildS3Client` throws descriptive errors.

- Validate `region` and `bucket` and include the file config id in messages.
- Require `accessKeyId` and `secretAccessKey` for `static` credentials.
- Require `siteSlug` for `managed` credentials and remove the empty-string fallback.
- All checks live in `buildS3Client`; tests added in `file-config-s3.test.ts`.

**Migration**
- Set `region` and `bucket` on all S3 configs.
- For `static` configs, provide `accessKeyId` and `secretAccessKey`.
- For `managed` configs, provide `siteSlug`.

<sup>Written for commit aa91c8098e2325f8d6924e1ae5da6134c3cc0d13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

