### PR TITLE
fix(task-board): pluralize the task-cost run count correctly

### DIFF
--- a/apps/web/src/i18n/en/task-board.ts
+++ b/apps/web/src/i18n/en/task-board.ts
@@ -149,8 +149,11 @@ export const taskBoard = {
   "taskBoard.taskDialog.shipToProductionButton": "Ship to production",
   "taskBoard.taskDialog.shipSuccess": "Merged and shipped to production",
   "taskBoard.taskDialog.shipError": "Couldn't merge the pull request",
-  "taskBoard.taskDialog.costRunCount": "in {runs} runs",
-  "taskBoard.taskDialog.costTooltip":
+  "taskBoard.taskDialog.costRunCountSingular": "in {runs} run",
+  "taskBoard.taskDialog.costRunCountPlural": "in {runs} runs",
+  "taskBoard.taskDialog.costTooltipSingular":
+    "Total AI cost of this task, across its only run — the Super Agent plus every reviewer and re-run round.",
+  "taskBoard.taskDialog.costTooltipPlural":
     "Total AI cost of this task, across all {runs} of its runs — the Super Agent plus every reviewer and re-run round.",
   "taskBoard.taskDialog.propertiesLabel": "Properties",
   "taskBoard.taskDialog.reportsContentLocked":

--- a/apps/web/src/i18n/pt-br/task-board.ts
+++ b/apps/web/src/i18n/pt-br/task-board.ts
@@ -157,8 +157,11 @@ export const taskBoard = {
   "taskBoard.taskDialog.shipToProductionButton": "Subir para produção",
   "taskBoard.taskDialog.shipSuccess": "Mesclado e enviado para produção",
   "taskBoard.taskDialog.shipError": "Não foi possível mesclar o pull request",
-  "taskBoard.taskDialog.costRunCount": "em {runs} execuções",
-  "taskBoard.taskDialog.costTooltip":
+  "taskBoard.taskDialog.costRunCountSingular": "em {runs} execução",
+  "taskBoard.taskDialog.costRunCountPlural": "em {runs} execuções",
+  "taskBoard.taskDialog.costTooltipSingular":
+    "Custo total de IA desta tarefa, somando sua única execução — o Super Agent mais cada rodada de revisão e reexecução.",
+  "taskBoard.taskDialog.costTooltipPlural":
     "Custo total de IA desta tarefa, somando as {runs} execuções — o Super Agent mais cada rodada de revisão e reexecução.",
   "taskBoard.taskDialog.propertiesLabel": "Propriedades",
   "taskBoard.taskDialog.reportsContentLocked":

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -152,12 +152,17 @@ function TaskCost({ threads }: { threads?: TaskBoardItemThread[] }) {
   const priced = (threads ?? []).filter((thread) => thread.costUsd !== null);
   if (priced.length === 0) return null;
   const total = priced.reduce((sum, thread) => sum + (thread.costUsd ?? 0), 0);
+  const runCount = (threads ?? []).length;
+  const isSingular = runCount === 1;
   return (
     <div
       className={cn(PROPERTY_BUTTON, "cursor-default hover:bg-transparent")}
-      title={t("taskBoard.taskDialog.costTooltip", {
-        runs: String((threads ?? []).length),
-      })}
+      title={t(
+        isSingular
+          ? "taskBoard.taskDialog.costTooltipSingular"
+          : "taskBoard.taskDialog.costTooltipPlural",
+        { runs: String(runCount) },
+      )}
     >
       <Coins01 size={16} className="shrink-0 text-muted-foreground" />
       <span className="tabular-nums">
@@ -167,9 +172,12 @@ function TaskCost({ threads }: { threads?: TaskBoardItemThread[] }) {
         })}
       </span>
       <span className="text-muted-foreground">
-        {t("taskBoard.taskDialog.costRunCount", {
-          runs: String((threads ?? []).length),
-        })}
+        {t(
+          isSingular
+            ? "taskBoard.taskDialog.costRunCountSingular"
+            : "taskBoard.taskDialog.costRunCountPlural",
+          { runs: String(runCount) },
+        )}
       </span>
     </div>
   );


### PR DESCRIPTION
#6154 (merged today) shipped the task-cost chip with a single hardcoded string for the run count and tooltip: `"in {runs} runs"` / `"em {runs} execuções"`. A task with exactly one linked run — the common case, a card that's just its Super Agent run with no reviewer/re-run rounds — reads **"in 1 runs"**, and the pt-br tooltip has the identical singular/plural mismatch (`"1 execuções"`).

A maintainer wants this fixed because it's user-visible copy shipped hours ago that reads wrong for the majority of cards (single-run tasks are the default, not the exception).

Failure scenario: open any task-board card whose only linked run recorded a cost. The chip currently shows `$X.XX in 1 runs`. After the fix it shows `$X.XX in 1 run`.

Fix: split `taskBoard.taskDialog.costRunCount` / `costTooltip` into `...Singular` / `...Plural` key pairs (en + pt-br) and pick by `runs === 1` in `TaskCost` — the same pattern already used by `settings.apiKeys.keysCount(Singular|Plural)` and `settings.secrets.secretsCount(Singular|Plural)` elsewhere in this codebase.

To confirm: open a task-board card whose only run has recorded cost — the chip reads "in 1 run", not "in 1 runs".

Checked locally: `bun run fmt` (clean), `cd apps/web && bunx tsc --noEmit` (clean — pt-br's `satisfies Record<keyof typeof enDomain, string>` catches any key mismatch at compile time), `bunx oxlint` on the three touched files (0 warnings/errors). No unit test exists for this component; the change is UI copy only. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the task-board cost chip to pluralize the run count and tooltip correctly. Previously it always showed “in {runs} runs” (e.g., “in 1 runs”); now it selects singular/plural for both the label and tooltip. No behavior change beyond copy.

- Split i18n keys into `taskBoard.taskDialog.costRunCountSingular`/`Plural` and `taskBoard.taskDialog.costTooltipSingular`/`Plural` in `en` and `pt-br`; removed the old `costRunCount`/`costTooltip` keys.
- `TaskCost` picks singular when `runCount === 1`; run counting and cost calculation logic are unchanged.
- Verify by opening a task with a single run and recorded cost: chip reads “in 1 run” (pt-br: “em 1 execução”). No migrations required.

<sup>Written for commit 06abbcf815bcec07a990694a298cf0e837fc6321. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

