### PR TITLE
fix(task-board): tell sandbox runs their checkout is shallow

### DIFF
--- a/apps/api/src/tools/task-board/claude-code-task-run.ts
+++ b/apps/api/src/tools/task-board/claude-code-task-run.ts
@@ -21,6 +21,7 @@
 import type { StudioContext } from "@/core/studio-context";
 import { selectLoadableRepos } from "@/harnesses/decopilot/built-in-tools/load-repo";
 import { isOrgSharedConnection } from "@decocms/shared/github-repo-scope";
+import { SHALLOW_CHECKOUT_NOTE } from "@decocms/shared/task-board";
 import type { SuperAgentPromptOpts } from "./enqueue-super-agent";
 
 /** The repo a claude-code task run works in. */
@@ -191,7 +192,7 @@ export function buildClaudeCodeTaskPrompt(
   lines.push(
     "",
     repo
-      ? `The repository ${repo.owner}/${repo.name} is already cloned at your working directory, on its own branch. \`git\` and \`gh\` are authenticated.`
+      ? `The repository ${repo.owner}/${repo.name} is already cloned at your working directory, on its own branch. \`git\` and \`gh\` are authenticated. ${SHALLOW_CHECKOUT_NOTE}`
       : [
           "Your working directory is EMPTY: this organization has several repositories, so " +
             "nothing has been cloned yet. FIRST call `mcp__studio__TASK_ADD_REPO` with the " +

--- a/apps/api/src/tools/task-board/enqueue-reviewer.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.ts
@@ -6,6 +6,7 @@ import {
   isReviewerThreadTitle,
   REVIEWER_LABEL,
   reviewCycleStart,
+  SHALLOW_CHECKOUT_NOTE,
   type ReviewerKind,
 } from "@decocms/shared/task-board";
 import { recordTaskActivity } from "./activity";
@@ -459,7 +460,7 @@ async function enqueueReviewerForTask(
     "How to work:",
     `- Call \`${prsGetTool}\` with the task id below to find the pull request under review.`,
     repo
-      ? `- The repository ${repo.owner}/${repo.name} is already cloned at your working directory and \`git\` and \`gh\` are authenticated — check the PR's branch out there to inspect / exercise the change.`
+      ? `- The repository ${repo.owner}/${repo.name} is already cloned at your working directory and \`git\` and \`gh\` are authenticated — check the PR's branch out there to inspect / exercise the change. ${SHALLOW_CHECKOUT_NOTE}`
       : sandboxed
         ? `- Your working directory is EMPTY. Call \`mcp__studio__TASK_ADD_REPO\` with the connectionId of the PR's repository FIRST; it clones the repository and waits for the checkout, and \`git\` and \`gh\` are authenticated once it returns.`
         : "- Load the PR's repository to inspect / exercise the change.",

--- a/packages/shared/src/task-board.ts
+++ b/packages/shared/src/task-board.ts
@@ -56,6 +56,26 @@ export function isReportsTask(item: { createdBy: string }): boolean {
  */
 export type ReviewerKind = "qa" | "code_review";
 
+/**
+ * What every sandbox-hosted run has to know about its checkout: it is
+ * `--depth 1`.
+ *
+ * Without being told, agents reach for `git diff main...HEAD` — the three-dot
+ * form needs a merge base, and a depth-1 clone has no common ancestor to find.
+ * `fatal: main...HEAD: no merge base` hit **229 production runs**. Every one
+ * recovered, and that is the cost: each spent model turns rediscovering the
+ * same fact. Deepening the clone instead would put the fix on the boot path,
+ * which is already the slowest part of a run.
+ */
+export const SHALLOW_CHECKOUT_NOTE =
+  "Your checkout is SHALLOW (`git clone --depth 1`), so it has no merge base " +
+  "and `git diff main...HEAD` (three dots) fails with " +
+  '"fatal: main...HEAD: no merge base". To see a branch diff, either use the ' +
+  "two-dot form against the fetched remote ref (`git fetch origin " +
+  "<base> && git diff origin/<base> HEAD`), or deepen first with " +
+  "`git fetch --deepen=100`. Same for `git log main..HEAD` and anything else " +
+  "that needs shared history.";
+
 export const REVIEWER_KINDS: ReviewerKind[] = ["qa", "code_review"];
 
 /** Human label for a reviewer — also the prefix of its run thread's title


### PR DESCRIPTION
## Why

The daemon clones `--depth 1` (`packages/sandbox/daemon-go/internal/setup/clone.go`). Nothing tells the agents that, so they reach for the habitual `git diff main...HEAD`. The three-dot form needs a merge base; a depth-1 clone has no common ancestor to find:

```
fatal: main...HEAD: no merge base
```

**229 production runs hit it.** All 229 recovered and ended with a PR — which is exactly the cost. Each one spent model turns rediscovering a fact about its own checkout, on a path where reviewer runs already account for 57% of task-board spend. Two neighbouring shapes show up alongside it: `you must first push the current branch to a remote` (57 threads, 51 recovered) and `Resource not accessible by integration` (54 threads, 53 recovered).

`gitx/status.go` already works around this internally with `fetch --depth 100`, so the constraint was known — just never surfaced to the agent.

## What changes

One shared `SHALLOW_CHECKOUT_NOTE`, given to both the Super Agent and the reviewers, naming the two forms that do work:

- two-dot against a fetched remote ref: `git fetch origin <base> && git diff origin/<base> HEAD`
- or deepen first: `git fetch --deepen=100`

Deepening the clone itself would move the fix onto the boot path, which is already the slowest part of a run — so this stays a prompt-side fix.

## Testing

`bun run fmt`, `bun run lint` (0 errors), `bun run check` on api + shared, `knip` clean. 46 existing task-board / reviewer-enqueue tests pass.

No new test: this adds a sentence to two prompt strings. There is no assertion worth writing that would not just restate the string.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tell sandbox runs their checkout is shallow (`--depth 1`) and how to diff anyway. Previously agents tried `git diff main...HEAD` and hit “no merge base”; prompts now instruct using two-dot against a fetched remote or deepening with `git fetch --deepen=100`.

- Adds `SHALLOW_CHECKOUT_NOTE` in `@decocms/shared/task-board` and appends it to Super Agent and Reviewer prompts in the API. No runtime changes beyond prompt text; we keep setup shallow to avoid slowing the boot path.

<sup>Written for commit f21d53b1d99aeba5658ab50c63c27050d92eef3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

