### PR TITLE
feat(infra-billing): legacy deco.cx infra usage and invoices in settings

### DIFF
--- a/apps/api/src/api/routes/deco-sites.ts
+++ b/apps/api/src/api/routes/deco-sites.ts
@@ -27,67 +27,11 @@ interface SupabaseSite {
   metadata: Record<string, unknown> | null;
 }
 
-async function supabaseGet<T>(
-  supabaseUrl: string,
-  serviceKey: string,
-  path: string,
-): Promise<T[]> {
-  const res = await fetch(`${supabaseUrl}/rest/v1/${path}`, {
-    headers: {
-      apikey: serviceKey,
-      Authorization: `Bearer ${serviceKey}`,
-      Accept: "application/json",
-    },
-  });
-  if (!res.ok) {
-    const text = await res.text().catch(() => res.statusText);
-    console.error(`[deco-sites] Supabase error (${res.status}): ${text}`);
-    throw new Error(`External service error (${res.status})`);
-  }
-  return res.json() as Promise<T[]>;
-}
-
-async function supabasePost<T>(
-  supabaseUrl: string,
-  serviceKey: string,
-  table: string,
-  body: Record<string, unknown>,
-): Promise<T> {
-  const res = await fetch(`${supabaseUrl}/rest/v1/${table}`, {
-    method: "POST",
-    headers: {
-      apikey: serviceKey,
-      Authorization: `Bearer ${serviceKey}`,
-      "Content-Type": "application/json",
-      Accept: "application/json",
-      Prefer: "return=representation",
-    },
-    body: JSON.stringify(body),
-  });
-  if (!res.ok) {
-    const text = await res.text().catch(() => res.statusText);
-    console.error(`[deco-sites] Supabase POST error (${res.status}): ${text}`);
-    throw new Error(`External service error (${res.status})`);
-  }
-  const rows = (await res.json()) as T[];
-  if (!rows[0]) {
-    throw new Error("Supabase POST returned no rows");
-  }
-  return rows[0];
-}
-
-import { getSettings } from "../../settings";
-
-function getSupabaseConfig(): {
-  supabaseUrl: string;
-  serviceKey: string;
-} | null {
-  const settings = getSettings();
-  const supabaseUrl = settings.decoSupabaseUrl;
-  const serviceKey = settings.decoSupabaseServiceKey;
-  if (!supabaseUrl || !serviceKey) return null;
-  return { supabaseUrl, serviceKey };
-}
+import {
+  getDecoSupabaseConfig as getSupabaseConfig,
+  supabaseGet,
+  supabasePost,
+} from "../../deco-legacy/supabase";
 
 async function resolveProfileId(
   supabaseUrl: string,

--- a/apps/api/src/billing/stripe-api.ts
+++ b/apps/api/src/billing/stripe-api.ts
@@ -220,6 +220,23 @@ export async function createBillingPortalSession(input: {
   return { url: session.url };
 }
 
+export interface StripeSubscription {
+  id: string;
+  customer: string;
+  /** Unix seconds. Recent API versions moved this onto the items. */
+  current_period_end?: number;
+  items?: { data?: { current_period_end?: number }[] };
+}
+
+/** Read a subscription by id — used to resolve its customer and period end. */
+export async function retrieveSubscription(
+  subscriptionId: string,
+): Promise<StripeSubscription> {
+  return stripeRequest<StripeSubscription>(
+    `/subscriptions/${encodeURIComponent(subscriptionId)}`,
+  );
+}
+
 /** Cancel a subscription outright. Used for orphans: a checkout that
  *  completed for an org already bound to a different subscription — the
  *  customer paid, the webhook refused the bind, nothing should keep billing. */

--- a/apps/api/src/deco-legacy/clickhouse-analytics.ts
+++ b/apps/api/src/deco-legacy/clickhouse-analytics.ts
@@ -1,0 +1,56 @@
+/**
+ * The legacy deco.cx analytics warehouse — a ClickHouse instance separate from
+ * the one Studio's own monitoring reads (`CLICKHOUSE_URL`). It holds the CDN /
+ * shared-infra usage facts the deco.cx platform bills on.
+ *
+ * Env vars (all three needed; missing any = feature absent, queries return []):
+ *   CLICKHOUSE_ANALYTICS_ADDRESS   – HTTP URL of the warehouse
+ *   CLICKHOUSE_ANALYTICS_USERNAME  – read-only user (default "admin_monitor")
+ *   CLICKHOUSE_ANALYTICS_PASSWORD  – its password
+ */
+
+import { getSettings } from "../settings";
+
+type ClickHouseClient = import("@clickhouse/client").ClickHouseClient;
+
+let clientPromise: Promise<ClickHouseClient> | null = null;
+
+export function isAnalyticsConfigured(): boolean {
+  const s = getSettings();
+  return !!(s.clickhouseAnalyticsUrl && s.clickhouseAnalyticsPassword);
+}
+
+async function getClient(): Promise<ClickHouseClient> {
+  if (!clientPromise) {
+    const s = getSettings();
+    clientPromise = import("@clickhouse/client").then(({ createClient }) =>
+      createClient({
+        url: s.clickhouseAnalyticsUrl,
+        username: s.clickhouseAnalyticsUsername,
+        password: s.clickhouseAnalyticsPassword,
+        request_timeout: 60_000,
+        // Compression is a per-query setting a `readonly` user may not set (164).
+      }),
+    );
+  }
+  return clientPromise;
+}
+
+/**
+ * Run a read query against the analytics warehouse. Returns [] when the
+ * warehouse isn't configured — every caller renders an empty dashboard rather
+ * than an error, matching how the legacy admin behaves.
+ */
+export async function analyticsQuery<T>(
+  query: string,
+  params: Record<string, unknown>,
+): Promise<T[]> {
+  if (!isAnalyticsConfigured()) return [];
+  const client = await getClient();
+  const result = await client.query({
+    query,
+    query_params: params,
+    format: "JSONEachRow",
+  });
+  return result.json<T>();
+}

--- a/apps/api/src/deco-legacy/infra-billing.test.ts
+++ b/apps/api/src/deco-legacy/infra-billing.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test";
+import { monthInterval, nextBillingDate, planTypeOf } from "./infra-billing";
+
+describe("monthInterval", () => {
+  it("spans the full UTC month", () => {
+    expect(monthInterval(new Date("2026-03-17T22:00:00Z"))).toEqual({
+      since: "2026-03-01",
+      until: "2026-03-31",
+    });
+  });
+
+  it("handles february in a leap year", () => {
+    expect(monthInterval(new Date("2024-02-05T00:00:00Z"))).toEqual({
+      since: "2024-02-01",
+      until: "2024-02-29",
+    });
+  });
+
+  it("does not roll into the next year on december", () => {
+    expect(monthInterval(new Date("2025-12-31T23:59:59Z"))).toEqual({
+      since: "2025-12-01",
+      until: "2025-12-31",
+    });
+  });
+});
+
+describe("planTypeOf", () => {
+  it("is free without a subscription row", () => {
+    expect(planTypeOf(undefined)).toBe("free");
+    expect(planTypeOf({ plan: null, status: "Live" })).toBe("free");
+  });
+
+  it("maps live pro and enterprise plans", () => {
+    expect(planTypeOf({ plan: 5, status: "Live" })).toBe("pro");
+    expect(planTypeOf({ plan: 6, status: "Live" })).toBe("enterprise");
+  });
+
+  it("downgrades a paid plan that is no longer live", () => {
+    expect(planTypeOf({ plan: 5, status: "Churned" })).toBe("free");
+    expect(planTypeOf({ plan: 6, status: null })).toBe("free");
+  });
+
+  it("keeps full access regardless of status", () => {
+    expect(planTypeOf({ plan: 420, status: "Churned" })).toBe("enterprise");
+  });
+
+  it("treats an unknown plan id as free", () => {
+    expect(planTypeOf({ plan: 99, status: "Live" })).toBe("free");
+  });
+});
+
+describe("nextBillingDate", () => {
+  const now = new Date("2026-08-16T12:00:00Z");
+
+  it("bills enterprise on the first of next month", () => {
+    expect(nextBillingDate("enterprise", undefined, now)).toBe("2026-09-01");
+  });
+
+  it("rolls the enterprise date into the next year from december", () => {
+    expect(
+      nextBillingDate(
+        "enterprise",
+        undefined,
+        new Date("2026-12-31T00:00:00Z"),
+      ),
+    ).toBe("2027-01-01");
+  });
+
+  it("uses the stripe period end for paid non-enterprise plans", () => {
+    const periodEnd = Math.floor(Date.UTC(2026, 8, 3) / 1000);
+    expect(nextBillingDate("pro", periodEnd, now)).toBe("2026-09-03");
+  });
+
+  it("has no date when stripe schedules nothing", () => {
+    expect(nextBillingDate("pro", undefined, now)).toBeNull();
+    expect(nextBillingDate("free", undefined, now)).toBeNull();
+  });
+});

--- a/apps/api/src/deco-legacy/infra-billing.ts
+++ b/apps/api/src/deco-legacy/infra-billing.ts
@@ -1,0 +1,358 @@
+/**
+ * Infra billing for a legacy deco.cx site: the daily CDN + shared-infra usage
+ * the platform bills on, the site's plan, and its issued invoices.
+ *
+ * Ported from the deco.cx admin's billing dashboard, with two differences:
+ *  - scoped to ONE site (admin aggregated a whole legacy "team"), because
+ *    Studio's tenancy unit is the org's `org_sites` claim, not the legacy team;
+ *  - read-only. Plan changes / checkout stay in the legacy admin.
+ *
+ * Every external read fails soft: an unconfigured or broken warehouse yields an
+ * empty dashboard, never a 500. Callers must have already authorized the org's
+ * ownership of the slug (see org_sites).
+ */
+
+import { analyticsQuery, isAnalyticsConfigured } from "./clickhouse-analytics";
+import { dailyPageviews, toOneDollarHostname } from "./onedollarstats";
+import { getDecoSupabaseConfig, supabaseGet } from "./supabase";
+import { retrieveSubscription } from "../billing/stripe-api";
+
+/** Legacy plan ids, from the deco.cx `plans` table. */
+const PLAN_IDS = { PRO: 5, ENTERPRISE: 6, FULL_ACCESS: 420 } as const;
+
+export type PlanType = "free" | "pro" | "enterprise";
+
+export interface DailyUsage {
+  date: string;
+  requests: number;
+  /** Egress + ingress; the platform bills them together as "data transfer". */
+  dataTransferBytes: number;
+  pageviews: number;
+}
+
+export interface LegacyInvoice {
+  id: string;
+  status: string;
+  dueDate: string | null;
+  value: number;
+  referenceMonth: string | null;
+  /** Fiscal-note (nota fiscal) PDF, when issued. */
+  nfUrl: string | null;
+  bankSlipUrl: string | null;
+}
+
+/**
+ * Plan and invoices belong to the legacy TEAM, not the site, so they only make
+ * sense when every selected site rolls up to the same team — null otherwise.
+ */
+export interface LegacyTeamBilling {
+  planType: PlanType;
+  invoices: LegacyInvoice[];
+  /** "YYYY-MM-DD", or null when nothing schedules a next charge. */
+  nextBillingDate: string | null;
+  /** Whether `INFRA_BILLING_PORTAL` has a Stripe customer to open for. */
+  canManageSubscription: boolean;
+}
+
+export interface SiteInfraBilling {
+  siteSlugs: string[];
+  /** First and last day of the reported month, "YYYY-MM-DD". */
+  since: string;
+  until: string;
+  usage: DailyUsage[];
+  /** False when no pageview source answered — the UI must render "—", not 0. */
+  pageviewsAvailable: boolean;
+  billing: LegacyTeamBilling | null;
+  /** True when the analytics warehouse isn't configured on this deployment. */
+  usageUnavailable: boolean;
+}
+
+/** UTC first/last day of the month containing `date`, as "YYYY-MM-DD". */
+export function monthInterval(date: Date): { since: string; until: string } {
+  const since = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1),
+  );
+  const until = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + 1, 0),
+  );
+  return {
+    since: since.toISOString().slice(0, 10),
+    until: until.toISOString().slice(0, 10),
+  };
+}
+
+interface UsageRow {
+  date: string;
+  requests: string | number;
+  egress_bytes: string | number;
+  ingress_bytes?: string | number;
+}
+
+/**
+ * Distinct hosts across the whole selection. Deduped on purpose: two sites can
+ * share an origin host, and counting that host's shared-infra traffic (or its
+ * pageviews) twice would inflate the total.
+ */
+async function siteHostnames(
+  siteSlugs: string[],
+  since: string,
+  until: string,
+): Promise<string[]> {
+  const rows = await analyticsQuery<{ host: string }>(
+    `SELECT DISTINCT host
+       FROM default.fact_usage_daily_view
+      WHERE site_id IN (SELECT id FROM default.dim_sites WHERE name IN ({sites:Array(String)}))
+        AND date >= {since:Date} AND date <= {until:Date}`,
+    { sites: siteSlugs, since, until },
+  );
+  return rows.map((r) => r.host).filter(Boolean);
+}
+
+/**
+ * CDN usage is keyed by site; shared-infra usage is keyed by origin hostname,
+ * so it can only be attributed to a site through that site's hosts. Both are
+ * part of what the platform bills — reporting CDN alone understates the bill.
+ */
+async function dailyInfraUsage(
+  siteSlugs: string[],
+  since: string,
+  until: string,
+  hostnames: string[],
+): Promise<Map<string, { requests: number; bytes: number }>> {
+  const [cdnRows, sharedRows] = await Promise.all([
+    analyticsQuery<UsageRow>(
+      `SELECT date,
+              sum(requests) AS requests,
+              sum(bandwidth_bytes) AS egress_bytes
+         FROM default.fact_usage_daily_view
+        WHERE site_id IN (SELECT id FROM default.dim_sites WHERE name IN ({sites:Array(String)}))
+          AND date >= {since:Date} AND date <= {until:Date}
+        GROUP BY date`,
+      { sites: siteSlugs, since, until },
+    ),
+    hostnames.length
+      ? analyticsQuery<UsageRow>(
+          `SELECT date,
+                  sum(requests) AS requests,
+                  sum(bandwidth_bytes) AS egress_bytes
+             FROM default.fact_shared_infra_usage_daily_view
+            WHERE origin_host IN ({hostnames:Array(String)})
+              AND date >= {since:Date} AND date <= {until:Date}
+            GROUP BY date`,
+          { hostnames, since, until },
+        )
+      : Promise.resolve([]),
+  ]);
+
+  const byDate = new Map<string, { requests: number; bytes: number }>();
+  for (const row of [...cdnRows, ...sharedRows]) {
+    const date = String(row.date);
+    const current = byDate.get(date) ?? { requests: 0, bytes: 0 };
+    current.requests += Number(row.requests) || 0;
+    current.bytes +=
+      (Number(row.egress_bytes) || 0) + (Number(row.ingress_bytes) || 0);
+    byDate.set(date, current);
+  }
+  return byDate;
+}
+
+/** Every UTC day in [since, until], so a gap in the facts renders as a zero. */
+function dateRange(since: string, until: string): string[] {
+  const dates: string[] = [];
+  const cursor = new Date(`${since}T00:00:00Z`);
+  const last = new Date(`${until}T00:00:00Z`);
+  while (cursor <= last) {
+    dates.push(cursor.toISOString().slice(0, 10));
+    cursor.setUTCDate(cursor.getUTCDate() + 1);
+  }
+  return dates;
+}
+
+interface LegacySubscriptionRow {
+  plan: number | null;
+  status: string | null;
+}
+
+interface LegacyInvoiceRow {
+  id: string | number;
+  status: string | null;
+  due_date: string | null;
+  value: number | null;
+  reference_month: string | null;
+  nf_url: string | null;
+  bank_slip_url: string | null;
+}
+
+export function planTypeOf(
+  subscription: LegacySubscriptionRow | undefined,
+): PlanType {
+  if (!subscription?.plan) return "free";
+  const live = subscription.status === "Live";
+  if (subscription.plan === PLAN_IDS.FULL_ACCESS) return "enterprise";
+  if (!live) return "free";
+  if (subscription.plan === PLAN_IDS.ENTERPRISE) return "enterprise";
+  if (subscription.plan === PLAN_IDS.PRO) return "pro";
+  return "free";
+}
+
+/** The legacy team that owns this site, or null (unclaimed / no credentials). */
+export async function resolveTeamId(siteSlug: string): Promise<number | null> {
+  const teams = await resolveTeamIds([siteSlug]);
+  return teams.length === 1 ? teams[0]! : null;
+}
+
+/** Distinct legacy teams behind a set of sites, in one round trip. */
+async function resolveTeamIds(siteSlugs: string[]): Promise<number[]> {
+  const config = getDecoSupabaseConfig();
+  if (!config || siteSlugs.length === 0) return [];
+  const list = siteSlugs.map((s) => `"${encodeURIComponent(s)}"`).join(",");
+  const rows = await supabaseGet<{ team: number | null }>(
+    config.supabaseUrl,
+    config.serviceKey,
+    `sites?name=in.(${list})&select=team`,
+  );
+  return [...new Set(rows.map((r) => r.team).filter((t): t is number => !!t))];
+}
+
+/**
+ * The Stripe subscription the legacy team pays with. Same Stripe account as
+ * Studio's own billing, so `stripeSecretKey` can read it. Null for teams
+ * billed outside Stripe (enterprise invoicing) — no portal, no period end.
+ */
+export async function teamStripeSubscriptionId(
+  teamId: number,
+): Promise<string | null> {
+  const config = getDecoSupabaseConfig();
+  if (!config) return null;
+  const rows = await supabaseGet<{ stripe_subscription_id: string | null }>(
+    config.supabaseUrl,
+    config.serviceKey,
+    `teams?id=eq.${teamId}&select=stripe_subscription_id&limit=1`,
+  );
+  return rows[0]?.stripe_subscription_id ?? null;
+}
+
+/** Enterprise bills on the 1st; everyone else on the Stripe period end. */
+export function nextBillingDate(
+  planType: PlanType,
+  periodEndSeconds: number | undefined,
+  now: Date,
+): string | null {
+  if (planType === "enterprise") {
+    return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1))
+      .toISOString()
+      .slice(0, 10);
+  }
+  if (!periodEndSeconds) return null;
+  return new Date(periodEndSeconds * 1000).toISOString().slice(0, 10);
+}
+
+async function loadPlanAndInvoices(
+  siteSlugs: string[],
+): Promise<LegacyTeamBilling | null> {
+  const config = getDecoSupabaseConfig();
+  const teams = await resolveTeamIds(siteSlugs);
+  const teamId = teams.length === 1 ? teams[0]! : null;
+  if (!config || teamId === null) {
+    return null;
+  }
+
+  const [subscriptions, invoiceRows, stripeSubscriptionId] = await Promise.all([
+    supabaseGet<LegacySubscriptionRow>(
+      config.supabaseUrl,
+      config.serviceKey,
+      `subscriptions?team=eq.${teamId}&select=plan,status&limit=1`,
+    ),
+    supabaseGet<LegacyInvoiceRow>(
+      config.supabaseUrl,
+      config.serviceKey,
+      `invoices?team=eq.${teamId}&select=id,status,due_date,value,reference_month,nf_url,bank_slip_url&order=reference_month.desc&limit=60`,
+    ),
+    teamStripeSubscriptionId(teamId),
+  ]);
+
+  const planType = planTypeOf(subscriptions[0]);
+  const stripeSubscription = stripeSubscriptionId
+    ? await retrieveSubscription(stripeSubscriptionId).catch((err) => {
+        console.error("[deco-legacy] stripe subscription read failed:", err);
+        return null;
+      })
+    : null;
+
+  return {
+    planType,
+    nextBillingDate: nextBillingDate(
+      planType,
+      stripeSubscription?.current_period_end ??
+        stripeSubscription?.items?.data?.[0]?.current_period_end,
+      new Date(),
+    ),
+    canManageSubscription: planType !== "enterprise" && !!stripeSubscription,
+    // Canceled invoices were never owed — the legacy admin hides them too.
+    invoices: invoiceRows
+      .filter((row) => row.status && row.status.toLowerCase() !== "canceled")
+      .map((row) => ({
+        id: String(row.id),
+        status: row.status ?? "",
+        dueDate: row.due_date,
+        value: Number(row.value) || 0,
+        referenceMonth: row.reference_month,
+        nfUrl: row.nf_url,
+        // Mirrored from Airtable as a JSON-ish string on some rows.
+        bankSlipUrl:
+          row.bank_slip_url?.replace(/^\["|"\]$|^"|"$|\[|\]/g, "") || null,
+      })),
+  };
+}
+
+export async function getSiteInfraBilling(params: {
+  /** One or more sites the caller has already authorized; totals are summed. */
+  siteSlugs: string[];
+  /** Any date inside the wanted month; defaults to the current month. */
+  period?: string;
+}): Promise<SiteInfraBilling> {
+  const siteSlugs = [...new Set(params.siteSlugs)].sort();
+  const periodDate = params.period ? new Date(params.period) : new Date();
+  const { since, until } = monthInterval(
+    Number.isNaN(periodDate.getTime()) ? new Date() : periodDate,
+  );
+
+  const [usageResult, billing] = await Promise.all([
+    (async () => {
+      const hostnames = await siteHostnames(siteSlugs, since, until);
+      const [infra, pageviews] = await Promise.all([
+        dailyInfraUsage(siteSlugs, since, until, hostnames),
+        dailyPageviews(hostnames.map(toOneDollarHostname), since, until),
+      ]);
+      return { infra, pageviews };
+    })().catch((err) => {
+      console.error("[deco-legacy] infra usage read failed:", err);
+      return { infra: new Map(), pageviews: null };
+    }),
+    loadPlanAndInvoices(siteSlugs).catch((err) => {
+      console.error("[deco-legacy] plan/invoices read failed:", err);
+      return null;
+    }),
+  ]);
+
+  const usage: DailyUsage[] = dateRange(since, until).map((date) => {
+    const infra = usageResult.infra.get(date);
+    return {
+      date,
+      requests: infra?.requests ?? 0,
+      dataTransferBytes: infra?.bytes ?? 0,
+      pageviews: usageResult.pageviews?.get(date) ?? 0,
+    };
+  });
+
+  return {
+    siteSlugs,
+    since,
+    until,
+    usage,
+    pageviewsAvailable: usageResult.pageviews !== null,
+    billing,
+    // Not the same as a month with no traffic (a legit all-zeros dashboard).
+    usageUnavailable: !isAnalyticsConfigured(),
+  };
+}

