### PR TITLE
feat(task-board): default QA Agent and Code Reviewer on

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,9 +343,18 @@ a new column. Adding one = one line in **`OrgFlagsSchema`**
 its consumer, then `bun run --cwd=apps/api generate:tool-contracts`. Read via
 `useOrgFlag("<flag>")` (web) or `settings?.flags?.<flag>` (api); set via
 `ORGANIZATION_SETTINGS_UPDATE { flags: { <flag>: true } }`. Updates
-shallow-merge (explicit `false` persists, omitted keys survive); unset reads as
-off. Flags are product gating, not access control. Anything non-boolean or ever
-needing an index/constraint gets its own column instead.
+shallow-merge (explicit `false` persists, omitted keys survive). Flags are
+product gating, not access control. Anything non-boolean or ever needing an
+index/constraint gets its own column instead.
+
+Most flags default OFF (unset reads as off). The exceptions are in
+**`DEFAULT_ON_FLAGS`** (`schema.ts`) — currently the automated reviewers
+(`qa_agent_enabled`, `code_reviewer_enabled`) — which default ON: unset reads as
+enabled and only an explicit `false` opts out. Because the default now depends on
+the flag, **read every flag through `orgFlagEnabled(flags, flag)`** (or
+`useOrgFlag`, which wraps it) — a raw `settings?.flags?.<flag>` read is only
+correct for default-off flags and silently disagrees with the gate for default-on
+ones.
 
 ### A/B tests (PostHog experiments)
 

--- a/apps/api/src/tools/reports/setup.test.ts
+++ b/apps/api/src/tools/reports/setup.test.ts
@@ -189,8 +189,6 @@ describe("COMMERCE_DISCOVERY_SETUP", () => {
         data: {
           flags: {
             reports_only: true,
-            qa_agent_enabled: true,
-            code_reviewer_enabled: true,
           },
         },
       },
@@ -217,19 +215,16 @@ describe("COMMERCE_DISCOVERY_SETUP", () => {
         data: {
           flags: {
             reports_only: true,
-            qa_agent_enabled: true,
-            code_reviewer_enabled: true,
           },
         },
       },
     ]);
   });
 
