### PR TITLE
fix(connection): label mcp-app view by annotations.title, fall back to name

### DIFF
--- a/apps/web/src/components/details/connection/connection-ui-tab.tsx
+++ b/apps/web/src/components/details/connection/connection-ui-tab.tsx
@@ -116,7 +116,7 @@ export function ConnectionUiTab({
                   <div className="flex flex-col gap-2 p-4">
                     <div className="flex items-center justify-between gap-2">
                       <h3 className="text-base font-medium text-foreground truncate">
-                        {tool.name}
+                        {tool.annotations?.title ?? tool.name}
                       </h3>
                       <ToolAnnotationBadges
                         annotations={tool.annotations}


### PR DESCRIPTION
The connection UI gallery (`connection-ui-tab.tsx`) labels each embedded app by the carrying tool's raw `name` (e.g. `IDENTITY_GET`). Honor the tool's display title (`annotations.title`) when present, falling back to `name`.

This lets an MCP server give its embedded view a readable, purposeful label (and vary it — e.g. a control-plane that self-scopes shows 'Control plane' to admins and 'Deco Hosting' to tenants). The runtime already forwards `annotations`; top-level `title` is not forwarded, so `annotations.title` is the field that reaches the client. One-line render change; no behavior change when `annotations.title` is absent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Labels each embedded MCP app in the Connection UI by its display title. Previously we showed the tool’s raw name (e.g., IDENTITY_GET); now we use `annotations.title`, falling back to `name`, so labels are human‑readable with no change when a title is missing.

**Review notes**
- The runtime forwards `annotations`; top‑level `title` does not reach the client, so `annotations.title` is the usable display field.
- One-line render change in `apps/web/src/components/details/connection/connection-ui-tab.tsx`; no other behavior changes.

<sup>Written for commit cf4b219ef6a5bae18af6814211d25fde5ded75f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

