### PR TITLE
fix(desktop): guard normalizeTerminalDimensions against NaN/Infinity

### DIFF
--- a/apps/web/src/desktop/agent-terminal/protocol.test.ts
+++ b/apps/web/src/desktop/agent-terminal/protocol.test.ts
@@ -272,6 +272,10 @@ describe("native terminal protocol", () => {
       rows: 2,
       cols: 1_000,
     });
+    expect(normalizeTerminalDimensions({ rows: NaN, cols: Infinity })).toEqual({
+      rows: 30,
+      cols: 100,
+    });
     expect(
       appendTerminalReplay(
         [

--- a/apps/web/src/desktop/agent-terminal/protocol.ts
+++ b/apps/web/src/desktop/agent-terminal/protocol.ts
@@ -402,12 +402,22 @@ export function parseTerminalBinaryServerFrame(
   }
 }
 
+const FALLBACK_ROWS = 30;
+const FALLBACK_COLS = 100;
+
+function clampDimension(value: number, fallback: number, max: number): number {
+  return Number.isFinite(value)
+    ? Math.min(max, Math.max(2, Math.floor(value)))
+    : fallback;
+}
+
+/** Reject non-finite rows/cols (e.g. a resize fired before layout settles) so a NaN never reaches the wire, where JSON.stringify would silently turn it into `null`. */
 export function normalizeTerminalDimensions(
   dimensions: TerminalDimensions,
 ): TerminalDimensions {
   return {
-    rows: Math.min(500, Math.max(2, Math.floor(dimensions.rows))),
-    cols: Math.min(1_000, Math.max(2, Math.floor(dimensions.cols))),
+    rows: clampDimension(dimensions.rows, FALLBACK_ROWS, 500),
+    cols: clampDimension(dimensions.cols, FALLBACK_COLS, 1_000),
   };
 }
 


### PR DESCRIPTION
**Source:** bug found while hunting `apps/web/src/desktop/agent-terminal` for reliability gaps (issue #5789's "agent reliability findings" area).

**Why it matters:** `normalizeTerminalDimensions` is the single point that sanitizes terminal rows/cols before every `start`/`resize`/`attach` control frame sent to local-api. It clamped with `Math.min(max, Math.max(2, Math.floor(value)))` but never checked `Number.isFinite` first — if `rows`/`cols` ever arrives as `NaN` or `Infinity` (e.g. xterm's `onResize`/`FitAddon` firing before the container has laid out, a real documented xterm-addon-fit edge case when a cell dimension is momentarily 0), `Math.floor(NaN)` propagates to `NaN`, and `Math.max`/`Math.min` with `NaN` also return `NaN`. `JSON.stringify({ rows: NaN })` silently turns that into `"rows":null` on the wire — the terminal session would receive a malformed resize/start frame instead of a clamped size, which reads exactly like the "flaky agent terminal" class of bug this area was flagged for.

**Fix:** `normalizeTerminalDimensions` now falls back to the existing default size (30 rows / 100 cols, matching `terminal-controller.ts`'s `DEFAULT_DIMENSIONS`) whenever a dimension isn't finite, instead of propagating `NaN`.

**Regression test:** added `normalizeTerminalDimensions({ rows: NaN, cols: Infinity })` case in `protocol.test.ts`, asserting it returns `{ rows: 30, cols: 100 }` instead of `{ rows: NaN, cols: NaN }`.

**To verify:** `bun test apps/web/src/desktop/agent-terminal/protocol.test.ts`

**Locally run:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents null terminal dimensions from reaching the wire by guarding `normalizeTerminalDimensions` against NaN/Infinity. Previously NaN propagated through clamping and serialized to null; now non‑finite values fall back to 30 rows / 100 cols before clamping.

**Review notes**
- Adds a `clampDimension` helper: min remains 2, max remains 500/1,000; non‑finite values default to 30/100 (matching the existing default size).
- Applies to all `start`/`resize`/`attach` frames from the desktop agent terminal, avoiding malformed control frames during early or unstable layout.

**Verification**
- Run: bun test apps/web/src/desktop/agent-terminal/protocol.test.ts (includes a NaN/Infinity case expecting { rows: 30, cols: 100 }).

<sup>Written for commit 5e6774fc9b2a38bd4606da7ca89d29480100c2ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

