### PR TITLE
fix(sections-editor): render loader-ref value when schema collapsed to inline array

### DIFF
--- a/apps/web/src/components/sections-editor/schema-form.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { inferBlockRefArrayItemSchema } from "./block-ref-array-inference";
+import { renderField, SchemaForm } from "./schema-form";
+import { ObjectField } from "./fields/object-field";
+import { AnyOfField } from "./fields/any-of-field";
+import type { LiveMeta } from "./resolve-schema";
 
 describe("inferBlockRefArrayItemSchema", () => {
   test("infers string, number, boolean from first item", () => {
@@ -53,5 +57,68 @@ describe("inferBlockRefArrayItemSchema", () => {
   test("returns undefined when all keys are internal (__prefixed)", () => {
     const items = [{ __resolveType: "X", __id: "123" }];
     expect(inferBlockRefArrayItemSchema(items)).toBeUndefined();
+  });
+});
+
+describe("renderField – collapsed loader-ref value routing", () => {
+  const LOADER = "site/loaders/BuyTogether.ts";
+  const loaderMeta: LiveMeta = {
+    manifest: {
+      blocks: {
+        loaders: { [LOADER]: { $ref: "#/definitions/BuyTogetherProps" } },
+      },
+    },
+    schema: {
+      definitions: {
+        BuyTogetherProps: {
+          type: "object",
+          properties: { rules: { type: "array", items: { type: "string" } } },
+        },
+      },
+    },
+  };
+  const loaderValue = { __resolveType: LOADER, rules: [] as string[] };
+  const baseProps = {
+    onChange: () => {},
+    path: "buyTogether",
+    label: "Buy Together",
+  };
+  const typeOf = (el: unknown) => (el as { type?: unknown } | null)?.type;
+
+  // Regression: collapsed-array schema + loader-ref value used to route to ObjectField (null).
+  test("collapsed loader-ref value renders the referenced block form", () => {
+    const el = renderField({
+      ...baseProps,
+      schema: { type: "array" },
+      value: loaderValue,
+      meta: loaderMeta,
+    });
+    expect(el).not.toBeNull();
+    expect(typeOf(el)).toBe(SchemaForm);
+  });
+
+  // Boundary: unresolvable ref (no meta) must fall through to the old object path.
+  test("falls through to ObjectField when the ref can't be resolved", () => {
+    const el = renderField({
+      ...baseProps,
+      schema: { type: "array" },
+      value: loaderValue,
+    });
+    expect(typeOf(el)).not.toBe(SchemaForm);
+    expect(typeOf(el)).toBe(ObjectField);
+  });
+
+  // Ordering guard: a schema that kept its picker branch must still render AnyOfField.
+  test("block-ref schema with anyOfRefs still renders the picker", () => {
+    const el = renderField({
+      ...baseProps,
+      schema: {
+        type: "block-ref",
+        anyOfRefs: [{ resolveType: LOADER, title: "Buy Together" }],
+      },
+      value: { __resolveType: LOADER },
+      meta: loaderMeta,
+    });
+    expect(typeOf(el)).toBe(AnyOfField);
   });
 });

--- a/apps/web/src/components/sections-editor/schema-form.tsx
+++ b/apps/web/src/components/sections-editor/schema-form.tsx
@@ -284,6 +284,45 @@ export function renderField(props: FieldProps) {
     return <SecretField key={props.path} {...props} />;
   }
 
+  /**
+   * Value is a resolved block ref (`{ __resolveType }`) whose schema collapsed to
+   * a bare array/object with no `anyOfRefs` (deco loader-backed props like
+   * `buyTogether`); render the referenced block's config form so it stays
+   * editable instead of vanishing into `ObjectField`'s null path.
+   */
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    typeof (value as Record<string, unknown>).__resolveType === "string" &&
+    props.meta
+  ) {
+    const referencedSchema = resolveSchema(
+      (value as Record<string, unknown>).__resolveType as string,
+      props.meta,
+    );
+    if (referencedSchema) {
+      return (
+        <SchemaForm
+          key={props.path}
+          schema={referencedSchema}
+          value={value}
+          onChange={props.onChange}
+          basePath={props.path}
+          breadcrumbPath={props.breadcrumbPath}
+          onBreadcrumbChange={props.onBreadcrumbChange}
+          meta={props.meta}
+          decofile={props.decofile}
+          onSaveReferencedBlock={props.onSaveReferencedBlock}
+          previewBaseUrl={props.previewBaseUrl}
+          onAddSectionItem={props.onAddSectionItem}
+          onRequestAddSection={props.onRequestAddSection}
+          sandbox={props.sandbox}
+        />
+      );
+    }
+  }
+
   // If value is null/undefined, try to produce a typed default from schema
   const effectiveValue =
     value === null || value === undefined

--- a/apps/web/src/components/sections-editor/schema-form.tsx
+++ b/apps/web/src/components/sections-editor/schema-form.tsx
@@ -114,6 +114,44 @@ function defaultForType(
   }
 }
 
+/**
+ * A resolved block-ref value (`{ __resolveType }`) whose schema no longer
+ * carries a picker branch — e.g. deco loader-backed props (`buyTogether:
+ * ProductBuyTogether[]`) whose union collapsed to a bare array/object, so the
+ * `anyOfRefs` block-ref path never fired. Render the referenced block's own
+ * config form (via `resolveSchema` on the value's `__resolveType`) so the field
+ * stays editable instead of vanishing into `ObjectField`'s null path. Returns
+ * `null` when the value isn't a resolvable block ref, so callers fall through.
+ */
+function renderResolvedBlockRefValue(props: FieldProps): ReactNode | null {
+  const { value, meta } = props;
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const resolveType = (value as Record<string, unknown>).__resolveType;
+  if (typeof resolveType !== "string" || !meta) return null;
+  const referencedSchema = resolveSchema(resolveType, meta);
+  if (!referencedSchema) return null;
+  return (
+    <SchemaForm
+      key={props.path}
+      schema={referencedSchema}
+      value={value}
+      onChange={props.onChange}
+      basePath={props.path}
+      breadcrumbPath={props.breadcrumbPath}
+      onBreadcrumbChange={props.onBreadcrumbChange}
+      meta={meta}
+      decofile={props.decofile}
+      onSaveReferencedBlock={props.onSaveReferencedBlock}
+      previewBaseUrl={props.previewBaseUrl}
+      onAddSectionItem={props.onAddSectionItem}
+      onRequestAddSection={props.onRequestAddSection}
+      sandbox={props.sandbox}
+    />
+  );
+}
+
 export function renderField(props: FieldProps) {
   const { schema, value } = props;
 
@@ -284,43 +322,10 @@ export function renderField(props: FieldProps) {
     return <SecretField key={props.path} {...props} />;
   }
 
-  /**
-   * Value is a resolved block ref (`{ __resolveType }`) whose schema collapsed to
-   * a bare array/object with no `anyOfRefs` (deco loader-backed props like
-   * `buyTogether`); render the referenced block's config form so it stays
-   * editable instead of vanishing into `ObjectField`'s null path.
-   */
-  if (
-    value !== null &&
-    typeof value === "object" &&
-    !Array.isArray(value) &&
-    typeof (value as Record<string, unknown>).__resolveType === "string" &&
-    props.meta
-  ) {
-    const referencedSchema = resolveSchema(
-      (value as Record<string, unknown>).__resolveType as string,
-      props.meta,
-    );
-    if (referencedSchema) {
-      return (
-        <SchemaForm
-          key={props.path}
-          schema={referencedSchema}
-          value={value}
-          onChange={props.onChange}
-          basePath={props.path}
-          breadcrumbPath={props.breadcrumbPath}
-          onBreadcrumbChange={props.onBreadcrumbChange}
-          meta={props.meta}
-          decofile={props.decofile}
-          onSaveReferencedBlock={props.onSaveReferencedBlock}
-          previewBaseUrl={props.previewBaseUrl}
-          onAddSectionItem={props.onAddSectionItem}
-          onRequestAddSection={props.onRequestAddSection}
-          sandbox={props.sandbox}
-        />
-      );
-    }
+  // Resolved block-ref value whose schema lost its picker branch — see renderResolvedBlockRefValue. Skip when a format/enum widget owns the field.
+  if (!schema.format && !schema.enum) {
+    const blockRefForm = renderResolvedBlockRefValue(props);
+    if (blockRefForm) return blockRefForm;
   }
 
   // If value is null/undefined, try to produce a typed default from schema
@@ -406,37 +411,8 @@ function renderMultivariateInnerField(
     return renderField({ ...props, schema: variantValueSchema });
   }
 
-  const value = props.value;
-  if (
-    value &&
-    typeof value === "object" &&
-    !Array.isArray(value) &&
-    typeof (value as Record<string, unknown>).__resolveType === "string" &&
-    props.meta
-  ) {
-    const innerSchema = resolveSchema(
-      (value as Record<string, unknown>).__resolveType as string,
-      props.meta,
-    );
-    if (innerSchema) {
-      return (
-        <SchemaForm
-          schema={innerSchema}
-          value={value}
-          onChange={props.onChange}
-          basePath={props.path}
-          breadcrumbPath={props.breadcrumbPath}
-          onBreadcrumbChange={props.onBreadcrumbChange}
-          meta={props.meta}
-          decofile={props.decofile}
-          onSaveReferencedBlock={props.onSaveReferencedBlock}
-          sandbox={props.sandbox}
-          previewBaseUrl={props.previewBaseUrl}
-          onRequestAddSection={props.onRequestAddSection}
-        />
-      );
-    }
-  }
+  const blockRefForm = renderResolvedBlockRefValue(props);
+  if (blockRefForm) return blockRefForm;
 
   return renderField(
     variantValueSchema ? { ...props, schema: variantValueSchema } : props,


### PR DESCRIPTION
## Summary

Deco loader-backed union props — e.g. `ProductDetails`' `buyTogether: ProductBuyTogether[]` bound to `site/loaders/Product/BuyTogether.ts` — stopped rendering in the section editor: the field vanished entirely (no header, no picker).

**Root cause.** #6057 correctly makes these props resolve to `type: "array"` (good when the decofile value is an inline array). But when the stored value is still a **loader reference** (`{ __resolveType: "site/loaders/Product/BuyTogether.ts", rules, ... }`), `renderField` combined schema `array` + object value and fell through to `ObjectField`, which does `if (!schema.properties) return null` — array schemas carry `items`, not `properties` — so the field silently disappeared.

- Pre-#6057: showed a (useless) loader picker.
- Post-#6057 (in 4.220.2): field disappears entirely.

**Fix.** In `renderField` (`apps/web/src/components/sections-editor/schema-form.tsx`), after the secret-block check and before the object fallthrough, add a branch: if the value is a non-array object with a string `__resolveType` and the schema didn't route through `anyOfRefs`, resolve the referenced block's schema (`resolveSchema(value.__resolveType, meta)`) and render its config form via `<SchemaForm>` — the same pattern `renderMultivariateInnerField` already uses. Loader-backed props now stay visible and editable (e.g. the loader's `rules` array). `__resolveType` is preserved on save (SchemaForm's `updateField` spreads the existing object value).

## Affected areas

Section editor field rendering only. Normal block-ref / secret / multivariate values are handled by earlier branches and are unaffected — only collapsed-union `__resolveType` values (previously dead-ending in `ObjectField`) reach the new branch.

## Testing

- `bun run check` (apps/web) — passes, 0 errors
- `bun test` schema-form + resolve-schema — 60 pass, 0 fail
- `bun run fmt` — clean
- Verified against montecarlo's real `/live/_meta`: `resolveSchema("site/loaders/Product/BuyTogether.ts", meta)` returns `{ rules: Rule[], productDetailsPage }`, so the new branch renders the loader's editable config instead of nothing.

## Notes / follow-up

Distinct from the farmrio `mediaKits` case #6057 fixed (value was an inline array → schema fix sufficed). Here the value remains a loader ref, so it needed a renderer fix. A fuller version could preserve the loader branch on the resolved array schema so the user can toggle between inline-array and loader — left as follow-up; this PR restores visibility/editability, matching the legacy admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression where loader-backed union props disappeared in the sections editor when the schema collapsed to an inline `array` but the value was a `{ __resolveType }` loader ref. Now we resolve the referenced block’s schema and render its config form, keeping the field visible and editable.

- Extracts `renderResolvedBlockRefValue` and uses it in both `renderField` and `renderMultivariateInnerField` in `apps/web/src/components/sections-editor/schema-form.tsx`, unifying behavior and restoring the "add section" affordance for multivariate section arrays.
- Guards the new branch with `!schema.format && !schema.enum` so format/enum widgets retain control.
- Adds tests in `schema-form.test.ts` for collapsed loader-ref → `SchemaForm`, unresolved ref → `ObjectField`, and `anyOfRefs` → `AnyOfField`.
- Preserves `__resolveType` on save. No migration required; scope limited to the sections editor.

<sup>Written for commit f7c8828ecfa442184922df3784a09f1b010c86a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

