### PR TITLE
refactor(infra-billing): dedupe the site-ownership check shared by GET and PORTAL

### DIFF
--- a/apps/api/src/tools/infra-billing/get.ts
+++ b/apps/api/src/tools/infra-billing/get.ts
@@ -9,6 +9,7 @@ import { isValidSiteSlug } from "@decocms/shared/site-slug";
 import { defineTool } from "../../core/define-tool";
 import { requireAuth, requireOrganization } from "../../core/studio-context";
 import { getSiteInfraBilling } from "../../deco-legacy/infra-billing";
+import { resolveOwnedSlugs } from "./ownership";
 
 export const INFRA_BILLING_GET = defineTool({
   name: "INFRA_BILLING_GET",
@@ -79,17 +80,11 @@ export const INFRA_BILLING_GET = defineTool({
     await ctx.access.check();
     const org = requireOrganization(ctx);
 
-    const slugs = [...new Set(input.siteSlugs.map((s) => s.toLowerCase()))];
-    const ownedSlugs = (await ctx.storage.orgSites.listByOrg(org.id)).map(
-      (site) => site.slug,
+    const { slugs, ownedSlugs } = await resolveOwnedSlugs(
+      ctx,
+      org.id,
+      input.siteSlugs,
     );
-    const owned = new Set(ownedSlugs);
-    const unowned = slugs.filter((slug) => !owned.has(slug));
-    if (unowned.length > 0) {
-      throw new Error(
-        `Site not found in organization: ${unowned.sort().join(", ")}`,
-      );
-    }
 
     return getSiteInfraBilling({
       siteSlugs: slugs,

--- a/apps/api/src/tools/infra-billing/ownership.ts
+++ b/apps/api/src/tools/infra-billing/ownership.ts
@@ -1,0 +1,31 @@
+/**
+ * Shared ownership gate for the infra-billing tools: every requested site slug
+ * must be owned by the calling org, or the whole call fails — one tool must
+ * never leak another org's usage/plan/invoices by guessing a slug.
+ */
+
+import type { StudioContext } from "../../core/studio-context";
+
+/**
+ * Lowercases + dedupes the requested slugs, loads the org's owned slugs, and
+ * throws if any requested slug isn't owned. Returns both lists so callers can
+ * reuse `ownedSlugs` for team-scoped checks (e.g. `resolveOwnedTeam`).
+ */
+export async function resolveOwnedSlugs(
+  ctx: StudioContext,
+  orgId: string,
+  siteSlugs: string[],
+): Promise<{ slugs: string[]; ownedSlugs: string[] }> {
+  const slugs = [...new Set(siteSlugs.map((s) => s.toLowerCase()))];
+  const ownedSlugs = (await ctx.storage.orgSites.listByOrg(orgId)).map(
+    (site) => site.slug,
+  );
+  const owned = new Set(ownedSlugs);
+  const unowned = slugs.filter((slug) => !owned.has(slug));
+  if (unowned.length > 0) {
+    throw new Error(
+      `Site not found in organization: ${unowned.sort().join(", ")}`,
+    );
+  }
+  return { slugs, ownedSlugs };
+}

--- a/apps/api/src/tools/infra-billing/portal.ts
+++ b/apps/api/src/tools/infra-billing/portal.ts
@@ -18,6 +18,7 @@ import {
   resolveOwnedTeam,
   teamStripeSubscriptionId,
 } from "../../deco-legacy/infra-billing";
+import { resolveOwnedSlugs } from "./ownership";
 
 export const INFRA_BILLING_PORTAL = defineTool({
   name: "INFRA_BILLING_PORTAL",
@@ -47,17 +48,11 @@ export const INFRA_BILLING_PORTAL = defineTool({
       throw new Error("Organization context required");
     }
 
-    const slugs = [...new Set(input.siteSlugs.map((s) => s.toLowerCase()))];
-    const ownedSlugs = (await ctx.storage.orgSites.listByOrg(org.id)).map(
-      (site) => site.slug,
+    const { slugs, ownedSlugs } = await resolveOwnedSlugs(
+      ctx,
+      org.id,
+      input.siteSlugs,
     );
-    const owned = new Set(ownedSlugs);
-    const unowned = slugs.filter((slug) => !owned.has(slug));
-    if (unowned.length > 0) {
-      throw new Error(
-        `Site not found in organization: ${unowned.sort().join(", ")}`,
-      );
-    }
 
     // Portal sessions can cancel the team's subscription — require the whole team.
     const scope = await resolveOwnedTeam(slugs, ownedSlugs);


### PR DESCRIPTION
**Source:** C1 duplication — `apps/api/src/tools/infra-billing/get.ts` and `portal.ts` each contained the identical 8-line block (lowercase+dedupe requested slugs, load the org's owned slugs, reject any unowned slug) verbatim.

**Payoff:** one home for a security-relevant check (this is the gate that stops one org reading another org's infra usage/plan/invoices by guessing a site slug) means a future fix to it can't be applied to one call site and missed in the other.

**Change:** extracted the block into `resolveOwnedSlugs(ctx, orgId, siteSlugs)` in a new `apps/api/src/tools/infra-billing/ownership.ts`, and call it from both tools. Byte-identical logic, just relocated — no behavior change. Net diff: -20 duplicated lines / +23 shared-helper lines (one-time cost, future callers add zero).

**Verify:** `cd apps/api && bunx tsc --noEmit` (clean) and `bun test apps/api/src/deco-legacy/infra-billing.test.ts` (32 pass, unchanged) confirm nothing about the ownership check's behavior moved.

**Checks run locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/api), `bun test apps/api/src/deco-legacy/infra-billing.test.ts`, `bunx oxlint` on the 3 changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates the infra-billing site-ownership check used by GET and PORTAL into a shared helper, keeping behavior identical. Centralizing this security gate avoids divergence and ensures fixes apply to both endpoints.

- Add `resolveOwnedSlugs(ctx, orgId, siteSlugs)` in `apps/api/src/tools/infra-billing/ownership.ts` (lowercase + dedupe, load owned slugs, throw on unowned; returns `slugs` and `ownedSlugs`).
- Replace inline checks in `apps/api/src/tools/infra-billing/get.ts` and `apps/api/src/tools/infra-billing/portal.ts` with the helper.
- No behavior change; tests and type checks unchanged. No rollout or migration actions.

<sup>Written for commit 9bfaca0647c70640c93c596d67ea68e2ee5da4da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6167?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

