### PR TITLE
fix(file-storage): normalize Content-Type before checking the upload allowlist

### DIFF
--- a/apps/api/src/file-storage/upload-policy.test.ts
+++ b/apps/api/src/file-storage/upload-policy.test.ts
@@ -13,6 +13,13 @@ describe("assertAllowed", () => {
     expect(() => assertAllowed("image/webp", MAX_UPLOAD_BYTES)).not.toThrow();
   });
 
+  test("accepts an allowed type regardless of casing or a trailing parameter", () => {
+    expect(() => assertAllowed("Text/CSV", 1024)).not.toThrow();
+    expect(() =>
+      assertAllowed("text/plain; charset=utf-8", 1024),
+    ).not.toThrow();
+  });
+
   test("rejects disallowed content types", () => {
     expect(() => assertAllowed("application/x-msdownload", 1024)).toThrow(
       UploadRejected,

--- a/apps/api/src/file-storage/upload-policy.ts
+++ b/apps/api/src/file-storage/upload-policy.ts
@@ -76,8 +76,19 @@ export class UploadRejected extends Error {
   }
 }
 
+/**
+ * Content-Type header values are case-insensitive per RFC 9110 and may carry
+ * a parameter (e.g. `text/csv; charset=utf-8`). Strip the parameter and
+ * lowercase the media type before matching against the allowlist, so a
+ * client that sends `Text/CSV` or appends a charset isn't wrongly rejected.
+ */
+function normalizeContentType(contentType: string): string {
+  return contentType.split(";")[0]!.trim().toLowerCase();
+}
+
 export function assertAllowed(contentType: string, size: number): void {
-  if (!ALLOWED_CONTENT_TYPES.has(contentType)) {
+  const normalized = normalizeContentType(contentType);
+  if (!ALLOWED_CONTENT_TYPES.has(normalized)) {
     throw new UploadRejected(`Content type "${contentType}" is not allowed.`);
   }
   if (!Number.isFinite(size) || size <= 0) {


### PR DESCRIPTION
Bug found while reviewing `apps/api/src/file-storage/upload-policy.ts` per this tick's file-storage upload-policy review assignment.

`assertAllowed` compared the raw `Content-Type` header byte-for-byte against `ALLOWED_CONTENT_TYPES`. Per RFC 9110, media types are case-insensitive and may carry parameters (e.g. `text/csv; charset=utf-8`, or a client sending `Text/CSV`). Since the allowlist only contains lowercase, bare media types, any client sending a differently-cased type or one with a trailing parameter got a hard `UploadRejected` (400) for an otherwise legitimate upload, even though the actual proxy route (`file-uploads.ts`) validates this exact header at the trust boundary before streaming the body to S3.

Failure scenario: a client uploads a `.csv` file with `Content-Type: text/csv; charset=utf-8` (a common browser/tool default for text uploads) — the upload is rejected with `Content type "text/csv; charset=utf-8" is not allowed.` even though `text/csv` is on the allowlist.

Fix: strip the `;`-delimited parameter and lowercase the media type before the allowlist check (`normalizeContentType`), matching HTTP's case-insensitivity for media types. The original raw string is still used in the rejection error message for clarity. Added two regression tests exercising a differently-cased type and a type with a `charset` parameter, both should now pass instead of throwing.

Reviewer command: `bun test apps/api/src/file-storage/upload-policy.test.ts`

Locally verified: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bun test apps/api/src/file-storage/upload-policy.test.ts` (11 pass), `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes the `Content-Type` header before checking the upload allowlist so legitimate uploads aren’t rejected. Previously `assertAllowed` required an exact match and rejected values like `text/csv; charset=utf-8`; now it lowercases and strips parameters before checking. The error message still echoes the raw header.

**Review notes**
- Adds `normalizeContentType()` and uses it in `assertAllowed`.
- Adds tests for mixed-case and parameterized types.
- Scope is limited to the allowlist check; size validation and allowlist values are unchanged.
- Verify with: `bun test apps/api/src/file-storage/upload-policy.test.ts`.

<sup>Written for commit 0ec1f132aca9b6e362db8f6ee893f0d6fc36c3e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

