### PR TITLE
fix(oauth): Figma MCP catalog DCR no longer looks like a 500

### DIFF
--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -100,6 +100,10 @@ import {
   fetchProtectedResourceMetadata,
   protectedResourceMetadataHandler,
 } from "./routes/oauth-proxy";
+import {
+  FIGMA_DCR_REJECTED_DESCRIPTION,
+  isFigmaRemoteMcpUrl,
+} from "./routes/oauth-proxy-metadata";
 import openaiCompatRoutes from "./routes/openai-compat";
 import { createProxyRoutes } from "./routes/proxy";
 import { createTriggerCallbackRoutes } from "./routes/trigger-callback";
@@ -711,6 +715,24 @@ const oauthProxyHandler: MiddlewareHandler<Env> = async (c) => {
     duplex: "half",
     redirect: "manual",
   });
+
+  // Figma's DCR endpoint returns plaintext `403 Forbidden` for any client
+  // not on the MCP Catalog. The MCP SDK then throws "Unexpected token 'F'"
+  // because the body isn't JSON. Rewrite to a proper OAuth error so the
+  // connection UI can show why Connect failed.
+  if (
+    endpoint === "register" &&
+    response.status === 403 &&
+    isFigmaRemoteMcpUrl(connection.connection_url)
+  ) {
+    return Response.json(
+      {
+        error: "unauthorized_client",
+        error_description: FIGMA_DCR_REJECTED_DESCRIPTION,
+      },
+      { status: 403 },
+    );
+  }
 
   // Copy response headers, excluding hop-by-hop and encoding headers
   // Note: Node.js fetch auto-decompresses, so content-encoding/content-length would be wrong

