### PR TITLE
fix(sandbox): cap the Go daemon's MCP JSON-RPC response body

### DIFF
--- a/packages/sandbox/daemon-go/internal/toolscatalog/mcp.go
+++ b/packages/sandbox/daemon-go/internal/toolscatalog/mcp.go
@@ -29,6 +29,11 @@ const clientName = "@decocms/sandbox-tools-catalog"
 // hang FetchCatalog indefinitely and grow `out` without bound.
 const maxCatalogPages = 1000
 
+// maxRPCResponseBytes bounds a single JSON-RPC response body: a misbehaving or
+// malicious endpoint could otherwise stream an unbounded body into memory.
+// Matches the SSE branch's per-frame buffer cap below.
+const maxRPCResponseBytes = 8 * 1024 * 1024
+
 type mcpClient struct {
 	http      *http.Client
 	url       string
@@ -198,7 +203,14 @@ func (c *mcpClient) call(ctx context.Context, method string, params any) (json.R
 // first `data:` frame.
 func readRPCBody(res *http.Response) (json.RawMessage, error) {
 	if !strings.Contains(res.Header.Get("Content-Type"), "text/event-stream") {
-		return io.ReadAll(res.Body)
+		body, err := io.ReadAll(io.LimitReader(res.Body, maxRPCResponseBytes+1))
+		if err != nil {
+			return nil, err
+		}
+		if len(body) > maxRPCResponseBytes {
+			return nil, fmt.Errorf("response exceeded %d bytes", maxRPCResponseBytes)
+		}
+		return body, nil
 	}
 	sc := bufio.NewScanner(res.Body)
 	sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)

--- a/packages/sandbox/daemon-go/internal/toolscatalog/mcp_test.go
+++ b/packages/sandbox/daemon-go/internal/toolscatalog/mcp_test.go
@@ -63,3 +63,28 @@ func TestFetchCatalogBoundsPagination(t *testing.T) {
 		t.Fatalf("expected a page-limit error, got: %v", err)
 	}
 }
+
+// TestReadRPCBodyBoundsPlainJSON guards against a misbehaving or malicious
+// endpoint streaming an unbounded plain-JSON response body: without a cap,
+// readRPCBody would buffer it entirely into memory via io.ReadAll.
+func TestReadRPCBodyBoundsPlainJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(make([]byte, maxRPCResponseBytes+1))
+	}))
+	defer srv.Close()
+
+	res, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("http.Get: %v", err)
+	}
+	defer res.Body.Close()
+
+	_, err = readRPCBody(res)
+	if err == nil {
+		t.Fatal("expected readRPCBody to reject an oversized body, got nil error")
+	}
+	if !strings.Contains(err.Error(), "exceeded") {
+		t.Fatalf("expected a size-limit error, got: %v", err)
+	}
+}


### PR DESCRIPTION
Bug found while auditing `packages/sandbox/daemon-go/internal/toolscatalog/mcp.go` for resource-leak / oversized-payload gaps per the file's own stated threat model.

`readRPCBody`'s plain-JSON branch called `io.ReadAll(res.Body)` with no size limit, while the SSE branch right next to it already caps a frame at 8MB via the scanner buffer (`sc.Buffer(make([]byte, 0, 64*1024), 8*1024*1024)`). The file already documents this exact threat model for pagination (`maxCatalogPages`'s comment: "a misbehaving or malicious endpoint") — the same endpoint answering `application/json` instead of SSE could stream an unbounded body straight into the daemon's memory during a tools catalog fetch, with no cap at all.

Fix: cap the plain-JSON path at the same 8MB via `io.LimitReader`, returning an error when exceeded — matching the SSE branch's existing bound instead of adding a new one.

Failure scenario before the fix: a malicious or buggy downstream MCP connection responding with `Content-Type: application/json` and an arbitrarily large body could exhaust the daemon pod's memory on every catalog fetch against that connection.

Regression test: `TestReadRPCBodyBoundsPlainJSON` in `mcp_test.go` — a test server writes `maxRPCResponseBytes+1` bytes as `application/json`; asserts `readRPCBody` rejects it with an "exceeded" error instead of buffering it.

Reviewer check: `cd packages/sandbox/daemon-go && go test ./internal/toolscatalog/...`

Locally ran: `go build ./...`, `go test ./internal/toolscatalog/...` (both existing and new tests pass), `gofmt -l` and `go vet` on the touched files (clean). Full CI validates the rest of the daemon-go suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the Go daemon’s MCP JSON‑RPC response body at 8MB to prevent unbounded memory use. Previously, `readRPCBody` used `io.ReadAll` for `application/json` responses with no limit; now it uses `io.LimitReader` and returns an error when the body exceeds 8MB, matching the SSE branch’s per‑frame cap.

**Review notes**
- Limits plain‑JSON responses to 8MB via `maxRPCResponseBytes`; oversized responses now fail with a “exceeded” error. SSE handling is unchanged.
- Adds `TestReadRPCBodyBoundsPlainJSON` to assert rejection of oversized bodies.
- If any MCP endpoints return >8MB JSON, reduce response size or paginate; these will now fail.
- To verify: in `packages/sandbox/daemon-go`, run `go test ./internal/toolscatalog/...`.

<sup>Written for commit 469d346dc70f9f62a0e55c3d32eaf3b03a42ef6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

