### PR TITLE
fix(connections): validate connection URL format in the settings form

### DIFF
--- a/apps/web/src/components/details/connection/settings-tab/schema.test.ts
+++ b/apps/web/src/components/details/connection/settings-tab/schema.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "bun:test";
+import { connectionFormSchema } from "./schema";
+
+const base = {
+  title: "My connection",
+  ui_type: "HTTP" as const,
+};
+
+test("rejects a non-URL connection_url for HTTP connections", () => {
+  const result = connectionFormSchema.safeParse({
+    ...base,
+    connection_url: "not-a-url",
+  });
+  expect(result.success).toBe(false);
+});
+
+test("accepts a well-formed connection_url", () => {
+  const result = connectionFormSchema.safeParse({
+    ...base,
+    connection_url: "https://example.com/mcp",
+  });
+  expect(result.success).toBe(true);
+});
+
+test("does not require a URL shape for non-HTTP ui_types", () => {
+  const result = connectionFormSchema.safeParse({
+    title: "My command",
+    ui_type: "STDIO",
+    stdio_command: "node server.js",
+  });
+  expect(result.success).toBe(true);
+});

--- a/apps/web/src/components/details/connection/settings-tab/schema.ts
+++ b/apps/web/src/components/details/connection/settings-tab/schema.ts
@@ -65,6 +65,20 @@ export const connectionFormSchema = z
       return true;
     },
     { message: "URL is required", path: ["connection_url"] },
+  )
+  .refine(
+    (data) => {
+      if (
+        (data.ui_type === "HTTP" ||
+          data.ui_type === "SSE" ||
+          data.ui_type === "Websocket") &&
+        data.connection_url?.trim()
+      ) {
+        return z.string().url().safeParse(data.connection_url.trim()).success;
+      }
+      return true;
+    },
+    { message: "Enter a valid URL", path: ["connection_url"] },
   );
 
 export type ConnectionFormData = z.infer<typeof connectionFormSchema>;


### PR DESCRIPTION
The connection settings form's zod schema (`apps/web/src/components/details/connection/settings-tab/schema.ts`) only checked that `connection_url` was non-empty for HTTP/SSE/Websocket connections — it never checked the value was actually a URL. Typing e.g. `not-a-url` passed client-side validation and the user only found out something was wrong from a confusing backend/network failure later.

Fix: add a `.refine` that parses `connection_url` with `z.string().url()` when the ui_type requires it, so the form surfaces "Enter a valid URL" immediately. STDIO/NPX connections (which don't use `connection_url`) are unaffected.

Regression test added in `schema.test.ts` (new file, no prior test existed for this schema): rejects a non-URL string for HTTP, accepts a well-formed URL, and confirms non-HTTP ui_types are untouched.

To verify: `cd apps/web && bun test src/components/details/connection/settings-tab/schema.test.ts`.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/web, clean), `bunx oxlint` on both changed files (0 warnings/errors), and the targeted test file above (3 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validates connection_url format in the connection settings form to surface client-side errors. Previously HTTP/SSE/Websocket only checked non-empty and allowed invalid strings that failed later; now it enforces a valid URL and shows "Enter a valid URL".

- Change is in the form schema: a `zod` refine uses `z.string().url()` when `ui_type` is HTTP/SSE/Websocket.
- STDIO and other non-URL-based types are unchanged; new tests cover invalid/valid URL cases and non-HTTP types.

<sup>Written for commit 1c5105f7bfd8851eadfbe5bcd626098833e6b82c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