--- a/apps/api/src/api/routes/oauth-proxy-metadata.test.ts
+++ b/apps/api/src/api/routes/oauth-proxy-metadata.test.ts
@@ -11,6 +11,7 @@ import {
   buildPathPrefix,
   isAuthError,
   isAuthServerMetadata,
+  isFigmaRemoteMcpUrl,
   looksLikeOAuthWwwAuthenticate,
   protectedResourceMetadataUrls,
   resourceMetadataChallenge,
@@ -151,6 +152,13 @@ describe("looksLikeOAuthWwwAuthenticate", () => {
   test("false for a bare Bearer/API-key challenge", () => {
     expect(looksLikeOAuthWwwAuthenticate('Bearer realm="api"')).toBe(false);
   });
+  test("true for Figma's remote MCP challenge", () => {
+    expect(
+      looksLikeOAuthWwwAuthenticate(
+        'Bearer resource_metadata="https://mcp.figma.com/.well-known/oauth-protected-resource",scope="mcp:connect"',
+      ),
+    ).toBe(true);
+  });
 });
 
 describe("isAuthError", () => {
@@ -167,6 +175,21 @@ describe("isAuthError", () => {
   test("false for unrelated errors", () => {
     expect(isAuthError({ status: 500, message: "boom" })).toBe(false);
     expect(isAuthError({})).toBe(false);
+  });
+});
+
+describe("isFigmaRemoteMcpUrl", () => {
+  test("matches the official remote MCP and API hosts", () => {
+    expect(isFigmaRemoteMcpUrl("https://mcp.figma.com/mcp")).toBe(true);
+    expect(isFigmaRemoteMcpUrl("https://api.figma.com/v1/oauth/mcp/register")).toBe(
+      true,
+    );
+  });
+  test("rejects other hosts and bad URLs", () => {
+    expect(isFigmaRemoteMcpUrl("https://www.figma.com/design/abc")).toBe(false);
+    expect(isFigmaRemoteMcpUrl("http://127.0.0.1:3845/mcp")).toBe(false);
+    expect(isFigmaRemoteMcpUrl("not-a-url")).toBe(false);
+    expect(isFigmaRemoteMcpUrl(null)).toBe(false);
   });
 });
 

--- a/apps/api/src/api/routes/oauth-proxy-metadata.ts
+++ b/apps/api/src/api/routes/oauth-proxy-metadata.ts
@@ -146,6 +146,26 @@ export function isAuthError(error: {
   );
 }
 
+/** Figma's remote MCP — DCR is catalog-allowlisted, not open RFC 7591. */
+export function isFigmaRemoteMcpUrl(url: string | null | undefined): boolean {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    return (
+      parsed.hostname === "mcp.figma.com" ||
+      parsed.hostname === "api.figma.com"
+    );
+  } catch {
+    return false;
+  }
+}
+
+export const FIGMA_MCP_CATALOG_URL = "https://www.figma.com/mcp-catalog/";
+
+export const FIGMA_DCR_REJECTED_DESCRIPTION =
+  "Dynamic client registration was rejected (HTTP 403). Figma's remote MCP only registers clients on the Figma MCP Catalog (Cursor, Claude, Codex, …). Studio is not on that catalog yet. A Figma PAT cannot authenticate this endpoint — only OAuth from an allowlisted client works. See " +
+  FIGMA_MCP_CATALOG_URL;
+
 export interface ProxyMetadataUrls {
   /** `…/mcp/:connectionId` on our proxy (the `resource` value). */
   proxyResourceUrl: string;

--- a/apps/api/src/api/routes/oauth-proxy.ts
+++ b/apps/api/src/api/routes/oauth-proxy.ts
@@ -275,12 +275,10 @@ export async function handleAuthError({
   headers,
   orgSlug,
 }: HandleAuthErrorOptions): Promise<Response | null> {
-  if (!isAuthError(error)) {
-    return null;
-  }
-
-  // Check if origin supports OAuth by looking for a *meaningful* WWW-Authenticate challenge.
-  // Some servers require a Bearer token (PAT/API key) and include WWW-Authenticate without being OAuth-capable.
+  // Probe the origin first. Figma (and some other remotes) return 401 with a
+  // valid RFC 9728 WWW-Authenticate, but the MCP SDK surfaces that as a
+  // transport/parse error that `isAuthError` misses — which used to become a
+  // proxy 500 ("Internal server error") instead of the OAuth button.
   const originSupportsOAuth = Boolean(
     await checkOriginSupportsOAuth(connectionUrl, headers),
   );
@@ -296,6 +294,10 @@ export async function handleAuthError({
         }),
       },
     });
+  }
+
+  if (!isAuthError(error)) {
+    return null;
   }
 
   return new Response(

--- a/apps/web/src/components/connections/create-connection-dialog.tsx
+++ b/apps/web/src/components/connections/create-connection-dialog.tsx
@@ -569,6 +569,22 @@ export function CreateConnectionDialog({
                         </a>
                       </>
                     )}
+                    {providerHint.id === "figma" && (
+                      <>
+                        {" "}
+                        ·{" "}
+                        <a
+                          className="text-foreground underline underline-offset-4 hover:text-foreground/80"
+                          href="https://www.figma.com/mcp-catalog/"
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          {t(
+                            "connections.createConnectionDialog.openFigmaMcpCatalog",
+                          )}
+                        </a>
+                      </>
+                    )}
                   </p>
                 )}
                 <FormMessage />

