### PR TITLE
feat(runs): classify why a run failed instead of one generic string

### DIFF
--- a/apps/api/src/api/routes/decopilot/classify-run-failure.test.ts
+++ b/apps/api/src/api/routes/decopilot/classify-run-failure.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import {
+  classifyRunFailure,
+  GENERIC_RUN_FAILURE,
+} from "./classify-run-failure";
+
+describe("classifyRunFailure", () => {
+  test("the 402 that killed most production runs", () => {
+    const real =
+      "Error: API Error: 402 This request requires more credits, or fewer " +
+      "max_tokens. You requested up to 64000 tokens, but can only afford 47750.";
+    expect(classifyRunFailure(real).kind).toBe("credits");
+    expect(classifyRunFailure("[CREDITS] out of balance").kind).toBe("credits");
+  });
+
+  test("credits beats the generic API-error pattern that also matches", () => {
+    // Order in the table decides; the specific kind has to win.
+    expect(
+      classifyRunFailure("Error: API Error: 402 requires more credits").kind,
+    ).toBe("credits");
+  });
+
+  test("classifies the other shapes seen in production", () => {
+    const cases: Array<[string, string]> = [
+      [
+        "Error: [SANDBOX_UNREACHABLE] the sandbox stream broke mid-run",
+        "sandbox_unreachable",
+      ],
+      ["Error: cancelled: run cancelled", "cancelled"],
+      ["Error: Overloaded.", "overloaded"],
+      ["429 Too Many Requests", "overloaded"],
+      ["Error: API Error: 500 upstream", "model_error"],
+    ];
+    for (const [text, kind] of cases) {
+      expect(classifyRunFailure(text).kind).toBe(kind);
+    }
+  });
+
+  test("unrecognized text keeps exactly today's behavior", () => {
+    for (const text of ["something new", "", "   ", null, undefined]) {
+      expect(classifyRunFailure(text)).toEqual({ ...GENERIC_RUN_FAILURE });
+    }
+  });
+
+  test("every kind carries a distinct human reason", () => {
+    const texts = [
+      "requires more credits",
+      "[SANDBOX_UNREACHABLE] x",
+      "cancelled: run cancelled",
+      "Overloaded.",
+      "exceeds the maximum context length",
+      "API Error: 500 provider",
+      "unrecognized",
+    ];
+    const seen = texts.map((t) => classifyRunFailure(t));
+    for (const r of seen) expect(r.reason.length).toBeGreaterThan(10);
+    const byKind = new Map(seen.map((r) => [r.kind, r.reason]));
+    expect(new Set(byKind.values()).size).toBe(byKind.size);
+  });
+});

--- a/apps/api/src/api/routes/decopilot/classify-run-failure.ts
+++ b/apps/api/src/api/routes/decopilot/classify-run-failure.ts
@@ -1,0 +1,74 @@
+/**
+ * Turn a failed run's error text into a `failure_kind` you can GROUP BY.
+ *
+ * Every error failure used to persist one string — "Run ended with an error —
+ * see the run's messages" — on 258 of 310 failed task-board threads. It is true
+ * and useless: the only way to learn why runs were dying was to leave the thread
+ * row entirely and mine `thread_message_parts`, which is how the single biggest
+ * failure cause in production (a 402 the harness provoked by asking for a fixed
+ * 64k `max_tokens`) went unnoticed. A kind on the row makes that a query.
+ *
+ * The kinds are the classes seen in production, not a taxonomy invented up
+ * front. Unclassified text keeps today's behavior exactly, so this can only add
+ * resolution, never lose it.
+ */
+
+/** Ordered: the first pattern that matches wins, so put the specific first. */
+const FAILURE_PATTERNS: ReadonlyArray<{
+  kind: string;
+  reason: string;
+  match: RegExp;
+}> = [
+  {
+    kind: "credits",
+    reason: "Run stopped: the organization is out of AI credits",
+    match: /\[CREDITS\]|requires more credits|\b402\b/i,
+  },
+  {
+    kind: "sandbox_unreachable",
+    reason: "Run stopped: its sandbox became unreachable mid-run",
+    match: /\[SANDBOX_UNREACHABLE\]|sandbox stream broke/i,
+  },
+  {
+    kind: "cancelled",
+    reason: "Run cancelled before it finished",
+    match: /^\s*(error:\s*)?cancelled\b|run cancelled/i,
+  },
+  {
+    kind: "overloaded",
+    reason: "Run stopped: the model provider was overloaded or rate-limited",
+    match: /\boverloaded\b|\brate.?limit|\b429\b/i,
+  },
+  {
+    kind: "context_length",
+    reason: "Run stopped: the conversation exceeded the model's context window",
+    match: /context (length|window)|too many tokens|maximum context/i,
+  },
+  {
+    kind: "model_error",
+    reason: "Run stopped: the model provider rejected the request",
+    match: /\bAPI Error\b|\b5\d{2}\b.*provider|provider returned/i,
+  },
+];
+
+/** What today's unclassified failure persists — unchanged, so an error this
+ *  does not recognize reads exactly as it did before. */
+export const GENERIC_RUN_FAILURE = {
+  kind: "error",
+  reason: "Run ended with an error — see the run's messages",
+} as const;
+
+/**
+ * Classify a run failure from its error text. Falls back to
+ * {@link GENERIC_RUN_FAILURE} for empty or unrecognized text. Pure.
+ */
+export function classifyRunFailure(errorText: string | null | undefined): {
+  kind: string;
+  reason: string;
+} {
+  if (!errorText?.trim()) return { ...GENERIC_RUN_FAILURE };
+  for (const { kind, reason, match } of FAILURE_PATTERNS) {
+    if (match.test(errorText)) return { kind, reason };
+  }
+  return { ...GENERIC_RUN_FAILURE };
+}

