### PR TITLE
ci(security): add CodeQL code scanning for JS/TS

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,20 @@
+# Shared CodeQL configuration for .github/workflows/codeql.yml.
+name: deco studio CodeQL config
+
+# Query selection. The default suite is intentional for this first rollout: it
+# is the low-false-positive set, so the alert list stays actionable across a
+# TypeScript surface this size. To widen coverage later, uncomment
+# `security-extended` (more security queries, more noise) or swap in
+# `security-and-quality` (also adds maintainability queries).
+# queries:
+#   - uses: security-extended
+
+# node_modules and other package-manager directories are already skipped by the
+# JS/TS extractor, so they are not repeated here.
+paths-ignore:
+  # Vendored third-party source — upstream's code, not ours to fix.
+  - packages/sandbox/image/skills/templating/vendor
+  # Build output, if a scan ever runs on a dirty tree.
+  - "**/dist"
+  - "**/build"
+  - "**/*.min.js"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,57 @@
+name: CodeQL
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  # CodeQL query packs ship new rules continuously, so re-scan the default
+  # branch weekly even when nothing lands — a scheduled run is what surfaces
+  # newly-written queries against already-merged code.
+  schedule:
+    - cron: "27 5 * * 1" # Mondays 05:27 UTC
+
+# A force-push to a PR obsoletes the in-flight scan — cancel it. Pushes to main
+# all run (no cancel) so every merged commit keeps its own set of alerts, and
+# scheduled runs are never cancelled by each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+# All third-party actions are pinned to a full commit SHA, not a tag.
+
+jobs:
+  # Scoped to JS/TS on purpose. The javascript-typescript extractor covers
+  # .js/.jsx/.ts/.tsx in one pass and needs no build, so this is the whole
+  # apps/ + packages/ TypeScript surface (~3.3k files) and nothing else.
+  # The repo's other languages are deliberately out of scope for now:
+  #   - go     (packages/sandbox/daemon-go) — compiled, needs a build step
+  #   - python (packages/sandbox/image/skills) — 8 script files
+  #   - rust   (apps/native) — src-tauri won't compile on Linux, so it would
+  #             need a macOS runner plus a full cargo build (see native.yml)
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      security-events: write # upload the SARIF results to code scanning
+      packages: read # CodeQL query packs are pulled from GHCR
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@faaa5d804fc648d0fdb28822a8e36cf7d0a6132c # v4
+        with:
+          languages: javascript-typescript
+          build-mode: none
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@faaa5d804fc648d0fdb28822a8e36cf7d0a6132c # v4
+        with:
+          category: /language:javascript-typescript


### PR DESCRIPTION
Adds CodeQL static analysis to CI. The repo has a `sast.yml` today, but it only
runs gitleaks (secret scanning) — there is no static analysis of the code
itself. This adds it.

Scoped to `javascript-typescript` on purpose: one extractor covers
`.js/.jsx/.ts/.tsx` and needs no build, so a single build-free pass covers the
whole `apps/` + `packages/` TypeScript surface (~3.3k files).

## What's here

- `.github/workflows/codeql.yml` — one `analyze` job: checkout → init → analyze.
- `.github/codeql/codeql-config.yml` — query suite and path exclusions.

Triggers follow `test.yml`: PRs to `main`, pushes to `main`, plus a weekly cron.
The cron matters more than it looks — CodeQL ships new queries continuously, and
a scheduled run against the default branch is what applies them to code that
already merged.

Concurrency cancels superseded PR runs only; pushes to `main` each keep their own
alert set. Permissions are `contents: read` at the workflow level, with
`security-events: write` and `packages: read` scoped to the job. Actions are
pinned to full commit SHAs with version comments, matching the convention
`sast.yml` documents.


## Notes for review

- **Query suite.** Using the default (low-false-positive) suite for the first
  rollout so the initial alert list stays actionable. `security-extended` is in
  the config, commented, ready to switch on once the baseline is triaged.
- **The 120-minute timeout is headroom, not an estimate.** Worth checking the
  first run's real duration and tightening it.
- **No path filters.** This runs on every PR, including docs-only ones. `test.yml`
  gates jobs through a `changes` job to avoid that; I kept this always-on since
  it's a security scan, but it's an easy change if the CI minutes bother you.
- Expect a batch of alerts on the first run against `main`. Triage is separate
  from this PR — nothing here blocks a merge on findings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CodeQL code scanning for JS/TS to CI to surface security issues early. CI previously only ran gitleaks; this adds a build-free `javascript-typescript` analysis on PRs, pushes to `main`, and a weekly scan.

- Single analyze job with minimal permissions, pinned actions, and a 120‑minute timeout; CI-only change.
- Uses the default low-noise query suite; `security-extended` is prepped but commented out.
- Excludes vendored and build artifacts; `node_modules` is auto-excluded by the extractor.
- Triggers on all PRs and pushes to `main` plus a weekly cron; PR runs cancel on updates, pushes keep separate alert sets.
- Scoped to JS/TS only; Go/Python/Rust are documented as out of scope for now. Expect initial alerts on `main`; no developer action required to adopt.

<sup>Written for commit d09c73d2e3a4eea3754e91fefa09d532161d4ee2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

