### PR TITLE
fix(i18n): translate the product-block CTA placeholder in the English locale

### DIFF
--- a/apps/web/src/i18n/en/sandbox.ts
+++ b/apps/web/src/i18n/en/sandbox.ts
@@ -442,7 +442,7 @@ export const sandbox = {
   "sandbox.productBlocks.changeButton": "Change",
   "sandbox.productBlocks.chooseProductButton": "Choose a product",
   "sandbox.productBlocks.ctaLabelField": "CTA label",
-  "sandbox.productBlocks.ctaLabelPlaceholder": "Ver produto",
+  "sandbox.productBlocks.ctaLabelPlaceholder": "View product",
   "sandbox.productBlocks.dragToReorderLabel": "Drag to reorder",
   "sandbox.productBlocks.headingH1": "H1",
   "sandbox.productBlocks.headingH2": "H2",


### PR DESCRIPTION
The English locale's `sandbox.productBlocks.ctaLabelPlaceholder` key held the raw Portuguese string "Ver produto" instead of an English placeholder, so English-locale users editing a product block's CTA field saw "Ver produto" as the input placeholder.

A cross-check of every key/value pair in `en/sandbox.ts` vs `pt-br/sandbox.ts` (matching keys, matching `{placeholder}` tokens) turned up this single case where the English value is untranslated Portuguese text — all other 579 keys and their placeholders line up correctly.

Fix: changed the English value to "View product" (matches the field's other English labels like "CTA label", "Choose a product", "Browse products").

To confirm: open the blog product block editor with English selected and check the CTA label field's placeholder text now reads "View product".

Locally ran: `bun run fmt` (clean) and `bunx oxlint apps/web/src/i18n/en/sandbox.ts` (0 warnings/errors). No type changes, so no targeted `tsc` run was needed. CI runs the full suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the English placeholder for the product block CTA: previously showed Portuguese "Ver produto"; now shows "View product". Only the placeholder text changes; no runtime behavior or types affected.

- Confirm by opening the blog product block editor in English and checking the CTA label field placeholder reads "View product".
- Scope is limited to `apps/web/src/i18n/en/sandbox.ts` key `sandbox.productBlocks.ctaLabelPlaceholder`; other `en` vs `pt-br` keys were cross-checked and align.

<sup>Written for commit ade98cc5fe738665e0cc2c22ec7cb85a0ee293b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

