### PR TITLE
fix(cli): reject a session file with a malformed expiresAt/refreshToken type

### DIFF
--- a/apps/api/src/cli/lib/session.test.ts
+++ b/apps/api/src/cli/lib/session.test.ts
@@ -123,6 +123,24 @@ describe("readSession", () => {
     });
     expect(await readSession(dir)).toBeNull();
   });
+
+  it("returns null when expiresAt is not a number", async () => {
+    await writeFile(
+      sessionPath(dir, sample.target),
+      JSON.stringify({ ...sample, expiresAt: "not-a-number" }),
+      { mode: 0o600 },
+    );
+    expect(await readSession(dir, sample.target)).toBeNull();
+  });
+
+  it("returns null when refreshToken is not a string", async () => {
+    await writeFile(
+      sessionPath(dir, sample.target),
+      JSON.stringify({ ...sample, refreshToken: 12345 }),
+      { mode: 0o600 },
+    );
+    expect(await readSession(dir, sample.target)).toBeNull();
+  });
 });
 
 describe("clearSession", () => {

--- a/apps/api/src/cli/lib/session.ts
+++ b/apps/api/src/cli/lib/session.ts
@@ -139,5 +139,12 @@ function isSession(value: unknown): value is Session {
   if (!v.user || typeof v.user !== "object") return false;
   const u = v.user as Record<string, unknown>;
   if (typeof u.sub !== "string") return false;
+  // A non-numeric expiresAt would make isExpired()'s NaN comparison always false.
+  if (v.refreshToken !== undefined && typeof v.refreshToken !== "string") {
+    return false;
+  }
+  if (v.expiresAt !== undefined && typeof v.expiresAt !== "number") {
+    return false;
+  }
   return true;
 }


### PR DESCRIPTION
Follows the recent session-refresh hardening chain (#6079-#6114) — those fixes cover the *remote* token-response body; this closes the matching gap on the *local* session file's `isSession()` type guard.

`isSession()` in `apps/api/src/cli/lib/session.ts` validates the type of every required field but skips the optional `expiresAt`/`refreshToken` fields entirely. A session file corrupted or hand-edited so that `expiresAt` is a non-numeric value (e.g. a string) still passes validation. `isExpired()` then computes `session.expiresAt - EXPIRY_SKEW_SECONDS < nowSeconds`, which is `NaN < number` — always `false` — so the session is treated as never expired and the CLI never attempts a refresh again, silently keeping a possibly-dead access token in use indefinitely. A non-string `refreshToken` has the analogous effect: it gets sent verbatim as the `refresh_token` form field to the token endpoint.

Fix: `isSession()` now also rejects a present-but-wrong-typed `expiresAt`/`refreshToken`, falling back to the existing "no session" / re-login path the same way a missing required field already does.

Reviewer check: `cd apps/api && bun test src/cli/lib/session.test.ts` — two new cases assert `readSession` returns `null` for a malformed `expiresAt`/`refreshToken`.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api), the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects malformed `expiresAt` or `refreshToken` in CLI session files so expired or invalid sessions no longer appear valid. Previously `isSession()` ignored types for these optional fields; now it rejects non-number `expiresAt` and non-string `refreshToken`, causing `readSession` to return null and trigger re-login.

- Affects only `apps/api/src/cli/lib/session.ts`: adds type checks in `isSession()`.
- Tests: adds two cases in `session.test.ts` asserting `readSession` returns null for bad `expiresAt` or `refreshToken`.
- Migration: none for valid sessions. If a user’s session file is corrupted, the CLI will prompt re-login; deleting the session file resolves it.

<sup>Written for commit 4771e706b33cf5ffb986802670482b7c86efbd3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

