### PR TITLE
fix(blocks): clear stale variant override on edit-seo target switch

### DIFF
--- a/apps/web/src/components/sandbox/blocks/blocks-preview-workspace-state.test.ts
+++ b/apps/web/src/components/sandbox/blocks/blocks-preview-workspace-state.test.ts
@@ -98,6 +98,23 @@ describe("blocksPreviewWorkspaceReducer", () => {
     expect(next.editSeoPageKey).toBeNull();
   });
 
+  test("editing SEO for a new target clears a stale variant override", () => {
+    const withOverride = blocksPreviewWorkspaceReducer(
+      INITIAL_BLOCKS_PREVIEW_WORKSPACE,
+      {
+        type: "variant-override",
+        params: ["pages-home@sections.variants.1.rule=1"],
+      },
+    );
+
+    const next = blocksPreviewWorkspaceReducer(withOverride, {
+      type: "edit-seo",
+      target: { kind: "page", key: "pages-about", path: "/about" },
+    });
+
+    expect(next.variantOverride).toBeNull();
+  });
+
   test("records variant override params for the preview iframe", () => {
     const next = blocksPreviewWorkspaceReducer(
       INITIAL_BLOCKS_PREVIEW_WORKSPACE,

--- a/apps/web/src/components/sandbox/blocks/blocks-preview-workspace-state.ts
+++ b/apps/web/src/components/sandbox/blocks/blocks-preview-workspace-state.ts
@@ -43,10 +43,12 @@ export function blocksPreviewWorkspaceReducer(
         editSeoPageKey: null,
       };
     case "edit-seo":
+      // Switching target drops a variant override scoped to the prior selection, same as "select".
       return {
         ...state,
         target: action.target,
         editSeoPageKey: action.target.key,
+        variantOverride: null,
       };
     case "consume-edit-seo":
       return { ...state, editSeoPageKey: null };


### PR DESCRIPTION
**Source:** a bug found reading `blocks-preview-workspace-state.ts` while hunting the recently-changed-files area (#6099 just hardened the neighboring "select" case for a very similar stale-intent leak in the same reducer).

**Why a maintainer wants it:** the `select` action already clears `variantOverride` when the target changes, because the override is scoped to whichever section/page it was set for (`"pages-home@sections.variants.1.rule=1"`). The `edit-seo` action also changes `target` — dispatched from `content-browser.tsx`'s page list, where the clicked page is not necessarily the one currently selected/previewed — but it never cleared `variantOverride`.

**Failure scenario:** user picks a variant on a section of page A (setting `variantOverride`), then clicks "Edit SEO" on page B from the page list. `target` switches to page B, but the stale page-A-scoped `x-deco-matchers-override` param stays in `workspace.state.variantOverride` and gets appended to page B's preview iframe URL (`preview.tsx`'s `withVariantMatcherOverride` calls), showing the wrong section variant on an unrelated page.

**Fix + regression test:** `edit-seo` now clears `variantOverride: null` on target switch, matching `select`. Added a test asserting this (`"editing SEO for a new target clears a stale variant override"`), mirroring the existing analogous test for `select`.

**To verify:** `cd apps/web && bun test ./src/components/sandbox/blocks/blocks-preview-workspace-state.test.ts` (9/9 pass, including the new one).

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/web, clean), the targeted test file above, `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears stale variant overrides when switching the SEO edit target, matching existing `select` behavior. Previously, `edit-seo` updated `target` but left `variantOverride` set, causing a page-scoped `x-deco-matchers-override` to leak into the new page’s preview; it now sets `variantOverride` to null on target switch.

**Review notes**
- Reducer: in the `edit-seo` case, set `target`, `editSeoPageKey`, and clear `variantOverride: null`.
- Test: adds “editing SEO for a new target clears a stale variant override.” Run: `cd apps/web && bun test ./src/components/sandbox/blocks/blocks-preview-workspace-state.test.ts`.
- No migrations. Risk is limited to preview URL construction; `select` is unchanged.

<sup>Written for commit 659f0bc7f87c711cf9efe074dbdfd40e2cec5cc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6137?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

