### PR TITLE
perf(task-board): bound the claude-code output budget, tier the reviewer model

### DIFF
--- a/apps/api/src/harnesses/claude-code-env.test.ts
+++ b/apps/api/src/harnesses/claude-code-env.test.ts
@@ -1,15 +1,22 @@
 import { describe, expect, test } from "bun:test";
 import {
+  CLAUDE_CODE_MAX_OUTPUT_TOKENS,
   CLAUDE_SUBSCRIPTION_PROVIDER_ID,
   claudeCodeEnvFromCredential,
+  modelClassFromMetadata,
   UnsupportedClaudeCodeProviderError,
 } from "./claude-code-env";
+
+const BUDGET = {
+  CLAUDE_CODE_MAX_OUTPUT_TOKENS: `${CLAUDE_CODE_MAX_OUTPUT_TOKENS}`,
+};
 
 describe("claudeCodeEnvFromCredential", () => {
   test("an Anthropic key is used directly", () => {
     expect(
       claudeCodeEnvFromCredential({ providerId: "anthropic", apiKey: "sk-a" }),
     ).toEqual({
+      ...BUDGET,
       CLAUDE_CODE_MODEL: "claude-opus-5",
       ANTHROPIC_API_KEY: "sk-a",
       ANTHROPIC_AUTH_TOKEN: null,
@@ -32,6 +39,7 @@ describe("claudeCodeEnvFromCredential", () => {
     expect(
       claudeCodeEnvFromCredential({ providerId: "openrouter", apiKey: "or-1" }),
     ).toEqual({
+      ...BUDGET,
       CLAUDE_CODE_MODEL: "anthropic/claude-opus-5",
       ANTHROPIC_API_KEY: "",
       ANTHROPIC_AUTH_TOKEN: "or-1",
@@ -68,6 +76,7 @@ describe("claudeCodeEnvFromCredential", () => {
     expect(
       claudeCodeEnvFromCredential({ providerId: "deco", apiKey: "deco-1" }),
     ).toEqual({
+      ...BUDGET,
       CLAUDE_CODE_MODEL: "anthropic/claude-opus-5",
       ANTHROPIC_API_KEY: "",
       ANTHROPIC_AUTH_TOKEN: "deco-1",
@@ -83,6 +92,7 @@ describe("claudeCodeEnvFromCredential", () => {
         apiKey: "sk-ant-oat-1",
       }),
     ).toEqual({
+      ...BUDGET,
       CLAUDE_CODE_MODEL: "claude-opus-5",
       CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat-1",
       // Both cleared: either one left behind outranks the OAuth token and the
@@ -110,6 +120,74 @@ describe("claudeCodeEnvFromCredential", () => {
       expect(() =>
         claudeCodeEnvFromCredential({ providerId, apiKey: "k" }),
       ).toThrow(new RegExp(providerId));
+    }
+  });
+
+  test("every shape bounds the per-response output budget", () => {
+    // Unbounded, the SDK asks the model's own 64k ceiling and OpenRouter 402s.
+    for (const providerId of [
+      "anthropic",
+      "openrouter",
+      "deco",
+      CLAUDE_SUBSCRIPTION_PROVIDER_ID,
+    ]) {
+      expect(
+        claudeCodeEnvFromCredential({ providerId, apiKey: "k" })
+          .CLAUDE_CODE_MAX_OUTPUT_TOKENS,
+      ).toBe(`${CLAUDE_CODE_MAX_OUTPUT_TOKENS}`);
+    }
+    expect(CLAUDE_CODE_MAX_OUTPUT_TOKENS).toBeLessThan(64_000);
+  });
+
+  test("the reviewer class runs a cheaper model on every provider", () => {
+    expect(
+      claudeCodeEnvFromCredential(
+        { providerId: "anthropic", apiKey: "sk-a" },
+        "reviewer",
+      ).CLAUDE_CODE_MODEL,
+    ).toBe("claude-sonnet-5");
+    expect(
+      claudeCodeEnvFromCredential(
+        { providerId: "openrouter", apiKey: "or-1" },
+        "reviewer",
+      ).CLAUDE_CODE_MODEL,
+    ).toBe("anthropic/claude-sonnet-5");
+    expect(
+      claudeCodeEnvFromCredential(
+        { providerId: "deco", apiKey: "deco-1" },
+        "reviewer",
+      ).CLAUDE_CODE_MODEL,
+    ).toBe("anthropic/claude-sonnet-5");
+    expect(
+      claudeCodeEnvFromCredential(
+        { providerId: CLAUDE_SUBSCRIPTION_PROVIDER_ID, apiKey: "sk-ant-oat-1" },
+        "reviewer",
+      ).CLAUDE_CODE_MODEL,
+    ).toBe("claude-sonnet-5");
+  });
+
+  test("the class changes only the model — credentials are untouched", () => {
+    const { CLAUDE_CODE_MODEL: _builder, ...builderRest } =
+      claudeCodeEnvFromCredential({ providerId: "openrouter", apiKey: "or-1" });
+    const { CLAUDE_CODE_MODEL: _reviewer, ...reviewerRest } =
+      claudeCodeEnvFromCredential(
+        { providerId: "openrouter", apiKey: "or-1" },
+        "reviewer",
+      );
+    expect(reviewerRest).toEqual(builderRest);
+  });
+
+  test("omitting the class keeps the model every run had before", () => {
+    expect(
+      claudeCodeEnvFromCredential({ providerId: "openrouter", apiKey: "or-1" })
+        .CLAUDE_CODE_MODEL,
+    ).toBe("anthropic/claude-opus-5");
+  });
+
+  test("modelClassFromMetadata only trusts the exact reviewer value", () => {
+    expect(modelClassFromMetadata("reviewer")).toBe("reviewer");
+    for (const value of [undefined, "", "default", "Reviewer", "qa", "cheap"]) {
+      expect(modelClassFromMetadata(value)).toBe("default");
     }
   });
 

--- a/apps/api/src/harnesses/claude-code-env.ts
+++ b/apps/api/src/harnesses/claude-code-env.ts
@@ -35,15 +35,60 @@ export const CLAUDE_SUBSCRIPTION_PROVIDER_ID = "claude-subscription";
 const OPENROUTER_ANTHROPIC_BASE_URL = "https://openrouter.ai/api";
 
 /**
- * The model this harness runs, per provider — the same model, named the way
- * each endpoint names it. Fixed rather than taken from the agent's thinking
- * slot: the SDK drives the `claude` CLI, which only works against Claude
- * models, so the slot's id is not usable here.
+ * Which model a run gets. Not the agent's thinking slot — the SDK drives the
+ * `claude` CLI, which only works against Claude models, so the slot's id is not
+ * usable here.
+ *
+ * `reviewer` is a cheaper tier for the QA Agent and Code Reviewer, whose job is
+ * to read a diff and reach a verdict rather than write the change. Together
+ * those two ran MORE threads than the Super Agent on one month of production
+ * boards (1,247 vs 707) and took 57% of the spend — all of it at the builder's
+ * model. Opt-in per org via the `cheap_reviewer_model` flag; unset orgs keep
+ * running every role on `default`, which is what shipped before.
  */
-const CLAUDE_CODE_MODEL = {
-  anthropic: "claude-opus-5",
-  openrouter: "anthropic/claude-opus-5",
-} as const;
+export type ClaudeCodeModelClass = "default" | "reviewer";
+
+const CLAUDE_CODE_MODEL: Record<
+  "anthropic" | "openrouter",
+  Record<ClaudeCodeModelClass, string>
+> = {
+  anthropic: { default: "claude-opus-5", reviewer: "claude-sonnet-5" },
+  openrouter: {
+    default: "anthropic/claude-opus-5",
+    reviewer: "anthropic/claude-sonnet-5",
+  },
+};
+
+/**
+ * `runMetadata` key carrying the class from the enqueue to this dispatch. A
+ * free-form string on the durable run snapshot, same as `runClass` — adding it
+ * changes no schema and no DBOS step I/O.
+ */
+export const MODEL_CLASS_METADATA_KEY = "claudeCodeModelClass";
+
+/** Narrow an untrusted `runMetadata` value to a class. Pure — unit-tested. */
+export function modelClassFromMetadata(
+  value: string | undefined,
+): ClaudeCodeModelClass {
+  return value === "reviewer" ? "reviewer" : "default";
+}
+
+/**
+ * Per-response output ceiling for the CLI, in tokens.
+ *
+ * Unset, the SDK asks for the model's own maximum (64k on Opus), and OpenRouter
+ * rejects the WHOLE request with a 402 unless the balance covers that ceiling —
+ * even though a turn almost never emits a fraction of it. That was the single
+ * biggest killer of production runs: 28 of 36 fatal thread errors across six
+ * orgs read `requires more credits … requested up to 64000 tokens, but can only
+ * afford 47750`, and every one of them forced a fresh retry that re-read the
+ * whole context.
+ *
+ * 32k is above any turn we have observed and halves the balance a run must hold
+ * to start. It bounds the REQUEST, not the work: a turn that needs more output
+ * continues in the next one.
+ */
+export const CLAUDE_CODE_MAX_OUTPUT_TOKENS = 32_000;
 
 /** The subset of a resolved model source this needs. */
 export interface ClaudeCodeCredential {
@@ -74,11 +119,17 @@ export class UnsupportedClaudeCodeProviderError extends Error {
  */
 export function claudeCodeEnvFromCredential(
   credential: ClaudeCodeCredential,
+  modelClass: ClaudeCodeModelClass = "default",
 ): Record<string, string | null> {
   const { providerId, apiKey, baseUrl } = credential;
+  /** A property of the run, not of the credential — so every shape carries it. */
+  const budget = {
+    CLAUDE_CODE_MAX_OUTPUT_TOKENS: `${CLAUDE_CODE_MAX_OUTPUT_TOKENS}`,
+  };
   if (providerId === "anthropic") {
     return {
-      CLAUDE_CODE_MODEL: CLAUDE_CODE_MODEL.anthropic,
+      ...budget,
+      CLAUDE_CODE_MODEL: CLAUDE_CODE_MODEL.anthropic[modelClass],
       ANTHROPIC_API_KEY: apiKey,
       ANTHROPIC_AUTH_TOKEN: null,
       CLAUDE_CODE_OAUTH_TOKEN: null,
@@ -90,7 +141,8 @@ export function claudeCodeEnvFromCredential(
     // token from its own variable; both key variables must be cleared or a
     // leftover one outranks it and the run bills the org's API credit instead.
     return {
-      CLAUDE_CODE_MODEL: CLAUDE_CODE_MODEL.anthropic,
+      ...budget,
+      CLAUDE_CODE_MODEL: CLAUDE_CODE_MODEL.anthropic[modelClass],
       CLAUDE_CODE_OAUTH_TOKEN: apiKey,
       ANTHROPIC_API_KEY: null,
       ANTHROPIC_AUTH_TOKEN: null,
@@ -99,7 +151,8 @@ export function claudeCodeEnvFromCredential(
   }
   if (providerId === "openrouter" || providerId === "deco") {
     return {
-      CLAUDE_CODE_MODEL: CLAUDE_CODE_MODEL.openrouter,
+      ...budget,
+      CLAUDE_CODE_MODEL: CLAUDE_CODE_MODEL.openrouter[modelClass],
       // Empty, not absent: a non-empty API key takes precedence over the auth
       // token and would be sent to OpenRouter as an Anthropic key.
       ANTHROPIC_API_KEY: "",

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -45,6 +45,8 @@ import { isTransientStreamError } from "@/harnesses/decopilot/built-in-tools/sub
 import type { HarnessId, HarnessStreamInput } from "@/harnesses/lib/types";
 import {
   claudeCodeEnvFromCredential,
+  modelClassFromMetadata,
+  MODEL_CLASS_METADATA_KEY,
   type ClaudeCodeCredential,
 } from "@/harnesses/claude-code-env";
 import type { StudioContext } from "../core/studio-context";
@@ -290,7 +292,12 @@ export class SandboxDispatchClient implements SandboxClient {
     }
     // Fail on an unusable provider BEFORE provisioning a pod: the alternative
     // is a booted sandbox that dies on an opaque model error minutes later.
-    const modelEnv = claudeCodeEnvFromCredential(this.credential);
+    const modelEnv = claudeCodeEnvFromCredential(
+      this.credential,
+      modelClassFromMetadata(
+        this.ctx.metadata?.runMetadata?.[MODEL_CLASS_METADATA_KEY],
+      ),
+    );
     const organization = this.ctx.organization;
     if (!organization) {
       throw new Error(

--- a/apps/api/src/tools/task-board/enqueue-reviewer.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.ts
@@ -14,6 +14,8 @@ import { enqueueAgentRunForTask } from "./enqueue-task-run";
 import { resolveTaskRepoChoice } from "./claude-code-task-run";
 import { isThreadRunStale } from "@/tools/thread/helpers";
 import { mintReviewToken } from "./review-token";
+import { orgFlagEnabled } from "@decocms/shared/organization/schema";
+import type { ClaudeCodeModelClass } from "@/harnesses/claude-code-env";
 
 /** Thread statuses past which a reviewer run is done — a live run has a
  *  non-terminal status. Mirrors the storage-layer set. */
@@ -142,6 +144,12 @@ export async function enqueueEnabledReviewers(
   );
   const enabled = enabledReviewerKinds(settings?.flags);
   if (enabled.length === 0) return;
+  const modelClass: ClaudeCodeModelClass = orgFlagEnabled(
+    settings?.flags,
+    "cheap_reviewer_model",
+  )
+    ? "reviewer"
+    : "default";
 
   // A reviewer belongs to the current cycle if its thread is still live, or was
   // created since the task last entered In Review — either way don't re-enqueue.
@@ -185,9 +193,15 @@ export async function enqueueEnabledReviewers(
       // RETRY and needs a fence of its own — the previous attempt's thread id
       // is taken, and reusing it would collapse the retry onto the corpse.
       const attempt = spentAttemptsThisCycle(task, kind, lastInReviewAt);
-      await enqueueReviewerForTask(ctx, task, kind, cycleAt, attempt).catch(
-        (err) =>
-          console.error(`[task-board] ${kind} reviewer enqueue failed`, err),
+      await enqueueReviewerForTask(
+        ctx,
+        task,
+        kind,
+        cycleAt,
+        attempt,
+        modelClass,
+      ).catch((err) =>
+        console.error(`[task-board] ${kind} reviewer enqueue failed`, err),
       );
     }),
   );
@@ -385,6 +399,7 @@ async function enqueueReviewerForTask(
   kind: ReviewerKind,
   cycleAt: Date,
   attempt: number,
+  modelClass: ClaudeCodeModelClass,
 ): Promise<void> {
   const organizationId = task.organizationId;
   // Proves to TASK_BOARD_REVIEW_DECISION that the caller is this reviewer.
@@ -487,6 +502,7 @@ async function enqueueReviewerForTask(
     ...(sandboxed
       ? {
           harnessId: "claude-code" as const,
+          modelClass,
           agent: {
             instructions,
             disallowedTools: REVIEWER_DISALLOWED_TOOLS[kind],

--- a/apps/api/src/tools/task-board/enqueue-task-run.ts
+++ b/apps/api/src/tools/task-board/enqueue-task-run.ts
@@ -12,6 +12,10 @@ import { getDecopilotId } from "@decocms/shared/sdk";
 import type { HostedHarnessId } from "@/api/routes/decopilot/dispatch-run";
 import { threadBranch } from "@/tools/sandbox/thread-repo";
 import { harnessRunsInSandbox } from "@/harnesses/sandbox-dispatch-client";
+import {
+  MODEL_CLASS_METADATA_KEY,
+  type ClaudeCodeModelClass,
+} from "@/harnesses/claude-code-env";
 import type { TaskRepo } from "./claude-code-task-run";
 
 /**
@@ -53,6 +57,12 @@ export async function enqueueAgentRunForTask(
     pinnedRef?: string | null;
     /** Admission class for this run. See `dispatch-queue/run-priority.ts`. */
     runClass?: RunClass;
+    /**
+     * Model tier for a sandbox-hosted run. `reviewer` puts a verdict-only run
+     * on a cheaper model than the Super Agent — see `claude-code-env.ts`.
+     * Defaults to the builder's model, which is what every run used before.
+     */
+    modelClass?: ClaudeCodeModelClass;
     /**
      * Deterministic thread id + run workflow id, for a caller whose triggers can
      * race (the reviewer enqueues). Both are `INSERT … ON CONFLICT DO NOTHING`
@@ -187,6 +197,9 @@ export async function enqueueAgentRunForTask(
         runMetadata: {
           ...taskRunMetadata(task),
           [RUN_CLASS_METADATA_KEY]: opts.runClass ?? "new_task",
+          ...(opts.modelClass && opts.modelClass !== "default"
+            ? { [MODEL_CLASS_METADATA_KEY]: opts.modelClass }
+            : {}),
         },
       },
     },

--- a/apps/web/src/components/settings/review-settings.tsx
+++ b/apps/web/src/components/settings/review-settings.tsx
@@ -1,6 +1,7 @@
 import { toast } from "sonner";
 import { Switch } from "@decocms/ui/components/switch.tsx";
 import {
+  Coins01,
   FileSearch02,
   GitMerge,
   ShieldTick,
@@ -40,6 +41,12 @@ export function ReviewSettings() {
           icon={<FileSearch02 size={16} />}
           titleKey="settings.review.codeReviewerTitle"
           descriptionKey="settings.review.codeReviewerDescription"
+        />
+        <FlagToggle
+          flag="cheap_reviewer_model"
+          icon={<Coins01 size={16} />}
+          titleKey="settings.review.cheapReviewerModelTitle"
+          descriptionKey="settings.review.cheapReviewerModelDescription"
         />
         <FlagToggle
           flag="auto_merge"

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -459,6 +459,9 @@ export const settings = {
   "settings.review.codeReviewerTitle": "Enable Code Reviewer",
   "settings.review.codeReviewerDescription":
     "Reviews the code using the repository's stack-appropriate review skills.",
+  "settings.review.cheapReviewerModelTitle": "Run reviewers on a cheaper model",
+  "settings.review.cheapReviewerModelDescription":
+    "The QA Agent and Code Reviewer read a diff and reach a verdict, so they run on a smaller model than the Super Agent that wrote the change. Cuts review cost; may cut review depth.",
   "settings.review.autoMergeTitle": "Enable Auto-merge",
   "settings.review.autoMergeDescription":
     "When every enabled reviewer approves, merge the pull request automatically instead of waiting for a human. If a conflict blocks the merge, the Super Agent resolves it first.",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -478,6 +478,10 @@ export const settings = {
   "settings.review.codeReviewerTitle": "Ativar Code Reviewer",
   "settings.review.codeReviewerDescription":
     "Revisa o c\u00f3digo usando as skills de review apropriadas \u00e0 stack do reposit\u00f3rio.",
+  "settings.review.cheapReviewerModelTitle":
+    "Rodar os revisores em um modelo mais barato",
+  "settings.review.cheapReviewerModelDescription":
+    "O QA Agent e o Code Reviewer leem um diff e chegam a um veredito, então rodam em um modelo menor que o Super Agent que escreveu a mudança. Reduz o custo da revisão; pode reduzir a profundidade.",
   "settings.review.autoMergeTitle": "Ativar Auto-merge",
   "settings.review.autoMergeDescription":
     "Quando todos os revisores habilitados aprovam, mescla o pull request automaticamente em vez de esperar por uma pessoa. Se um conflito bloquear o merge, o Super Agent resolve antes.",

--- a/packages/shared/src/organization/schema.ts
+++ b/packages/shared/src/organization/schema.ts
@@ -155,6 +155,12 @@ export const OrgFlagsSchema = z.object({
     .describe(
       "When every enabled reviewer (QA Agent / Code Reviewer) approves a task's pull request, merge it automatically instead of leaving the merge to a human. If the merge is blocked by a conflict with the base branch, hand the PR back to the Super Agent to resolve the conflict (check out the branch, merge the base, push) so it can then merge.",
     ),
+  cheap_reviewer_model: z
+    .boolean()
+    .optional()
+    .describe(
+      "Run the QA Agent and Code Reviewer on a cheaper model than the Super Agent. A review reads a diff and reaches a verdict; it does not need the model that wrote the code. Off by default — turning it on trades some review depth for cost.",
+    ),
   auto_assign_report_tasks_to_super_agent: z
     .boolean()
     .optional()

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -124,6 +124,7 @@ export interface StudioToolIO {
             qa_agent_enabled?: boolean | undefined;
             code_reviewer_enabled?: boolean | undefined;
             auto_merge?: boolean | undefined;
+            cheap_reviewer_model?: boolean | undefined;
             auto_assign_report_tasks_to_super_agent?: boolean | undefined;
           }
         | null
@@ -190,6 +191,7 @@ export interface StudioToolIO {
             qa_agent_enabled?: boolean | undefined;
             code_reviewer_enabled?: boolean | undefined;
             auto_merge?: boolean | undefined;
+            cheap_reviewer_model?: boolean | undefined;
             auto_assign_report_tasks_to_super_agent?: boolean | undefined;
           }
         | undefined;
@@ -256,6 +258,7 @@ export interface StudioToolIO {
             qa_agent_enabled?: boolean | undefined;
             code_reviewer_enabled?: boolean | undefined;
             auto_merge?: boolean | undefined;
+            cheap_reviewer_model?: boolean | undefined;
             auto_assign_report_tasks_to_super_agent?: boolean | undefined;
           }
         | null


### PR DESCRIPTION
## Why

Rolled one month of production task-board spend up to the **task** (a task is many threads: Super Agent → Code Reviewer → QA → back to Super Agent → …). Across 319 dispatched tasks / 1,961 threads: **$1,612.73**, avg $5.06/task.

| Role | Threads | Cost | % of spend |
|---|---|---|---|
| Super Agent | 707 | $698.76 | 43% |
| QA Agent | 509 | $467.43 | 29% |
| Code Reviewer | 738 | $444.41 | 28% |

Verification is 57% of spend, the reviewer runs *more* threads than the builder, and QA's median thread ($0.88) costs more than the builder's ($0.63). Separately, 310 threads died — 28 of the 36 fatal errors were the same OpenRouter 402.

## What changes

**1. Bound the per-response output budget.** `CLAUDE_CODE_MAX_OUTPUT_TOKENS` was never set, so the SDK asks for the model's own ceiling (64k on Opus) and OpenRouter 402s the *whole request* unless the balance covers that ceiling — even though a turn emits a fraction of it:

```
Error: API Error: 402 This request requires more credits, or fewer max_tokens.
You requested up to 64000 tokens, but can only afford 47750.
```

Now pinned to 32k on every credential shape. It bounds the **request**, not the work — a turn needing more output continues in the next one. Halves the balance a run must hold to start.

**2. Tier the reviewer model.** The harness hard-codes `claude-opus-5` for every run, so QA and Code Reviewer — read a diff, reach a verdict — run on the model that wrote the code. Behind the new **default-off** `cheap_reviewer_model` org flag they run Sonnet instead. An unset org gets a byte-identical env to today (asserted in a test).

The class rides `runMetadata` from the reviewer enqueue (which already loads org settings — no extra read) to the dispatch client, next to the existing `runClass`. Settings toggle added under Review settings, en + pt-BR.

## What this deliberately does NOT do

- **Cap the reviewer ↔ Super Agent loop.** I found one task with **105 reviewer threads / $67**, then found #5804 already capped it at 5 bounces on 2026-08-06 — the same day that task's last thread ran. Already fixed; not re-fixed here.
- **Gate reviewers on task status.** `review-sweeper.ts:470` already skips anything not `in_review`. The $84 of reviewer spend on later-archived tasks was spent while they were legitimately in review — that's a product signal (one POC org has 22 tasks in review, 1 merged), not a bug.

## Testing

- `bun test apps/api/src/harnesses/claude-code-env.test.ts` — 15 pass. New cases: budget present on all four credential shapes and below 64k; reviewer model on every provider; the class changes *only* `CLAUDE_CODE_MODEL`; omitting it keeps today's model; `modelClassFromMetadata` narrows an untrusted string to exactly `reviewer`.
- `bun run fmt`, `bun run lint` (0 errors), `bun run check` on api/web/shared, `knip` clean.
- 35 failures under `apps/api/src/tools/task-board/` are `*.integration.test.ts` needing a live Postgres — identical count on `main` (verified by stashing).

## Rollout

Ship dormant. Flip `cheap_reviewer_model` on one org, compare its reviewers' change-request rate against a control before widening. The output-budget change is unflagged — it is a bound, not a new code path.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the Claude Code per-response output to 32k tokens and adds a cheaper reviewer model tier behind an org flag. Previously requests asked for the model’s 64k ceiling and could 402 on OpenRouter; reviewers always used Opus. Now requests cap at 32k (long outputs continue next turn), and QA Agent/Code Reviewer use Sonnet when `cheap_reviewer_model` is enabled; unset orgs continue on Opus.

- Review notes
  - `apps/api`: `claude-code-env.ts` adds `CLAUDE_CODE_MAX_OUTPUT_TOKENS = 32_000`, model tier mapping, and `MODEL_CLASS_METADATA_KEY` with `modelClassFromMetadata`. `sandbox-dispatch-client.ts` reads the metadata and passes the class to `claudeCodeEnvFromCredential`. `enqueue-reviewer.ts` sets `modelClass` from the org flag; `enqueue-task-run.ts` writes it into `runMetadata`.
  - `apps/web`: adds a Review Settings toggle for `cheap_reviewer_model` with copy in `en` and `pt-br`.
  - `packages/shared`: adds `cheap_reviewer_model` to the org flags schema and to tool IO types.
  - Tests in `apps/api/src/harnesses/claude-code-env.test.ts` assert the budget is present for all provider shapes, below 64k; verify the reviewer class only changes `CLAUDE_CODE_MODEL`; and validate metadata narrowing.

- Rollout
  - Ships dormant. Enable `cheap_reviewer_model` on one org to compare reviewer outcomes before widening.
  - The output-budget cap is unflagged and applies to all credentials.
  - No migrations required.

<sup>Written for commit 50037c57fdce02cc201d6538405bed93d47384c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6147?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

