### PR TITLE
docs(architecture): reflect the HOSTED_HARNESS_QUEUE child-workflow split

### DIFF
--- a/apps/docs/client/src/content/deco-studio/en/studio/architecture.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/architecture.mdx
@@ -81,8 +81,8 @@ The set of queues a worker pod listens on is configured by env (`listenQueues`).
 1. A message (`POST /messages`) or an automation fire creates a **run** on a thread.
 2. The **API** enqueues it onto a DBOS queue in Postgres:
    - `THREAD_GATE_QUEUE` — serialized per thread (concurrency 1 per `threadId`).
-   - `AUTOMATIONS_QUEUE` — per-org parallelism.
-3. A **Worker** dequeues it and runs the agent loop: call the model, execute any tool calls, repeat (up to a step limit).
+   - `AUTOMATIONS_QUEUE` — partitioned by org, so a saturated org only blocks its own partition.
+3. A **Worker** dequeues the gate workflow, which starts a child workflow on `HOSTED_HARNESS_QUEUE` (also concurrency 1 per `threadId`) that runs the agent loop: call the model, execute any tool calls, repeat (up to a step limit). The parent gate doesn't wait on the child — it live-tails the same NATS stream the child publishes to and is the one that writes terminal status.
 4. Output chunks are published to NATS and tailed back to the UI over `/stream`.
 5. If the pod crashes, **DBOS journal replay** resumes retriable steps on another pod — recovery is the framework's job, not hand-rolled.
 

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/architecture.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/architecture.mdx
@@ -81,8 +81,8 @@ O conjunto de queues que um pod worker escuta é configurado por env (`listenQue
 1. Uma mensagem (`POST /messages`) ou o disparo de uma automation cria um **run** em uma thread.
 2. A **API** o enfileira em uma queue do DBOS no Postgres:
    - `THREAD_GATE_QUEUE` — serializada por thread (concorrência 1 por `threadId`).
-   - `AUTOMATIONS_QUEUE` — paralelismo por org.
-3. Um **Worker** o desenfileira e roda o agent loop: chama o model, executa as chamadas de tool, repete (até um limite de steps).
+   - `AUTOMATIONS_QUEUE` — particionada por org, então uma org saturada só bloqueia a própria partição.
+3. Um **Worker** desenfileira o gate workflow, que inicia um child workflow na `HOSTED_HARNESS_QUEUE` (também concorrência 1 por `threadId`) que roda o agent loop: chama o model, executa as chamadas de tool, repete (até um limite de steps). O gate pai não espera o child — ele acompanha (live-tail) o mesmo stream do NATS que o child publica e é quem escreve o status terminal.
 4. Os chunks de output são publicados no NATS e acompanhados de volta para a UI via `/stream`.
 5. Se o pod cair, o **replay do journal do DBOS** retoma os steps retriáveis em outro pod — a recuperação é trabalho do framework, não feito à mão.
 


### PR DESCRIPTION
The architecture doc's "Decopilot run lifecycle" section was stale against the code: it described a single Worker dequeuing `THREAD_GATE_QUEUE` and running the agent loop inline. Since the unified-control-plane refactor (`apps/api/src/dispatch-queue/hosted-harness-workflow.ts`, wired in `apps/api/src/api/app.ts`'s `initDbos`), the gate workflow starts a separate child workflow on `HOSTED_HARNESS_QUEUE` (concurrency 1 per `threadId`, mirroring the gate) that actually runs the agent loop — the parent gate does NOT await the child; it live-tails the same NATS stream the child publishes to and is the one that writes terminal status. The doc omitted this queue entirely, which matters for anyone reasoning about run durability/recovery from this page.

Also fixed `AUTOMATIONS_QUEUE`'s description (partitioned-by-org concurrency, matching its `partitionQueue: true` registration) rather than flat "per-org parallelism."

Updated both the English and pt-br locale files to keep them in sync (project convention).

How to verify: read `apps/api/src/dispatch-queue/hosted-harness-workflow.ts`'s header comment and `apps/api/src/api/app.ts` lines ~2279-2306 (the `DBOS.registerQueue` calls) against the updated doc text.

Doc-only change (no code/types touched) — ran `bun run fmt`, which reformatted only the two touched files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reflects the child-workflow split in the run lifecycle: instead of a Worker running the agent loop inline from `THREAD_GATE_QUEUE`, the gate starts a child on `HOSTED_HARNESS_QUEUE` (concurrency 1 per `threadId`), the parent live-tails NATS, and writes terminal status. Also fixes `AUTOMATIONS_QUEUE` to “partitioned by org” to match its registration.

**Review notes**
- Cross-check with `apps/api/src/dispatch-queue/hosted-harness-workflow.ts` (header comment) and `DBOS.registerQueue` calls in `apps/api/src/api/app.ts` (~2279–2306).
- Doc-only change; `en` and `pt-br` kept in sync; ran formatter.

<sup>Written for commit 8f403c602809fbca856372d0025e27675c623072. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

