### PR TITLE
fix(auth): drop JWT header on boundAuth org.create/addMember

### DIFF
--- a/apps/api/src/core/context-factory.ts
+++ b/apps/api/src/core/context-factory.ts
@@ -341,8 +341,14 @@ export function createBoundAuthClient(ctx: AuthContext): BoundAuthClient {
 
     organization: {
       create: async (data) => {
+        // Don't pass headers — same reason as apiKey.create below. A Bearer-JWT
+        // caller's Authorization header trips the apiKey plugin's global
+        // before-hook ("Invalid API key") before this handler runs. `data`
+        // already carries `userId` for server-side creation (see
+        // tools/organization/create.ts), and boundAuth resolves the actor once
+        // from the session, so identity is preserved for cookie and JWT callers
+        // alike. Authorization is enforced by ctx.access.check() before the call.
         return auth.api.createOrganization({
-          headers,
           body: data,
         } as unknown as Parameters<typeof auth.api.createOrganization>[0]);
       },
@@ -381,8 +387,11 @@ export function createBoundAuthClient(ctx: AuthContext): BoundAuthClient {
       },
 
       addMember: async (data) => {
+        // Don't pass headers — see organization.create above. `data` carries
+        // userId/organizationId/role; the member-add tool already checks the
+        // caller's real membership + canAssignRole before calling. Matches the
+        // headerless pattern in auth/ensure-user-organization.ts.
         return auth.api.addMember({
-          headers,
           body: data,
         } as unknown as Parameters<typeof auth.api.addMember>[0]);
       },


### PR DESCRIPTION
## Problem

`boundAuth.organization.create` and `.addMember` (`apps/api/src/core/context-factory.ts`) forward the request `headers` to Better Auth. For a **Bearer-JWT** caller, the `Authorization: Bearer <jwt>` header trips the apiKey plugin's global before-hook — it matches any `Bearer`, tries to validate the JWT as an API key, fails, and throws **"Invalid API key"** before the handler runs.

Effect: cookie/session callers (the web UI, which uses the client SDK, not boundAuth) are unaffected, but any **Bearer-JWT integration** is fully blocked from `ORGANIZATION_CREATE` / `ORGANIZATION_MEMBER_ADD`. This blocks the control-plane migrator (deco.cx → Studio) from creating an org or adding members via the minted `self`-MCP JWT.

## Fix

Drop `headers` from these two methods, mirroring `apiKey.create` right below (identical comment and reason: *"Better Auth treats requests with headers as client requests"*).

## Why it's safe

- Both MCP tools already pass `userId` in the body for server-side creation (`tools/organization/create.ts`, `tools/organization/member-add.ts`), and boundAuth resolves the actor **once** from the session (`userId: authResult.user?.id`) — so actor identity is preserved for **cookie and JWT callers alike**.
- **Not a security regression:** the web UI does not use boundAuth here (it calls `authClient.organization.create` → HTTP endpoint with cookie). Blast radius is the MCP tools only. `member-add.ts` already checks the caller's real membership + `canAssignRole` before the call; `create.ts` requires `getUserId(ctx)`; authorization runs via `ctx.access.check()` regardless of headers.
- The exact headerless form (`createOrganization({ body: { name, slug, userId } })`, `addMember({ body: { userId, role, organizationId } })`) is **already used in production** by `apps/api/src/auth/ensure-user-organization.ts` (first-login org bootstrap). `afterCreate → seedOrgDb` still fires.

## Testing

- `apps/api` typecheck clean for this file; the only `bun run check` error is a pre-existing `ajv` version skew in `packages/mcp-utils/src/shared-schema-validator.ts` (present on `main`, unrelated).
- `biome format` + `oxlint` pass on the changed file.
- End-to-end validation via the control-plane migrator on Studio **stg** (create org + add members through the `self` MCP with a Bearer JWT).

## Follow-up

- [ ] TODO: add an e2e test asserting `ORGANIZATION_CREATE` / `ORGANIZATION_MEMBER_ADD` succeed for a Bearer-JWT principal (currently only cookie-session paths are covered).
- The sibling methods (`update`, `delete`, `removeMember`, `updateMemberRole`) have the same latent issue but don't pass `userId` in the body, so they're left untouched here — a separate change if a JWT caller needs them.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops headers from boundAuth `organization.create` and `addMember` so Bearer-JWT calls no longer trigger the apiKey plugin and fail with “Invalid API key.” Previously these methods forwarded `Authorization: Bearer <jwt>`; now they send only the body, restoring create/add for JWT integrations while leaving cookie/session behavior unchanged.

- Mirrors the headerless pattern in `apiKey.create`; preserves actor identity via `userId` in the body and session, with authorization enforced by `ctx.access.check()`.
- No migration required; the web UI path is unaffected. The same headerless calls already run in `apps/api/src/auth/ensure-user-organization.ts`.
- Out of scope: other org methods still forward headers; follow up if JWT callers need them.

<sup>Written for commit 2b9f7708634da806422a0597d564b89fae4bb825. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

