### PR TITLE
fix(i18n): translate the pt-br auto tasks billing card title

### DIFF
--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -802,7 +802,7 @@ export const settings = {
   "settings.aiProviders.decoConnectError":
     "Falha ao conectar o Deco AI Gateway: {error}",
   "settings.billing.title": "Cobrança",
-  "settings.billing.autoTasksTitle": "Auto tasks",
+  "settings.billing.autoTasksTitle": "Tarefas automáticas",
   "settings.billing.unlimitedDescription":
     "As execuções de auto tasks são ilimitadas neste deployment. Tasks criadas por você também nunca têm limite.",
   "settings.billing.autoTasksDescriptionTrial":


### PR DESCRIPTION
Found while auditing key-parity between apps/web/src/i18n/en/settings.ts and apps/web/src/i18n/pt-br/settings.ts: every key exists in both files, but `settings.billing.autoTasksTitle` in the pt-br file was left as the raw English string "Auto tasks" while every surrounding string in that same billing block (statusTrial, runsUsedLabel, subscribeButton, etc.) is properly translated — a leftover from whenever the key was added.

A Portuguese-language user sees an English card title ("Auto tasks") in the middle of an otherwise fully-translated billing settings page (apps/web/src/views/settings/billing.tsx:95,118).

Fix: translated the string to "Tarefas automáticas", matching the existing pt-br terminology used elsewhere in the same section (e.g. "execuções de auto tasks" stays as-is since that's a compound term, but the standalone card title now reads naturally in Portuguese).

To confirm: open Settings → Billing with the pt-br locale selected and check the auto-tasks card title.

Locally verified: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (green — TranslationKey compile check still passes since the key itself is unchanged, only the value), and `bunx oxlint apps/web/src/i18n/pt-br/settings.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the pt-br translation for the Billing auto-tasks card title; no other behavior changes. Previously pt-br users saw "Auto tasks"; now they see "Tarefas automáticas".

**Review and verification**
- Only changes the `settings.billing.autoTasksTitle` value in apps/web/src/i18n/pt-br/settings.ts; the key is unchanged.
- Verify by opening Settings → Billing with the pt-br locale and checking the card title.

<sup>Written for commit 4edf3d73d1c0d044b7f85789a46fd5a9ec4794f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

