### PR TITLE
fix(task-board): TASK_ADD_REPO looked the sandbox up under the wrong key

### DIFF
--- a/apps/api/src/tools/task-board/add-repo.ts
+++ b/apps/api/src/tools/task-board/add-repo.ts
@@ -15,7 +15,7 @@
  * repo (`pickSoleTaskRepo`) because the checkout was resolved at dispatch;
  * everything else fell back to Decopilot.
  *
- * The sandbox key is whatever the run was DISPATCHED on (`threads.branch`) — see
+ * The sandbox key is whatever the run was DISPATCHED on (NOT `threads.branch`) — see
  * `resolveSandboxBranch`. Deriving it (from the repo like `load_repo`, or as the
  * bare key this tool used to assume) misses the pod the agent loop is in.
  */
@@ -38,11 +38,11 @@ import {
 import { resolveVm } from "@/tools/sandbox/sandbox-map";
 import {
   getThreadSandboxMap,
+  resolveSandboxBranchForThread,
   resolveSandboxUserId,
   syntheticBranchToGitRef,
-  threadBranch,
 } from "@/tools/sandbox/thread-repo";
-import { sleep } from "@decocms/shared/std";
+import { retry, sleep } from "@decocms/shared/std";
 import type { SandboxProvider } from "@decocms/sandbox/provider";
 import { requireTaskRunContext } from "./task-run-context";
 
@@ -57,6 +57,52 @@ import { requireTaskRunContext } from "./task-run-context";
  * re-minted by the next one.
  */
 const CLONE_TOKEN_MIN_TTL_MS = 55 * 60 * 1000;
+
+/**
+ * How long to wait for the run's sandbox record to appear before giving up.
+ *
+ * The record is written when `provisionSandbox` finishes; the harness can call
+ * this tool as its first action, which on 13 production runs beat that write
+ * and threw. The model then re-called the tool blind — three times each — so
+ * the wait already happens, just as whole extra model turns. Bounded and short:
+ * the pod is already up (it is running the caller), so this is a database write
+ * landing, not a boot.
+ */
+const SANDBOX_RECORD_WAIT_ATTEMPTS = 4;
+const SANDBOX_RECORD_WAIT_MIN_MS = 250;
+const SANDBOX_RECORD_WAIT_MAX_MS = 2_000;
+
+/**
+ * The run's sandbox record, waiting out the provisioning write if it has not
+ * landed yet. `null` once the budget is spent — the caller reports that as the
+ * hard failure it is.
+ */
+async function waitForSandboxRecord(
+  ctx: StudioContext,
+  threadId: string,
+  sandboxUserId: string,
+  branch: string,
+  kind: Parameters<typeof resolveVm>[3],
+): Promise<ReturnType<typeof resolveVm>> {
+  return retry(
+    async () => {
+      const record = resolveVm(
+        await getThreadSandboxMap(ctx, threadId),
+        sandboxUserId,
+        branch,
+        kind,
+      );
+      if (!record) throw new Error("sandbox record not written yet");
+      return record;
+    },
+    {
+      maxAttempts: SANDBOX_RECORD_WAIT_ATTEMPTS,
+      minTimeout: SANDBOX_RECORD_WAIT_MIN_MS,
+      maxTimeout: SANDBOX_RECORD_WAIT_MAX_MS,
+      jitter: 0,
+    },
+  ).catch(() => null);
+}
 
 /** Wait at most this long for the checkout before answering anyway. */
 const CLONE_TIMEOUT_MS = 180_000;
@@ -200,16 +246,28 @@ export const TASK_ADD_REPO = defineTool({
     const thread = await ctx.storage.threads.get(threadId);
     if (!thread) throw new Error(`Thread not found: ${threadId}`);
 
-    // The key this run was dispatched on — bare thread branch, or a pinned ref.
-    const branch = thread.branch ?? threadBranch(threadId);
+    /**
+     * The sandbox key, from the one derivation every sandbox consumer shares —
+     * NOT `threads.branch` raw, which this used to read.
+     *
+     * They are different namespaces, and the mismatch was silent and fatal: a
+     * run whose column holds a git ref (`sandbox/thread-<id>` on a
+     * continuation, or a plain PR head like `fix/foo` on a re-run) never
+     * matched the `sandboxMap`, which is keyed by the SYNTHETIC key the
+     * dispatcher provisioned on. 48 production runs died on "No sandbox is
+     * registered" — every one a task that could not clone, so never shipped,
+     * after the model had already been paid for.
+     */
+    const branch = await resolveSandboxBranchForThread(ctx, { threadId });
     const sandboxUserId = await resolveSandboxUserId(ctx, branch, userId);
     const { provider, kind } = await resolveSandboxProvider(ctx, {
       userId: sandboxUserId,
       branch,
       virtualMcpMetadata: null,
     });
-    const record = resolveVm(
-      await getThreadSandboxMap(ctx, threadId),
+    const record = await waitForSandboxRecord(
+      ctx,
+      threadId,
       sandboxUserId,
       branch,
       kind,


### PR DESCRIPTION
## The bug

**48 production task runs died** on `No sandbox is registered for this run (thread …), so there is nowhere to clone into`. Every one was a task that could never clone, and so never shipped, *after* the model had already been paid for. None recovered — the agent re-called the tool blind (three times each) and gave up.

Two causes, both in this file.

### 1. The lookup used the wrong key — 48 threads, 0 recovered

The tool read `threads.branch` raw. That column and `metadata.sandboxMap` are **different namespaces**: the map is keyed by the *synthetic* key the dispatcher provisioned on, while the column holds a git ref whenever the run is a continuation or a re-run pinned to a PR head.

| `threads.branch` shape | Threads | Ever cloned |
|---|---|---|
| `sandbox/thread-<id>` (continuation) | 33 | 0 |
| `fix/foo` (pinned PR head) | 15 | 0 |

Neither ever matched. It now uses `resolveSandboxBranchForThread` — the one derivation every other sandbox consumer already shares, and the one the dispatch client provisions with, so the two cannot disagree. The dispatch client's own comment already warns that "a divergence here provisions a second pod (or 404s the proxy)"; this was that divergence.

### 2. A race against the provisioning write — 13 threads, all recovered expensively

13 further threads had a correct map that simply hadn't been written yet: the record lands when `provisionSandbox` finishes, and the harness can call this tool as its first action. Those threads *did* recover — by burning whole model turns on blind retries.

Now a bounded wait (4 attempts, 250ms→2s, via the shared `retry` from `@decocms/shared/std`) absorbs it. The pod is already up — it is running the caller — so this waits on a database write landing, not a boot.

## Testing

No new unit test: both changes are wiring (a call-site swap, and the shared, already-tested `retry`), and this repo's unit tier takes no mocks or stubbed `StudioContext`. The pure `parseRepoProbe` tests still pass. `bun run fmt`, `bun run lint` (0 errors), `bun run check`, `knip` clean.

Diagnosis came from prod: grouping the failing threads by `sandboxMap IS NULL` against their branch shape is what separated the two populations.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sandbox lookup in `TASK_ADD_REPO` and adds a short, bounded wait for the sandbox record to land, preventing clone failures and wasted model turns. Previously it read `threads.branch` (git ref/PR head) and missed the `sandboxMap`; now it derives the synthetic key via `resolveSandboxBranchForThread` and waits using `retry`.

- Lookup now uses the shared sandbox-branch derivation, aligning with dispatcher provisioning and eliminating “No sandbox is registered” errors.
- If the sandbox record isn’t written yet, wait up to 4 attempts with 250ms→2s backoff via `retry` from `@decocms/shared/std`; worst-case adds ~2s, then fails once instead of triggering blind re-invocations.
- Swaps the direct `resolveVm` call for a `waitForSandboxRecord` wrapper; no API or schema changes.

<sup>Written for commit 5ab1f9261513aac520d101c4ea9f97209e35ea39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

