### PR TITLE
fix(infra-billing): scope legacy billing to fully-owned teams, harden reads

### DIFF
--- a/apps/api/src/deco-legacy/clickhouse-analytics.ts
+++ b/apps/api/src/deco-legacy/clickhouse-analytics.ts
@@ -15,6 +15,11 @@ type ClickHouseClient = import("@clickhouse/client").ClickHouseClient;
 
 let clientPromise: Promise<ClickHouseClient> | null = null;
 
+/** Client-side ceiling. `MAX_EXECUTION_SECONDS` is the server-side one that
+ *  actually stops the query; this only bounds how long we wait for it. */
+const REQUEST_TIMEOUT_MS = 20_000;
+const MAX_EXECUTION_SECONDS = 15;
+
 export function isAnalyticsConfigured(): boolean {
   const s = getSettings();
   return !!(s.clickhouseAnalyticsUrl && s.clickhouseAnalyticsPassword);
@@ -23,15 +28,21 @@ export function isAnalyticsConfigured(): boolean {
 async function getClient(): Promise<ClickHouseClient> {
   if (!clientPromise) {
     const s = getSettings();
-    clientPromise = import("@clickhouse/client").then(({ createClient }) =>
-      createClient({
-        url: s.clickhouseAnalyticsUrl,
-        username: s.clickhouseAnalyticsUsername,
-        password: s.clickhouseAnalyticsPassword,
-        request_timeout: 60_000,
-        // Compression is a per-query setting a `readonly` user may not set (164).
-      }),
-    );
+    clientPromise = import("@clickhouse/client")
+      .then(({ createClient }) =>
+        createClient({
+          url: s.clickhouseAnalyticsUrl,
+          username: s.clickhouseAnalyticsUsername,
+          password: s.clickhouseAnalyticsPassword,
+          request_timeout: REQUEST_TIMEOUT_MS,
+          // Compression is a per-query setting a `readonly` user may not set (164).
+        }),
+      )
+      // Uncache on failure, so a bad boot doesn't wedge the process forever.
+      .catch((err) => {
+        clientPromise = null;
+        throw err;
+      });
   }
   return clientPromise;
 }
@@ -51,6 +62,11 @@ export async function analyticsQuery<T>(
     query,
     query_params: params,
     format: "JSONEachRow",
+    // Shared multi-tenant fact tables; same caps as monitoring/query-engine.ts.
+    clickhouse_settings: {
+      max_execution_time: MAX_EXECUTION_SECONDS,
+      max_threads: 1,
+    },
   });
   return result.json<T>();
 }

