### PR TITLE
fix(reports): don't hijack keydown while typing in the deck

### DIFF
--- a/apps/web/src/routes/reports/signal-deck.tsx
+++ b/apps/web/src/routes/reports/signal-deck.tsx
@@ -241,7 +241,18 @@ export default function SignalDeck({
     };
     window.addEventListener("popstate", onPopState);
 
+    // Don't hijack keys meant for a focused form control (the feedback textarea).
+    const isTypingTarget = (target: EventTarget | null) => {
+      const el = target as HTMLElement | null;
+      return (
+        !!el &&
+        (el.tagName === "INPUT" ||
+          el.tagName === "TEXTAREA" ||
+          el.isContentEditable)
+      );
+    };
     const onKey = (e: KeyboardEvent) => {
+      if (isTypingTarget(e.target)) return;
       if (["ArrowDown", "ArrowRight", "PageDown", " "].includes(e.key)) {
         e.preventDefault();
         go(index + 1);


### PR DESCRIPTION
A bug in the signal-deck route (`apps/web/src/routes/reports/signal-deck.tsx`), the newly-added "Did the AI get it wrong?" feedback textarea.

The deck binds a global `keydown` listener for slide navigation (Space/Arrow/PageUp/PageDown). It never checks the event target, so it also fires while the user is typing into the feedback `<textarea>` inside the "Did the AI get it wrong?" popover: pressing Space calls `e.preventDefault()` (swallowing the keystroke — no space gets typed) and navigates the deck, which resets `feedbackText` to `""` via `announceSlide` — silently discarding whatever the visitor had already typed. Arrow keys and PageUp/PageDown have the same effect.

Fix: skip the navigation handler when the event target is an `input`, `textarea`, or `contentEditable` element, matching the existing Escape-key precedent elsewhere in the app (e.g. `ice-breakers.tsx`) of not hijacking keys meant for a focused form control.

To confirm: open a report's signal deck, open the "Did the AI get it wrong?" popover on any slide, click into the textarea, and type a sentence with spaces — before the fix, typing space or an arrow key jumped to another slide and cleared the textarea; after the fix, typing works normally and deck navigation via keyboard still works everywhere else.

Verified locally: `bun run fmt`, `bunx tsc --noEmit` (apps/web, clean), `bunx oxlint src/routes/reports/signal-deck.tsx` (0 warnings/errors). No existing test covers this route's DOM-event wiring (it's callback-ref-driven, not amenable to a narrow unit test without a browser), so this is a straightforward, low-risk read-and-fix; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop hijacking keydown in the report signal deck when typing feedback. Previously Space/Arrow/PageUp/PageDown triggered navigation and cleared `feedbackText` even while focused in the feedback textarea; now the handler skips when the target is an input, textarea, or contentEditable, so typing is preserved and navigation still works elsewhere.

- Review/QA:
  - Change is isolated to `apps/web/src/routes/reports/signal-deck.tsx`: added `isTypingTarget` and an early return in the global keydown handler.
  - To verify: open a signal deck, open “Did the AI get it wrong?”, focus the textarea, type with spaces/arrows/PageUp/PageDown. It should not navigate or clear text. Keyboard navigation still works when focus is outside form controls.

<sup>Written for commit e49158c27208d0c11c7f22f7ff38d155572f2ed8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

