### PR TITLE
refactor(native): dedupe the WebDAV org-fs client's status-check shape

### DIFF
--- a/apps/native/crates/local-api/src/routes/webdav/org_fs.rs
+++ b/apps/native/crates/local-api/src/routes/webdav/org_fs.rs
@@ -131,6 +131,18 @@ impl UpstreamOrgFs {
         Ok(send_org_request(method, url, headers, body).await?)
     }
 
+    /// Pass a 2xx response through unchanged, otherwise turn it into an
+    /// [`OrgFsError`] via [`Self::fail`] — the
+    /// `if !response.status().is_success() { return Err(...) }` shape that
+    /// was repeated at every call site below.
+    async fn ensure_success(response: reqwest::Response) -> Result<reqwest::Response, OrgFsError> {
+        if response.status().is_success() {
+            Ok(response)
+        } else {
+            Err(Self::fail(response).await)
+        }
+    }
+
     /// Turn a non-2xx upstream response into an [`OrgFsError`], preferring the
     /// contract's `{"error": "..."}` body over a bare status line.
     async fn fail(response: reqwest::Response) -> OrgFsError {
@@ -188,9 +200,7 @@ impl OrgFs for UpstreamOrgFs {
         let response = self
             .send(Method::GET, &url, json_accept_headers(), Bytes::new())
             .await?;
-        if !response.status().is_success() {
-            return Err(Self::fail(response).await);
-        }
+        let response = Self::ensure_success(response).await?;
         let body: Value = response
             .json()
             .await
@@ -210,9 +220,7 @@ impl OrgFs for UpstreamOrgFs {
         if response.status() == reqwest::StatusCode::NOT_FOUND {
             return Ok(None);
         }
-        if !response.status().is_success() {
-            return Err(Self::fail(response).await);
-        }
+        let response = Self::ensure_success(response).await?;
         let body: Value = response
             .json()
             .await
@@ -225,9 +233,7 @@ impl OrgFs for UpstreamOrgFs {
         let response = self
             .send(Method::GET, &url, HeaderMap::new(), Bytes::new())
             .await?;
-        if !response.status().is_success() {
-            return Err(Self::fail(response).await);
-        }
+        let response = Self::ensure_success(response).await?;
         response
             .bytes()
             .await
@@ -304,9 +310,7 @@ impl OrgFs for UpstreamOrgFs {
             .unwrap_or_else(|| HeaderValue::from_static("application/octet-stream"));
         headers.insert(header::CONTENT_TYPE, content_type);
         let response = self.send(Method::PUT, &url, headers, body).await?;
-        if !response.status().is_success() {
-            return Err(Self::fail(response).await);
-        }
+        Self::ensure_success(response).await?;
         Ok(())
     }
 
@@ -315,9 +319,7 @@ impl OrgFs for UpstreamOrgFs {
         let response = self
             .send(Method::POST, &url, json_accept_headers(), Bytes::new())
             .await?;
-        if !response.status().is_success() {
-            return Err(Self::fail(response).await);
-        }
+        Self::ensure_success(response).await?;
         Ok(())
     }
 
@@ -326,9 +328,7 @@ impl OrgFs for UpstreamOrgFs {
         let response = self
             .send(Method::DELETE, &url, json_accept_headers(), Bytes::new())
             .await?;
-        if !response.status().is_success() {
-            return Err(Self::fail(response).await);
-        }
+        Self::ensure_success(response).await?;
         Ok(())
     }
 
@@ -344,9 +344,7 @@ impl OrgFs for UpstreamOrgFs {
                 .map_err(|e| OrgFsError::new(StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?,
         );
         let response = self.send(Method::POST, &url, headers, body).await?;
-        if !response.status().is_success() {
-            return Err(Self::fail(response).await);
-        }
+        Self::ensure_success(response).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
**Source:** C1 code reduction found while auditing `apps/native/crates/local-api/src/routes/webdav/` (native WebDAV routes focus area) for correctness/permission issues per this tick's hunt — the routes themselves (dav.rs, junk.rs, the read-only/mac-junk gates in webdav.rs) are already exceptionally hardened and tested, so the real win here is a duplication cleanup in `org_fs.rs`.

**What:** `UpstreamOrgFs`'s 7 methods (`list_dir`, `stat`, `read`, `write`, `mkdir`, `remove`, `rename`) each repeated the identical `if !response.status().is_success() { return Err(Self::fail(response).await); }` check-and-throw shape. Extracted it into one `ensure_success(response) -> Result<reqwest::Response, OrgFsError>` helper and replaced all 6 duplicate sites (the 7th, `read_stream`'s presign check, has different fallback-to-`Ok(None)` semantics and is left untouched).

**Net diff:** -21 / +19 lines, one file, behavior-preserving — `ensure_success` is exactly the inlined logic it replaces (2xx passes the response through unchanged, anything else goes through the existing `Self::fail` mapping), so every call site's observable status/error-body mapping is identical to before.

**Verify:**
- `cd apps/native && cargo build -p local-api` — clean.
- `cargo test -p local-api --lib routes::webdav` — all 50 existing tests pass unchanged (no new test needed: this is a pure internal refactor of the org_fs.rs client, already covered by `upstream_call_errors_map_to_401_and_502` plus the webdav.rs integration tests exercising every op through `serve()`).
- `cargo fmt -p local-api -- --check` — clean.

CI runs the full Rust/native suite; these are the targeted checks I ran locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dedupes the WebDAV org-fs upstream client’s response status check to reduce repetition while preserving behavior. Previously each method in `UpstreamOrgFs` performed an inline `is_success` check and called `fail`; now they call `ensure_success` for the same mapping.

- Adds `ensure_success(response) -> Result<reqwest::Response, OrgFsError>` and replaces duplicates in `list_dir`, `stat`, `read`, `write`, `mkdir`, `remove`, `rename` within `apps/native/crates/local-api/src/routes/webdav/org_fs.rs`.
- Leaves `read_stream` presign logic unchanged due to its `Ok(None)` fallback.
- No behavior change: 2xx responses pass through; non-2xx still map via `Self::fail`. No migration required.

<sup>Written for commit 7f3340c834bfa227c59bb9562474b202fd8d8c55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

