### PR TITLE
fix(sections-editor): scope block save/delete rollback to its own key

### DIFF
--- a/apps/web/src/components/sections-editor/use-delete-block.ts
+++ b/apps/web/src/components/sections-editor/use-delete-block.ts
@@ -76,6 +76,8 @@ export function useDeleteBlock({
       await queryClient.cancelQueries({ queryKey });
       const previous =
         queryClient.getQueryData<Record<string, unknown>>(queryKey);
+      const hadKey = !!previous && blockKey in previous;
+      const previousValue = previous?.[blockKey];
       queryClient.setQueryData(
         queryKey,
         (current: Record<string, unknown> | undefined) => {
@@ -84,12 +86,21 @@ export function useDeleteBlock({
           return rest;
         },
       );
-      return { previous, queryKey };
+      return { queryKey, blockKey, hadKey, previousValue };
     },
+    // Restore only this mutation's own key so a concurrent sibling save isn't clobbered.
     onError: (_error, _variables, context) => {
-      if (context?.queryKey) {
-        queryClient.setQueryData(context.queryKey, context.previous);
-      }
+      if (!context) return;
+      queryClient.setQueryData(
+        context.queryKey,
+        (current: Record<string, unknown> | undefined) => {
+          if (!context.hadKey) return current;
+          return {
+            ...(current ?? {}),
+            [context.blockKey]: context.previousValue,
+          };
+        },
+      );
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({

--- a/apps/web/src/components/sections-editor/use-save-block.ts
+++ b/apps/web/src/components/sections-editor/use-save-block.ts
@@ -89,6 +89,8 @@ export function useSaveBlock({
       await queryClient.cancelQueries({ queryKey });
       const previous =
         queryClient.getQueryData<Record<string, unknown>>(queryKey);
+      const hadKey = !!previous && blockKey in previous;
+      const previousValue = previous?.[blockKey];
       queryClient.setQueryData(
         queryKey,
         (current: Record<string, unknown> | undefined) => ({
@@ -96,12 +98,22 @@ export function useSaveBlock({
           [blockKey]: data,
         }),
       );
-      return { previous, queryKey };
+      return { queryKey, blockKey, hadKey, previousValue };
     },
+    // Restore only this mutation's own key so a concurrent sibling save isn't clobbered.
     onError: (_error, _variables, context) => {
-      if (context?.queryKey) {
-        queryClient.setQueryData(context.queryKey, context.previous);
-      }
+      if (!context) return;
+      queryClient.setQueryData(
+        context.queryKey,
+        (current: Record<string, unknown> | undefined) => {
+          if (!current) return current;
+          if (!context.hadKey) {
+            const { [context.blockKey]: _removed, ...rest } = current;
+            return rest;
+          }
+          return { ...current, [context.blockKey]: context.previousValue };
+        },
+      );
     },
     onSuccess: (_result, { blockKey, data }) => {
       const cacheKey = `${orgSlug}/${virtualMcpId}/${branch}`;


### PR DESCRIPTION
A concurrency bug in the block save/delete mutation hooks: bug found while auditing sections-editor block lifecycle for race conditions/stale state, per the workaround-comment in `use-save-block.ts` itself, which already documents that a page's name/path edits and its SEO edits autosave as separate debounced blockKey mutations against the same decofile query key.

Why a maintainer wants it: today, if two of those sibling autosaves are in flight at once and ONE of them fails (a network blip, a 409, etc.), its `onError` restores the *entire* pre-mutation cache snapshot — silently discarding the other, still-succeeding mutation's already-applied optimistic write. The user sees their SEO edit (or whichever sibling field) vanish from the editor with no error, even though nothing about that field's save failed.

Fix: `onMutate` now records only the mutated key's prior value/presence (instead of a snapshot of the whole decofile object), and `onError` patches just that one key back, leaving any concurrent sibling mutation's optimistic write untouched. Applied identically to both `useSaveBlock` and `useDeleteBlock` since they share the exact same snapshot/restore shape.

How to confirm: `bunx tsc --noEmit` in `apps/web` is clean, and `bunx oxlint` on both changed files is clean. No behavior change on the non-racing path (single in-flight mutation): the restored value/presence is identical to what the old whole-object snapshot would have produced for that key.

A render-hook regression test would need heavy mocking (org context + MCP client via `useVirtualMCP`) not used by any existing test of these hooks, so verification here is the type/lint check plus manual trace of the onMutate/onError pairing above — full CI validates the rest.

Local checks run: `bun run fmt`, `bunx tsc --noEmit` (apps/web), `bunx oxlint` on both changed files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes sections-editor rollback to the mutated block so concurrent autosaves don’t clobber each other. Previously, a failed save/delete restored the entire decofile cache entry; now only the failed mutation’s `blockKey` is reverted.

- Changes are limited to `useSaveBlock` and `useDeleteBlock`: `onMutate` records `hadKey` and `previousValue`; `onError` restores only that `blockKey` (or removes it if it didn’t exist before a failed save).
- Preserves optimistic updates from sibling mutations sharing the same `queryKey`; single-mutation behavior is unchanged and there are no API changes.

<sup>Written for commit 3ee595f32f1782047d0566b56dff2c15968c1deb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

