### PR TITLE
fix(harness): don't re-stamp model metadata on a sandbox continuation

### DIFF
--- a/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { UIMessageChunk } from "ai";
 import { harnessRunResultSchema } from "@decocms/sandbox/dispatch/schemas";
+import { withModelMetadata } from "./with-model-metadata";
 import {
   describeTermination,
   dispatchWithContinuation,
@@ -293,6 +294,33 @@ describe("dispatchWithContinuation", () => {
     // The second dispatch is told it is continuing, and why.
     expect(resumes[0]).toBeNull();
     expect(resumes[1]?.reason).toContain("pod gone");
+  });
+
+  test("a continuation does not re-stamp model metadata", async () => {
+    // Mirrors the real `dispatchOnce`, which wraps each attempt in `withModelMetadata`.
+    let attempt = 0;
+    const chunks = await collect(
+      dispatchWithContinuation({
+        runId: "run_1",
+        resume: null,
+        aborted: () => false,
+        dispatchOnce: (resume) => {
+          attempt++;
+          const first = attempt === 1;
+          return withModelMetadata(
+            first
+              ? dispatch(
+                  [chunk("start"), chunk("text-delta")],
+                  new SandboxUnreachableError("pod gone"),
+                )()
+              : dispatch([chunk("start"), chunk("finish")])(),
+            resume ? null : "claude-sonnet-5",
+            "anthropic",
+          );
+        },
+      }),
+    );
+    expect(chunks.filter((c) => c.type === "message-metadata")).toHaveLength(1);
   });
 
   test("an attempt that died before streaming anything lets the continuation open the message", async () => {

--- a/apps/api/src/harnesses/sandbox-dispatch-client.ts
+++ b/apps/api/src/harnesses/sandbox-dispatch-client.ts
@@ -393,7 +393,8 @@ export class SandboxDispatchClient implements SandboxClient {
             runId,
             signal: input.signal,
           }),
-          modelEnv.CLAUDE_CODE_MODEL,
+          // A continuation's `start` is dropped downstream, so don't re-stamp it.
+          resume ? null : modelEnv.CLAUDE_CODE_MODEL,
           credentialProviderId,
         );
       })();


### PR DESCRIPTION
Follows #6151, which added `withModelMetadata` to stamp `metadata.models.thinking` onto the claude-code harness's first `start` chunk (mirroring what Decopilot already does).

**Bug:** `sandbox-dispatch-client.ts`'s `dispatchOnce` wraps every dispatch attempt — including sandbox-lost continuations — in `withModelMetadata`, and each call gets a fresh generator whose internal `stamped` flag resets to `false`. `dispatchWithContinuation` already drops a continuation's `start` chunk (documented: forwarding a second one would re-id the message), but it does NOT know about the `message-metadata` chunk `withModelMetadata` yields right after `start` — so a run that survives a sandbox-lost retry gets a second, redundant `message-metadata` chunk spliced into an already-open message. Harmless when the model id is unchanged, but it's dead weight on every continuation and a landmine if a retry ever picks a different model.

**Fix:** pass `null` for the model id on a continuation attempt (`resume ? null : modelEnv.CLAUDE_CODE_MODEL`) so `withModelMetadata` no-ops, consistent with `dispatchWithContinuation` already treating a continuation's `start` as a no-op.

**Verify:** `bun test apps/api/src/harnesses/sandbox-dispatch-client.test.ts` — added a regression test (`a continuation does not re-stamp model metadata`) composing `dispatchWithContinuation` + `withModelMetadata` the same way the real dispatch path does, asserting exactly one `message-metadata` chunk survives a sandbox-lost retry. Also ran `apps/api/src/harnesses/with-model-metadata.test.ts` (unchanged, still green) and `cd apps/api && bunx tsc --noEmit`.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api), the two targeted test files, `bunx oxlint` on both changed files. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent duplicate model metadata on sandbox continuation retries. Previously, a continuation emitted a second `message-metadata` chunk because `dispatchOnce` always wrapped attempts in `withModelMetadata`; downstream dropped the second `start` but not the metadata. Now, continuation attempts pass `null` as the model id so `withModelMetadata` no-ops, matching how the continuation’s `start` is suppressed and avoiding mismatched model ids.

- Changes: in `sandbox-dispatch-client.ts`, pass `resume ? null : modelEnv.CLAUDE_CODE_MODEL` into `withModelMetadata`.
- Behavior: first attempt still stamps metadata; continuations no longer add another `message-metadata` chunk.
- Tests: adds a regression test asserting exactly one `message-metadata` survives a sandbox-lost retry.

<sup>Written for commit 5d27e275b6ee1c2a309442ceac429f6d1c48d502. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6165?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

