### PR TITLE
fix(reports): degrade a non-JSON Commerce Discovery response body instead of throwing raw SyntaxError

### DIFF
--- a/apps/api/src/tools/reports/auth-client.test.ts
+++ b/apps/api/src/tools/reports/auth-client.test.ts
@@ -170,6 +170,24 @@ describe("fetchCommerceDiscoveryAuth", () => {
       "Commerce Discovery auth response did not include a token.",
     );
   });
+
+  test("rejects a non-JSON 200 body with the classified error, not a raw SyntaxError", async () => {
+    await expect(
+      fetchCommerceDiscoveryAuth(
+        {
+          siteUrl: "https://example.com",
+          orgId: "org_123",
+        },
+        {
+          baseUrl: "https://commerce.example.test",
+          apiKey: "master-key",
+          fetchImpl: async () => new Response("<html>not json</html>"),
+        },
+      ),
+    ).rejects.toThrow(
+      "Commerce Discovery auth response did not include a token.",
+    );
+  });
 });
 
 describe("commerceDiscoveryClaimMessagePtBr", () => {
@@ -426,6 +444,49 @@ describe("bindCommerceDiscoveryResource", () => {
     }
   });
 
+  test("rejects a non-JSON 200 binding body with the classified error", async () => {
+    await expect(
+      bindCommerceDiscoveryResource(
+        {
+          siteUrl: "https://example.com",
+          orgId: "org_123",
+          provider: "ga4",
+          resourceId: "1",
+        },
+        {
+          baseUrl: "https://commerce.example.test",
+          apiKey: "master-key",
+          fetchImpl: async () => new Response("<html>not json</html>"),
+        },
+      ),
+    ).rejects.toThrow(
+      "Commerce Discovery bind response did not include a binding.",
+    );
+  });
+
+  test("treats a non-JSON 422 body as a generic verification failure, not a throw", async () => {
+    const out = await bindCommerceDiscoveryResource(
+      {
+        siteUrl: "https://example.com",
+        orgId: "org_123",
+        provider: "ga4",
+        resourceId: "1",
+      },
+      {
+        baseUrl: "https://commerce.example.test",
+        apiKey: "master-key",
+        fetchImpl: async () =>
+          new Response("<html>not json</html>", { status: 422 }),
+      },
+    );
+
+    expect(out).toEqual({
+      ok: false,
+      reason: "verification_failed",
+      detail: "Não foi possível verificar o acesso a este recurso.",
+    });
+  });
+
   test("throws on an unexpected status", async () => {
     await expect(
       bindCommerceDiscoveryResource(
@@ -505,6 +566,18 @@ describe("fetchCommerceDiscoveryConnectionStatus", () => {
         url: "https://commerce.example.test/api/v2/internal/diagnostics/example.com/connections/status?org_id=org_123",
       },
     ]);
+  });
+
+  test("degrades a non-JSON 200 status body to empty providers, not a throw", async () => {
+    const out = await fetchCommerceDiscoveryConnectionStatus(
+      { siteUrl: "https://example.com", orgId: "org_123" },
+      {
+        baseUrl: "https://commerce.example.test",
+        apiKey: "master-key",
+        fetchImpl: async () => new Response("<html>not json</html>"),
+      },
+    );
+    expect(out).toEqual({ providers: {}, claimed: true });
   });
 
   test("flags a 409 (not claimed for this org) as claimed:false, not a throw", async () => {

--- a/apps/api/src/tools/reports/auth-client.ts
+++ b/apps/api/src/tools/reports/auth-client.ts
@@ -184,6 +184,22 @@ async function parseClaimErrorCode(
   }
 }
 
+/**
+ * Parse a response body as JSON without throwing — Commerce Discovery is an
+ * external service, and an unparseable body on an otherwise-`ok` response
+ * (empty body, HTML error page, truncated stream, …) must degrade to the
+ * schema's "missing field" error instead of an unhandled `SyntaxError`.
+ */
+async function parseJsonResponse(response: Response): Promise<unknown> {
+  const text = await response.text().catch(() => "");
+  if (!text) return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
 async function responseErrorMessage(response: Response): Promise<string> {
   const fallback = `Commerce Discovery auth failed with status ${response.status}.`;
   const text = await response.text().catch(() => "");
@@ -242,7 +258,9 @@ export async function fetchCommerceDiscoveryAuth(
     });
   }
 
-  const parsed = UpgradeResponseSchema.safeParse(await response.json());
+  const parsed = UpgradeResponseSchema.safeParse(
+    await parseJsonResponse(response),
+  );
   if (!parsed.success) {
     throw new Error(
       "Commerce Discovery auth response did not include a token.",
@@ -298,7 +316,9 @@ export async function bindCommerceDiscoveryResource(
     };
   }
   if (response.status === 422) {
-    const parsed = BindResponseSchema.safeParse(await response.json());
+    const parsed = BindResponseSchema.safeParse(
+      await parseJsonResponse(response),
+    );
     return {
       ok: false,
       reason: parsed.success
@@ -313,7 +333,9 @@ export async function bindCommerceDiscoveryResource(
     throw new Error(await responseErrorMessage(response));
   }
 
-  const parsed = BindResponseSchema.safeParse(await response.json());
+  const parsed = BindResponseSchema.safeParse(
+    await parseJsonResponse(response),
+  );
   if (!parsed.success || !parsed.data.binding) {
     throw new Error(
       "Commerce Discovery bind response did not include a binding.",
@@ -419,7 +441,9 @@ export async function fetchCommerceDiscoveryConnectionStatus(
   if (!response.ok) {
     throw new Error(await responseErrorMessage(response));
   }
-  const parsed = ConnectionStatusSchema.safeParse(await response.json());
+  const parsed = ConnectionStatusSchema.safeParse(
+    await parseJsonResponse(response),
+  );
   return {
     providers: parsed.success ? parsed.data.providers : {},
     claimed: true,


### PR DESCRIPTION
**Source:** bug found while hardening `apps/api/src/tools/reports/auth-client.ts` (assigned focus area: reports auth client hardening).

**Why:** Four call sites (`fetchCommerceDiscoveryAuth`, `bindCommerceDiscoveryResource` twice, `fetchCommerceDiscoveryConnectionStatus`) call `response.json()` directly on the external Commerce Discovery service's response. Every OTHER failure shape in this file (bad status, missing field, malformed claim-error code) degrades to a specific classified error or a soft-tolerant result — but an unparseable JSON body on an otherwise-`ok`/422 response (empty body, an HTML error page from a proxy/LB, a truncated stream) instead throws a raw, unhandled `SyntaxError` (e.g. "Unexpected end of JSON input") that reaches the onboarding UI as a cryptic message instead of the file's own friendly copy.

**Failure scenario:** Commerce Discovery returns HTTP 200 with a non-JSON body (e.g. an intermediary proxy error page) during `COMMERCE_DISCOVERY_SETUP`/`_BIND`/`_STATUS` — the tool call throws `SyntaxError: Unexpected end of JSON input` instead of the existing "...did not include a token/binding" error, or (for connection status) instead of gracefully returning empty providers.

**Fix:** added a shared `parseJsonResponse()` helper (mirrors the existing `parseClaimErrorCode`/`responseErrorMessage` pattern already in the file) that swallows a JSON parse failure and returns `undefined`, so the existing zod `safeParse` takes the same well-defined "missing field" path already used for a well-formed-but-incomplete body. No behavior change on any currently-passing body shape.

**Regression tests added** (4, one per call site) simulate a non-JSON body and assert the existing classified error/soft-tolerant result, not a raw SyntaxError.

**Reviewer command:** `bun test apps/api/src/tools/reports/auth-client.test.ts` (26 pass, 0 fail).

**Local checks run:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bun test apps/api/src/tools/reports/auth-client.test.ts` (26/26 pass), `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Degrades non-JSON Commerce Discovery responses to safe defaults instead of throwing a raw SyntaxError. Previously `response.json()` throws surfaced cryptic errors; now a shared `parseJsonResponse` returns undefined on parse failure so existing classified errors and tolerant paths apply.

- Apply `parseJsonResponse` in `fetchCommerceDiscoveryAuth`, `bindCommerceDiscoveryResource`, and `fetchCommerceDiscoveryConnectionStatus`.
- Non-JSON 200 auth → throw "did not include a token"; non-JSON 200 bind → throw "did not include a binding"; non-JSON 422 bind → `{ ok: false, reason: 'verification_failed' }`; non-JSON 200 status → `{ providers: {}, claimed: true }`.
- Add four regression tests; no behavior change for valid JSON bodies.

<sup>Written for commit 7a08df6b5ad98175e41df553160c61a9b529e53a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6134?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