--- a/apps/api/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/api/src/api/routes/decopilot/dispatch-run.ts
@@ -1671,6 +1671,7 @@ async function prepareRun(
                 type: "FINISH",
                 taskId: mem.thread.id,
                 threadStatus: "failed",
+                errorText: stringifyError(error),
               })
               .catch((e) => {
                 console.error("[decopilot:stream] onError reactor failed", e);
@@ -1700,6 +1701,7 @@ async function prepareRun(
           type: "FINISH",
           taskId,
           threadStatus: "failed",
+          errorText: stringifyError(err),
         })
         .catch((e) => {
           console.error("[decopilot:stream] catch-block reactor failed", e);

--- a/apps/api/src/api/routes/decopilot/run-decider.test.ts
+++ b/apps/api/src/api/routes/decopilot/run-decider.test.ts
@@ -155,6 +155,24 @@ describe("FINISH", () => {
       taskId: "t1",
       orgId: "org1",
       reason: "error",
+      errorText: null,
+    });
+  });
+
+  it("forwards the failure's error text so the reactor can classify it", () => {
+    const events = decide(
+      {
+        type: "FINISH",
+        taskId: "t1",
+        threadStatus: "failed",
+        errorText: "Error: API Error: 402 requires more credits",
+      },
+      makeRunningState({ orgId: "org1" }),
+    );
+
+    expect(events[0]).toMatchObject({
+      reason: "error",
+      errorText: "Error: API Error: 402 requires more credits",
     });
   });
 

--- a/apps/api/src/api/routes/decopilot/run-decider.ts
+++ b/apps/api/src/api/routes/decopilot/run-decider.ts
@@ -85,6 +85,7 @@ export function decide(
           taskId: command.taskId,
           orgId: state.orgId,
           reason: "error",
+          errorText: command.errorText ?? null,
         },
       ];
     }

--- a/apps/api/src/api/routes/decopilot/run-reactor.ts
+++ b/apps/api/src/api/routes/decopilot/run-reactor.ts
@@ -17,6 +17,10 @@ import {
   createDecopilotStepEvent,
   createDecopilotThreadStatusEvent,
 } from "@decocms/shared/sdk";
+import {
+  classifyRunFailure,
+  GENERIC_RUN_FAILURE,
+} from "./classify-run-failure";
 import type { RunEvent, RunFailedReason, RunTransition } from "./run-state";
 
 /** Recorded on a run the idle reaper force-fails for lack of progress. */
@@ -44,10 +48,26 @@ const RUN_FAILURE_RECORD: Record<
     failure_kind: "cancelled",
   },
   error: {
-    failure_reason: "Run ended with an error — see the run's messages",
-    failure_kind: "error",
+    failure_reason: GENERIC_RUN_FAILURE.reason,
+    failure_kind: GENERIC_RUN_FAILURE.kind,
   },
 };