--- a/apps/api/src/deco-legacy/infra-billing.test.ts
+++ b/apps/api/src/deco-legacy/infra-billing.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "bun:test";
-import { monthInterval, nextBillingDate, planTypeOf } from "./infra-billing";
+import {
+  aggregateUsage,
+  clampUntil,
+  dateRange,
+  monthInterval,
+  nextBillingDate,
+  planTypeOf,
+  toInvoices,
+} from "./infra-billing";
+import { mergePageviews, toOneDollarHostname } from "./onedollarstats";
 
 describe("monthInterval", () => {
   it("spans the full UTC month", () => {
@@ -74,5 +83,155 @@ describe("nextBillingDate", () => {
   it("has no date when stripe schedules nothing", () => {
     expect(nextBillingDate("pro", undefined, now)).toBeNull();
     expect(nextBillingDate("free", undefined, now)).toBeNull();
+  });
+});
+
+describe("aggregateUsage", () => {
+  it("sums CDN and shared-infra rows landing on the same date", () => {
+    const totals = aggregateUsage([
+      { date: "2026-08-01", requests: "10", egress_bytes: "100" },
+      { date: "2026-08-01", requests: 5, egress_bytes: 50 },
+      { date: "2026-08-02", requests: 7, egress_bytes: 70 },
+    ]);
+    expect(totals.get("2026-08-01")).toEqual({ requests: 15, bytes: 150 });
+    expect(totals.get("2026-08-02")).toEqual({ requests: 7, bytes: 70 });
+  });
+
+  it("normalizes a DateTime column down to the calendar day", () => {
+    const totals = aggregateUsage([
+      { date: "2026-08-01 00:00:00", requests: 3, egress_bytes: 30 },
+    ]);
+    expect(totals.get("2026-08-01")).toEqual({ requests: 3, bytes: 30 });
+  });
+
+  it("coerces unparseable sums to zero rather than NaN", () => {
+    const totals = aggregateUsage([
+      { date: "2026-08-01", requests: "oops", egress_bytes: "" },
+    ]);
+    expect(totals.get("2026-08-01")).toEqual({ requests: 0, bytes: 0 });
+  });
+
+  it("is empty for no rows", () => {
+    expect(aggregateUsage([]).size).toBe(0);
+  });
+});
+
+describe("dateRange", () => {
+  it("fills every day inclusive of both ends", () => {
+    expect(dateRange("2026-08-01", "2026-08-31")).toHaveLength(31);
+    expect(dateRange("2024-02-01", "2024-02-29")).toHaveLength(29);
+  });
+
+  it("returns a single day when both ends match", () => {
+    expect(dateRange("2026-08-16", "2026-08-16")).toEqual(["2026-08-16"]);
+  });
+});
+
+describe("clampUntil", () => {
+  const now = new Date("2026-08-16T12:00:00Z");
+
+  it("stops the current month at today", () => {
+    expect(clampUntil("2026-08-31", now)).toBe("2026-08-16");
+  });
+
+  it("leaves a completed month whole", () => {
+    expect(clampUntil("2026-07-31", now)).toBe("2026-07-31");
+  });
+});
+
+describe("toInvoices", () => {
+  const row = {
+    id: 1,
+    status: "Paid",
+    due_date: "2026-08-10",
+    value: 100,
+    reference_month: "2026-08-01",
+    nf_url: null,
+    bank_slip_url: null,
+  };
+
+  it("hides canceled invoices in either spelling", () => {
+    const out = toInvoices([
+      { ...row, id: 1, status: "canceled" },
+      { ...row, id: 2, status: "Cancelled" },
+      { ...row, id: 3, status: "Paid" },
+    ]);
+    expect(out.map((i) => i.id)).toEqual(["3"]);
+  });
+
+  it("keeps a row whose status is missing", () => {
+    expect(toInvoices([{ ...row, status: null }])).toHaveLength(1);
+  });
+
+  it("unwraps a bank slip mirrored as a JSON array", () => {
+    const [invoice] = toInvoices([
+      { ...row, bank_slip_url: '["https://example.com/a.pdf"]' },
+    ]);
+    expect(invoice!.bankSlipUrl).toBe("https://example.com/a.pdf");
+  });
+
+  it("keeps a plain url containing brackets intact", () => {
+    const [invoice] = toInvoices([
+      { ...row, bank_slip_url: "https://example.com/a.pdf?ids[]=1" },
+    ]);
+    expect(invoice!.bankSlipUrl).toBe("https://example.com/a.pdf?ids[]=1");
+  });
+
+  it("drops document links that are not https", () => {
+    const [invoice] = toInvoices([
+      {
+        ...row,
+        nf_url: "javascript:alert(1)",
+        bank_slip_url: "http://example.com/a.pdf",
+      },
+    ]);
+    expect(invoice!.nfUrl).toBeNull();
+    expect(invoice!.bankSlipUrl).toBeNull();
+  });
+
+  it("renders a null amount as zero", () => {
+    expect(toInvoices([{ ...row, value: null }])[0]!.value).toBe(0);
+  });
+});
+
+describe("toOneDollarHostname", () => {
+  it("prefixes a bare custom domain", () => {
+    expect(toOneDollarHostname("example.com")).toBe("www.example.com");
+  });
+
+  it("does not double-prefix a host that already has www", () => {
+    expect(toOneDollarHostname("www.example.com")).toBe("www.example.com");
+  });
+
+  it("leaves deco.site subdomains alone", () => {
+    expect(toOneDollarHostname("shop.deco.site")).toBe("shop.deco.site");
+  });
+});
+
+describe("mergePageviews", () => {
+  const ok = (rows: { dimensions: string[]; metrics: number[] }[]) =>
+    ({ status: "fulfilled", value: rows }) as const;
+
+  it("sums the same day across hosts", () => {
+    const merged = mergePageviews([
+      ok([{ dimensions: ["2026-08-01"], metrics: [10] }]),
+      ok([{ dimensions: ["2026-08-01"], metrics: [5] }]),
+    ]);
+    expect(merged?.get("2026-08-01")).toBe(15);
+  });
+
+  it("normalizes a timestamped dimension to its day", () => {
+    const merged = mergePageviews([
+      ok([{ dimensions: ["2026-08-01 00:00:00"], metrics: [4] }]),
+    ]);
+    expect(merged?.get("2026-08-01")).toBe(4);
+  });
+
+  it("is null when any host failed, so the UI shows a dash not a low number", () => {
+    const merged = mergePageviews([
+      ok([{ dimensions: ["2026-08-01"], metrics: [10] }]),
+      { status: "rejected", reason: new Error("timeout") },
+    ]);
+    expect(merged).toBeNull();
   });
 });

--- a/apps/api/src/deco-legacy/infra-billing.ts
+++ b/apps/api/src/deco-legacy/infra-billing.ts
@@ -25,7 +25,7 @@ export type PlanType = "free" | "pro" | "enterprise";
 export interface DailyUsage {
   date: string;
   requests: number;
-  /** Egress + ingress; the platform bills them together as "data transfer". */
+  /** Egress only — `bandwidth_bytes` is what both usage views expose. */
   dataTransferBytes: number;
   pageviews: number;
 }
@@ -40,6 +40,16 @@ export interface LegacyInvoice {
   nfUrl: string | null;
   bankSlipUrl: string | null;
 }
+
+/**
+ * Why `billing` is null. The UI must not tell a user to "narrow the selection"
+ * when the real cause is a dead warehouse or a team they only partly own.
+ */
+export type BillingUnavailableReason =
+  | "no_team"
+  | "multiple_teams"
+  | "partial_team"
+  | "unavailable";
 
 /**
  * Plan and invoices belong to the legacy TEAM, not the site, so they only make
@@ -63,7 +73,13 @@ export interface SiteInfraBilling {
   /** False when no pageview source answered — the UI must render "—", not 0. */
   pageviewsAvailable: boolean;
   billing: LegacyTeamBilling | null;
-  /** True when the analytics warehouse isn't configured on this deployment. */
+  /** Set whenever `billing` is null, so the UI can say which cause it was. */
+  billingUnavailableReason: BillingUnavailableReason | null;
+  /**
+   * True when usage could not be read at all — warehouse unconfigured OR the
+   * query failed. Either way the zeros in `usage` are absence of data, not
+   * absence of traffic, and the UI must not render them as a real bill.
+   */
   usageUnavailable: boolean;
 }
 
@@ -85,13 +101,15 @@ interface UsageRow {
   date: string;
   requests: string | number;
   egress_bytes: string | number;
-  ingress_bytes?: string | number;
 }
 
+/** Hosts fanned out to. Bounds both the `IN` list and the pageview requests. */
+const MAX_HOSTNAMES = 25;
+
 /**
- * Distinct hosts across the whole selection. Deduped on purpose: two sites can
- * share an origin host, and counting that host's shared-infra traffic (or its
- * pageviews) twice would inflate the total.
+ * Busiest distinct hosts across the whole selection. Deduped on purpose: two
+ * sites can share an origin host, and counting that host's shared-infra traffic
+ * (or its pageviews) twice would inflate the total.
  */
 async function siteHostnames(
   siteSlugs: string[],
@@ -99,65 +117,76 @@ async function siteHostnames(
   until: string,
 ): Promise<string[]> {
   const rows = await analyticsQuery<{ host: string }>(
-    `SELECT DISTINCT host
+    `SELECT host
        FROM default.fact_usage_daily_view
       WHERE site_id IN (SELECT id FROM default.dim_sites WHERE name IN ({sites:Array(String)}))
-        AND date >= {since:Date} AND date <= {until:Date}`,
-    { sites: siteSlugs, since, until },
+        AND date >= {since:Date} AND date <= {until:Date}
+      GROUP BY host
+      ORDER BY sum(requests) DESC
+      LIMIT {limit:UInt32}`,
+    { sites: siteSlugs, since, until, limit: MAX_HOSTNAMES },
   );
   return rows.map((r) => r.host).filter(Boolean);
 }
 
 /**
- * CDN usage is keyed by site; shared-infra usage is keyed by origin hostname,
- * so it can only be attributed to a site through that site's hosts. Both are
- * part of what the platform bills — reporting CDN alone understates the bill.
+ * Sum CDN and shared-infra rows into date → totals. Both are part of what the
+ * platform bills; reporting CDN alone understates the bill.
  */
-async function dailyInfraUsage(
-  siteSlugs: string[],
-  since: string,
-  until: string,
-  hostnames: string[],
-): Promise<Map<string, { requests: number; bytes: number }>> {
-  const [cdnRows, sharedRows] = await Promise.all([
-    analyticsQuery<UsageRow>(
-      `SELECT date,
-              sum(requests) AS requests,
-              sum(bandwidth_bytes) AS egress_bytes
-         FROM default.fact_usage_daily_view
-        WHERE site_id IN (SELECT id FROM default.dim_sites WHERE name IN ({sites:Array(String)}))
-          AND date >= {since:Date} AND date <= {until:Date}
-        GROUP BY date`,
-      { sites: siteSlugs, since, until },
-    ),
-    hostnames.length
-      ? analyticsQuery<UsageRow>(
-          `SELECT date,
-                  sum(requests) AS requests,
-                  sum(bandwidth_bytes) AS egress_bytes
-             FROM default.fact_shared_infra_usage_daily_view
-            WHERE origin_host IN ({hostnames:Array(String)})
-              AND date >= {since:Date} AND date <= {until:Date}
-            GROUP BY date`,
-          { hostnames, since, until },
-        )
-      : Promise.resolve([]),
-  ]);
-
+export function aggregateUsage(
+  rows: UsageRow[],
+): Map<string, { requests: number; bytes: number }> {
   const byDate = new Map<string, { requests: number; bytes: number }>();
-  for (const row of [...cdnRows, ...sharedRows]) {
-    const date = String(row.date);
+  for (const row of rows) {
+    // ClickHouse returns sums as strings in JSONEachRow; dates may carry a time.
+    const date = String(row.date).slice(0, 10);
     const current = byDate.get(date) ?? { requests: 0, bytes: 0 };
     current.requests += Number(row.requests) || 0;
-    current.bytes +=
-      (Number(row.egress_bytes) || 0) + (Number(row.ingress_bytes) || 0);
+    current.bytes += Number(row.egress_bytes) || 0;
     byDate.set(date, current);
   }
   return byDate;
 }
 
+/** CDN usage, keyed by site. */
+function cdnUsageRows(
+  siteSlugs: string[],
+  since: string,
+  until: string,
+): Promise<UsageRow[]> {
+  return analyticsQuery<UsageRow>(
+    `SELECT date,
+            sum(requests) AS requests,
+            sum(bandwidth_bytes) AS egress_bytes
+       FROM default.fact_usage_daily_view
+      WHERE site_id IN (SELECT id FROM default.dim_sites WHERE name IN ({sites:Array(String)}))
+        AND date >= {since:Date} AND date <= {until:Date}
+      GROUP BY date`,
+    { sites: siteSlugs, since, until },
+  );
+}
+
+/** Shared-infra usage, attributable to a site only through its origin hosts. */
+function sharedInfraUsageRows(
+  hostnames: string[],
+  since: string,
+  until: string,
+): Promise<UsageRow[]> {
+  if (hostnames.length === 0) return Promise.resolve([]);
+  return analyticsQuery<UsageRow>(
+    `SELECT date,
+            sum(requests) AS requests,
+            sum(bandwidth_bytes) AS egress_bytes
+       FROM default.fact_shared_infra_usage_daily_view
+      WHERE origin_host IN ({hostnames:Array(String)})
+        AND date >= {since:Date} AND date <= {until:Date}
+      GROUP BY date`,
+    { hostnames, since, until },
+  );
+}
+
 /** Every UTC day in [since, until], so a gap in the facts renders as a zero. */
-function dateRange(since: string, until: string): string[] {
+export function dateRange(since: string, until: string): string[] {
   const dates: string[] = [];
   const cursor = new Date(`${since}T00:00:00Z`);
   const last = new Date(`${until}T00:00:00Z`);
@@ -195,12 +224,6 @@ export function planTypeOf(
   return "free";
 }
 
-/** The legacy team that owns this site, or null (unclaimed / no credentials). */
-export async function resolveTeamId(siteSlug: string): Promise<number | null> {
-  const teams = await resolveTeamIds([siteSlug]);
-  return teams.length === 1 ? teams[0]! : null;
-}
-
 /** Distinct legacy teams behind a set of sites, in one round trip. */
 async function resolveTeamIds(siteSlugs: string[]): Promise<number[]> {
   const config = getDecoSupabaseConfig();
@@ -212,6 +235,50 @@ async function resolveTeamIds(siteSlugs: string[]): Promise<number[]> {
     `sites?name=in.(${list})&select=team`,
   );
   return [...new Set(rows.map((r) => r.team).filter((t): t is number => !!t))];
+}
+
+/** Every site name belonging to a legacy team. */
+async function teamSiteNames(teamId: number): Promise<string[]> {
+  const config = getDecoSupabaseConfig();
+  if (!config) return [];
+  const rows = await supabaseGet<{ name: string | null }>(
+    config.supabaseUrl,
+    config.serviceKey,
+    `sites?team=eq.${teamId}&select=name`,
+  );
+  return rows.map((r) => r.name).filter((n): n is string => !!n);
+}
+
+export type TeamScope =
+  | { ok: true; teamId: number }
+  | { ok: false; reason: BillingUnavailableReason };
+
+/**
+ * The legacy team behind `siteSlugs`, but ONLY if the org owns every site that
+ * team has.
+ *
+ * Plan, invoices and the Stripe portal are team-scoped, while `org_sites` is a
+ * per-slug claim — so owning one site of a shared team must not hand over the
+ * team's invoices (which carry the paying entity's legal name and tax id) or a
+ * portal session that can cancel a subscription paying for someone else's site.
+ */
+export async function resolveOwnedTeam(
+  siteSlugs: string[],
+  ownedSlugs: string[],
+): Promise<TeamScope> {
+  if (!getDecoSupabaseConfig()) return { ok: false, reason: "unavailable" };
+
+  const teams = await resolveTeamIds(siteSlugs);
+  if (teams.length === 0) return { ok: false, reason: "no_team" };
+  if (teams.length > 1) return { ok: false, reason: "multiple_teams" };
+
+  const teamId = teams[0]!;
+  const owned = new Set(ownedSlugs);
+  const teamSites = await teamSiteNames(teamId);
+  if (teamSites.length === 0 || !teamSites.every((name) => owned.has(name))) {
+    return { ok: false, reason: "partial_team" };
+  }
+  return { ok: true, teamId };
 }
 
 /**
@@ -247,15 +314,61 @@ export function nextBillingDate(
   return new Date(periodEndSeconds * 1000).toISOString().slice(0, 10);
 }
 
-async function loadPlanAndInvoices(
-  siteSlugs: string[],
-): Promise<LegacyTeamBilling | null> {
-  const config = getDecoSupabaseConfig();
-  const teams = await resolveTeamIds(siteSlugs);
-  const teamId = teams.length === 1 ? teams[0]! : null;
-  if (!config || teamId === null) {
+/**
+ * Only `https:` links are rendered. These strings come from an Airtable mirror,
+ * not from Studio, and end up as an `<a href>`.
+ */
+function safeDocumentUrl(raw: string | null): string | null {
+  if (!raw) return null;
+  try {
+    return new URL(raw).protocol === "https:" ? raw : null;
+  } catch {
     return null;
   }
+}
+
+/** Some rows mirror this column from Airtable as a JSON array literal. */
+function unwrapBankSlipUrl(raw: string | null): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("[") && !trimmed.startsWith('"')) return trimmed;
+  try {
+    const parsed: unknown = JSON.parse(trimmed);
+    if (typeof parsed === "string") return parsed;
+    if (Array.isArray(parsed) && typeof parsed[0] === "string") {
+      return parsed[0];
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Both spellings appear in the Airtable-mirrored status column. */
+const CANCELED_STATUSES = new Set(["canceled", "cancelled"]);
+
+/** Canceled invoices were never owed — the legacy admin hides them too. */
+export function toInvoices(rows: LegacyInvoiceRow[]): LegacyInvoice[] {
+  return rows
+    .filter(
+      (row) => !CANCELED_STATUSES.has((row.status ?? "").trim().toLowerCase()),
+    )
+    .map((row) => ({
+      id: String(row.id),
+      status: row.status ?? "",
+      dueDate: row.due_date,
+      value: Number(row.value) || 0,
+      referenceMonth: row.reference_month,
+      nfUrl: safeDocumentUrl(row.nf_url),
+      bankSlipUrl: safeDocumentUrl(unwrapBankSlipUrl(row.bank_slip_url)),
+    }));
+}
+
+async function loadPlanAndInvoices(
+  teamId: number,
+): Promise<LegacyTeamBilling | null> {
+  const config = getDecoSupabaseConfig();
+  if (!config) return null;
 
   const [subscriptions, invoiceRows, stripeSubscriptionId] = await Promise.all([
     supabaseGet<LegacySubscriptionRow>(
@@ -288,50 +401,69 @@ async function loadPlanAndInvoices(
       new Date(),
     ),
     canManageSubscription: planType !== "enterprise" && !!stripeSubscription,
-    // Canceled invoices were never owed — the legacy admin hides them too.
-    invoices: invoiceRows
-      .filter((row) => row.status && row.status.toLowerCase() !== "canceled")
-      .map((row) => ({
-        id: String(row.id),
-        status: row.status ?? "",
-        dueDate: row.due_date,
-        value: Number(row.value) || 0,
-        referenceMonth: row.reference_month,
-        nfUrl: row.nf_url,
-        // Mirrored from Airtable as a JSON-ish string on some rows.
-        bankSlipUrl:
-          row.bank_slip_url?.replace(/^\["|"\]$|^"|"$|\[|\]/g, "") || null,
-      })),
+    invoices: toInvoices(invoiceRows),
   };
+}
+
+/** Never report days that haven't happened yet — they'd plot as a crash to 0. */
+export function clampUntil(until: string, now: Date): string {
+  const today = now.toISOString().slice(0, 10);
+  return until > today ? today : until;
 }
 
 export async function getSiteInfraBilling(params: {
   /** One or more sites the caller has already authorized; totals are summed. */
   siteSlugs: string[];
+  /** Every slug the org owns — gates team-scoped plan/invoice/portal access. */
+  ownedSlugs: string[];
   /** Any date inside the wanted month; defaults to the current month. */
   period?: string;
 }): Promise<SiteInfraBilling> {
   const siteSlugs = [...new Set(params.siteSlugs)].sort();
   const periodDate = params.period ? new Date(params.period) : new Date();
-  const { since, until } = monthInterval(
-    Number.isNaN(periodDate.getTime()) ? new Date() : periodDate,
+  const now = new Date();
+  const { since, until: monthEnd } = monthInterval(
+    Number.isNaN(periodDate.getTime()) ? now : periodDate,
   );
+  const until = clampUntil(monthEnd, now);
 
-  const [usageResult, billing] = await Promise.all([
+  const [usageResult, billingResult] = await Promise.all([
     (async () => {
-      const hostnames = await siteHostnames(siteSlugs, since, until);
-      const [infra, pageviews] = await Promise.all([
-        dailyInfraUsage(siteSlugs, since, until, hostnames),
+      // The CDN query keys on site_id, so it needn't wait for the host lookup.
+      const [cdnRows, hostnames] = await Promise.all([
+        cdnUsageRows(siteSlugs, since, until),
+        siteHostnames(siteSlugs, since, until),
+      ]);
+      const [sharedRows, pageviews] = await Promise.all([
+        sharedInfraUsageRows(hostnames, since, until),
         dailyPageviews(hostnames.map(toOneDollarHostname), since, until),
       ]);
-      return { infra, pageviews };
+      return {
+        infra: aggregateUsage([...cdnRows, ...sharedRows]),
+        pageviews,
+        failed: false,
+      };
     })().catch((err) => {
       console.error("[deco-legacy] infra usage read failed:", err);
-      return { infra: new Map(), pageviews: null };
+      return {
+        infra: new Map<string, { requests: number; bytes: number }>(),
+        pageviews: null,
+        failed: true,
+      };
     }),
-    loadPlanAndInvoices(siteSlugs).catch((err) => {
+    (async (): Promise<{
+      billing: LegacyTeamBilling | null;
+      reason: BillingUnavailableReason | null;
+    }> => {
+      const scope = await resolveOwnedTeam(siteSlugs, params.ownedSlugs);
+      if (!scope.ok) return { billing: null, reason: scope.reason };
+      const billing = await loadPlanAndInvoices(scope.teamId);
+      return billing
+        ? { billing, reason: null }
+        : { billing: null, reason: "unavailable" };
+    })().catch((err) => {
       console.error("[deco-legacy] plan/invoices read failed:", err);
-      return null;
+      return { billing: null, reason: "unavailable" as const };
     }),
   ]);
 
@@ -351,8 +483,9 @@ export async function getSiteInfraBilling(params: {
     until,
     usage,
     pageviewsAvailable: usageResult.pageviews !== null,
-    billing,
+    billing: billingResult.billing,
+    billingUnavailableReason: billingResult.reason,
     // Not the same as a month with no traffic (a legit all-zeros dashboard).
-    usageUnavailable: !isAnalyticsConfigured(),
+    usageUnavailable: !isAnalyticsConfigured() || usageResult.failed,
   };
 }

--- a/apps/api/src/deco-legacy/onedollarstats.ts
+++ b/apps/api/src/deco-legacy/onedollarstats.ts
@@ -10,50 +10,27 @@
 import { getSettings } from "../settings";
 
 const API = "https://deco.lilstts.com";
+const REQUEST_TIMEOUT_MS = 10_000;
+/** Hosts queried at once. Each is a separate POST to a third party. */
+const CONCURRENCY = 6;
 
 interface PlausibleResponse {
   results?: { dimensions: string[]; metrics: number[] }[];
 }
 
+export type PageviewRows = { dimensions: string[]; metrics: number[] }[];
+
 /**
- * Daily pageviews summed across `hostnames`, as date ("YYYY-MM-DD") → count.
- * Null when unconfigured or when every host query failed — the caller must
- * distinguish "no data source" from "zero pageviews".
+ * Sum per-host daily rows into date ("YYYY-MM-DD") → pageviews.
+ *
+ * Null if ANY host failed: these feed the requests-per-pageview ratio the page
+ * bills on, and a silently undercounted denominator is worse than "—".
  */
-export async function dailyPageviews(
-  hostnames: string[],
-  startDate: string,
-  endDate: string,
-): Promise<Map<string, number> | null> {
-  const apiKey = getSettings().oneDollarStatsApiKey;
-  if (!apiKey || hostnames.length === 0) return null;
-
-  const results = await Promise.allSettled(
-    hostnames.map(async (hostname) => {
-      const res = await fetch(`${API}/plausible`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "x-api-key": apiKey,
-          Accept: "application/json",
-        },
-        body: JSON.stringify({
-          site_id: hostname,
-          date_range: [startDate, endDate],
-          metrics: ["pageviews"],
-          dimensions: ["time:day"],
-          pagination: { limit: 10000, offset: 0 },
-        }),
-      });
-      if (!res.ok) {
-        throw new Error(`OneDollarStats ${res.status}`);
-      }
-      return ((await res.json()) as PlausibleResponse).results ?? [];
-    }),
-  );
-
-  if (results.every((r) => r.status === "rejected")) {
-    console.warn("[deco-legacy] every OneDollarStats host query failed");
+export function mergePageviews(
+  results: PromiseSettledResult<PageviewRows>[],
+): Map<string, number> | null {
+  if (results.some((r) => r.status === "rejected")) {
+    console.warn("[deco-legacy] a OneDollarStats host query failed");
     return null;
   }
 
@@ -71,9 +48,60 @@ export async function dailyPageviews(
 }
 
 /**
+ * Daily pageviews summed across `hostnames`, as date ("YYYY-MM-DD") → count.
+ * Null when unconfigured or when any host query failed — the caller must
+ * distinguish "no data source" from "zero pageviews".
+ */
+export async function dailyPageviews(
+  hostnames: string[],
+  startDate: string,
+  endDate: string,
+): Promise<Map<string, number> | null> {
+  const apiKey = getSettings().oneDollarStatsApiKey;
+  // Two warehouse hosts can map to one OneDollarStats site — dedupe or double-count.
+  const hosts = [...new Set(hostnames)];
+  if (!apiKey || hosts.length === 0) return null;
+
+  const queryHost = async (hostname: string): Promise<PageviewRows> => {
+    const res = await fetch(`${API}/plausible`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": apiKey,
+        Accept: "application/json",
+      },
+      body: JSON.stringify({
+        site_id: hostname,
+        date_range: [startDate, endDate],
+        metrics: ["pageviews"],
+        dimensions: ["time:day"],
+        pagination: { limit: 10000, offset: 0 },
+      }),
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      throw new Error(`OneDollarStats ${res.status}`);
+    }
+    return ((await res.json()) as PlausibleResponse).results ?? [];
+  };
+
+  const results: PromiseSettledResult<PageviewRows>[] = [];
+  for (let i = 0; i < hosts.length; i += CONCURRENCY) {
+    results.push(
+      ...(await Promise.allSettled(
+        hosts.slice(i, i + CONCURRENCY).map(queryHost),
+      )),
+    );
+  }
+  return mergePageviews(results);
+}
+
+/**
  * OneDollarStats indexes custom domains by their `www.` hostname while the
- * warehouse stores the bare domain; `.deco.site` subdomains are used as-is.
+ * warehouse stores the bare domain; `.deco.site` subdomains are used as-is,
+ * and a host already carrying `www.` is left alone.
  */
 export function toOneDollarHostname(host: string): string {
-  return host.endsWith(".deco.site") ? host : `www.${host}`;
+  if (host.endsWith(".deco.site") || host.startsWith("www.")) return host;
+  return `www.${host}`;
 }

--- a/apps/api/src/deco-legacy/supabase.ts
+++ b/apps/api/src/deco-legacy/supabase.ts
@@ -14,6 +14,10 @@
 
 import { getSettings } from "../settings";
 
+/** Matches `stripe-api.ts`. Without it a *degraded* (not down) Supabase hangs
+ *  the handler forever: nothing rejects, so no caller's `.catch` ever runs. */
+const REQUEST_TIMEOUT_MS = 15_000;
+
 export interface DecoSupabaseConfig {
   supabaseUrl: string;
   serviceKey: string;
@@ -39,6 +43,7 @@ export async function supabaseGet<T>(
       Authorization: `Bearer ${serviceKey}`,
       Accept: "application/json",
     },
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
   if (!res.ok) {
     const text = await res.text().catch(() => res.statusText);
@@ -64,6 +69,7 @@ export async function supabasePost<T>(
       Prefer: "return=representation",
     },
     body: JSON.stringify(body),
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   });
   if (!res.ok) {
     const text = await res.text().catch(() => res.statusText);

--- a/apps/api/src/tools/infra-billing/get.ts
+++ b/apps/api/src/tools/infra-billing/get.ts
@@ -5,6 +5,7 @@
  */
 
 import { z } from "zod";
+import { isValidSiteSlug } from "@decocms/shared/site-slug";
 import { defineTool } from "../../core/define-tool";
 import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { getSiteInfraBilling } from "../../deco-legacy/infra-billing";
@@ -22,7 +23,10 @@ export const INFRA_BILLING_GET = defineTool({
   },
   inputSchema: z.object({
     /** Sites to aggregate. Every one must be owned by the calling org. */
-    siteSlugs: z.array(z.string().min(1).max(60)).min(1).max(50),
+    siteSlugs: z
+      .array(z.string().min(1).max(60).refine(isValidSiteSlug))
+      .min(1)
+      .max(50),
     /** Any date inside the wanted month (ISO). Defaults to the current month. */
     period: z.string().optional(),
   }),
@@ -42,8 +46,12 @@ export const INFRA_BILLING_GET = defineTool({
     pageviewsAvailable: z.boolean(),
     /** True when this deployment has no analytics warehouse configured. */
     usageUnavailable: z.boolean(),
+    /** Why `billing` is null, so the UI names the real cause. */
+    billingUnavailableReason: z
+      .enum(["no_team", "multiple_teams", "partial_team", "unavailable"])
+      .nullable(),
     /** Plan and invoices belong to the legacy team, so they are only reported
-     *  when the whole selection rolls up to exactly one team. */
+     *  when the whole selection rolls up to exactly one team the org fully owns. */
     billing: z
       .object({
         planType: z.enum(["free", "pro", "enterprise"]),
@@ -72,16 +80,21 @@ export const INFRA_BILLING_GET = defineTool({
     const org = requireOrganization(ctx);
 
     const slugs = [...new Set(input.siteSlugs.map((s) => s.toLowerCase()))];
-    const owned = await Promise.all(
-      slugs.map((slug) => ctx.storage.orgSites.isOwnedBy(slug, org.id)),
+    const ownedSlugs = (await ctx.storage.orgSites.listByOrg(org.id)).map(
+      (site) => site.slug,
     );
-    const unowned = slugs.filter((_, i) => !owned[i]);
+    const owned = new Set(ownedSlugs);
+    const unowned = slugs.filter((slug) => !owned.has(slug));
     if (unowned.length > 0) {
       throw new Error(
         `Site not found in organization: ${unowned.sort().join(", ")}`,
       );
     }
 
-    return getSiteInfraBilling({ siteSlugs: slugs, period: input.period });
+    return getSiteInfraBilling({
+      siteSlugs: slugs,
+      ownedSlugs,
+      period: input.period,
+    });
   },
 });

--- a/apps/api/src/tools/infra-billing/portal.ts
+++ b/apps/api/src/tools/infra-billing/portal.ts
@@ -5,6 +5,7 @@
  */
 
 import { z } from "zod";
+import { isValidSiteSlug } from "@decocms/shared/site-slug";
 import {
   createBillingPortalSession,
   retrieveSubscription,
@@ -14,7 +15,7 @@ import { defineTool } from "../../core/define-tool";
 import { getPublicUrl } from "../../core/server-constants";
 import { requireAuth, requireOrganization } from "../../core/studio-context";
 import {
-  resolveTeamId,
+  resolveOwnedTeam,
   teamStripeSubscriptionId,
 } from "../../deco-legacy/infra-billing";
 
@@ -29,7 +30,13 @@ export const INFRA_BILLING_PORTAL = defineTool({
     idempotentHint: false,
     openWorldHint: true,
   },
-  inputSchema: z.object({ siteSlug: z.string().min(1).max(60) }),
+  inputSchema: z.object({
+    /** The same selection the page is showing; they must share one team. */
+    siteSlugs: z
+      .array(z.string().min(1).max(60).refine(isValidSiteSlug))
+      .min(1)
+      .max(50),
+  }),
   outputSchema: z.object({ url: z.string() }),
 
   handler: async (input, ctx) => {
@@ -40,14 +47,29 @@ export const INFRA_BILLING_PORTAL = defineTool({
       throw new Error("Organization context required");
     }
 
-    const slug = input.siteSlug.toLowerCase();
-    if (!(await ctx.storage.orgSites.isOwnedBy(slug, org.id))) {
-      throw new Error(`Site not found in organization: ${slug}`);
+    const slugs = [...new Set(input.siteSlugs.map((s) => s.toLowerCase()))];
+    const ownedSlugs = (await ctx.storage.orgSites.listByOrg(org.id)).map(
+      (site) => site.slug,
+    );
+    const owned = new Set(ownedSlugs);
+    const unowned = slugs.filter((slug) => !owned.has(slug));
+    if (unowned.length > 0) {
+      throw new Error(
+        `Site not found in organization: ${unowned.sort().join(", ")}`,
+      );
     }
 
-    const teamId = await resolveTeamId(slug);
-    const subscriptionId =
-      teamId === null ? null : await teamStripeSubscriptionId(teamId);
+    // Portal sessions can cancel the team's subscription — require the whole team.
+    const scope = await resolveOwnedTeam(slugs, ownedSlugs);
+    if (!scope.ok) {
+      throw new Error(
+        scope.reason === "partial_team"
+          ? "This site's legacy team also bills sites outside this organization. Manage the subscription from the deco.cx admin."
+          : "This site has no Stripe subscription to manage.",
+      );
+    }
+
+    const subscriptionId = await teamStripeSubscriptionId(scope.teamId);
     if (!subscriptionId) {
       throw new Error("This site has no Stripe subscription to manage.");
     }
@@ -60,7 +82,11 @@ export const INFRA_BILLING_PORTAL = defineTool({
         returnUrl: `${getPublicUrl()}/${encodeURIComponent(org.slug)}/settings/infra-billing`,
       });
     } catch (err) {
-      if (err instanceof StripeApiError) throw new Error(err.message);
+      // Stripe's raw message names the subscription id — not the caller's to see.
+      if (err instanceof StripeApiError) {
+        console.error("[infra-billing] portal session failed:", err);
+        throw new Error("Could not open the billing portal. Try again later.");
+      }
       throw err;
     }
   },

--- a/apps/web/src/hooks/use-infra-billing.ts
+++ b/apps/web/src/hooks/use-infra-billing.ts
@@ -6,18 +6,27 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { useProjectContext } from "@/sdk";
+import { useCapabilities } from "@/hooks/use-capability";
 import { useStudioTools } from "@/lib/studio-tools";
 import { KEYS } from "@/lib/query-keys";
 import { useT } from "@/i18n/use-t.ts";
 
+/**
+ * Empty unless the caller can manage members — the LIST tool is
+ * members:manage-gated server-side, and this runs on every settings page, so
+ * an ungated call 403s for every regular member.
+ */
 export function useOwnedSites() {
   const { org } = useProjectContext();
   const studio = useStudioTools();
+  const { capabilities, isPrivileged } = useCapabilities();
+  const canManage = isPrivileged || !!capabilities["members:manage"];
 
   const { data, isLoading } = useQuery({
     queryKey: KEYS.infraBillingSites(org.id),
     // Ownership changes only on a site import — no need to refetch per nav.
     staleTime: 5 * 60_000,
+    enabled: !!org.id && canManage,
     queryFn: () => studio.call("INFRA_BILLING_SITES_LIST", {}),
   });
 
@@ -31,8 +40,8 @@ export function useInfraBillingPortal() {
   const t = useT();
 
   return useMutation({
-    mutationFn: (siteSlug: string) =>
-      studio.call("INFRA_BILLING_PORTAL", { siteSlug }),
+    mutationFn: (siteSlugs: string[]) =>
+      studio.call("INFRA_BILLING_PORTAL", { siteSlugs }),
     onSuccess: ({ url }) => window.open(url, "_blank", "noopener,noreferrer"),
     onError: (err: Error) =>
       toast.error(

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -776,11 +776,19 @@ export const settings = {
     "This organization doesn't own any deco.cx site yet.",
   "settings.infraBilling.siteLabel": "Sites",
   "settings.infraBilling.pickASite": "Select at least one site.",
+  "settings.infraBilling.tooManySites":
+    "Showing the first {count} sites. Select specific sites to see the rest.",
   "settings.infraBilling.multipleTeams":
     "Plan and invoices belong to a single legacy team — narrow the selection to see them.",
+  "settings.infraBilling.noTeam":
+    "These sites aren't linked to a legacy billing team.",
+  "settings.infraBilling.partialTeam":
+    "This site's legacy team also bills sites outside this organization, so its plan and invoices aren't shown here.",
+  "settings.infraBilling.billingUnavailable":
+    "Plan and invoices are temporarily unavailable.",
   "settings.infraBilling.monthLabel": "Month",
   "settings.infraBilling.warehouseUnavailable":
-    "Usage data is unavailable on this deployment.",
+    "Usage data couldn't be read, so the figures below are incomplete.",
   "settings.infraBilling.summaryTitle": "Summary",
   "settings.infraBilling.metricsTitle": "Metrics",
   "settings.infraBilling.invoicesTitle": "Invoices",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -822,11 +822,19 @@ export const settings = {
     "Esta organização ainda não é dona de nenhum site deco.cx.",
   "settings.infraBilling.siteLabel": "Sites",
   "settings.infraBilling.pickASite": "Selecione ao menos um site.",
+  "settings.infraBilling.tooManySites":
+    "Mostrando os primeiros {count} sites. Selecione sites específicos para ver os demais.",
   "settings.infraBilling.multipleTeams":
     "Plano e faturas são de um único time legado — filtre a seleção para vê-los.",
+  "settings.infraBilling.noTeam":
+    "Estes sites não estão vinculados a um time de cobrança legado.",
+  "settings.infraBilling.partialTeam":
+    "O time legado deste site também cobra sites fora desta organização, então o plano e as faturas não aparecem aqui.",
+  "settings.infraBilling.billingUnavailable":
+    "Plano e faturas estão temporariamente indisponíveis.",
   "settings.infraBilling.monthLabel": "Mês",
   "settings.infraBilling.warehouseUnavailable":
-    "Os dados de uso não estão disponíveis nesta instalação.",
+    "Não foi possível ler os dados de uso, então os números abaixo estão incompletos.",
   "settings.infraBilling.summaryTitle": "Resumo",
   "settings.infraBilling.metricsTitle": "Métricas",
   "settings.infraBilling.invoicesTitle": "Faturas",

--- a/apps/web/src/views/settings/infra-billing.tsx
+++ b/apps/web/src/views/settings/infra-billing.tsx
@@ -74,6 +74,9 @@ function formatBytes(bytes: number): string {
   return `${value.toFixed(value >= 100 || exponent === 0 ? 0 : 1)} ${BYTE_UNITS[exponent]}`;
 }
 
+/** Mirrors the `siteSlugs` cap on INFRA_BILLING_GET. */
+const MAX_SELECTED_SITES = 50;
+
 /** Bank-transfer instructions, for teams billed by transfer rather than boleto. */
 const BANK_TRANSFER_PDF_URL =
   "https://assets.decocache.com/decocms/45f9e905-046b-4aeb-8420-0377a7d0d041/deco_Transferencia.pdf";
@@ -83,6 +86,14 @@ const CURRENCY_FMT = new Intl.NumberFormat("pt-BR", {
   style: "currency",
   currency: "BRL",
 });
+
+/**
+ * PostgREST emits offset-less timestamps, which JS parses as *local* time — far
+ * enough east and an August invoice renders as July. Pin the calendar day.
+ */
+function utcDay(value: string): Date {
+  return new Date(`${value.slice(0, 10)}T00:00:00Z`);
+}
 
 /** The last 12 months, newest first, as "YYYY-MM-01" values. */
 function monthOptions(): { value: string; label: string }[] {
@@ -197,7 +208,9 @@ function InfraBillingContent() {
   const months = monthOptions();
   const [period, setPeriod] = useState(months[0]!.value);
 
-  const selected = narrowedTo ?? sites;
+  // Unnarrowed, a 51-site org would fail INFRA_BILLING_GET's schema every load.
+  const selected = narrowedTo ?? sites.slice(0, MAX_SELECTED_SITES);
+  const truncated = !narrowedTo && sites.length > MAX_SELECTED_SITES;
   const { data, isLoading } = useInfraBilling(selected, period);
   const portal = useInfraBillingPortal();
 
@@ -214,6 +227,10 @@ function InfraBillingContent() {
 
   const usage = data?.usage ?? [];
   const pageviewsAvailable = data?.pageviewsAvailable ?? false;
+  /** Zeros from an unread warehouse are absence of data, not absence of traffic. */
+  const usageReadable = !!data && !data.usageUnavailable;
+  const usageTotal = (metric: MetricKey, format: (n: number) => string) =>
+    usageReadable ? format(sum(usage, metric)) : "—";
 
   const metrics: {
     key: MetricKey;
@@ -227,23 +244,24 @@ function InfraBillingContent() {
       title: t("settings.infraBilling.pageviews"),
       description: t("settings.infraBilling.pageviewsDescription"),
       colorNum: 1,
-      total: pageviewsAvailable
-        ? NUMBER_FMT.format(sum(usage, "pageviews"))
-        : "—",
+      total:
+        pageviewsAvailable && usageReadable
+          ? NUMBER_FMT.format(sum(usage, "pageviews"))
+          : "—",
     },
     {
       key: "requests",
       title: t("settings.infraBilling.requests"),
       description: t("settings.infraBilling.requestsDescription"),
       colorNum: 2,
-      total: NUMBER_FMT.format(sum(usage, "requests")),
+      total: usageTotal("requests", (n) => NUMBER_FMT.format(n)),
     },
     {
       key: "dataTransferBytes",
       title: t("settings.infraBilling.dataTransfer"),
       description: t("settings.infraBilling.dataTransferDescription"),
       colorNum: 3,
-      total: formatBytes(sum(usage, "dataTransferBytes")),
+      total: usageTotal("dataTransferBytes", formatBytes),
     },
   ];
 
@@ -259,10 +277,20 @@ function InfraBillingContent() {
   );
 
   const totalPageviews = sum(usage, "pageviews");
+  const ratio =
+    totalPageviews > 0 ? sum(usage, "requests") / totalPageviews : 0;
   const requestRatio =
-    pageviewsAvailable && totalPageviews > 0
-      ? (sum(usage, "requests") / totalPageviews).toFixed(0)
+    pageviewsAvailable && usageReadable && totalPageviews > 0
+      ? ratio.toFixed(ratio < 10 ? 1 : 0)
       : "—";
+
+  /** Null billing has four causes; only one of them is the user's to fix. */
+  const billingMessage = {
+    multiple_teams: t("settings.infraBilling.multipleTeams"),
+    no_team: t("settings.infraBilling.noTeam"),
+    partial_team: t("settings.infraBilling.partialTeam"),
+    unavailable: t("settings.infraBilling.billingUnavailable"),
+  }[data?.billingUnavailableReason ?? "multiple_teams"];
 
   return (
     <div className="flex flex-col gap-8">
@@ -298,6 +326,14 @@ function InfraBillingContent() {
         </Card>
       )}
 
+      {truncated && (
+        <Card className="mx-4 p-4 text-sm text-muted-foreground">
+          {t("settings.infraBilling.tooManySites", {
+            count: String(MAX_SELECTED_SITES),
+          })}
+        </Card>
+      )}
+
       {data?.usageUnavailable && (
         <Card className="mx-4 p-4 text-sm text-muted-foreground">
           {t("settings.infraBilling.warehouseUnavailable")}
@@ -319,7 +355,7 @@ function InfraBillingContent() {
                   variant="outline"
                   size="sm"
                   disabled={portal.isPending}
-                  onClick={() => portal.mutate(selected[0]!)}
+                  onClick={() => portal.mutate(selected)}
                 >
                   {t("settings.infraBilling.manageButton")}
                 </Button>
@@ -365,7 +401,7 @@ function InfraBillingContent() {
               ) : (
                 !isLoading && (
                   <p className="text-xs text-muted-foreground">
-                    {t("settings.infraBilling.multipleTeams")}
+                    {billingMessage}
                   </p>
                 )
               )}
@@ -431,11 +467,11 @@ function InfraBillingContent() {
 
       <SettingsSection title={t("settings.infraBilling.invoicesTitle")}>
         <Card className="mx-4 overflow-x-auto">
-          {data && (billing?.invoices.length ?? 0) === 0 ? (
+          {!data ? (
+            <Skeleton className="m-4 h-24" />
+          ) : (billing?.invoices.length ?? 0) === 0 ? (
             <p className="p-4 text-sm text-muted-foreground">
-              {billing
-                ? t("settings.infraBilling.noInvoices")
-                : t("settings.infraBilling.multipleTeams")}
+              {billing ? t("settings.infraBilling.noInvoices") : billingMessage}
             </p>
           ) : (
             <Table>
@@ -461,7 +497,7 @@ function InfraBillingContent() {
                   <TableRow key={invoice.id}>
                     <TableCell>
                       {invoice.referenceMonth
-                        ? new Date(invoice.referenceMonth).toLocaleDateString(
+                        ? utcDay(invoice.referenceMonth).toLocaleDateString(
                             undefined,
                             { month: "long", year: "numeric", timeZone: "UTC" },
                           )
@@ -469,7 +505,7 @@ function InfraBillingContent() {
                     </TableCell>
                     <TableCell>
                       {invoice.dueDate
-                        ? new Date(invoice.dueDate).toLocaleDateString(
+                        ? utcDay(invoice.dueDate).toLocaleDateString(
                             undefined,
                             {
                               day: "numeric",

--- a/packages/e2e/tests/infra-billing-tenancy.spec.ts
+++ b/packages/e2e/tests/infra-billing-tenancy.spec.ts
@@ -75,14 +75,45 @@ test.describe("Infra billing site tenancy", () => {
       );
       expect(after.sites).toEqual([{ slug }]);
 
-      // The owner is served (usage may be empty without a warehouse).
-      const billing = await callSelfMcpTool<{ siteSlugs: string[] }>(
+      // Served — and an unconfigured deployment must not pass zeros off as a bill.
+      const billing = await callSelfMcpTool<{
+        siteSlugs: string[];
+        since: string;
+        until: string;
+        usage: { date: string }[];
+        pageviewsAvailable: boolean;
+        usageUnavailable: boolean;
+        billing: unknown;
+        billingUnavailableReason: string | null;
+      }>(ownerCtx, owner.orgSlug, "INFRA_BILLING_GET", { siteSlugs: [slug] });
+      expect(billing.siteSlugs).toEqual([slug]);
+      expect(billing.usageUnavailable).toBe(true);
+      expect(billing.pageviewsAvailable).toBe(false);
+      expect(billing.billing).toBeNull();
+      expect(billing.billingUnavailableReason).toBe("unavailable");
+      // Zero-filled day by day, and never past today.
+      expect(billing.usage.length).toBe(
+        new Date(`${billing.until}T00:00:00Z`).getUTCDate(),
+      );
+      expect(billing.until <= new Date().toISOString().slice(0, 10)).toBe(true);
+      expect(billing.usage[0]?.date).toBe(billing.since);
+
+      // An explicit period selects that month.
+      const july = await callSelfMcpTool<{ since: string; until: string }>(
         ownerCtx,
         owner.orgSlug,
         "INFRA_BILLING_GET",
-        { siteSlugs: [slug] },
+        { siteSlugs: [slug], period: "2026-07-15" },
       );
-      expect(billing.siteSlugs).toEqual([slug]);
+      expect(july.since).toBe("2026-07-01");
+      expect(july.until).toBe("2026-07-31");
+
+      // The owner reaches the team lookup and is refused cleanly, not with a 500.
+      await expect(
+        callSelfMcpTool(ownerCtx, owner.orgSlug, "INFRA_BILLING_PORTAL", {
+          siteSlugs: [slug],
+        }),
+      ).rejects.toThrow(/no Stripe subscription to manage/i);
 
       // The gate inspects EVERY slug, not just the first one.
       await expect(
@@ -102,7 +133,7 @@ test.describe("Infra billing site tenancy", () => {
       // Same gate on the portal — it mints a Stripe session for the site's team.
       await expect(
         callSelfMcpTool(otherCtx, other.orgSlug, "INFRA_BILLING_PORTAL", {
-          siteSlug: slug,
+          siteSlugs: [slug],
         }),
       ).rejects.toThrow(/not found/i);
 
@@ -115,6 +146,8 @@ test.describe("Infra billing site tenancy", () => {
       expect(otherSites.sites).toEqual([]);
     } finally {
       await db.query(`DELETE FROM org_sites WHERE slug = $1`, [slug]);
+      await ownerCtx.dispose();
+      await otherCtx.dispose();
     }
   });
 });

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -1123,6 +1123,12 @@ export interface StudioToolIO {
       }[];
       pageviewsAvailable: boolean;
       usageUnavailable: boolean;
+      billingUnavailableReason:
+        | "no_team"
+        | "multiple_teams"
+        | "partial_team"
+        | "unavailable"
+        | null;
       billing: {
         planType: "free" | "pro" | "enterprise";
         nextBillingDate: string | null;
@@ -1140,7 +1146,7 @@ export interface StudioToolIO {
     };
   };
   INFRA_BILLING_PORTAL: {
-    input: { siteSlug: string };
+    input: { siteSlugs: string[] };
     output: { url: string };
   };
   COLLECTION_CONNECTIONS_CREATE: {


### PR DESCRIPTION
Follow-up to #6141, from a multi-perspective review of that branch. Nothing here changes what the page is for — it fixes who may see it, and whether its numbers can be trusted.

## The security fix

Plan, invoices and the Stripe portal are scoped to the legacy **team**, but `org_sites` is a **per-slug** claim. Two orgs can each legitimately own a *different* site of the same team (both imports pass the team-membership check). Either one could then:

- read the team's full invoice history, including nota-fiscal PDFs carrying the paying entity's legal name and tax id;
- open a Stripe Customer Portal session for the team's subscription and change the payment method or **cancel it** — churning sites belonging to the other org.

The previous `teams.length === 1` check narrowed *which* team, never *whether the org owns all of it*.

`resolveOwnedTeam(siteSlugs, ownedSlugs)` now requires the org to own every site of the resolved team before any team-scoped data is returned, on both the read and the portal path. `INFRA_BILLING_PORTAL` also takes the whole selection now, so it can't resolve a different team than the one the page is displaying.

## Trust in the numbers

| Problem | Effect |
|---|---|
| `usageUnavailable` was a *config* check; the catch swallowed runtime failures | A warehouse outage rendered as a legitimate all-zeros bill |
| `toOneDollarHostname` prefixed `www.` unconditionally | `www.foo.com` → `www.www.foo.com` → 404, pageviews lost |
| Hosts not deduped after mapping | `foo.com` + `www.foo.com` → pageviews **doubled**, ratio halved |
| Pageviews returned partial data on partial failure | Silently undercounted the billing denominator |
| `ingress_bytes` documented, typed and summed | Never selected by either query — dead |
| `until` always the month end | Current-month charts trailed off to zero mid-month |

## Bounded I/O

Every Supabase and OneDollarStats fetch now has a timeout (a *degraded* — not down — dependency hung the handler forever, since nothing rejected and no `.catch` fired). ClickHouse gets the same execution caps `monitoring/query-engine.ts` already uses. The per-hostname fan-out is capped and runs with limited concurrency instead of unbounded parallel POSTs. A rejected ClickHouse client is uncached rather than wedging the process for its lifetime.

## Also

- `useOwnedSites` is gated on `members:manage` — it ran unconditionally in the settings sidebar, so **every regular member got a 403 on every settings page**. Follows the existing `use-join-requests.ts` pattern.
- Document links validated as `https:` before rendering (values come from an Airtable mirror, and React does not block `javascript:` hrefs).
- Bank-slip unwrapping uses `JSON.parse` instead of a global regex that stripped brackets anywhere in the URL.
- One ownership query instead of N.
- Stripe's raw error no longer forwarded to the browser (it names the subscription id).
- Invoice dates pinned to UTC — offset-less PostgREST timestamps rendered an August invoice as July east of UTC.
- Default selection capped at the schema's 50, with a visible note; a 51-site org previously failed validation on every load.

## Testing

`bun test` 32 pass. Unit coverage added for the extracted pure logic: usage aggregation, invoice mapping (both `canceled` spellings, JSON-array bank slips, non-https rejection), date range, pageview merge, hostname mapping. E2E now pins the unconfigured-deployment contract (`usageUnavailable`, `pageviewsAvailable`, zero-fill length, `until` never in the future), an explicit `period`, and the owner-side portal rejection.

`bun run fmt`, `lint` (0 errors), `check` (all workspaces), and `knip` all pass.

## Note for the reviewer

⚠️ **`invoices.value` units are still unverified.** Nothing in the code establishes whether the legacy column is reais or centavos. If it's centavos, every amount renders 100× too large. I could not check this from the repo — please confirm against one real row.

Separately: `bun run --cwd=apps/api generate:tool-contracts` is broken locally — it drops ~7000 lines from `tool-io.ts` on a **clean** checkout, unrelated to this branch. I hand-patched the two changed contracts. Worth a look on its own.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes legacy infra billing to fully-owned legacy teams and hardens reads to avoid misleading usage totals. Previously, owning any site of a team exposed that team’s invoices and Stripe portal; now access requires ownership of all sites in that team and the UI explains why billing is unavailable.

- Gates plan, invoices, and portal with a team ownership check; returns billingUnavailableReason: "no_team" | "multiple_teams" | "partial_team" | "unavailable".
- `INFRA_BILLING_PORTAL` now accepts the full selection as `siteSlugs` and refuses partial ownership; Stripe errors are sanitized.
- Usage accuracy: `usageUnavailable` covers runtime failures (not just missing config); clamp current month to today; drop unused ingress bytes; dedupe/normalize hosts and avoid double `www.`; pageviews are null if any host query fails to prevent a low biased denominator.
- Bounded I/O: timeouts on Supabase and OneDollarStats, ClickHouse execution caps, limited fan-out/concurrency, and uncache a failed ClickHouse client.
- UI: gate `useOwnedSites` on members:manage, cap default selection at 50 with a notice, validate `https:` document links, JSON-parse bank slips, render invoice dates in UTC, and show "—" when usage is unreadable.

**Review and rollout**
- Update callers to `INFRA_BILLING_PORTAL` to pass `siteSlugs: string[]` instead of `siteSlug`.
- Clients of `INFRA_BILLING_GET` should read `billingUnavailableReason` and treat `usageUnavailable: true` as “incomplete data,” not a zero bill.
- Verify production units of `invoices.value` (reais vs centavos) to confirm displayed amounts.

<sup>Written for commit d116db3a8de49692d83c0214724d08be434dbba4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

