### PR TITLE
refactor(sandbox): make activePhaseIndex exhaustive over PhaseKey

### DIFF
--- a/apps/web/src/components/sandbox/preview/state-card-helpers.ts
+++ b/apps/web/src/components/sandbox/preview/state-card-helpers.ts
@@ -1,6 +1,14 @@
-import { PHASE_ORDER, type PhaseProgress } from "./derive-phase-progress";
+import type { PhaseKey, PhaseProgress } from "./derive-phase-progress";
+
+// Exhaustive over `PhaseKey`, unlike the `.indexOf(...) as 0 | 1 | 2 | 3` cast it replaces.
+const PHASE_INDEX: Record<PhaseKey, 0 | 1 | 2 | 3> = {
+  provision: 0,
+  cloning: 1,
+  install: 2,
+  dev: 3,
+};
 
 /** The card index (0..3) the booting visual should show as active. */
 export function activePhaseIndex(progress: PhaseProgress): 0 | 1 | 2 | 3 {
-  return PHASE_ORDER.indexOf(progress.step) as 0 | 1 | 2 | 3;
+  return PHASE_INDEX[progress.step];
 }


### PR DESCRIPTION
Small type-safety cleanup found while auditing the sandbox preview state-card area (booting-visual.tsx / state-card.tsx / state-card-helpers.ts were otherwise clean — no visual or state-management bugs found there).

**What:** `activePhaseIndex` computed `PHASE_ORDER.indexOf(progress.step) as 0 | 1 | 2 | 3`. The `as`-cast compiles regardless of whether `PHASE_ORDER`'s runtime contents actually match the `0 | 1 | 2 | 3` return type — if a phase were ever added to `PHASE_ORDER` (`derive-phase-progress.ts`) without updating this cast, TypeScript would keep compiling and silently produce an out-of-range index for `BootingVisual`'s 4-card stack.

**Fix:** replaced it with a `Record<PhaseKey, 0 | 1 | 2 | 3>` lookup. `Record` over the `PhaseKey` union requires every key to be present, so adding a phase without updating this map is now a compile error instead of a silent runtime one — a union-narrow instead of a cast, per the repo's own "keep type-safety at compile time" guidance.

Behavior is unchanged (same output for all 4 existing phases) — verified by the existing `state-card-helpers.test.ts`, which passes unmodified.

**To verify:** `cd apps/web && bunx tsc --noEmit` and `bun test apps/web/src/components/sandbox/preview/state-card-helpers.test.ts`.

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/web, clean), targeted test (1 pass), `bunx oxlint` on the changed file (0 warnings/errors). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `activePhaseIndex` exhaustive over `PhaseKey` to remove the unsafe `PHASE_ORDER.indexOf(step) as 0 | 1 | 2 | 3` cast. Behavior is unchanged; this converts a potential out-of-range index into a compile-time error if phases change.

- Replace the cast with `PHASE_INDEX: Record<PhaseKey, 0 | 1 | 2 | 3>` and lookups via `PHASE_INDEX[progress.step]`.
- Why it matters: adding a new phase now fails `tsc` until the index map is updated, preventing silent bad indexes in the 4-card booting visual.
- Review/verify: only `state-card-helpers.ts` changed; existing tests pass. Run `bunx tsc --noEmit` and `bun test apps/web/src/components/sandbox/preview/state-card-helpers.test.ts`.

<sup>Written for commit e959cc0d0027beff328fec7b5043c3adf7b3c9c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