+
+/**
+ * The columns to persist for one failure. Identical to
+ * {@link RUN_FAILURE_RECORD} except on the `error` reason, where the run's own
+ * error text is classified into a kind that can be grouped by — `credits`,
+ * `sandbox_unreachable`, `overloaded`, … — instead of the one generic string
+ * every error failure used to share.
+ */
+function failureRecord(
+  reason: Exclude<RunFailedReason, "ghost">,
+  errorText: string | null | undefined,
+): { failure_reason: string; failure_kind: string } {
+  if (reason !== "error") return RUN_FAILURE_RECORD[reason];
+  const { kind, reason: text } = classifyRunFailure(errorText);
+  return { failure_reason: text, failure_kind: kind };
+}
 
 // ============================================================================
 // Errors
@@ -236,7 +256,7 @@ async function react(event: RunEvent, deps: RunReactorDeps): Promise<void> {
         await storage.update(event.taskId, event.orgId, {
           run_config: null,
           run_started_at: null,
-          ...RUN_FAILURE_RECORD[event.reason],
+          ...failureRecord(event.reason, event.errorText),
         });
       }
       // Deliberately NO JetStream purge here. The consume step projects every

--- a/apps/api/src/api/routes/decopilot/run-state.ts
+++ b/apps/api/src/api/routes/decopilot/run-state.ts
@@ -83,6 +83,9 @@ export type RunCommand =
       type: "FINISH";
       taskId: string;
       threadStatus: "completed" | "failed" | "requires_action";
+      /** The failure's error text, when there is one — classified into a
+       *  `failure_kind` by the reactor. Omitted for a clean finish. */
+      errorText?: string | null;
     }
   | { type: "CANCEL"; taskId: string }
   | {
@@ -164,6 +167,9 @@ export type RunEvent =
       taskId: string;
       orgId: string;
       reason: RunFailedReason;
+      /** Error text for `reason: "error"`, classified by the reactor into a
+       *  `failure_kind` the board and a support query can group by. */
+      errorText?: string | null;
       /**
        * Fence scope for a ghost force-fail (see the FORCE_FAIL command). Only
        * set on the ghost path; when present the reactor's `forceFailIfInProgress`


### PR DESCRIPTION
## Why

Every error-class failure persisted the same `failure_reason` — `"Run ended with an error — see the run's messages"` — with `failure_kind: "error"`. On production task-board threads that is **258 of 310 failures**.

True, and useless: you cannot `GROUP BY` it. The only way to learn why runs were dying was to leave the thread row entirely and mine `thread_message_parts` by hand. That is exactly how the single biggest cause went unnoticed for a month — a 402 the harness provoked by requesting a fixed 64k `max_tokens`, **28 of 36 fatal errors across six orgs** — and it is the reason the recent cost/failure analysis had to bypass `failure_reason` completely.

## What changes

The run's error text now rides the `FINISH` command → `RUN_FAILED` event → reactor, which classifies it:

| kind | matches |
|---|---|
| `credits` | `[CREDITS]`, `requires more credits`, `402` |
| `sandbox_unreachable` | `[SANDBOX_UNREACHABLE]`, `sandbox stream broke` |
| `cancelled` | `cancelled: run cancelled` |
| `overloaded` | `Overloaded`, rate-limit, `429` |
| `context_length` | context window / max tokens |
| `model_error` | other provider rejections |

The classes are the ones actually observed in production, not a taxonomy invented up front. First match wins, so the specific kind beats the generic API-error pattern that also matches the 402 string.

**Unrecognized or empty text falls back to exactly today's string and kind**, so this can only add resolution, never lose it.

## Testing

`bun test apps/api/src/api/routes/decopilot/` — 543 pass, 0 fail. The classifier is pure, with 5 new tests including the verbatim production 402 and a case pinning the precedence between `credits` and `model_error`.

Per the repo's first-pass checklist, the decider test that encoded the old event shape is **updated** (not appended to), plus one new case asserting the text is forwarded.

`bun run fmt`, `bun run lint` (0 errors), `bun run check`, `knip` clean.