--- a/apps/api/src/deco-legacy/onedollarstats.ts
+++ b/apps/api/src/deco-legacy/onedollarstats.ts
@@ -1,0 +1,79 @@
+/**
+ * OneDollarStats (Plausible-compatible) — the legacy platform's pageview
+ * source. Pageviews are NOT in the analytics warehouse, so the Infra Billing
+ * page needs this second read. Indexed by public hostname, one query per host.
+ *
+ * Env: ONEDOLLAR_BACKEND_API_KEY. Unset (or any failure) = null, and the UI
+ * renders "—" for pageviews instead of a wrong zero.
+ */
+
+import { getSettings } from "../settings";
+
+const API = "https://deco.lilstts.com";
+
+interface PlausibleResponse {
+  results?: { dimensions: string[]; metrics: number[] }[];
+}
+
+/**
+ * Daily pageviews summed across `hostnames`, as date ("YYYY-MM-DD") → count.
+ * Null when unconfigured or when every host query failed — the caller must
+ * distinguish "no data source" from "zero pageviews".
+ */
+export async function dailyPageviews(
+  hostnames: string[],
+  startDate: string,
+  endDate: string,
+): Promise<Map<string, number> | null> {
+  const apiKey = getSettings().oneDollarStatsApiKey;
+  if (!apiKey || hostnames.length === 0) return null;
+
+  const results = await Promise.allSettled(
+    hostnames.map(async (hostname) => {
+      const res = await fetch(`${API}/plausible`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-api-key": apiKey,
+          Accept: "application/json",
+        },
+        body: JSON.stringify({
+          site_id: hostname,
+          date_range: [startDate, endDate],
+          metrics: ["pageviews"],
+          dimensions: ["time:day"],
+          pagination: { limit: 10000, offset: 0 },
+        }),
+      });
+      if (!res.ok) {
+        throw new Error(`OneDollarStats ${res.status}`);
+      }
+      return ((await res.json()) as PlausibleResponse).results ?? [];
+    }),
+  );
+
+  if (results.every((r) => r.status === "rejected")) {
+    console.warn("[deco-legacy] every OneDollarStats host query failed");
+    return null;
+  }
+
+  const byDate = new Map<string, number>();
+  for (const result of results) {
+    if (result.status !== "fulfilled") continue;
+    for (const row of result.value) {
+      // Normalize "YYYY-MM-DD HH:MM:SS" → "YYYY-MM-DD".
+      const date = row.dimensions[0]?.split(" ")[0];
+      if (!date) continue;
+      byDate.set(date, (byDate.get(date) ?? 0) + (row.metrics[0] ?? 0));
+    }
+  }
+  return byDate;
+}
+
+/**
+ * OneDollarStats indexes custom domains by their `www.` hostname while the
+ * warehouse stores the bare domain; `.deco.site` subdomains are used as-is.
+ */
+export function toOneDollarHostname(host: string): string {
+  return host.endsWith(".deco.site") ? host : `www.${host}`;
+}

