### PR TITLE
fix(oauth): make the token-status route's canRefresh match the real predicate

### DIFF
--- a/apps/api/src/api/routes/downstream-token.ts
+++ b/apps/api/src/api/routes/downstream-token.ts
@@ -7,6 +7,7 @@
 
 import { Hono } from "hono";
 import type { StudioContext } from "../../core/studio-context";
+import { canRefresh } from "../../oauth/token-refresh";
 import { resolveOriginTokenEndpoint } from "../../oauth/resolve-token-endpoint";
 import {
   DownstreamTokenStorage,
@@ -209,12 +210,11 @@ export const createDownstreamTokenRoutes = () => {
     }
 
     const isExpired = tokenStorage.isExpired(token);
-    const canRefresh = !!token.refreshToken && !!token.tokenEndpoint;
 
     return c.json({
       hasToken: true,
       isExpired,
-      canRefresh,
+      canRefresh: canRefresh(token),
       expiresAt: token.expiresAt,
     });
   });


### PR DESCRIPTION
**Source:** bug found while auditing the per-user OAuth flow (lazy-client/virtual-mcp/mcp-oauth) — `GET /api/:org/connections/:connectionId/oauth-token/status` in `apps/api/src/api/routes/downstream-token.ts`.

**Payoff:** the status route computed `canRefresh` inline as `!!token.refreshToken && !!token.tokenEndpoint`, but the actual refresh path (`oauth/token-refresh.ts`'s exported `canRefresh()`, used by `getValidDownstreamAccessToken`) additionally requires `clientId` — and `refresh-access-token.ts` fails immediately with "No client ID available" when it's missing. A token saved with a refresh token + endpoint but no `clientId` would report `canRefresh: true` from this endpoint while a real refresh attempt is guaranteed to fail. Any caller of this status endpoint (current or future UI, or an external app integrating per the documented API) gets a wrong signal about whether the connection can self-heal.

**Fix:** import and reuse the canonical `canRefresh()` from `oauth/token-refresh.ts` instead of a second, drifted copy of the same predicate.

**Reviewer check:** `grep -n canRefresh apps/api/src/api/routes/downstream-token.ts apps/api/src/oauth/token-refresh.ts` — one definition, one call site.

**Verified locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint apps/api/src/api/routes/downstream-token.ts` (0 warnings/errors). No local Postgres available to run the route's integration test tier; full CI covers that.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the OAuth token status route with the real refresh predicate so `canRefresh` no longer returns a false positive when `clientId` is missing. Previously, the route reported `canRefresh: true` if `refreshToken` and `tokenEndpoint` existed; now it uses the canonical `canRefresh(token)` that also requires `clientId`, matching the actual refresh path.

- Affects `GET /api/:org/connections/:connectionId/oauth-token/status` only; response shape is unchanged, but tokens without `clientId` now return `canRefresh: false`.
- Replaces the inlined predicate with `canRefresh` from `oauth/token-refresh` to keep a single source of truth.

<sup>Written for commit 480efe44c7a77ff1d8d5f7e7721a9f5e4737102e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6160?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

