### PR TITLE
feat(harness): record the model a claude-code run used

### DIFF
--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -49,6 +49,7 @@ import {
   MODEL_CLASS_METADATA_KEY,
   type ClaudeCodeCredential,
 } from "@/harnesses/claude-code-env";
+import { withModelMetadata } from "@/harnesses/with-model-metadata";
 import type { StudioContext } from "../core/studio-context";
 import { mintMcpEndpoint } from "@/mcp-clients/virtual-mcp/mint-endpoint";
 import { resolveSandboxProvider } from "@/sandbox/resolve-provider";
@@ -353,6 +354,7 @@ export class SandboxDispatchClient implements SandboxClient {
     // `Registry.claim`).
     const runId = input.threadId;
     const { ctx, harnessId, virtualMcpId, branch } = this;
+    const credentialProviderId = this.credential.providerId;
 
     // Provisioning is re-done per attempt on purpose. On the continuation path
     // the pod is gone, and `ensureSandbox` + `pushSandboxEnv` are what put a
@@ -382,14 +384,18 @@ export class SandboxDispatchClient implements SandboxClient {
         // The daemon deep-merges its config, so re-running on an already-claimed
         // sandbox just rotates the credential.
         await pushSandboxEnv(provider, sandbox.sandboxHandle, modelEnv);
-        yield* dispatchToDaemon({
-          provider,
-          handle: sandbox.sandboxHandle,
-          harnessId,
-          input: resume ? { ...wireInput, resume } : wireInput,
-          runId,
-          signal: input.signal,
-        });
+        yield* withModelMetadata(
+          dispatchToDaemon({
+            provider,
+            handle: sandbox.sandboxHandle,
+            harnessId,
+            input: resume ? { ...wireInput, resume } : wireInput,
+            runId,
+            signal: input.signal,
+          }),
+          modelEnv.CLAUDE_CODE_MODEL,
+          credentialProviderId,
+        );
       })();
 
     try {

--- a/apps/api/src/harnesses/with-model-metadata.test.ts
+++ b/apps/api/src/harnesses/with-model-metadata.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test";
+import type { UIMessageChunk } from "ai";
+import { withModelMetadata } from "./with-model-metadata";
+
+const chunk = (type: string, extra: Record<string, unknown> = {}) =>
+  ({ type, ...extra }) as UIMessageChunk;
+
+async function collect(
+  source: AsyncIterable<UIMessageChunk>,
+): Promise<Array<Record<string, unknown>>> {
+  const out: Array<Record<string, unknown>> = [];
+  for await (const c of source) out.push(c as Record<string, unknown>);
+  return out;
+}
+
+function stream(...types: string[]): AsyncIterable<UIMessageChunk> {
+  return (async function* () {
+    for (const t of types) yield chunk(t);
+  })();
+}
+
+describe("withModelMetadata", () => {
+  test("stamps the model immediately after start, and nowhere else", async () => {
+    const out = await collect(
+      withModelMetadata(
+        stream("start", "text-start", "text-end", "finish"),
+        "anthropic/claude-opus-5",
+        "deco",
+      ),
+    );
+    expect(out.map((c) => c.type)).toEqual([
+      "start",
+      "message-metadata",
+      "text-start",
+      "text-end",
+      "finish",
+    ]);
+    expect(out[1]?.messageMetadata).toEqual({
+      models: {
+        thinking: {
+          id: "anthropic/claude-opus-5",
+          title: "anthropic/claude-opus-5",
+          provider: "deco",
+        },
+      },
+    });
+  });
+
+  test("stamps once even when a continuation replays start", async () => {
+    const out = await collect(
+      withModelMetadata(
+        stream("start", "text-start", "start", "finish"),
+        "claude-sonnet-5",
+        "anthropic",
+      ),
+    );
+    expect(out.filter((c) => c.type === "message-metadata")).toHaveLength(1);
+  });
+
+  test("passes every chunk through untouched", async () => {
+    const source = (async function* () {
+      yield chunk("start");
+      yield chunk("text-delta", { id: "t", delta: "hi" });
+      yield chunk("finish", { finishReason: "stop" });
+    })();
+    const out = await collect(withModelMetadata(source, "m", "p"));
+    expect(out.filter((c) => c.type !== "message-metadata")).toEqual([
+      { type: "start" },
+      { type: "text-delta", id: "t", delta: "hi" },
+      { type: "finish", finishReason: "stop" },
+    ]);
+  });
+
+  test("stamps nothing when the model is unknown", async () => {
+    for (const modelId of [null, undefined, ""]) {
+      const out = await collect(
+        withModelMetadata(stream("start", "finish"), modelId, "deco"),
+      );
+      expect(out.map((c) => c.type)).toEqual(["start", "finish"]);
+    }
+  });
+
+  test("a stream that never starts is passed through as-is", async () => {
+    const out = await collect(
+      withModelMetadata(stream("error"), "claude-opus-5", "anthropic"),
+    );
+    expect(out.map((c) => c.type)).toEqual(["error"]);
+  });
+});

--- a/apps/api/src/harnesses/with-model-metadata.ts
+++ b/apps/api/src/harnesses/with-model-metadata.ts
@@ -1,0 +1,41 @@
+import type { UIMessageChunk } from "ai";
+
+/**
+ * Stamp the model a sandbox-hosted run actually used onto its assistant
+ * message, in the shape Decopilot already emits (`metadata.models.thinking`).
+ *
+ * Decopilot writes that key from its own `messageMetadata` callback; the
+ * claude-code harness has no such hook — its chunks come off the daemon over
+ * SSE — so its finished messages carried `usage` (tokens, cost) and no model at
+ * all. On one month of production task-board runs that was 328 of 391 billed
+ * steps: every number attributable to an org and a task, none of it to a model.
+ * Cost per model, and any experiment that moves a role onto a cheaper one, are
+ * unanswerable without this.
+ *
+ * The model is not on the wire either — it reaches the pod as an environment
+ * variable (`CLAUDE_CODE_MODEL`), so the dispatch client is the last place that
+ * still knows it. Injected right after `start`, which is where Decopilot emits
+ * the same key (a metadata chunk before `start` has no message to attach to and
+ * is dropped), so both harnesses persist one shape and one query reads both.
+ */
+export async function* withModelMetadata(
+  chunks: AsyncIterable<UIMessageChunk>,
+  modelId: string | null | undefined,
+  providerId: string,
+): AsyncIterable<UIMessageChunk> {
+  let stamped = false;
+  for await (const chunk of chunks) {
+    yield chunk;
+    if (stamped || !modelId) continue;
+    if ((chunk as { type?: string }).type !== "start") continue;
+    stamped = true;
+    yield {
+      type: "message-metadata",
+      messageMetadata: {
+        models: {
+          thinking: { id: modelId, title: modelId, provider: providerId },
+        },
+      },
+    } as UIMessageChunk;
+  }
+}


### PR DESCRIPTION
Prerequisite for evaluating #6147 (`cheap_reviewer_model`). Without it that flag's effect is unmeasurable.

## The gap

Decopilot stamps `metadata.models.thinking` on its assistant messages from its own `messageMetadata` callback. The `claude-code` harness has no such hook — its chunks arrive off the daemon over SSE — so its finished messages carried `usage` (tokens, cost) and **no model at all**.

On one month of production task-board runs that was **328 of 391 billed steps**: every dollar attributable to an org and a task, none of it to a model. Cost-per-model is unanswerable, and so is "did moving reviewers to Sonnet make reviews worse".

## The fix

The model isn't on the wire either — it reaches the pod as the `CLAUDE_CODE_MODEL` env var — so `SandboxDispatchClient` is the last place that still knows it. It now injects a `message-metadata` chunk right after `start`: the same key, same shape, same stream position Decopilot uses, so one query reads both harnesses.

## Testing

`bun test apps/api/src/harnesses/with-model-metadata.test.ts` — 5 pass. Covers position (after `start`, never before — an earlier chunk has no message to attach to and the SDK drops it), stamped exactly once when a continuation replays `start`, every other chunk passed through byte-identical, and no stamp at all when the model is unknown.

`bun run fmt`, `bun run lint` (0 errors), `bun run check` on apps/api, `knip` clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Records the model used by `claude-code` runs so we can attribute cost per model and measure `cheap_reviewer_model`. Previously, finished messages had `usage` but no model; now we inject a `message-metadata` chunk after `start` with `metadata.models.thinking`, matching Decopilot.

- Wraps the daemon stream in `SandboxDispatchClient` with `withModelMetadata`, using `CLAUDE_CODE_MODEL` and the credential’s provider id.
- Emits the metadata exactly once after the first `start`; passes all other chunks through unchanged; emits nothing if the model is unknown.
- Keeps the same key and position as Decopilot so a single query reads both harnesses.
- Tests cover insertion point, idempotency on continuation, pass-through integrity, unknown model, and streams without `start`.

<sup>Written for commit 1b62a5aada3ba0a57c051ef156bcfe2843703064. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6151?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