--- a/apps/api/src/deco-legacy/supabase.ts
+++ b/apps/api/src/deco-legacy/supabase.ts
@@ -1,0 +1,78 @@
+/**
+ * Read/write access to the legacy deco.cx Supabase project.
+ *
+ * This whole `deco-legacy/` folder is the seam to the pre-Studio deco.cx
+ * platform (sites, teams, plans, invoices, CDN usage). Nothing here is part of
+ * Studio's own data model — it exists so an org that still owns deco.cx sites
+ * can see its infra usage and bills inside Studio. Everything is env-gated and
+ * fails closed (unconfigured deployment = feature absent, never a 500).
+ *
+ * Required env vars:
+ *   DECO_SUPABASE_URL          – Supabase project URL
+ *   DECO_SUPABASE_SERVICE_KEY  – Supabase service role key
+ */
+
+import { getSettings } from "../settings";
+
+export interface DecoSupabaseConfig {
+  supabaseUrl: string;
+  serviceKey: string;
+}
+
+/** Null when the deployment has no legacy Supabase credentials. */
+export function getDecoSupabaseConfig(): DecoSupabaseConfig | null {
+  const settings = getSettings();
+  const supabaseUrl = settings.decoSupabaseUrl;
+  const serviceKey = settings.decoSupabaseServiceKey;
+  if (!supabaseUrl || !serviceKey) return null;
+  return { supabaseUrl, serviceKey };
+}
+
+export async function supabaseGet<T>(
+  supabaseUrl: string,
+  serviceKey: string,
+  path: string,
+): Promise<T[]> {
+  const res = await fetch(`${supabaseUrl}/rest/v1/${path}`, {
+    headers: {
+      apikey: serviceKey,
+      Authorization: `Bearer ${serviceKey}`,
+      Accept: "application/json",
+    },
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    console.error(`[deco-legacy] Supabase error (${res.status}): ${text}`);
+    throw new Error(`External service error (${res.status})`);
+  }
+  return res.json() as Promise<T[]>;
+}
+
+export async function supabasePost<T>(
+  supabaseUrl: string,
+  serviceKey: string,
+  table: string,
+  body: Record<string, unknown>,
+): Promise<T> {
+  const res = await fetch(`${supabaseUrl}/rest/v1/${table}`, {
+    method: "POST",
+    headers: {
+      apikey: serviceKey,
+      Authorization: `Bearer ${serviceKey}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+      Prefer: "return=representation",
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    console.error(`[deco-legacy] Supabase POST error (${res.status}): ${text}`);
+    throw new Error(`External service error (${res.status})`);
+  }
+  const rows = (await res.json()) as T[];
+  if (!rows[0]) {
+    throw new Error("Supabase POST returned no rows");
+  }
+  return rows[0];
+}

--- a/apps/api/src/settings/resolve-config.ts
+++ b/apps/api/src/settings/resolve-config.ts
@@ -418,6 +418,11 @@ export function resolveConfig(
     decoSupabaseUrl: envVars.DECO_SUPABASE_URL,
     decoSupabaseServiceKey: envVars.DECO_SUPABASE_SERVICE_KEY,
     firecrawlApiKey: envVars.FIRECRAWL_API_KEY,
+    clickhouseAnalyticsUrl: envVars.CLICKHOUSE_ANALYTICS_ADDRESS,
+    clickhouseAnalyticsUsername:
+      envVars.CLICKHOUSE_ANALYTICS_USERNAME || "admin_monitor",
+    clickhouseAnalyticsPassword: envVars.CLICKHOUSE_ANALYTICS_PASSWORD,
+    oneDollarStatsApiKey: envVars.ONEDOLLAR_BACKEND_API_KEY,
     // New name first, legacy Commerce Discovery envs as fallback — one
     // setting, so prod migrates secrets whenever convenient without a
     // coordinated deploy. Drop the fallback once the CD envs are renamed.

--- a/apps/api/src/settings/types.ts
+++ b/apps/api/src/settings/types.ts
@@ -196,6 +196,16 @@ export interface Settings {
   decoSupabaseUrl: string | undefined;
   decoSupabaseServiceKey: string | undefined;
   firecrawlApiKey: string | undefined;
+  /** Legacy deco.cx analytics warehouse (CDN + shared-infra usage facts) read
+   *  by the Infra Billing settings page. A DIFFERENT ClickHouse from
+   *  `clickhouseUrl`, which is Studio's own monitoring store. Unset = the
+   *  feature reports no usage; see deco-legacy/clickhouse-analytics.ts. */
+  clickhouseAnalyticsUrl: string | undefined;
+  clickhouseAnalyticsUsername: string;
+  clickhouseAnalyticsPassword: string | undefined;
+  /** OneDollarStats backend key — the legacy platform's pageview source
+   *  (pageviews do not live in the warehouse). Unset = pageviews render "—". */
+  oneDollarStatsApiKey: string | undefined;
   /** Reports service internal API (the service historically named "Commerce
    *  Discovery" — REPORTS_INTERNAL_API_URL, with the legacy
    *  COMMERCE_DISCOVERY_INTERNAL_API_URL env still honored as fallback). */

--- a/apps/api/src/storage/org-sites.ts
+++ b/apps/api/src/storage/org-sites.ts
@@ -114,6 +114,16 @@ export class OrgSiteStorage implements OrgSiteStoragePort {
     return row ? toEntity(row as OrgSiteRow) : null;
   }
 
+  async listByOrg(organizationId: string): Promise<OrgSite[]> {
+    const rows = await this.db
+      .selectFrom("org_sites")
+      .selectAll()
+      .where("organization_id", "=", organizationId)
+      .orderBy("slug", "asc")
+      .execute();
+    return rows.map((row) => toEntity(row as OrgSiteRow));
+  }
+
   async isOwnedBy(slug: string, organizationId: string): Promise<boolean> {
     const row = await this.db
       .selectFrom("org_sites")

--- a/apps/api/src/storage/ports.ts
+++ b/apps/api/src/storage/ports.ts
@@ -775,6 +775,8 @@ export interface OrgSiteStoragePort {
     by: string;
   }): Promise<OrgSite>;
   getBySlug(slug: string): Promise<OrgSite | null>;
+  /** Every slug this org owns, slug-ascending. */
+  listByOrg(organizationId: string): Promise<OrgSite[]>;
   /** Authorization primitive: does this org own this slug? */
   isOwnedBy(slug: string, organizationId: string): Promise<boolean>;
 }

--- a/apps/api/src/tools/index.ts
+++ b/apps/api/src/tools/index.ts
@@ -28,6 +28,7 @@ import * as AiProvidersTools from "./ai-providers";
 import * as ClaudeSubscriptionTools from "./claude-subscription";
 import * as SecretsTools from "./secrets";
 import * as FileConfigTools from "./file-configs";
+import * as InfraBillingTools from "./infra-billing";
 import { ORG_FS_PUBLIC_SETS_SYNC } from "./org-fs/sync-public-sets";
 import * as OrgRepoSyncTools from "./org-repo-sync";
 import { getPrompts, getResources } from "./guides";
@@ -91,6 +92,11 @@ export const CORE_TOOLS = [
   OrganizationTools.ORGANIZATION_BILLING_CHECKOUT_START,
   OrganizationTools.ORGANIZATION_BILLING_PORTAL,
   OrganizationTools.ORGANIZATION_TASK_QUOTA_GET,
+
+  // Legacy deco.cx infra billing
+  InfraBillingTools.INFRA_BILLING_SITES_LIST,
+  InfraBillingTools.INFRA_BILLING_GET,
+  InfraBillingTools.INFRA_BILLING_PORTAL,
 
   // Connection collection tools
   ConnectionTools.COLLECTION_CONNECTIONS_CREATE,

--- a/apps/api/src/tools/infra-billing/get.ts
+++ b/apps/api/src/tools/infra-billing/get.ts
@@ -1,0 +1,87 @@
+/**
+ * INFRA_BILLING_GET — one month of infra usage, plan and invoices for a legacy
+ * deco.cx site the org owns. Ownership is checked against `org_sites`, so a
+ * member of org A can never read org B's site by guessing its slug.
+ */
+
+import { z } from "zod";
+import { defineTool } from "../../core/define-tool";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
+import { getSiteInfraBilling } from "../../deco-legacy/infra-billing";
+
+export const INFRA_BILLING_GET = defineTool({
+  name: "INFRA_BILLING_GET",
+  description:
+    "Get infra usage (requests, data transfer, pageviews), plan and invoices for one legacy deco.cx site owned by this organization, for a given month.",
+  annotations: {
+    title: "Get Infra Billing",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  inputSchema: z.object({
+    /** Sites to aggregate. Every one must be owned by the calling org. */
+    siteSlugs: z.array(z.string().min(1).max(60)).min(1).max(50),
+    /** Any date inside the wanted month (ISO). Defaults to the current month. */
+    period: z.string().optional(),
+  }),
+  outputSchema: z.object({
+    siteSlugs: z.array(z.string()),
+    since: z.string(),
+    until: z.string(),
+    usage: z.array(
+      z.object({
+        date: z.string(),
+        requests: z.number(),
+        dataTransferBytes: z.number(),
+        pageviews: z.number(),
+      }),
+    ),
+    /** False when no pageview source answered — render "—", never 0. */
+    pageviewsAvailable: z.boolean(),
+    /** True when this deployment has no analytics warehouse configured. */
+    usageUnavailable: z.boolean(),
+    /** Plan and invoices belong to the legacy team, so they are only reported
+     *  when the whole selection rolls up to exactly one team. */
+    billing: z
+      .object({
+        planType: z.enum(["free", "pro", "enterprise"]),
+        /** "YYYY-MM-DD", or null when nothing schedules a next charge. */
+        nextBillingDate: z.string().nullable(),
+        /** Whether INFRA_BILLING_PORTAL has a Stripe customer to open for. */
+        canManageSubscription: z.boolean(),
+        invoices: z.array(
+          z.object({
+            id: z.string(),
+            status: z.string(),
+            dueDate: z.string().nullable(),
+            value: z.number(),
+            referenceMonth: z.string().nullable(),
+            nfUrl: z.string().nullable(),
+            bankSlipUrl: z.string().nullable(),
+          }),
+        ),
+      })
+      .nullable(),
+  }),
+
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const org = requireOrganization(ctx);
+
+    const slugs = [...new Set(input.siteSlugs.map((s) => s.toLowerCase()))];
+    const owned = await Promise.all(
+      slugs.map((slug) => ctx.storage.orgSites.isOwnedBy(slug, org.id)),
+    );
+    const unowned = slugs.filter((_, i) => !owned[i]);
+    if (unowned.length > 0) {
+      throw new Error(
+        `Site not found in organization: ${unowned.sort().join(", ")}`,
+      );
+    }
+
+    return getSiteInfraBilling({ siteSlugs: slugs, period: input.period });
+  },
+});

--- a/apps/api/src/tools/infra-billing/index.ts
+++ b/apps/api/src/tools/infra-billing/index.ts
@@ -1,0 +1,3 @@
+export { INFRA_BILLING_SITES_LIST } from "./list-sites";
+export { INFRA_BILLING_GET } from "./get";
+export { INFRA_BILLING_PORTAL } from "./portal";

--- a/apps/api/src/tools/infra-billing/list-sites.ts
+++ b/apps/api/src/tools/infra-billing/list-sites.ts
@@ -1,0 +1,36 @@
+/**
+ * INFRA_BILLING_SITES_LIST — the legacy deco.cx sites this org owns, from
+ * `org_sites` (Studio's tenancy source of truth). Cheap, single indexed read:
+ * the settings nav calls it to decide whether to show Infra Billing at all, and
+ * the page uses it to populate the site selector.
+ */
+
+import { z } from "zod";
+import { defineTool } from "../../core/define-tool";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
+
+export const INFRA_BILLING_SITES_LIST = defineTool({
+  name: "INFRA_BILLING_SITES_LIST",
+  description:
+    "List the legacy deco.cx site slugs this organization owns. Empty for orgs with no sites.",
+  annotations: {
+    title: "List Owned Sites",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: false,
+  },
+  inputSchema: z.object({}),
+  outputSchema: z.object({
+    sites: z.array(z.object({ slug: z.string() })),
+  }),
+
+  handler: async (_input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const org = requireOrganization(ctx);
+
+    const sites = await ctx.storage.orgSites.listByOrg(org.id);
+    return { sites: sites.map(({ slug }) => ({ slug })) };
+  },
+});

--- a/apps/api/src/tools/infra-billing/portal.ts
+++ b/apps/api/src/tools/infra-billing/portal.ts
@@ -1,0 +1,67 @@
+/**
+ * INFRA_BILLING_PORTAL — Stripe's hosted Customer Portal for the legacy team
+ * that owns this site. Same Stripe account as Studio's own subscription, so it
+ * reuses `stripe-api.ts`; the session returns to the Infra Billing page.
+ */
+
+import { z } from "zod";
+import {
+  createBillingPortalSession,
+  retrieveSubscription,
+  StripeApiError,
+} from "../../billing/stripe-api";
+import { defineTool } from "../../core/define-tool";
+import { getPublicUrl } from "../../core/server-constants";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
+import {
+  resolveTeamId,
+  teamStripeSubscriptionId,
+} from "../../deco-legacy/infra-billing";
+
+export const INFRA_BILLING_PORTAL = defineTool({
+  name: "INFRA_BILLING_PORTAL",
+  description:
+    "Open the Stripe billing portal for the legacy deco.cx team that owns a site this organization owns. Returns the portal URL.",
+  annotations: {
+    title: "Open Infra Billing Portal",
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  inputSchema: z.object({ siteSlug: z.string().min(1).max(60) }),
+  outputSchema: z.object({ url: z.string() }),
+
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    await ctx.access.check();
+    const org = requireOrganization(ctx);
+    if (!org.slug) {
+      throw new Error("Organization context required");
+    }
+
+    const slug = input.siteSlug.toLowerCase();
+    if (!(await ctx.storage.orgSites.isOwnedBy(slug, org.id))) {
+      throw new Error(`Site not found in organization: ${slug}`);
+    }
+
+    const teamId = await resolveTeamId(slug);
+    const subscriptionId =
+      teamId === null ? null : await teamStripeSubscriptionId(teamId);
+    if (!subscriptionId) {
+      throw new Error("This site has no Stripe subscription to manage.");
+    }
+
+    try {
+      const subscription = await retrieveSubscription(subscriptionId);
+      return await createBillingPortalSession({
+        customerId: subscription.customer,
+        // Followed from Stripe's domain, so it must be externally reachable.
+        returnUrl: `${getPublicUrl()}/${encodeURIComponent(org.slug)}/settings/infra-billing`,
+      });
+    } catch (err) {
+      if (err instanceof StripeApiError) throw new Error(err.message);
+      throw err;
+    }
+  },
+});

--- a/apps/web/src/hooks/use-infra-billing.ts
+++ b/apps/web/src/hooks/use-infra-billing.ts
@@ -1,0 +1,57 @@
+/**
+ * Legacy deco.cx infra billing reads. `useOwnedSites` is also the gate for the
+ * whole feature: an org that owns no site never sees the nav item or the page.
+ */
+
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useProjectContext } from "@/sdk";
+import { useStudioTools } from "@/lib/studio-tools";
+import { KEYS } from "@/lib/query-keys";
+import { useT } from "@/i18n/use-t.ts";
+
+export function useOwnedSites() {
+  const { org } = useProjectContext();
+  const studio = useStudioTools();
+
+  const { data, isLoading } = useQuery({
+    queryKey: KEYS.infraBillingSites(org.id),
+    // Ownership changes only on a site import — no need to refetch per nav.
+    staleTime: 5 * 60_000,
+    queryFn: () => studio.call("INFRA_BILLING_SITES_LIST", {}),
+  });
+
+  return { sites: data?.sites.map((s) => s.slug) ?? [], isLoading };
+}
+
+/** Opens the legacy team's Stripe portal in a new tab, like every other
+ *  Stripe-hosted URL in the app. */
+export function useInfraBillingPortal() {
+  const studio = useStudioTools();
+  const t = useT();
+
+  return useMutation({
+    mutationFn: (siteSlug: string) =>
+      studio.call("INFRA_BILLING_PORTAL", { siteSlug }),
+    onSuccess: ({ url }) => window.open(url, "_blank", "noopener,noreferrer"),
+    onError: (err: Error) =>
+      toast.error(
+        t("settings.infraBilling.portalError", { message: err.message }),
+      ),
+  });
+}
+
+export function useInfraBilling(siteSlugs: string[], period: string) {
+  const { org } = useProjectContext();
+  const studio = useStudioTools();
+  // Sorted so the same selection in a different click order is one cache entry.
+  const slugs = [...siteSlugs].sort();
+
+  return useQuery({
+    queryKey: KEYS.infraBilling(org.id, slugs.join(","), period),
+    enabled: slugs.length > 0,
+    staleTime: 60_000,
+    queryFn: () =>
+      studio.call("INFRA_BILLING_GET", { siteSlugs: slugs, period }),
+  });
+}

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -8,6 +8,7 @@ export const settings = {
   "settings.nav.secrets": "Secrets",
   "settings.nav.apiKeys": "API Keys",
   "settings.nav.billing": "Billing",
+  "settings.nav.infraBilling": "Infra Billing",
   "settings.nav.buckets": "Buckets",
   "settings.nav.syncedRepos": "Synced repos",
   "settings.nav.build": "Build",
@@ -769,4 +770,49 @@ export const settings = {
   "settings.billing.manageButton": "Manage billing",
   "settings.billing.checkoutError": "Couldn't start checkout: {message}",
   "settings.billing.portalError": "Couldn't open billing portal: {message}",
+
+  "settings.infraBilling.pageTitle": "Infra Billing",
+  "settings.infraBilling.noSites":
+    "This organization doesn't own any deco.cx site yet.",
+  "settings.infraBilling.siteLabel": "Sites",
+  "settings.infraBilling.pickASite": "Select at least one site.",
+  "settings.infraBilling.multipleTeams":
+    "Plan and invoices belong to a single legacy team — narrow the selection to see them.",
+  "settings.infraBilling.monthLabel": "Month",
+  "settings.infraBilling.warehouseUnavailable":
+    "Usage data is unavailable on this deployment.",
+  "settings.infraBilling.summaryTitle": "Summary",
+  "settings.infraBilling.metricsTitle": "Metrics",
+  "settings.infraBilling.invoicesTitle": "Invoices",
+  "settings.infraBilling.detailsTitle": "Billing details",
+  "settings.infraBilling.currentPlan": "Current plan",
+  "settings.infraBilling.nextBilling": "Next billing",
+  "settings.infraBilling.manageButton": "Manage",
+  "settings.infraBilling.portalError":
+    "Couldn't open billing portal: {message}",
+  "settings.infraBilling.requestsPerPageview": "Requests per pageview",
+  "settings.infraBilling.plan.free": "Free",
+  "settings.infraBilling.plan.pro": "Pro",
+  "settings.infraBilling.plan.enterprise": "Enterprise",
+  "settings.infraBilling.pageviews": "Pageviews",
+  "settings.infraBilling.pageviewsDescription":
+    "Pages served to visitors this month.",
+  "settings.infraBilling.requests": "Requests",
+  "settings.infraBilling.requestsDescription":
+    "CDN and shared infrastructure requests.",
+  "settings.infraBilling.dataTransfer": "Data transfer",
+  "settings.infraBilling.dataTransferDescription":
+    "Bandwidth served from the edge and the origin.",
+  "settings.infraBilling.noInvoices": "No invoices issued for this site.",
+  "settings.infraBilling.invoiceReference": "Reference",
+  "settings.infraBilling.invoiceDue": "Due date",
+  "settings.infraBilling.invoiceAmount": "Amount",
+  "settings.infraBilling.invoiceStatus": "Status",
+  "settings.infraBilling.invoiceDocuments": "Documents",
+  "settings.infraBilling.invoiceNf": "Invoice",
+  "settings.infraBilling.invoiceBankSlip": "Bank slip",
+  "settings.infraBilling.invoiceBankTransfer": "Bank transfer",
+  "settings.infraBilling.statusPaid": "Paid",
+  "settings.infraBilling.statusOverdue": "Overdue",
+  "settings.infraBilling.statusPending": "Pending",
 } as const;

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -10,6 +10,7 @@ export const settings = {
   "settings.nav.secrets": "Segredos",
   "settings.nav.apiKeys": "Chaves de API",
   "settings.nav.billing": "Cobrança",
+  "settings.nav.infraBilling": "Cobrança de infra",
   "settings.nav.buckets": "Buckets",
   "settings.nav.syncedRepos": "Repos sincronizados",
   "settings.syncedRepos.pageDescription":
@@ -815,4 +816,49 @@ export const settings = {
     "Não foi possível iniciar o checkout: {message}",
   "settings.billing.portalError":
     "Não foi possível abrir o portal de cobrança: {message}",
+
+  "settings.infraBilling.pageTitle": "Cobrança de infra",
+  "settings.infraBilling.noSites":
+    "Esta organização ainda não é dona de nenhum site deco.cx.",
+  "settings.infraBilling.siteLabel": "Sites",
+  "settings.infraBilling.pickASite": "Selecione ao menos um site.",
+  "settings.infraBilling.multipleTeams":
+    "Plano e faturas são de um único time legado — filtre a seleção para vê-los.",
+  "settings.infraBilling.monthLabel": "Mês",
+  "settings.infraBilling.warehouseUnavailable":
+    "Os dados de uso não estão disponíveis nesta instalação.",
+  "settings.infraBilling.summaryTitle": "Resumo",
+  "settings.infraBilling.metricsTitle": "Métricas",
+  "settings.infraBilling.invoicesTitle": "Faturas",
+  "settings.infraBilling.detailsTitle": "Detalhes de cobrança",
+  "settings.infraBilling.currentPlan": "Plano atual",
+  "settings.infraBilling.nextBilling": "Próxima cobrança",
+  "settings.infraBilling.manageButton": "Gerenciar",
+  "settings.infraBilling.portalError":
+    "Não foi possível abrir o portal de cobrança: {message}",
+  "settings.infraBilling.requestsPerPageview": "Requisições por pageview",
+  "settings.infraBilling.plan.free": "Free",
+  "settings.infraBilling.plan.pro": "Pro",
+  "settings.infraBilling.plan.enterprise": "Enterprise",
+  "settings.infraBilling.pageviews": "Pageviews",
+  "settings.infraBilling.pageviewsDescription":
+    "Páginas entregues a visitantes neste mês.",
+  "settings.infraBilling.requests": "Requisições",
+  "settings.infraBilling.requestsDescription":
+    "Requisições de CDN e da infraestrutura compartilhada.",
+  "settings.infraBilling.dataTransfer": "Transferência de dados",
+  "settings.infraBilling.dataTransferDescription":
+    "Banda entregue pela edge e pela origem.",
+  "settings.infraBilling.noInvoices": "Nenhuma fatura emitida para este site.",
+  "settings.infraBilling.invoiceReference": "Referência",
+  "settings.infraBilling.invoiceDue": "Vencimento",
+  "settings.infraBilling.invoiceAmount": "Valor",
+  "settings.infraBilling.invoiceStatus": "Status",
+  "settings.infraBilling.invoiceDocuments": "Documentos",
+  "settings.infraBilling.invoiceNf": "Nota fiscal",
+  "settings.infraBilling.invoiceBankSlip": "Boleto",
+  "settings.infraBilling.invoiceBankTransfer": "Transferência",
+  "settings.infraBilling.statusPaid": "Paga",
+  "settings.infraBilling.statusOverdue": "Vencida",
+  "settings.infraBilling.statusPending": "Pendente",
 } satisfies Record<keyof typeof settingsEn, string>;

--- a/apps/web/src/layouts/settings-layout.tsx
+++ b/apps/web/src/layouts/settings-layout.tsx
@@ -55,6 +55,7 @@ import { useProjectContext } from "@/sdk";
 import { useT } from "@/i18n/use-t.ts";
 import { useCapabilities, type CapabilityId } from "@/hooks/use-capability";
 import { usePendingJoinRequests } from "@/hooks/use-join-requests";
+import { useOwnedSites } from "@/hooks/use-infra-billing";
 import { useIsMobile } from "@decocms/ui/hooks/use-mobile.ts";
 import { Suspense } from "react";
 import { useStatusSounds } from "../hooks/use-status-sounds";
@@ -92,6 +93,7 @@ function useSettingsSidebarGroups(): SettingsNavGroup[] {
   const t = useT();
   const { capabilities, isPrivileged, loading, error } = useCapabilities();
   const joinRequestCount = usePendingJoinRequests().length;
+  const ownsSites = useOwnedSites().sites.length > 0;
 
   const groups: SettingsNavGroup[] = [
     {
@@ -135,6 +137,18 @@ function useSettingsSidebarGroups(): SettingsNavGroup[] {
           // `members:manage` group).
           requires: "members:manage",
         },
+        // Absent for orgs that own no legacy deco.cx site — nothing to bill.
+        ...(ownsSites
+          ? [
+              {
+                key: "infra-billing",
+                label: t("settings.nav.infraBilling"),
+                icon: <BarChart10 size={14} />,
+                to: "/$org/settings/infra-billing",
+                requires: "members:manage" as const,
+              },
+            ]
+          : []),
         {
           key: "secrets",
           label: t("settings.nav.secrets"),

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -205,6 +205,12 @@ export const KEYS = {
   organizationTaskQuota: (organizationId: string) =>
     ["organization-task-quota", organizationId] as const,
 
+  infraBillingSites: (organizationId: string) =>
+    ["infra-billing-sites", organizationId] as const,
+
+  infraBilling: (organizationId: string, siteSlug: string, period: string) =>
+    ["infra-billing", organizationId, siteSlug, period] as const,
+
   userModelPreferences: (organizationId: string) =>
     ["user-model-preferences", organizationId] as const,
 

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -482,6 +482,14 @@ const settingsBillingRoute = createRoute({
   ),
 });
 
+const settingsInfraBillingRoute = createRoute({
+  getParentRoute: () => settingsLayout,
+  path: "/infra-billing",
+  component: lazyRouteComponent(
+    () => import("./routes/orgs/settings/infra-billing.tsx"),
+  ),
+});
+
 const settingsSecretsRoute = createRoute({
   getParentRoute: () => settingsLayout,
   path: "/secrets",
@@ -609,6 +617,7 @@ const settingsWithChildren = settingsLayout.addChildren([
   settingsBrandContextRoute,
   settingsAiProvidersRoute,
   settingsBillingRoute,
+  settingsInfraBillingRoute,
   settingsSecretsRoute,
   settingsApiKeysRoute,
   settingsBucketsRoute,

--- a/apps/web/src/routes/orgs/settings/infra-billing.tsx
+++ b/apps/web/src/routes/orgs/settings/infra-billing.tsx
@@ -1,0 +1,10 @@
+import { OrgInfraBillingPage } from "@/views/settings/infra-billing";
+import { RequireCapability } from "@/components/require-capability";
+
+export default function InfraBillingRoute() {
+  return (
+    <RequireCapability capability="members:manage" area="billing">
+      <OrgInfraBillingPage />
+    </RequireCapability>
+  );
+}

--- a/apps/web/src/views/settings/infra-billing.tsx
+++ b/apps/web/src/views/settings/infra-billing.tsx
@@ -1,0 +1,578 @@
+/**
+ * Settings > Infra Billing — a port of the deco.cx admin's billing dashboard
+ * for orgs that still own legacy sites (`org_sites`). Read-only: usage,
+ * plan and issued invoices. Scoped to one site at a time, since Studio's
+ * ownership unit is the site slug, not the legacy team.
+ */
+
+import { useState } from "react";
+import { CreditCard01, LinkExternal01 } from "@untitledui/icons";
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { Badge } from "@decocms/ui/components/badge.tsx";
+import { Button } from "@decocms/ui/components/button.tsx";
+import { Card } from "@decocms/ui/components/card.tsx";
+import { MultiSelect } from "@decocms/ui/components/multi-select.tsx";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@decocms/ui/components/select.tsx";
+import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@decocms/ui/components/table.tsx";
+import { Page } from "@/components/page";
+import {
+  SettingsPage,
+  SettingsSection,
+} from "@/components/settings/settings-section";
+import { useT } from "@/i18n/use-t.ts";
+import {
+  useInfraBilling,
+  useInfraBillingPortal,
+  useOwnedSites,
+} from "@/hooks/use-infra-billing";
+
+type UsageRow = {
+  date: string;
+  requests: number;
+  dataTransferBytes: number;
+  pageviews: number;
+};
+
+type MetricKey = keyof Omit<UsageRow, "date">;
+
+const NUMBER_FMT = new Intl.NumberFormat(undefined, {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+
+const BYTE_UNITS = ["B", "KB", "MB", "GB", "TB", "PB"];
+
+function formatBytes(bytes: number): string {
+  if (bytes <= 0) return "0 B";
+  const exponent = Math.min(
+    BYTE_UNITS.length - 1,
+    Math.floor(Math.log(bytes) / Math.log(1024)),
+  );
+  const value = bytes / 1024 ** exponent;
+  return `${value.toFixed(value >= 100 || exponent === 0 ? 0 : 1)} ${BYTE_UNITS[exponent]}`;
+}
+
+/** Bank-transfer instructions, for teams billed by transfer rather than boleto. */
+const BANK_TRANSFER_PDF_URL =
+  "https://assets.decocache.com/decocms/45f9e905-046b-4aeb-8420-0377a7d0d041/deco_Transferencia.pdf";
+
+/** Legacy invoices are issued in BRL. */
+const CURRENCY_FMT = new Intl.NumberFormat("pt-BR", {
+  style: "currency",
+  currency: "BRL",
+});
+
+/** The last 12 months, newest first, as "YYYY-MM-01" values. */
+function monthOptions(): { value: string; label: string }[] {
+  const now = new Date();
+  return Array.from({ length: 12 }, (_, i) => {
+    const date = new Date(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - i, 1),
+    );
+    return {
+      value: date.toISOString().slice(0, 10),
+      label: date.toLocaleDateString(undefined, {
+        month: "long",
+        year: "numeric",
+        timeZone: "UTC",
+      }),
+    };
+  });
+}
+
+function dayLabel(date: string): string {
+  return new Date(`${date}T00:00:00Z`).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+function UsageChart({
+  usage,
+  metric,
+  colorNum,
+  formatValue,
+  height,
+}: {
+  usage: UsageRow[];
+  metric: MetricKey;
+  colorNum: number;
+  formatValue: (value: number) => string;
+  height: number;
+}) {
+  const color = `var(--chart-${colorNum})`;
+  const gradientId = `infra-billing-${metric}`;
+  const data = usage.map((row) => ({ ...row, label: dayLabel(row.date) }));
+
+  return (
+    <ResponsiveContainer width="100%" height={height}>
+      <AreaChart data={data} margin={{ left: 0, right: 4, top: 8, bottom: 0 }}>
+        <defs>
+          <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%" stopColor={color} stopOpacity={0.25} />
+            <stop offset="100%" stopColor={color} stopOpacity={0} />
+          </linearGradient>
+        </defs>
+        {height > 100 && (
+          <>
+            <CartesianGrid
+              strokeDasharray="4 4"
+              stroke="var(--border)"
+              strokeOpacity={0.5}
+              vertical={false}
+            />
+            <XAxis
+              dataKey="label"
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
+              interval="preserveStartEnd"
+              tickMargin={8}
+            />
+            <YAxis
+              orientation="right"
+              axisLine={false}
+              tickLine={false}
+              tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
+              tickFormatter={formatValue}
+              width={68}
+            />
+          </>
+        )}
+        <Tooltip
+          cursor={{ stroke: "var(--border)", strokeDasharray: "4 4" }}
+          contentStyle={{
+            background: "var(--background)",
+            border: "1px solid var(--border)",
+            borderRadius: 8,
+            fontSize: 12,
+          }}
+          formatter={(value) => formatValue(Number(value) || 0)}
+        />
+        <Area
+          type="linear"
+          dataKey={metric}
+          stroke={color}
+          strokeWidth={2}
+          fill={`url(#${gradientId})`}
+          dot={false}
+        />
+      </AreaChart>
+    </ResponsiveContainer>
+  );
+}
+
+function sum(usage: UsageRow[], metric: MetricKey): number {
+  return usage.reduce((total, row) => total + row[metric], 0);
+}
+
+function InfraBillingContent() {
+  const t = useT();
+  const { sites, isLoading: sitesLoading } = useOwnedSites();
+  /** null = not narrowed, which reads as every site the org owns. */
+  const [narrowedTo, setNarrowedTo] = useState<string[] | null>(null);
+  const months = monthOptions();
+  const [period, setPeriod] = useState(months[0]!.value);
+
+  const selected = narrowedTo ?? sites;
+  const { data, isLoading } = useInfraBilling(selected, period);
+  const portal = useInfraBillingPortal();
+
+  if (sitesLoading) {
+    return <Skeleton className="h-64 w-full" />;
+  }
+  if (sites.length === 0) {
+    return (
+      <Card className="p-6 text-sm text-muted-foreground">
+        {t("settings.infraBilling.noSites")}
+      </Card>
+    );
+  }
+
+  const usage = data?.usage ?? [];
+  const pageviewsAvailable = data?.pageviewsAvailable ?? false;
+
+  const metrics: {
+    key: MetricKey;
+    title: string;
+    description: string;
+    colorNum: number;
+    total: string;
+  }[] = [
+    {
+      key: "pageviews",
+      title: t("settings.infraBilling.pageviews"),
+      description: t("settings.infraBilling.pageviewsDescription"),
+      colorNum: 1,
+      total: pageviewsAvailable
+        ? NUMBER_FMT.format(sum(usage, "pageviews"))
+        : "—",
+    },
+    {
+      key: "requests",
+      title: t("settings.infraBilling.requests"),
+      description: t("settings.infraBilling.requestsDescription"),
+      colorNum: 2,
+      total: NUMBER_FMT.format(sum(usage, "requests")),
+    },
+    {
+      key: "dataTransferBytes",
+      title: t("settings.infraBilling.dataTransfer"),
+      description: t("settings.infraBilling.dataTransferDescription"),
+      colorNum: 3,
+      total: formatBytes(sum(usage, "dataTransferBytes")),
+    },
+  ];
+
+  const formatFor = (key: MetricKey) =>
+    key === "dataTransferBytes"
+      ? formatBytes
+      : (value: number) => NUMBER_FMT.format(value);
+
+  const billing = data?.billing ?? null;
+  /** One boleto in the team's history means boleto is how they pay. */
+  const teamUsesBankSlip = (billing?.invoices ?? []).some(
+    (i) => !!i.bankSlipUrl,
+  );
+
+  const totalPageviews = sum(usage, "pageviews");
+  const requestRatio =
+    pageviewsAvailable && totalPageviews > 0
+      ? (sum(usage, "requests") / totalPageviews).toFixed(0)
+      : "—";
+
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="flex flex-wrap items-center gap-3 px-4">
+        <MultiSelect
+          className="w-auto min-w-56 max-w-full"
+          options={sites.map((slug) => ({ label: slug, value: slug }))}
+          defaultValue={selected}
+          maxCount={2}
+          placeholder={t("settings.infraBilling.siteLabel")}
+          onValueChange={setNarrowedTo}
+        />
+        <Select value={period} onValueChange={setPeriod}>
+          <SelectTrigger
+            className="w-48"
+            aria-label={t("settings.infraBilling.monthLabel")}
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {months.map((month) => (
+              <SelectItem key={month.value} value={month.value}>
+                {month.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {selected.length === 0 && (
+        <Card className="mx-4 p-4 text-sm text-muted-foreground">
+          {t("settings.infraBilling.pickASite")}
+        </Card>
+      )}
+
+      {data?.usageUnavailable && (
+        <Card className="mx-4 p-4 text-sm text-muted-foreground">
+          {t("settings.infraBilling.warehouseUnavailable")}
+        </Card>
+      )}
+
+      <SettingsSection title={t("settings.infraBilling.summaryTitle")}>
+        <div className="flex flex-col lg:flex-row gap-4 px-4">
+          <Card className="flex-1 flex flex-col gap-4 p-4">
+            <div className="flex items-center justify-between gap-2">
+              <div className="flex items-center gap-2">
+                <CreditCard01 size={16} className="text-muted-foreground" />
+                <span className="text-sm font-medium">
+                  {t("settings.infraBilling.detailsTitle")}
+                </span>
+              </div>
+              {billing?.canManageSubscription && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={portal.isPending}
+                  onClick={() => portal.mutate(selected[0]!)}
+                >
+                  {t("settings.infraBilling.manageButton")}
+                </Button>
+              )}
+            </div>
+            <div className="flex flex-col gap-2 text-sm">
+              {billing ? (
+                <>
+                  <div className="flex justify-between gap-3">
+                    <span className="text-muted-foreground">
+                      {t("settings.infraBilling.currentPlan")}
+                    </span>
+                    {isLoading ? (
+                      <Skeleton className="h-5 w-16" />
+                    ) : (
+                      <Badge
+                        variant={
+                          billing.planType === "free" ? "secondary" : "success"
+                        }
+                      >
+                        {t(`settings.infraBilling.plan.${billing.planType}`)}
+                      </Badge>
+                    )}
+                  </div>
+                  <div className="flex justify-between gap-3">
+                    <span className="text-muted-foreground">
+                      {t("settings.infraBilling.nextBilling")}
+                    </span>
+                    <span className="font-medium tabular-nums">
+                      {billing.nextBillingDate
+                        ? new Date(
+                            `${billing.nextBillingDate}T00:00:00Z`,
+                          ).toLocaleDateString(undefined, {
+                            day: "numeric",
+                            month: "short",
+                            year: "numeric",
+                            timeZone: "UTC",
+                          })
+                        : "—"}
+                    </span>
+                  </div>
+                </>
+              ) : (
+                !isLoading && (
+                  <p className="text-xs text-muted-foreground">
+                    {t("settings.infraBilling.multipleTeams")}
+                  </p>
+                )
+              )}
+              <div className="flex justify-between gap-3">
+                <span className="text-muted-foreground">
+                  {t("settings.infraBilling.requestsPerPageview")}
+                </span>
+                <span className="font-medium tabular-nums">{requestRatio}</span>
+              </div>
+            </div>
+          </Card>
+
+          {metrics.map((metric) => (
+            <Card key={metric.key} className="flex-1 flex flex-col gap-2 p-4">
+              <div className="flex items-baseline justify-between gap-2">
+                <span className="text-sm font-medium">{metric.title}</span>
+                <span className="text-xs text-muted-foreground">
+                  {months.find((m) => m.value === period)?.label}
+                </span>
+              </div>
+              {isLoading ? (
+                <Skeleton className="h-8 w-24" />
+              ) : (
+                <span className="text-2xl font-semibold tabular-nums">
+                  {metric.total}
+                </span>
+              )}
+              <div className="-mx-2">
+                <UsageChart
+                  usage={usage}
+                  metric={metric.key}
+                  colorNum={metric.colorNum}
+                  formatValue={formatFor(metric.key)}
+                  height={64}
+                />
+              </div>
+            </Card>
+          ))}
+        </div>
+      </SettingsSection>
+
+      <SettingsSection title={t("settings.infraBilling.metricsTitle")}>
+        <div className="flex flex-col xl:flex-row gap-4 px-4">
+          {metrics.map((metric) => (
+            <Card key={metric.key} className="flex-1 flex flex-col gap-3 p-4">
+              <div className="flex flex-col gap-1">
+                <span className="text-sm font-medium">{metric.title}</span>
+                <span className="text-xs text-muted-foreground">
+                  {metric.description}
+                </span>
+              </div>
+              <UsageChart
+                usage={usage}
+                metric={metric.key}
+                colorNum={metric.colorNum}
+                formatValue={formatFor(metric.key)}
+                height={220}
+              />
+            </Card>
+          ))}
+        </div>
+      </SettingsSection>
+
+      <SettingsSection title={t("settings.infraBilling.invoicesTitle")}>
+        <Card className="mx-4 overflow-x-auto">
+          {data && (billing?.invoices.length ?? 0) === 0 ? (
+            <p className="p-4 text-sm text-muted-foreground">
+              {billing
+                ? t("settings.infraBilling.noInvoices")
+                : t("settings.infraBilling.multipleTeams")}
+            </p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>
+                    {t("settings.infraBilling.invoiceReference")}
+                  </TableHead>
+                  <TableHead>{t("settings.infraBilling.invoiceDue")}</TableHead>
+                  <TableHead>
+                    {t("settings.infraBilling.invoiceAmount")}
+                  </TableHead>
+                  <TableHead>
+                    {t("settings.infraBilling.invoiceStatus")}
+                  </TableHead>
+                  <TableHead>
+                    {t("settings.infraBilling.invoiceDocuments")}
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {(billing?.invoices ?? []).map((invoice) => (
+                  <TableRow key={invoice.id}>
+                    <TableCell>
+                      {invoice.referenceMonth
+                        ? new Date(invoice.referenceMonth).toLocaleDateString(
+                            undefined,
+                            { month: "long", year: "numeric", timeZone: "UTC" },
+                          )
+                        : "—"}
+                    </TableCell>
+                    <TableCell>
+                      {invoice.dueDate
+                        ? new Date(invoice.dueDate).toLocaleDateString(
+                            undefined,
+                            {
+                              day: "numeric",
+                              month: "short",
+                              year: "numeric",
+                              timeZone: "UTC",
+                            },
+                          )
+                        : "—"}
+                    </TableCell>
+                    <TableCell className="tabular-nums">
+                      {CURRENCY_FMT.format(invoice.value)}
+                    </TableCell>
+                    <TableCell>
+                      <InvoiceStatus status={invoice.status} />
+                    </TableCell>
+                    <TableCell className="flex gap-2">
+                      {invoice.nfUrl && (
+                        <DocumentLink
+                          href={invoice.nfUrl}
+                          label={t("settings.infraBilling.invoiceNf")}
+                        />
+                      )}
+                      {invoice.bankSlipUrl && (
+                        <DocumentLink
+                          href={invoice.bankSlipUrl}
+                          label={t("settings.infraBilling.invoiceBankSlip")}
+                        />
+                      )}
+                      {!invoice.bankSlipUrl &&
+                        !teamUsesBankSlip &&
+                        invoice.nfUrl && (
+                          <DocumentLink
+                            href={BANK_TRANSFER_PDF_URL}
+                            label={t(
+                              "settings.infraBilling.invoiceBankTransfer",
+                            )}
+                          />
+                        )}
+                      {!invoice.nfUrl && !invoice.bankSlipUrl && "—"}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </Card>
+      </SettingsSection>
+    </div>
+  );
+}
+
+/** A downloadable invoice document — an outline button so it reads as an
+ *  action, not as the plain text in the cell next to it. */
+function DocumentLink({ href, label }: { href: string; label: string }) {
+  return (
+    <Button variant="outline" size="sm" asChild>
+      <a href={href} target="_blank" rel="noreferrer">
+        <LinkExternal01 size={14} />
+        {label}
+      </a>
+    </Button>
+  );
+}
+
+/** Status comes from the legacy mirror in mixed casing; normalize to compare. */
+function InvoiceStatus({ status }: { status: string }) {
+  const t = useT();
+  const normalized = status.toLowerCase();
+  if (normalized === "paid") {
+    return (
+      <Badge variant="success">{t("settings.infraBilling.statusPaid")}</Badge>
+    );
+  }
+  if (normalized === "overdue") {
+    return (
+      <Badge variant="destructive">
+        {t("settings.infraBilling.statusOverdue")}
+      </Badge>
+    );
+  }
+  if (normalized === "registered") {
+    return (
+      <Badge variant="warning">
+        {t("settings.infraBilling.statusPending")}
+      </Badge>
+    );
+  }
+  return <Badge variant="secondary">{status}</Badge>;
+}
+
+export function OrgInfraBillingPage() {
+  const t = useT();
+  return (
+    <Page>
+      <Page.Content>
+        <Page.Body>
+          <SettingsPage>
+            <Page.Title>{t("settings.infraBilling.pageTitle")}</Page.Title>
+            <InfraBillingContent />
+          </SettingsPage>
+        </Page.Body>
+      </Page.Content>
+    </Page>
+  );
+}

--- a/packages/e2e/tests/infra-billing-tenancy.spec.ts
+++ b/packages/e2e/tests/infra-billing-tenancy.spec.ts
@@ -1,0 +1,120 @@
+/**
+ * Infra Billing is scoped by `org_sites` ownership, and that ownership is the
+ * ONLY thing standing between one tenant and another tenant's usage and
+ * invoices — site slugs are globally unique and guessable (they're public
+ * hostnames). So this asserts, over the wire:
+ *
+ *   - a fresh org owns nothing → the feature is absent (empty site list);
+ *   - the owning org reads its own site;
+ *   - a second org asking for that same slug is rejected, not served.
+ *
+ * The usage numbers themselves need the legacy analytics warehouse, which the
+ * e2e stack has no credentials for; the ownership gate runs before any of that
+ * and is what a regression would silently break.
+ */
+
+import { type Client } from "pg";
+import { connectDevDb } from "../fixtures/db";
+import { signUpViaApi } from "../fixtures/auth-api";
+import { callSelfMcpTool } from "../fixtures/mcp-tools";
+import { expect, newApiContext, test } from "../fixtures/test";
+
+interface SitesList {
+  sites: { slug: string }[];
+}
+
+test.describe("Infra billing site tenancy", () => {
+  let db: Client;
+
+  test.beforeAll(async () => {
+    db = await connectDevDb();
+  });
+
+  test.afterAll(async () => {
+    await db?.end();
+  });
+
+  test("only the owning org can read a site's infra billing", async ({
+    playwright,
+  }) => {
+    const ownerCtx = await newApiContext(playwright);
+    const owner = await signUpViaApi(ownerCtx);
+    const otherCtx = await newApiContext(playwright);
+    const other = await signUpViaApi(otherCtx);
+
+    // Fresh orgs own no site — the nav gate reads exactly this.
+    const before = await callSelfMcpTool<SitesList>(
+      ownerCtx,
+      owner.orgSlug,
+      "INFRA_BILLING_SITES_LIST",
+      {},
+    );
+    expect(before.sites).toEqual([]);
+
+    const slug = `e2e-site-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const ownerOrgId = (
+      await db.query<{ id: string }>(
+        `SELECT id FROM "organization" WHERE slug = $1`,
+        [owner.orgSlug],
+      )
+    ).rows[0]!.id;
+
+    await db.query(
+      `INSERT INTO org_sites
+         (slug, organization_id, source, created_by, updated_by)
+       VALUES ($1, $2, 'manual', $3, $3)`,
+      [slug, ownerOrgId, owner.userId],
+    );
+
+    try {
+      const after = await callSelfMcpTool<SitesList>(
+        ownerCtx,
+        owner.orgSlug,
+        "INFRA_BILLING_SITES_LIST",
+        {},
+      );
+      expect(after.sites).toEqual([{ slug }]);
+
+      // The owner is served (usage may be empty without a warehouse).
+      const billing = await callSelfMcpTool<{ siteSlugs: string[] }>(
+        ownerCtx,
+        owner.orgSlug,
+        "INFRA_BILLING_GET",
+        { siteSlugs: [slug] },
+      );
+      expect(billing.siteSlugs).toEqual([slug]);
+
+      // The gate inspects EVERY slug, not just the first one.
+      await expect(
+        callSelfMcpTool(ownerCtx, owner.orgSlug, "INFRA_BILLING_GET", {
+          siteSlugs: [slug, `${slug}-not-owned`],
+        }),
+      ).rejects.toThrow(/not found/i);
+
+      // A different tenant naming the same slug must be refused.
+      expect(other.orgSlug).not.toBe(owner.orgSlug);
+      await expect(
+        callSelfMcpTool(otherCtx, other.orgSlug, "INFRA_BILLING_GET", {
+          siteSlugs: [slug],
+        }),
+      ).rejects.toThrow(/not found/i);
+
+      // Same gate on the portal — it mints a Stripe session for the site's team.
+      await expect(
+        callSelfMcpTool(otherCtx, other.orgSlug, "INFRA_BILLING_PORTAL", {
+          siteSlug: slug,
+        }),
+      ).rejects.toThrow(/not found/i);
+
+      const otherSites = await callSelfMcpTool<SitesList>(
+        otherCtx,
+        other.orgSlug,
+        "INFRA_BILLING_SITES_LIST",
+        {},
+      );
+      expect(otherSites.sites).toEqual([]);
+    } finally {
+      await db.query(`DELETE FROM org_sites WHERE slug = $1`, [slug]);
+    }
+  });
+});

--- a/packages/shared/src/tools/registry-metadata.ts
+++ b/packages/shared/src/tools/registry-metadata.ts
@@ -76,6 +76,10 @@ const ALL_TOOL_NAMES = [
   "ORGANIZATION_BILLING_CHECKOUT_START",
   "ORGANIZATION_BILLING_PORTAL",
   "ORGANIZATION_TASK_QUOTA_GET",
+  // Legacy deco.cx infra billing
+  "INFRA_BILLING_SITES_LIST",
+  "INFRA_BILLING_GET",
+  "INFRA_BILLING_PORTAL",
   // Connection tools
   "COLLECTION_CONNECTIONS_CREATE",
   "COLLECTION_CONNECTIONS_LIST",
@@ -430,6 +434,22 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
   {
     name: "ORGANIZATION_TASK_QUOTA_GET",
     description: "Get the org's auto-task quota usage",
+    category: "Organizations",
+  },
+  // Legacy deco.cx infra billing
+  {
+    name: "INFRA_BILLING_SITES_LIST",
+    description: "List the legacy deco.cx sites the org owns",
+    category: "Organizations",
+  },
+  {
+    name: "INFRA_BILLING_GET",
+    description: "Get infra usage, plan and invoices for an owned site",
+    category: "Organizations",
+  },
+  {
+    name: "INFRA_BILLING_PORTAL",
+    description: "Open the Stripe billing portal for an owned site",
     category: "Organizations",
   },
   // Connection tools
@@ -1327,6 +1347,10 @@ const PERMISSION_CAPABILITIES: PermissionCapability[] = [
       "ORGANIZATION_BILLING_CHECKOUT_START",
       "ORGANIZATION_BILLING_PORTAL",
       "ORGANIZATION_TASK_QUOTA_GET",
+      // Legacy deco.cx infra usage, invoices and Stripe portal for owned sites.
+      "INFRA_BILLING_SITES_LIST",
+      "INFRA_BILLING_GET",
+      "INFRA_BILLING_PORTAL",
       // Approving/denying join requests adds members, and the UI lives on the
       // members page — keep it under members:manage.
       "ORGANIZATION_JOIN_REQUEST_LIST",

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -1105,6 +1105,44 @@ export interface StudioToolIO {
       currentPeriodEnd: string | null;
     };
   };
+  INFRA_BILLING_SITES_LIST: {
+    input: { [x: string]: never };
+    output: { sites: { slug: string }[] };
+  };
+  INFRA_BILLING_GET: {
+    input: { siteSlugs: string[]; period?: string | undefined };
+    output: {
+      siteSlugs: string[];
+      since: string;
+      until: string;
+      usage: {
+        date: string;
+        requests: number;
+        dataTransferBytes: number;
+        pageviews: number;
+      }[];
+      pageviewsAvailable: boolean;
+      usageUnavailable: boolean;
+      billing: {
+        planType: "free" | "pro" | "enterprise";
+        nextBillingDate: string | null;
+        canManageSubscription: boolean;
+        invoices: {
+          id: string;
+          status: string;
+          dueDate: string | null;
+          value: number;
+          referenceMonth: string | null;
+          nfUrl: string | null;
+          bankSlipUrl: string | null;
+        }[];
+      } | null;
+    };
+  };
+  INFRA_BILLING_PORTAL: {
+    input: { siteSlug: string };
+    output: { url: string };
+  };
   COLLECTION_CONNECTIONS_CREATE: {
     input: {
       data: {


### PR DESCRIPTION
## Summary

Adds **Settings → Infra Billing** for organizations that still own deco.cx
sites: monthly usage (pageviews, requests, data transfer), the legacy plan and
its issued invoices. Ported from the deco.cx admin's billing dashboard, with
Studio's design system.

Two deliberate differences from the old screen:

- **Scoped by `org_sites` ownership**, not by legacy team — that is Studio's
  tenancy unit. The site picker is a multi-select that defaults to every site
  the org owns. Hosts are deduped across the selection before summing
  shared-infra usage and pageviews, so a host shared by two sites is not
  double-counted.
- **Read-only.** Plan and invoices are reported only when the whole selection
  rolls up to a single legacy team (they belong to the team, not the site) —
  otherwise the UI says so instead of showing another team's invoice. The one
  write is a Stripe Customer Portal session, on the same Stripe account as
  Studio's own subscription.

## Where it lives

The entire seam to the old platform is `apps/api/src/deco-legacy/` — analytics
warehouse client, pageview client, Supabase reads, aggregation — so it can be
deleted in one piece once billing finishes moving into Studio. Three tools
(`INFRA_BILLING_SITES_LIST`, `INFRA_BILLING_GET`, `INFRA_BILLING_PORTAL`) sit
under the existing `members:manage` capability, next to Billing.

`supabaseGet`/`supabasePost` moved out of `api/routes/deco-sites.ts` into that
module; the route now imports them (no duplicate fetch helper).

## Gating

No flag. The nav item shows when the org owns ≥1 row in `org_sites` **and** the
member has `members:manage`. Deployment env does not gate it: without the
warehouse the page renders with a "usage data is unavailable" notice, and plan
and invoices still load.

## Config

New and optional, all fail-soft:

| Env | Effect when unset |
| --- | --- |
| `CLICKHOUSE_ANALYTICS_ADDRESS` / `_USERNAME` / `_PASSWORD` | usage cards and charts empty, with a notice. A **different** instance from `CLICKHOUSE_URL`, which is Studio's own monitoring store. |
| `ONEDOLLAR_BACKEND_API_KEY` | pageviews render `—` rather than a wrong `0` |

`DECO_SUPABASE_URL` / `_SERVICE_KEY` and `STRIPE_SECRET_KEY` already existed.

## Notes for the reviewer

- The client sends **no** compression setting: it is a per-query setting a
  `readonly` ClickHouse user may not change (error 164), and least privilege is
  exactly the kind of user this should run as. Verified against a read-only
  user; with compression on, every query failed and the page rendered a silent
  all-zeros dashboard.
- Every external read is wrapped so a failure logs and degrades to empty. An
  unconfigured deployment never 500s.
- Ownership is checked for **every** slug in the payload, not just the first.

## Testing

- Unit: `monthInterval`, `planTypeOf`, `nextBillingDate` (pure date/plan logic).
- E2E (`packages/e2e/tests/infra-billing-tenancy.spec.ts`): a fresh org owns
  nothing; the owning org reads its own site; a second org naming the same slug
  is refused on both `INFRA_BILLING_GET` and `INFRA_BILLING_PORTAL`; a payload
  mixing an owned and an unowned slug is refused.
- Verified end to end against the real warehouse, pageview API, legacy Supabase
  and Stripe on a local instance: totals reconcile day-for-day with the old
  admin screen over the same window.

`bun run fmt`, `bun run check`, `bun run lint`, `knip` and `bun test` pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Settings → Infra Billing for orgs that still own deco.cx sites, showing monthly usage (pageviews, requests, data transfer), the legacy plan, and invoices. Previously this lived in the legacy admin and was team‑scoped and writable; now it is org‑scoped by `org_sites`, read‑only, and dedupes shared hosts across a multi‑site selection.

- Tenancy and behavior
  - Three tools behind `members:manage`: `INFRA_BILLING_SITES_LIST`, `INFRA_BILLING_GET`, `INFRA_BILLING_PORTAL`. Every requested slug is ownership‑checked against `org_sites`.
  - Hosts are deduped across the selection before summing shared‑infra usage and pageviews; a shared host is counted once.
  - Plan and invoices are shown only when all selected sites roll up to one legacy team; otherwise the UI explains why.
  - Pageviews render as "—" when OneDollarStats is unavailable; missing analytics renders an empty usage dashboard with a notice. No 500s.

- Implementation and rollout
  - New seam at `apps/api/src/deco-legacy/` (ClickHouse analytics, OneDollarStats, Supabase access). `supabaseGet`/`supabasePost` moved there and are reused.
  - `stripe-api` adds `retrieveSubscription`; the portal tool opens a Stripe Customer Portal session and returns to the Infra Billing page.
  - Web: new route, hooks, and i18n; nav item appears only if the org owns ≥1 `org_sites` row and the member has `members:manage`.
  - Optional envs (fail‑soft): `CLICKHOUSE_ANALYTICS_ADDRESS`/`_USERNAME`/`_PASSWORD` (separate from `CLICKHOUSE_URL`) for usage; `ONEDOLLAR_BACKEND_API_KEY` for pageviews. Existing `DECO_SUPABASE_*` and `STRIPE_SECRET_KEY` are used.
  - E2E tests assert per‑slug ownership gates for reads and the portal; a non‑owning org cannot access another org’s site.

<sup>Written for commit 53a5ed5dfc19245a8bd67ad0dd02a09607aeb250. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6141?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

