### PR TITLE
chore(cli): remove dead --prune/-e flags from parseArgs

### DIFF
--- a/apps/api/src/cli.ts
+++ b/apps/api/src/cli.ts
@@ -58,12 +58,7 @@ const { values, positionals } = parseArgs({
       type: "boolean",
       default: false,
     },
-    prune: {
-      type: "boolean",
-      default: false,
-    },
     target: { type: "string" },
-    env: { type: "string", short: "e" },
     "dry-run": {
       type: "boolean",
       default: false,


### PR DESCRIPTION
The desktop `link` feature (the only consumer of `--prune` and `-e/--env`) was removed in #5570 ("chore(link): remove the desktop link feature"), but that PR left the two flag definitions dangling in `apps/api/src/cli.ts`'s `parseArgs` options — they're accepted on the command line but never read anywhere (`values.prune` / `values.env` have zero references), and neither appears in the `--help` output.

A maintainer wants this because dead CLI flags are misleading: they silently accept `--prune`/`-e <value>` and do nothing, which is confusing for anyone poking at `deco --help` or grepping the source for what a flag does.

Net change: -5 lines, 0 added. Confirmed dead via `grep -rn "values\.prune\|values\.env" apps/api/src/` (no hits) and by reading the git history of `cli.ts` back to the commit that introduced them for the `link` command.

A reviewer can confirm with:
```
grep -n "prune\|env: { type" apps/api/src/cli.ts
```
(no matches after this change) and `cd apps/api && bunx tsc --noEmit`.

Locally verified: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint src/cli.ts` (0 warnings/errors). No test exercises these flags (there's no `cli.test.ts`), so this is a pure dead-code deletion — full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unused CLI flags `--prune` and `-e/--env` from `apps/api/src/cli.ts`’s `parseArgs`. These flags belonged to the removed desktop link feature; they were previously accepted but no-ops and are now unrecognized to prevent confusion.

- Old vs new behavior: previously accepted and ignored; now not recognized. If your scripts pass these flags, remove them—there is no replacement.
- Review: only deletes the two option definitions (-5 lines). Verify with grep in `cli.ts`; typecheck remains clean.
- Help output is unchanged (these flags weren’t listed).

<sup>Written for commit 1e8b3b03d57c492f0b420ad2b187e75754079b04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6163?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

