### PR TITLE
fix(cli): don't treat a 429 from the token endpoint as invalid_grant

### DIFF
--- a/apps/api/src/cli/lib/refresh-session.test.ts
+++ b/apps/api/src/cli/lib/refresh-session.test.ts
@@ -198,6 +198,19 @@ describe("refreshSession", () => {
     await expect(promise).rejects.toMatchObject({ kind: "invalid_grant" });
   });
 
+  it("throws RefreshFailedError(transient) on 429, not invalid_grant", async () => {
+    const fetchMock = mock(
+      async () => new Response("rate limited", { status: 429 }),
+    );
+    const promise = refreshSession(
+      makeSession(),
+      fetchMock as unknown as typeof fetch,
+      () => FIXED_NOW,
+    );
+    await expect(promise).rejects.toBeInstanceOf(RefreshFailedError);
+    await expect(promise).rejects.toMatchObject({ kind: "transient" });
+  });
+
   it("throws RefreshFailedError(transient) on 500", async () => {
     const fetchMock = mock(async () => new Response("oops", { status: 500 }));
     const promise = refreshSession(

--- a/apps/api/src/cli/lib/refresh-session.ts
+++ b/apps/api/src/cli/lib/refresh-session.ts
@@ -74,7 +74,8 @@ export async function refreshSession(
 
   if (!res.ok) {
     const text = await res.text().catch(() => "");
-    if (res.status >= 400 && res.status < 500) {
+    // 429 is throttling, not a rejected token — never mark it invalid_grant.
+    if (res.status >= 400 && res.status < 500 && res.status !== 429) {
       throw new RefreshFailedError(
         "invalid_grant",
         `HTTP ${res.status} ${text}`,


### PR DESCRIPTION
Bug found while auditing `refresh-session.ts` (CLI session-refresh, a heavily-hardened area from #6083/#6085/#6090/#6113/#6114).

`refreshSession` classified *every* 4xx response from the token endpoint as `invalid_grant`, including 429 (rate limited). `getValidSession` treats `invalid_grant` as "the refresh token is dead" and responds by deleting the session file (`clearSession`) so the user has to re-run interactive browser login. A transient rate-limit response from the token endpoint would therefore silently log the user out, even though the refresh token itself was perfectly valid.

Failure scenario: token endpoint returns 429 (e.g. under load or a shared-IP rate limit) → CLI treats it as `invalid_grant` → deletes the on-disk session → next command forces a full re-login, even though a retry a moment later would have refreshed fine.

Fix: exclude 429 from the `invalid_grant` classification so it falls through to `transient` like other retriable failures (5xx, network errors) — the session file is preserved and callers can retry.

Added a regression test asserting a 429 response yields `kind: "transient"`, not `"invalid_grant"`.

To verify: `cd apps/api && bun test src/cli/lib/refresh-session.test.ts`.

Locally ran: `bun run fmt`, the targeted test file (14 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the CLI from clearing a valid session when the token endpoint returns 429. Previously, all 4xx were treated as invalid_grant (deleting the on-disk session and forcing re-login); now 429 is treated as transient so the session is preserved and callers can retry.

- Adjusts `refreshSession` to exclude 429 from the 4xx invalid_grant check; other 4xx still map to invalid_grant.
- Returns `RefreshFailedError` with kind "transient" on 429.
- Adds a regression test asserting 429 yields "transient".

<sup>Written for commit f791e878782d9db253fcb829bf8fc79a406c6c64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

