### PR TITLE
fix(chat): make message-queue thread eviction actually LRU

### DIFF
--- a/apps/web/src/components/chat/message-queue-store.test.ts
+++ b/apps/web/src/components/chat/message-queue-store.test.ts
@@ -39,4 +39,22 @@ describe("messageQueueStore eviction", () => {
     // A fresh lookup after eviction starts a clean, empty store.
     expect(messageQueueStore(evictedThreadId).get()).toEqual([]);
   });
+
+  test("a thread touched again mid-session survives eviction over an untouched one", () => {
+    const stillActive = "still-active";
+    const goesIdle = "goes-idle";
+    messageQueueStore(stillActive);
+    markQueueDirty(stillActive);
+    messageQueueStore(goesIdle);
+    markQueueDirty(goesIdle);
+
+    for (let i = 0; i < 250; i++) {
+      messageQueueStore(`mid-filler-${i}`);
+      if (i === 50) messageQueueStore(stillActive); // re-touch halfway through
+    }
+
+    // Re-touched mid-session, so it outlives the never-touched-again thread.
+    expect(isQueueDirty(stillActive)).toBe(true);
+    expect(isQueueDirty(goesIdle)).toBe(false);
+  });
 });

--- a/apps/web/src/components/chat/message-queue-store.ts
+++ b/apps/web/src/components/chat/message-queue-store.ts
@@ -62,12 +62,16 @@ export function clearQueueDirty(threadId: string): void {
 }
 
 export function messageQueueStore(threadId: string): Store<QueueItemDTO[]> {
-  let store = stores.get(threadId);
-  if (!store) {
-    touchThread(threadId);
-    store = new Store<QueueItemDTO[]>([]);
-    stores.set(threadId, store);
+  const existing = stores.get(threadId);
+  if (existing) {
+    // Re-insert to bump this thread to the map's most-recently-used end.
+    stores.delete(threadId);
+    stores.set(threadId, existing);
+    return existing;
   }
+  touchThread(threadId);
+  const store = new Store<QueueItemDTO[]>([]);
+  stores.set(threadId, store);
   return store;
 }
 


### PR DESCRIPTION
**Source:** a real bug found while hardening the chat message-queue area (queue-items.ts / message-queue-store.ts), not tied to an open issue.

**The bug:** `messageQueueStore`'s cap-eviction (`MAX_TRACKED_THREADS = 200`) claims to evict the "least-recently-touched" thread, but it only ever consulted `Map` iteration order — which is insertion order, not access order. Reading an *existing* store (every render of a mounted chat, every `enqueueMessage`/`removeMessage` call) never repositioned its key. So a thread the user is actively chatting in gets silently evicted — losing its optimistic queue, dirty flag, and stashed pending body — purely because 200 *other* threads were opened since it was first created, while a thread opened once and never revisited survives by luck of insertion order.

**Failure scenario:** user opens thread A, sends a message behind a running turn (queued optimistically), then browses through 200+ other threads over a session without closing the tab. Thread A's queue store gets evicted even though the user is still mid-conversation there — going back to A shows an empty queue and loses the `dirty` flag needed to reconcile the body against the server once the queued turn completes.

**Fix:** on every access to an *existing* store, delete+re-insert its map entry so it moves to the map's most-recently-used end. Eviction (still just `stores.keys().next().value`) now correctly targets the actually-idle thread.

**Regression test:** `message-queue-store.test.ts` — added a case where a thread is re-touched halfway through 250 filler-thread creations; it now survives the cap while an untouched thread created at the same time gets evicted (previously both would race purely on creation order).

**To verify:** `cd apps/web && bun test src/components/chat/message-queue-store.test.ts`

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/web, clean), `bunx oxlint` on both touched files (0 warnings/errors), targeted test file above (2/2 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes chat message-queue eviction truly LRU so active threads aren’t dropped. Previously eviction used insertion order, so an actively used thread could be evicted; now any access reorders the thread as most-recently-used, so only idle threads are evicted at the cap.

- On `messageQueueStore(threadId)`, existing entries are delete+reinserted to bump recency; creation path is unchanged.
- Eviction still selects the first key; only the target changes from oldest-created to least-recently-touched.
- Adds a regression test: a re-touched thread survives while an untouched peer is evicted among 250 filler threads.
- User impact: preserves optimistic messages, the dirty flag, and pending body for active threads.

<sup>Written for commit ed0ad3f6d2e12ee26810438f4f41ddefff43af8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

