### PR TITLE
fix(infra-billing): drop per-query ClickHouse settings the readonly user rejects

### DIFF
--- a/apps/api/src/deco-legacy/clickhouse-analytics.ts
+++ b/apps/api/src/deco-legacy/clickhouse-analytics.ts
@@ -15,10 +15,14 @@ type ClickHouseClient = import("@clickhouse/client").ClickHouseClient;
 
 let clientPromise: Promise<ClickHouseClient> | null = null;
 
-/** Client-side ceiling. `MAX_EXECUTION_SECONDS` is the server-side one that
- *  actually stops the query; this only bounds how long we wait for it. */
+/**
+ * The only ceiling we can set from here. This user is `readonly`, which makes
+ * ClickHouse reject *any* per-query setting with code 164 — including
+ * `max_execution_time`, so unlike monitoring/query-engine.ts there is no
+ * server-side cap to pair with this. Bound execution on the warehouse's user
+ * profile instead; a timeout here only stops us waiting.
+ */
 const REQUEST_TIMEOUT_MS = 20_000;
-const MAX_EXECUTION_SECONDS = 15;
 
 export function isAnalyticsConfigured(): boolean {
   const s = getSettings();
@@ -62,11 +66,6 @@ export async function analyticsQuery<T>(
     query,
     query_params: params,
     format: "JSONEachRow",
-    // Shared multi-tenant fact tables; same caps as monitoring/query-engine.ts.
-    clickhouse_settings: {
-      max_execution_time: MAX_EXECUTION_SECONDS,
-      max_threads: 1,
-    },
   });
   return result.json<T>();
 }


### PR DESCRIPTION
Hotfix for a regression I introduced in #6142. Infra usage is currently broken in production.

## What broke

#6142 added `clickhouse_settings: { max_execution_time, max_threads }` to `analyticsQuery`, mirroring `monitoring/query-engine.ts`. The analytics warehouse user is `readonly`, and in that mode ClickHouse rejects **any** per-query setting:

```
error: Cannot modify 'max_execution_time' setting in readonly mode.
type: "READONLY", code: "164"
```

Every analytics query fails, so all three usage reads (CDN, hostnames, shared-infra) throw and the page reports usage as unavailable.

Observed in prod on 4.220.1: 18 × code 164, 6 × `[deco-legacy] infra usage read failed` — three queries per page load. The plan/invoice path is unaffected.

## What this changes

Removes the per-query settings. `request_timeout` (20s) still bounds how long we wait; execution has to be capped on the warehouse's ClickHouse **user profile**, which is an infra change, not a code one.

The file already warned about exactly this one line above the client — `// Compression is a per-query setting a readonly user may not set (164)` — for compression. I added a different setting and hit the same wall. Restated the constraint where the settings would otherwise go.

## Silver lining

The other half of #6142 worked as intended: because `usageUnavailable` now covers a *failed* read and not just an unconfigured one, the page correctly reported "couldn't read usage" instead of presenting zeros as a real bill. Pre-#6142 this same failure would have rendered a confident all-zeros dashboard.

## Testing

No test covers this — it needs a live `readonly` ClickHouse, which neither the unit tier nor the e2e stack has. `bun test` 32 pass, `fmt`/`lint`/`check` clean.

## Follow-up

Cap execution on the analytics user's profile in ClickHouse (`max_execution_time` on the role/profile) so the queries are bounded server-side. Tracking separately — no code change involved.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes per-query ClickHouse settings from `analyticsQuery` because the analytics warehouse user is `readonly` and ClickHouse rejects any per-query setting (code 164). This restores infra usage reads; previously all analytics queries failed and the usage page reported unavailable.

- Changes only `apps/api/src/deco-legacy/clickhouse-analytics.ts`: drops `clickhouse_settings` (`max_execution_time`, `max_threads`) and retains `REQUEST_TIMEOUT_MS`.
- Unlike `monitoring/query-engine.ts`, this client has no server-side cap; the timeout only bounds how long we wait.
- Queries now run without per-query settings; timeouts may still occur, but 164 errors are eliminated.

**Rollout**
- No app migrations; deploy to restore usage reads.
- Required infra action: set `max_execution_time` (and any desired limits) on the analytics user's ClickHouse role/profile to cap execution server-side.

<sup>Written for commit 3076046d1ebe409a1810ad9e5c05888f540e8a72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

