### PR TITLE
fix(settings): stop the infra-billing page rendering permanently in deselected-sites state

### DIFF
--- a/apps/web/src/views/settings/infra-billing.tsx
+++ b/apps/web/src/views/settings/infra-billing.tsx
@@ -340,220 +340,244 @@ function InfraBillingContent() {
         </Card>
       )}
 
-      <SettingsSection title={t("settings.infraBilling.summaryTitle")}>
-        <div className="flex flex-col lg:flex-row gap-4 px-4">
-          <Card className="flex-1 flex flex-col gap-4 p-4">
-            <div className="flex items-center justify-between gap-2">
-              <div className="flex items-center gap-2">
-                <CreditCard01 size={16} className="text-muted-foreground" />
-                <span className="text-sm font-medium">
-                  {t("settings.infraBilling.detailsTitle")}
-                </span>
-              </div>
-              {billing?.canManageSubscription && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  disabled={portal.isPending}
-                  onClick={() => portal.mutate(selected)}
-                >
-                  {t("settings.infraBilling.manageButton")}
-                </Button>
-              )}
-            </div>
-            <div className="flex flex-col gap-2 text-sm">
-              {billing ? (
-                <>
-                  <div className="flex justify-between gap-3">
-                    <span className="text-muted-foreground">
-                      {t("settings.infraBilling.currentPlan")}
+      {selected.length > 0 && (
+        <>
+          <SettingsSection title={t("settings.infraBilling.summaryTitle")}>
+            <div className="flex flex-col lg:flex-row gap-4 px-4">
+              <Card className="flex-1 flex flex-col gap-4 p-4">
+                <div className="flex items-center justify-between gap-2">
+                  <div className="flex items-center gap-2">
+                    <CreditCard01 size={16} className="text-muted-foreground" />
+                    <span className="text-sm font-medium">
+                      {t("settings.infraBilling.detailsTitle")}
                     </span>
-                    {isLoading ? (
-                      <Skeleton className="h-5 w-16" />
-                    ) : (
-                      <Badge
-                        variant={
-                          billing.planType === "free" ? "secondary" : "success"
-                        }
-                      >
-                        {t(`settings.infraBilling.plan.${billing.planType}`)}
-                      </Badge>
-                    )}
                   </div>
+                  {billing?.canManageSubscription && (
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      disabled={portal.isPending}
+                      onClick={() => portal.mutate(selected)}
+                    >
+                      {t("settings.infraBilling.manageButton")}
+                    </Button>
+                  )}
+                </div>
+                <div className="flex flex-col gap-2 text-sm">
+                  {billing ? (
+                    <>
+                      <div className="flex justify-between gap-3">
+                        <span className="text-muted-foreground">
+                          {t("settings.infraBilling.currentPlan")}
+                        </span>
+                        {isLoading ? (
+                          <Skeleton className="h-5 w-16" />
+                        ) : (
+                          <Badge
+                            variant={
+                              billing.planType === "free"
+                                ? "secondary"
+                                : "success"
+                            }
+                          >
+                            {t(
+                              `settings.infraBilling.plan.${billing.planType}`,
+                            )}
+                          </Badge>
+                        )}
+                      </div>
+                      <div className="flex justify-between gap-3">
+                        <span className="text-muted-foreground">
+                          {t("settings.infraBilling.nextBilling")}
+                        </span>
+                        <span className="font-medium tabular-nums">
+                          {billing.nextBillingDate
+                            ? new Date(
+                                `${billing.nextBillingDate}T00:00:00Z`,
+                              ).toLocaleDateString(undefined, {
+                                day: "numeric",
+                                month: "short",
+                                year: "numeric",
+                                timeZone: "UTC",
+                              })
+                            : "—"}
+                        </span>
+                      </div>
+                    </>
+                  ) : (
+                    !isLoading && (
+                      <p className="text-xs text-muted-foreground">
+                        {billingMessage}
+                      </p>
+                    )
+                  )}
                   <div className="flex justify-between gap-3">
                     <span className="text-muted-foreground">
-                      {t("settings.infraBilling.nextBilling")}
+                      {t("settings.infraBilling.requestsPerPageview")}
                     </span>
                     <span className="font-medium tabular-nums">
-                      {billing.nextBillingDate
-                        ? new Date(
-                            `${billing.nextBillingDate}T00:00:00Z`,
-                          ).toLocaleDateString(undefined, {
-                            day: "numeric",
-                            month: "short",
-                            year: "numeric",
-                            timeZone: "UTC",
-                          })
-                        : "—"}
+                      {requestRatio}
                     </span>
                   </div>
-                </>
-              ) : (
-                !isLoading && (
-                  <p className="text-xs text-muted-foreground">
-                    {billingMessage}
-                  </p>
-                )
-              )}
-              <div className="flex justify-between gap-3">
-                <span className="text-muted-foreground">
-                  {t("settings.infraBilling.requestsPerPageview")}
-                </span>
-                <span className="font-medium tabular-nums">{requestRatio}</span>
-              </div>
+                </div>
+              </Card>
+
+              {metrics.map((metric) => (
+                <Card
+                  key={metric.key}
+                  className="flex-1 flex flex-col gap-2 p-4"
+                >
+                  <div className="flex items-baseline justify-between gap-2">
+                    <span className="text-sm font-medium">{metric.title}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {months.find((m) => m.value === period)?.label}
+                    </span>
+                  </div>
+                  {isLoading ? (
+                    <Skeleton className="h-8 w-24" />
+                  ) : (
+                    <span className="text-2xl font-semibold tabular-nums">
+                      {metric.total}
+                    </span>
+                  )}
+                  <div className="-mx-2">
+                    <UsageChart
+                      usage={usage}
+                      metric={metric.key}
+                      colorNum={metric.colorNum}
+                      formatValue={formatFor(metric.key)}
+                      height={64}
+                    />
+                  </div>
+                </Card>
+              ))}
             </div>
-          </Card>
+          </SettingsSection>
 
-          {metrics.map((metric) => (
-            <Card key={metric.key} className="flex-1 flex flex-col gap-2 p-4">
-              <div className="flex items-baseline justify-between gap-2">
-                <span className="text-sm font-medium">{metric.title}</span>
-                <span className="text-xs text-muted-foreground">
-                  {months.find((m) => m.value === period)?.label}
-                </span>
-              </div>
-              {isLoading ? (
-                <Skeleton className="h-8 w-24" />
+          <SettingsSection title={t("settings.infraBilling.metricsTitle")}>
+            <div className="flex flex-col xl:flex-row gap-4 px-4">
+              {metrics.map((metric) => (
+                <Card
+                  key={metric.key}
+                  className="flex-1 flex flex-col gap-3 p-4"
+                >
+                  <div className="flex flex-col gap-1">
+                    <span className="text-sm font-medium">{metric.title}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {metric.description}
+                    </span>
+                  </div>
+                  <UsageChart
+                    usage={usage}
+                    metric={metric.key}
+                    colorNum={metric.colorNum}
+                    formatValue={formatFor(metric.key)}
+                    height={220}
+                  />
+                </Card>
+              ))}
+            </div>
+          </SettingsSection>
+
+          <SettingsSection title={t("settings.infraBilling.invoicesTitle")}>
+            <Card className="mx-4 overflow-x-auto">
+              {!data ? (
+                <Skeleton className="m-4 h-24" />
+              ) : (billing?.invoices.length ?? 0) === 0 ? (
+                <p className="p-4 text-sm text-muted-foreground">
+                  {billing
+                    ? t("settings.infraBilling.noInvoices")
+                    : billingMessage}
+                </p>
               ) : (
-                <span className="text-2xl font-semibold tabular-nums">
-                  {metric.total}
-                </span>
-              )}
-              <div className="-mx-2">
-                <UsageChart
-                  usage={usage}
-                  metric={metric.key}
-                  colorNum={metric.colorNum}
-                  formatValue={formatFor(metric.key)}
-                  height={64}
-                />
-              </div>
-            </Card>
-          ))}
-        </div>
-      </SettingsSection>
-
-      <SettingsSection title={t("settings.infraBilling.metricsTitle")}>
-        <div className="flex flex-col xl:flex-row gap-4 px-4">
-          {metrics.map((metric) => (
-            <Card key={metric.key} className="flex-1 flex flex-col gap-3 p-4">
-              <div className="flex flex-col gap-1">
-                <span className="text-sm font-medium">{metric.title}</span>
-                <span className="text-xs text-muted-foreground">
-                  {metric.description}
-                </span>
-              </div>
-              <UsageChart
-                usage={usage}
-                metric={metric.key}
-                colorNum={metric.colorNum}
-                formatValue={formatFor(metric.key)}
-                height={220}
-              />
-            </Card>
-          ))}
-        </div>
-      </SettingsSection>
-
-      <SettingsSection title={t("settings.infraBilling.invoicesTitle")}>
-        <Card className="mx-4 overflow-x-auto">
-          {!data ? (
-            <Skeleton className="m-4 h-24" />
-          ) : (billing?.invoices.length ?? 0) === 0 ? (
-            <p className="p-4 text-sm text-muted-foreground">
-              {billing ? t("settings.infraBilling.noInvoices") : billingMessage}
-            </p>
-          ) : (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>
-                    {t("settings.infraBilling.invoiceReference")}
-                  </TableHead>
-                  <TableHead>{t("settings.infraBilling.invoiceDue")}</TableHead>
-                  <TableHead>
-                    {t("settings.infraBilling.invoiceAmount")}
-                  </TableHead>
-                  <TableHead>
-                    {t("settings.infraBilling.invoiceStatus")}
-                  </TableHead>
-                  <TableHead>
-                    {t("settings.infraBilling.invoiceDocuments")}
-                  </TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {(billing?.invoices ?? []).map((invoice) => (
-                  <TableRow key={invoice.id}>
-                    <TableCell>
-                      {invoice.referenceMonth
-                        ? utcDay(invoice.referenceMonth).toLocaleDateString(
-                            undefined,
-                            { month: "long", year: "numeric", timeZone: "UTC" },
-                          )
-                        : "—"}
-                    </TableCell>
-                    <TableCell>
-                      {invoice.dueDate
-                        ? utcDay(invoice.dueDate).toLocaleDateString(
-                            undefined,
-                            {
-                              day: "numeric",
-                              month: "short",
-                              year: "numeric",
-                              timeZone: "UTC",
-                            },
-                          )
-                        : "—"}
-                    </TableCell>
-                    <TableCell className="tabular-nums">
-                      {CURRENCY_FMT.format(invoice.value)}
-                    </TableCell>
-                    <TableCell>
-                      <InvoiceStatus status={invoice.status} />
-                    </TableCell>
-                    <TableCell className="flex gap-2">
-                      {invoice.nfUrl && (
-                        <DocumentLink
-                          href={invoice.nfUrl}
-                          label={t("settings.infraBilling.invoiceNf")}
-                        />
-                      )}
-                      {invoice.bankSlipUrl && (
-                        <DocumentLink
-                          href={invoice.bankSlipUrl}
-                          label={t("settings.infraBilling.invoiceBankSlip")}
-                        />
-                      )}
-                      {!invoice.bankSlipUrl &&
-                        !teamUsesBankSlip &&
-                        invoice.nfUrl && (
-                          <DocumentLink
-                            href={BANK_TRANSFER_PDF_URL}
-                            label={t(
-                              "settings.infraBilling.invoiceBankTransfer",
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>
+                        {t("settings.infraBilling.invoiceReference")}
+                      </TableHead>
+                      <TableHead>
+                        {t("settings.infraBilling.invoiceDue")}
+                      </TableHead>
+                      <TableHead>
+                        {t("settings.infraBilling.invoiceAmount")}
+                      </TableHead>
+                      <TableHead>
+                        {t("settings.infraBilling.invoiceStatus")}
+                      </TableHead>
+                      <TableHead>
+                        {t("settings.infraBilling.invoiceDocuments")}
+                      </TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {(billing?.invoices ?? []).map((invoice) => (
+                      <TableRow key={invoice.id}>
+                        <TableCell>
+                          {invoice.referenceMonth
+                            ? utcDay(invoice.referenceMonth).toLocaleDateString(
+                                undefined,
+                                {
+                                  month: "long",
+                                  year: "numeric",
+                                  timeZone: "UTC",
+                                },
+                              )
+                            : "—"}
+                        </TableCell>
+                        <TableCell>
+                          {invoice.dueDate
+                            ? utcDay(invoice.dueDate).toLocaleDateString(
+                                undefined,
+                                {
+                                  day: "numeric",
+                                  month: "short",
+                                  year: "numeric",
+                                  timeZone: "UTC",
+                                },
+                              )
+                            : "—"}
+                        </TableCell>
+                        <TableCell className="tabular-nums">
+                          {CURRENCY_FMT.format(invoice.value)}
+                        </TableCell>
+                        <TableCell>
+                          <InvoiceStatus status={invoice.status} />
+                        </TableCell>
+                        <TableCell className="flex gap-2">
+                          {invoice.nfUrl && (
+                            <DocumentLink
+                              href={invoice.nfUrl}
+                              label={t("settings.infraBilling.invoiceNf")}
+                            />
+                          )}
+                          {invoice.bankSlipUrl && (
+                            <DocumentLink
+                              href={invoice.bankSlipUrl}
+                              label={t("settings.infraBilling.invoiceBankSlip")}
+                            />
+                          )}
+                          {!invoice.bankSlipUrl &&
+                            !teamUsesBankSlip &&
+                            invoice.nfUrl && (
+                              <DocumentLink
+                                href={BANK_TRANSFER_PDF_URL}
+                                label={t(
+                                  "settings.infraBilling.invoiceBankTransfer",
+                                )}
+                              />
                             )}
-                          />
-                        )}
-                      {!invoice.nfUrl && !invoice.bankSlipUrl && "—"}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          )}
-        </Card>
-      </SettingsSection>
+                          {!invoice.nfUrl && !invoice.bankSlipUrl && "—"}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
+            </Card>
+          </SettingsSection>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Follows up on the recently-added infra-billing UI (`apps/web/src/views/settings/infra-billing.tsx`, `apps/web/src/hooks/use-infra-billing.ts`).

**The bug**: `useInfraBilling`'s query is `enabled: slugs.length > 0`. When a user deselects every site in the `MultiSelect`, `narrowedTo` becomes `[]` (not `null`), so `selected` is `[]` and the query stays disabled forever — `data` never resolves and `isLoading` never becomes `true`. Two visible consequences on the page:
1. The billing summary card falls into the `!isLoading` branch and renders `billingMessage`, which defaults to the `"multiple_teams"` key when `data?.billingUnavailableReason` is `undefined` — showing a wrong "sites belong to different legacy teams" message even though the real cause is just an empty selection.
2. The invoices table's `!data` check renders a `<Skeleton>` that never resolves — a permanent loading spinner.

**The fix**: skip the summary/metrics/invoices `SettingsSection`s entirely when `selected.length === 0` — the existing `pickASite` card above already covers that state, so there's nothing else to show.

**Reviewer check**: open Settings > Infra Billing with an org that owns 2+ sites, then clear the site MultiSelect down to zero selections — confirm only the "pick a site" card shows, with no stuck skeleton or wrong billing message underneath.

**Verified locally**: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (green), `bunx oxlint apps/web/src/views/settings/infra-billing.tsx` (0 warnings/errors). No existing unit test covers this React view; full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents stuck loading and wrong messaging on Infra Billing when the site selection is empty. Previously, deselecting all sites left the query disabled, showed a misleading “multiple teams” message, and kept the invoices table skeleton visible; now the summary, metrics, and invoices sections are hidden when no sites are selected so only the “pick a site” card remains.

- Reviewer notes:
  - In `Settings > Infra Billing`, clear the site MultiSelect to zero selections. Confirm only the “pick a site” card shows, with no skeletons or billing message underneath.
  - Change is isolated to `apps/web/src/views/settings/infra-billing.tsx`: the summary/metrics/invoices `SettingsSection`s render only when `selected.length > 0`.

<sup>Written for commit 585f89ace4f249df6980c76282d168f46f03f794. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6161?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