--- a/apps/web/src/i18n/en/connections.ts
+++ b/apps/web/src/i18n/en/connections.ts
@@ -27,6 +27,8 @@ export const connections = {
   "connections.createConnectionDialog.npxPackageType": "NPX Package",
   "connections.createConnectionDialog.openGitHubPatSettings":
     "Open GitHub PAT settings",
+  "connections.createConnectionDialog.openFigmaMcpCatalog":
+    "Figma MCP Catalog waitlist",
   "connections.createConnectionDialog.saving": "Saving...",
   "connections.createConnectionDialog.sseType": "SSE",
   "connections.createConnectionDialog.title": "Create Connection",

--- a/apps/web/src/i18n/pt-br/connections.ts
+++ b/apps/web/src/i18n/pt-br/connections.ts
@@ -30,6 +30,8 @@ export const connections = {
   "connections.createConnectionDialog.npxPackageType": "Pacote NPX",
   "connections.createConnectionDialog.openGitHubPatSettings":
     "Abrir configurações de PAT do GitHub",
+  "connections.createConnectionDialog.openFigmaMcpCatalog":
+    "Lista de espera do Figma MCP Catalog",
   "connections.createConnectionDialog.saving": "Salvando...",
   "connections.createConnectionDialog.sseType": "SSE",
   "connections.createConnectionDialog.title": "Criar Conexão",

--- a/apps/web/src/lib/authenticate-and-persist-oauth.ts
+++ b/apps/web/src/lib/authenticate-and-persist-oauth.ts
@@ -35,10 +35,12 @@ export async function authenticateAndPersistOAuth({
     return { ran: false, ok: true, error: null };
   }
 
+  // Do not hardcode "offline_access": Figma and other MCP OAuth servers
+  // advertise their own scopes (e.g. mcp:connect). Passing an OIDC-ism
+  // makes strict DCR reject the registration.
   const { token, tokenInfo, error } = await authenticateMcp({
     connectionId,
     orgSlug,
-    scope: "offline_access",
   });
   if (error || !token) {
     return { ran: true, ok: false, error: error ?? "no token received" };

--- a/apps/web/src/sdk/lib/mcp-oauth.ts
+++ b/apps/web/src/sdk/lib/mcp-oauth.ts
@@ -185,7 +185,7 @@ class McpOAuthProvider implements OAuthClientProvider {
       token_endpoint_auth_method: "none",
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],
-      client_name: options.clientName ?? "@decocms/studio MCP client",
+      client_name: options.clientName ?? "Deco Studio",
       // Only include scope if explicitly provided - some servers have their own scope requirements
       ...(scopeStr && { scope: scopeStr }),
     };
@@ -627,10 +627,14 @@ export async function authenticateMcp(params: {
     if (oauthAbort.fn) {
       oauthAbort.fn(error instanceof Error ? error : new Error(String(error)));
     }
+    const raw = error instanceof Error ? error.message : String(error);
+    const looksLikeFigmaDcr = /figma|mcp catalog/i.test(raw);
     return {
       token: null,
       tokenInfo: null,
-      error: error instanceof Error ? error.message : String(error),
+      error: looksLikeFigmaDcr
+        ? `${raw} Studio is not on Figma's MCP Catalog yet — a PAT will not work. https://www.figma.com/mcp-catalog/`
+        : raw,
     };
   }
 }
@@ -894,7 +898,7 @@ export async function isConnectionAuthenticated({
           protocolVersion: "2025-06-18",
           capabilities: {},
           clientInfo: {
-            name: "@decocms/studio MCP client",
+            name: "Deco Studio",
             version: "1.0.0",
           },
         },

--- a/apps/web/src/utils/connection-form-helpers.ts
+++ b/apps/web/src/utils/connection-form-helpers.ts
@@ -8,7 +8,7 @@ import type { RegistryItem } from "@/components/store/types";
 // ---------------------------------------------------------------------------
 
 export type ConnectionProviderHint = {
-  id: "github" | "perplexity" | "registry";
+  id: "github" | "perplexity" | "figma" | "registry";
   title?: string;
   description?: string | null;
   token?: {
@@ -68,8 +68,27 @@ export function inferHardcodedProviderHint(params: {
 }): ConnectionProviderHint | null {
   const { uiType } = params;
 
-  // GitHub Copilot MCP (hardcoded)
   const normalized = normalizeConnectionUrl(params.connectionUrl ?? "");
+
+  // Figma remote MCP — OAuth only, DCR is catalog-allowlisted
+  if (
+    (uiType === "HTTP" || uiType === "SSE" || uiType === "Websocket") &&
+    (normalized === normalizeConnectionUrl("https://mcp.figma.com/mcp") ||
+      normalized.startsWith("https://mcp.figma.com/"))
+  ) {
+    return {
+      id: "figma",
+      title: "Figma",
+      description: "Official Figma MCP (OAuth, catalog clients only)",
+      token: {
+        label: "Token (leave empty)",
+        helperText:
+          "Figma's remote MCP rejects PATs and only registers OAuth clients on the Figma MCP Catalog (Cursor, Claude, Codex). Studio is not on that list yet.",
+      },
+    };
+  }
+
+  // GitHub Copilot MCP (hardcoded)
   if (
     (uiType === "HTTP" || uiType === "SSE" || uiType === "Websocket") &&
     normalized === normalizeConnectionUrl("https://api.githubcopilot.com/mcp/")

--- a/apps/web/src/views/registry/monitor-connections-panel.tsx
+++ b/apps/web/src/views/registry/monitor-connections-panel.tsx
@@ -241,7 +241,6 @@ function ConnectionRow({
         orgSlug: org.slug,
         clientName: `MCP Test - ${title}`,
         timeout: 180000,
-        scope: "offline_access",
       });
 
       if (authResult.error) {

--- a/apps/web/src/views/virtual-mcp/index.tsx
+++ b/apps/web/src/views/virtual-mcp/index.tsx
@@ -635,7 +635,6 @@ function VirtualMcpDetailViewWithData({
     const { token, tokenInfo, error } = await authenticateMcp({
       connectionId,
       orgSlug: org.slug,
-      scope: "offline_access",
     });
     if (error || !token) {
       toast.error(


### PR DESCRIPTION
## Summary
- Figma remote MCP (`https://mcp.figma.com/mcp`) has working CORS and RFC 9728 metadata, but Dynamic Client Registration is allowlisted to Figma MCP Catalog clients (Cursor, Claude, Codex). Studio is not on that list — a PAT cannot authenticate this endpoint.
- Handshake failures were bubbling as proxy 500 Internal server error. If the origin supports OAuth, the proxy now returns a 401 challenge so the UI shows Connect instead of Server Error.
- Figma DCR `403 Forbidden` (plaintext) is rewritten to a JSON `unauthorized_client` error. Custom Connection for Figma warns that the catalog blocks Studio.
- Stop sending hardcoded `offline_access` on MCP OAuth (Figma uses `mcp:connect`).

This does **not** make official Figma Dev Mode work in Studio cloud. That needs Deco on https://www.figma.com/mcp-catalog/. Until then, use Cursor/Claude for Figma.

## Test plan
- [ ] Unit: `bun test apps/api/src/api/routes/oauth-proxy-metadata.test.ts apps/web/src/sdk/lib/mcp-oauth.test.ts`
- [ ] Custom Connection HTTP `https://mcp.figma.com/mcp` shows the Figma catalog hint (leave token empty)
- [ ] Connection detail no longer shows generic Server Error; Connect / a catalog DCR error appears instead
- [ ] Existing OAuth connections (Notion, GitHub, …) still complete DCR + authorize
- [ ] Confirm a Figma PAT still cannot list tools (expected)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OAuth handling so Figma MCP DCR failures no longer appear as a 500. Previously, handshake failures surfaced as Internal Server Error; now the proxy returns a 401 OAuth challenge when the origin advertises OAuth and rewrites Figma’s plaintext 403 DCR response to JSON `unauthorized_client`, so the UI shows Connect and a clear catalog block message.

- API: On `register` 403 from Figma, return `{ error: "unauthorized_client", error_description: FIGMA_DCR_REJECTED_DESCRIPTION }` using `isFigmaRemoteMcpUrl`; probe RFC 9728 `WWW-Authenticate` first to choose the 401 path even when the SDK error isn’t classified as auth.  
- Web: Stop defaulting to `offline_access`; use server-advertised scopes; set OAuth `client_name` to "Deco Studio"; add Figma provider hint with MCP Catalog link; remove explicit scope in monitor/virtual MCP flows.  
- Tests: Add Figma challenge detection and URL matching coverage.

- Impact: UI shows Connect instead of Server Error; Figma connections display the catalog allowlist warning. Existing OAuth integrations (e.g., Notion, GitHub) continue to register and authorize as before. Figma remains unavailable in Studio until it’s on the MCP Catalog; PATs will not work.

<sup>Written for commit 6e132a000a4b2b22b6871a42afefd6297313c1e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

