### PR TITLE
fix(cli): reject an absurdly large expires_in during interactive login

### DIFF
--- a/apps/api/src/cli/commands/auth/login.test.ts
+++ b/apps/api/src/cli/commands/auth/login.test.ts
@@ -187,6 +187,54 @@ describe("loginCommand", () => {
     expect(await readSession(dir)).toBeNull();
   });
 
+  it("ignores an absurdly large expires_in and leaves expiresAt unset", async () => {
+    const target = "https://studio.decocms.com";
+    const fetchMock = mock(async (url: string, init?: RequestInit) => {
+      if (url === `${target}/api/auth/mcp/register`) {
+        return new Response(JSON.stringify({ client_id: "client_x" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (url === `${target}/api/auth/mcp/token`) {
+        const body = new URLSearchParams(init?.body as string);
+        expect(body.get("grant_type")).toBe("authorization_code");
+        const idTokenPayload = Buffer.from(
+          JSON.stringify({ sub: "user-123" }),
+        ).toString("base64url");
+        return new Response(
+          JSON.stringify({
+            access_token: "at_1",
+            expires_in: 1e20,
+            id_token: `header.${idTokenPayload}.signature`,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    const openBrowser = mock(async (url: string) => {
+      const parsed = new URL(url);
+      const callback = parsed.searchParams.get("redirect_uri")!;
+      const state = parsed.searchParams.get("state")!;
+      await new Promise((r) => setTimeout(r, 10));
+      await fetch(`${callback}?code=c&state=${state}`, {
+        redirect: "manual",
+      });
+    });
+
+    const code = await loginCommand({
+      dataDir: dir,
+      target,
+      openBrowser,
+      fetch: fetchMock,
+    });
+
+    expect(code).toBe(0);
+    const session = await readSession(dir);
+    expect(session?.expiresAt).toBeUndefined();
+  });
+
   it("returns non-zero when client registration fails", async () => {
     const fetchMock = mock(async (url: string) => {
       if (url.endsWith("/register")) {

--- a/apps/api/src/cli/commands/auth/login.ts
+++ b/apps/api/src/cli/commands/auth/login.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { startOAuthCallbackServer } from "../../lib/oauth-callback";
 import { generatePkcePair } from "../../lib/pkce";
+import { MAX_EXPIRES_IN_SECONDS } from "../../lib/refresh-session";
 import { type Session, writeSession } from "../../lib/session";
 
 export interface LoginOptions {
@@ -101,9 +102,13 @@ export async function performInteractiveLogin(
       user: { sub: claims.sub, email: claims.email, name: claims.name },
       accessToken: token.access_token,
       refreshToken: token.refresh_token,
-      expiresAt: token.expires_in
-        ? Math.floor(Date.now() / 1000) + token.expires_in
-        : undefined,
+      // expires_in is untrusted server input, same bound as refreshSession.
+      expiresAt:
+        Number.isFinite(token.expires_in) &&
+        token.expires_in! > 0 &&
+        token.expires_in! <= MAX_EXPIRES_IN_SECONDS
+          ? Math.floor(Date.now() / 1000) + token.expires_in!
+          : undefined,
       createdAt: new Date().toISOString(),
     };
   } finally {

--- a/apps/api/src/cli/lib/refresh-session.ts
+++ b/apps/api/src/cli/lib/refresh-session.ts
@@ -29,7 +29,7 @@ const TOKEN_REFRESH_FETCH_TIMEOUT_MS = 10_000;
  * real upstream token has long expired. 100 years is far past any real
  * OAuth token TTL.
  */
-const MAX_EXPIRES_IN_SECONDS = 100 * 365 * 24 * 60 * 60;
+export const MAX_EXPIRES_IN_SECONDS = 100 * 365 * 24 * 60 * 60;
 
 /**
  * Exchanges the session's refresh token for a fresh access token.


### PR DESCRIPTION
PR #6113 bounded `expires_in` in `refreshSession` (the refresh-token path) so an absurd server value can't make a session look valid forever. `performInteractiveLogin`'s initial token exchange in `apps/api/src/cli/commands/auth/login.ts` computes `expiresAt` from `token.expires_in` the exact same way, but never got that bound — it only checked truthiness (`token.expires_in ? now + expires_in : undefined`), so a token endpoint returning e.g. `1e20` (or any value past `MAX_EXPIRES_IN_SECONDS`) on the very first login sets `expiresAt` far enough in the future that `isExpired()` in `get-valid-session.ts` never fires, and the CLI never refreshes the session again for the lifetime of a long-running dev machine.

Fix: export `MAX_EXPIRES_IN_SECONDS` from `refresh-session.ts` and apply the identical `Number.isFinite && > 0 && <= MAX` guard in `login.ts`, falling back to `undefined` (unknown expiry, same as before) on an out-of-range value — mirrors the already-hardened refresh path instead of adding a new bound.

Failure scenario: malicious or buggy token endpoint returns `expires_in: 1e20` on `decocms auth login` → `expiresAt` lands ~100+ years out → session is treated as perpetually fresh → CLI keeps using a token that may have long since been rotated/revoked server-side, with no proactive refresh to catch it.

Regression test added in `login.test.ts`: mocks the token endpoint returning `expires_in: 1e20` and asserts the persisted session's `expiresAt` is `undefined` (not a resolved timestamp), matching the existing `refresh-session.test.ts` coverage for the same class.

Reviewer command: `bun test apps/api/src/cli/commands/auth/login.test.ts`

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), `bun test apps/api/src/cli/commands/auth/login.test.ts` (5/5 pass), `bunx oxlint` on the three touched files (0 warnings/errors). Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds `expires_in` during interactive CLI login so absurd server values no longer set a far‑future `expiresAt`. Previously we accepted any truthy `expires_in`, which could make a session appear valid for decades; now we only accept finite, positive values up to `MAX_EXPIRES_IN_SECONDS`, otherwise we treat expiry as unknown.

- Export `MAX_EXPIRES_IN_SECONDS` from `cli/lib/refresh-session.ts` and reuse the same guard in `performInteractiveLogin` to compute `expiresAt`. Out-of-range `expires_in` results in `expiresAt: undefined` (same behavior as no expiry provided).
- Add a regression test in `cli/commands/auth/login.test.ts` that mocks `expires_in: 1e20`; run with: bun test apps/api/src/cli/commands/auth/login.test.ts.

<sup>Written for commit 8ac7abacd0bea75a19540dce2eec6c679ae663ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6149?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