-  test("defaults reports_only on but does not clobber an already-explicit reviewer flag", async () => {
+  test("defaults reports_only on without touching the default-on reviewer flags", async () => {
     const upserts: Array<{ orgId: string; data: Record<string, unknown> }> = [];
     const ctx = makeCtx({
-      // reports_only was never set, but the org already turned code review off
-      // by hand — the reports_only default must not re-enable it.
+      // Org opted code review off by hand; setup only defaults reports_only.
       codeReviewerEnabled: false,
       settingsUpsert: (orgId, data) => upserts.push({ orgId, data }),
     });
@@ -243,7 +238,7 @@ describe("COMMERCE_DISCOVERY_SETUP", () => {
       {
         orgId: ORG_ID,
         data: {
-          flags: { reports_only: true, qa_agent_enabled: true },
+          flags: { reports_only: true },
         },
       },
     ]);

--- a/apps/api/src/tools/reports/setup.ts
+++ b/apps/api/src/tools/reports/setup.ts
@@ -278,18 +278,9 @@ export const COMMERCE_DISCOVERY_SETUP = defineTool({
       );
       const flags = settings?.flags;
       const defaults: Record<string, boolean> = {};
+      // Reviewers are default-on org-wide (DEFAULT_ON_FLAGS); no forcing here.
       if (flags?.reports_only == null) {
         defaults.reports_only = true;
-        // Reports-only orgs hide agent navigation, so the QA Agent / Code
-        // Reviewer that would otherwise run from that UI must be on by
-        // default for the reviewer flow (task-board PR review) to still
-        // function. Only ride along with a fresh reports_only default, not
-        // independently — an org that explicitly turned reports_only off
-        // must not have these forced on.
-        if (flags?.qa_agent_enabled == null) defaults.qa_agent_enabled = true;
-        if (flags?.code_reviewer_enabled == null) {
-          defaults.code_reviewer_enabled = true;
-        }
       }
       if (Object.keys(defaults).length > 0) {
         await ctx.storage.organizationSettings.upsert(organization.id, {

--- a/apps/web/src/hooks/use-organization-settings.ts
+++ b/apps/web/src/hooks/use-organization-settings.ts
@@ -13,6 +13,10 @@ import { callStudioTool, useStudioTools } from "@/lib/studio-tools";
 import type { StudioToolInput as ToolInput } from "@decocms/shared/tools/tool-io";
 
 export type { SimpleModeTier } from "@decocms/shared/organization/schema";
+import {
+  DEFAULT_ON_FLAGS,
+  orgFlagEnabled,
+} from "@decocms/shared/organization/schema";
 import type {
   OrgFlags,
   SimpleModeTier,
@@ -241,13 +245,16 @@ export function useReportsOnly(): boolean {
 }
 
 /**
- * Read one org flag from the `flags` bag (see OrgFlagsSchema in
- * @decocms/shared/organization/schema — the single place flags are defined).
- * Unset and NULL both read as `false`. Non-blocking, cosmetic-gating only.
+ * Read one org flag from the `flags` bag via `orgFlagEnabled` (see
+ * OrgFlagsSchema / DEFAULT_ON_FLAGS in @decocms/shared/organization/schema —
+ * the single place flag defaults are defined). The pre-load fallback uses the
+ * same default. Non-blocking, cosmetic-gating only.
  */
 export function useOrgFlag(flag: keyof OrgFlags): boolean {
-  const { data } = useOrganizationSettings((s) => s.flags?.[flag] ?? false);
-  return data ?? false;
+  const { data } = useOrganizationSettings((s) =>
+    orgFlagEnabled(s.flags, flag),
+  );
+  return data ?? DEFAULT_ON_FLAGS.has(flag);
 }
 
 /**

--- a/packages/shared/src/organization/schema.test.ts
+++ b/packages/shared/src/organization/schema.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import { DEFAULT_ON_FLAGS, orgFlagEnabled } from "./schema";
+
+describe("orgFlagEnabled", () => {
+  it("default-on flags read as enabled unless stored exactly false", () => {
+    expect(DEFAULT_ON_FLAGS.has("qa_agent_enabled")).toBe(true);
+    // unset / null / true → on; only explicit false opts out.
+    expect(orgFlagEnabled(null, "qa_agent_enabled")).toBe(true);
+    expect(orgFlagEnabled(undefined, "qa_agent_enabled")).toBe(true);
+    expect(orgFlagEnabled({}, "qa_agent_enabled")).toBe(true);
+    expect(orgFlagEnabled({ qa_agent_enabled: null }, "qa_agent_enabled")).toBe(
+      true,
+    );
+    expect(orgFlagEnabled({ qa_agent_enabled: true }, "qa_agent_enabled")).toBe(
+      true,
+    );
+    expect(
+      orgFlagEnabled({ qa_agent_enabled: false }, "qa_agent_enabled"),
+    ).toBe(false);
+  });
+
+  it("default-off flags read as disabled unless stored exactly true", () => {
+    expect(DEFAULT_ON_FLAGS.has("auto_merge")).toBe(false);
+    expect(orgFlagEnabled(null, "auto_merge")).toBe(false);
+    expect(orgFlagEnabled(undefined, "auto_merge")).toBe(false);
+    expect(orgFlagEnabled({}, "auto_merge")).toBe(false);
+    expect(orgFlagEnabled({ auto_merge: null }, "auto_merge")).toBe(false);
+    expect(orgFlagEnabled({ auto_merge: false }, "auto_merge")).toBe(false);
+    expect(orgFlagEnabled({ auto_merge: true }, "auto_merge")).toBe(true);
+  });
+
+  it("a non-boolean stored value follows the branch's strict comparison", () => {
+    // Reads hit raw jsonb, bypassing zod: only a strict boolean flips the gate.
+    expect(
+      orgFlagEnabled({ qa_agent_enabled: "true" }, "qa_agent_enabled"),
+    ).toBe(true);
+    expect(orgFlagEnabled({ auto_merge: "true" }, "auto_merge")).toBe(false);
+  });
+});

--- a/packages/shared/src/organization/schema.ts
+++ b/packages/shared/src/organization/schema.ts
@@ -166,6 +166,35 @@ export const OrgFlagsSchema = z.object({
 export type OrgFlags = z.infer<typeof OrgFlagsSchema>;
 
 /**
+ * Flags that default ON: an unset (or NULL) value reads as enabled, and only an
+ * explicit `false` disables. Every other flag defaults OFF (unset reads as
+ * off). New orgs get these behaviors without opting in — a team opts OUT by
+ * toggling the flag off, which persists an explicit `false`.
+ *
+ * The automated reviewers live here: the QA Agent and Code Reviewer run on a
+ * task's PR by default; disabling one is the deliberate action.
+ */
+export const DEFAULT_ON_FLAGS: ReadonlySet<keyof OrgFlags> = new Set([
+  "qa_agent_enabled",
+  "code_reviewer_enabled",
+]);
+
+/**
+ * Resolve one org flag to its effective boolean. Honors {@link DEFAULT_ON_FLAGS}
+ * — a default-on flag is enabled unless stored as exactly `false`; every other
+ * flag is enabled only when stored as exactly `true`. The single reader shared
+ * by the server gate (`enabledReviewerKinds`) and the web hook (`useOrgFlag`),
+ * so both agree on what "unset" means.
+ */
+export function orgFlagEnabled(
+  flags: Record<string, unknown> | null | undefined,
+  flag: keyof OrgFlags,
+): boolean {
+  const value = flags?.[flag];
+  return DEFAULT_ON_FLAGS.has(flag) ? value !== false : value === true;
+}
+
+/**
  * Brand context schema - org-scoped company profile
  */
 export const BrandContextSchema = z.object({

--- a/packages/shared/src/task-board.test.ts
+++ b/packages/shared/src/task-board.test.ts
@@ -13,13 +13,13 @@ import {
 } from "./task-board";
 
 describe("enabledReviewerKinds", () => {
-  it("returns nothing for missing/empty flags", () => {
-    expect(enabledReviewerKinds(null)).toEqual([]);
-    expect(enabledReviewerKinds(undefined)).toEqual([]);
-    expect(enabledReviewerKinds({})).toEqual([]);
+  it("enables both reviewers when flags are missing/empty (default-on)", () => {
+    expect(enabledReviewerKinds(null)).toEqual(["qa", "code_review"]);
+    expect(enabledReviewerKinds(undefined)).toEqual(["qa", "code_review"]);
+    expect(enabledReviewerKinds({})).toEqual(["qa", "code_review"]);
   });
 
-  it("returns only the reviewers whose flag is exactly true", () => {
+  it("drops a reviewer only when its flag is exactly false", () => {
     expect(
       enabledReviewerKinds({
         qa_agent_enabled: true,
@@ -28,12 +28,14 @@ describe("enabledReviewerKinds", () => {
     ).toEqual(["qa"]);
     expect(
       enabledReviewerKinds({
-        qa_agent_enabled: true,
-        code_reviewer_enabled: true,
+        qa_agent_enabled: false,
+        code_reviewer_enabled: false,
       }),
-    ).toEqual(["qa", "code_review"]);
-    // Truthy-but-not-`true` must not enable it (org flags are booleans).
-    expect(enabledReviewerKinds({ qa_agent_enabled: "true" })).toEqual([]);
+    ).toEqual([]);
+    // An unset flag stays on; only an explicit `false` opts out.
+    expect(enabledReviewerKinds({ qa_agent_enabled: false })).toEqual([
+      "code_review",
+    ]);
   });
 });
 

--- a/packages/shared/src/task-board.ts
+++ b/packages/shared/src/task-board.ts
@@ -1,3 +1,5 @@
+import { orgFlagEnabled } from "./organization/schema";
+
 /**
  * Sentinel `assigneeId` for the org's Super Agent (the well-known Decopilot
  * agent). Not a real member userId — `validate-assignee` skips membership for
@@ -74,11 +76,12 @@ export const REVIEWER_FLAG: Record<
 
 /** The reviewer kinds this org has enabled, per its settings flags. Single
  *  home for a filter repeated at every call site that reads the review gate
- *  (enqueue, auto-merge, conflict resolution, manual ship). */
+ *  (enqueue, auto-merge, conflict resolution, manual ship). Both reviewers are
+ *  default-on via `orgFlagEnabled` — only an explicit `false` drops one. */
 export function enabledReviewerKinds(
   flags: Record<string, unknown> | null | undefined,
 ): ReviewerKind[] {
-  return REVIEWER_KINDS.filter((k) => flags?.[REVIEWER_FLAG[k]] === true);
+  return REVIEWER_KINDS.filter((k) => orgFlagEnabled(flags, REVIEWER_FLAG[k]));
 }
 
 /** True when a thread title belongs to the given reviewer's run. */


### PR DESCRIPTION
## Summary

Both automated reviewers (**QA Agent** and **Code Reviewer**) now default **ON** for every org. An unset flag reads as enabled; only an explicit `false` disables. Teams opt **out** by toggling them off in Review settings (which persists `false`).

Before, the flags were default-off — a team had to go into settings to turn each reviewer on. Now they run out of the box and disabling is the deliberate action.

## Changes

- **`packages/shared/src/organization/schema.ts`** — add `DEFAULT_ON_FLAGS` (`qa_agent_enabled`, `code_reviewer_enabled`) and the `orgFlagEnabled(flags, flag)` reader: the single source of truth for flag defaults. Default-on flags read as enabled unless stored as exactly `false`; every other flag stays default-off (`=== true`).
- **`packages/shared/src/task-board.ts`** — `enabledReviewerKinds` reads via `orgFlagEnabled` instead of `=== true`. All server call sites (enqueue, auto-merge, conflict resolution, manual ship) go through this one function.
- **`apps/web/src/hooks/use-organization-settings.ts`** — `useOrgFlag` honors default-on, including the pre-load fallback, so the Review settings switch shows checked by default and the task dialog counts the reviewers as enabled.
- **`apps/api/src/tools/reports/setup.ts`** — drop the now-redundant reviewer forcing in reports onboarding; default-on already covers reports-only orgs (which hide the agent UI). Setup only defaults `reports_only`.

## Behavior change (worth flagging)

No migration — the default is computed at read time. Existing orgs that **never touched** these flags will start running both reviewers on tasks that reach **In Review** after deploy, consuming sandbox runs and opening review threads. Orgs that explicitly turned a reviewer off (stored `false`) keep it off.

## Testing

- `bun test` on the affected files (30 pass) — inverted the `enabledReviewerKinds` test (unset → both enabled; only `false` drops one) and updated `reports/setup.test.ts` expects (upsert only writes `reports_only`).
- `bun run check` clean across shared/web/api; `bun run lint` 0 errors; `bun run fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default-enables QA Agent and Code Reviewer for all orgs. Previously both were default-off; now an unset flag reads as enabled and only an explicit false disables, so reviewers run out of the box.

- Add `DEFAULT_ON_FLAGS` and `orgFlagEnabled` in `packages/shared/src/organization/schema.ts` as the single source of truth for default-on flags (`qa_agent_enabled`, `code_reviewer_enabled`).
- Read reviewer enablement via `orgFlagEnabled` in `packages/shared/src/task-board.ts` and `apps/web/src/hooks/use-organization-settings.ts`; the pre-load fallback mirrors the same defaults.
- Remove reviewer forcing in `apps/api/src/tools/reports/setup.ts`; setup now only defaults `reports_only`. Update tests and add `packages/shared/src/organization/schema.test.ts` to cover `orgFlagEnabled`.
- Update `AGENTS.md` to document `DEFAULT_ON_FLAGS` and require reading flags via `orgFlagEnabled`/`useOrgFlag`.

- Behavior and rollout
  - Orgs that never set these flags will start running both reviewers on tasks that enter In Review, consuming sandbox runs and opening review threads.
  - Orgs with a reviewer set to `false` keep it off; no data migration required.
  - To opt out, toggle each reviewer off in Review settings (persists `false`).

<sup>Written for commit 12853b42f2eb93d7c0dee443131b010cc12f63b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

