### PR TITLE
fix(sections-editor): merge allOf intersection props instead of picker

### DIFF
--- a/apps/web/src/components/sections-editor/resolve-schema.test.ts
+++ b/apps/web/src/components/sections-editor/resolve-schema.test.ts
@@ -1972,4 +1972,29 @@ describe("resolveSchema – intersection-typed props (allOf) merge into one form
       ?.properties?.title;
     expect(title?.title).toBeUndefined();
   });
+
+  test("prop-level title wins over the suppressed intersection title", () => {
+    const withPropTitle = structuredClone(meta) as LiveMeta;
+    const section = (
+      withPropTitle.schema.definitions as Record<string, unknown>
+    ).TabbedShelfSection as { properties: { title: Record<string, unknown> } };
+    section.properties.title.title = "Título";
+    const title = resolveSchema("site/sections/TabbedShelf.tsx", withPropTitle)
+      ?.properties?.title;
+    expect(title?.title).toBe("Título");
+    expect(title?.properties?.content?.title).toBe("Content");
+  });
+
+  test("keeps a human-authored title on a named intersection def", () => {
+    const named = structuredClone(meta) as LiveMeta;
+    const defs = named.schema.definitions as Record<
+      string,
+      Record<string, unknown>
+    >;
+    defs.TitleIntersection!.title = "Layout options";
+    const title = resolveSchema("site/sections/TabbedShelf.tsx", named)
+      ?.properties?.title;
+    expect(title?.type).toBe("object");
+    expect(title?.title).toBe("Layout options");
+  });
 });

--- a/apps/web/src/components/sections-editor/resolve-schema.test.ts
+++ b/apps/web/src/components/sections-editor/resolve-schema.test.ts
@@ -1906,3 +1906,70 @@ describe("resolveSchema – block-config-wrapped union (matcher Props)", () => {
     expect(resolved?.inlineUnionBranches).toBeUndefined();
   });
 });
+
+describe("resolveSchema – intersection-typed props (allOf) merge into one form", () => {
+  /**
+   * Reproduces ALS's TabbedShelf `title` prop, typed
+   * `Omit<RichTextWidget, "tag"> & { tag?: HeadingTag }`. deco emits it as an
+   * allOf of two object `$ref`s with a machine-generated title. Before the fix
+   * this fell into the block-ref path, dropped every branch (no discriminator),
+   * and rendered as "[object Object]" labeled with the machine name.
+   */
+  const meta: LiveMeta = {
+    manifest: {
+      blocks: {
+        sections: {
+          "site/sections/TabbedShelf.tsx": {
+            $ref: "#/definitions/TabbedShelfSection",
+          },
+        },
+      },
+    },
+    schema: {
+      definitions: {
+        TabbedShelfSection: {
+          type: "object",
+          properties: {
+            title: { $ref: "#/definitions/TitleIntersection" },
+          },
+        },
+        TitleIntersection: {
+          title: "omitdGFnRichTextWidget&tl@1767-1787",
+          allOf: [
+            { $ref: "#/definitions/RichTextMinusTag" },
+            { $ref: "#/definitions/TagOnly" },
+          ],
+        },
+        RichTextMinusTag: {
+          type: "object",
+          title: "omitdGFnRichTextWidget",
+          properties: {
+            content: { type: "string", title: "Content" },
+            color: { type: "string", format: "color-input", title: "Color" },
+          },
+        },
+        TagOnly: {
+          type: "object",
+          title: "tl@1767-1787",
+          properties: { tag: { type: "string", title: "Tag" } },
+        },
+      },
+    },
+  };
+
+  test("renders an object form with all merged fields, not a picker", () => {
+    const title = resolveSchema("site/sections/TabbedShelf.tsx", meta)
+      ?.properties?.title;
+    expect(title?.type).toBe("object");
+    expect(title?.anyOfRefs).toBeUndefined();
+    expect(title?.properties?.content?.title).toBe("Content");
+    expect(title?.properties?.color?.format).toBe("color-input");
+    expect(title?.properties?.tag?.title).toBe("Tag");
+  });
+
+  test("drops the machine-generated intersection title as the field label", () => {
+    const title = resolveSchema("site/sections/TabbedShelf.tsx", meta)
+      ?.properties?.title;
+    expect(title?.title).toBeUndefined();
+  });
+});

--- a/apps/web/src/components/sections-editor/resolve-schema.ts
+++ b/apps/web/src/components/sections-editor/resolve-schema.ts
@@ -503,14 +503,14 @@ export function resolveSchema(
     // would be silently dropped.
     let type: string | undefined;
     let unionLeaf: RawSchema | undefined;
+    // When set, `resolved.title` is a machine-generated intersection name, not a label.
+    let suppressResolvedTitle = false;
     if (resolved.type) {
       type = Array.isArray(resolved.type)
         ? String(resolved.type.find((t) => t !== "null") ?? resolved.type[0])
         : String(resolved.type);
-    } else if (resolved.anyOf || resolved.allOf || resolved.oneOf) {
-      const arr = (resolved.anyOf ??
-        resolved.allOf ??
-        resolved.oneOf) as RawSchema[];
+    } else if (resolved.anyOf || resolved.oneOf) {
+      const arr = (resolved.anyOf ?? resolved.oneOf) as RawSchema[];
       const nonNull = arr.filter(
         (a) => !(a.type === "null" || a.type === null),
       );
@@ -960,6 +960,19 @@ export function resolveSchema(
 
         type = "object";
       }
+    } else if (resolved.allOf) {
+      /**
+       * `allOf` is a type INTERSECTION (A & B), not a choice union. deco emits
+       * anonymous intersections like `Omit<RichTextWidget, "tag"> & { tag?: … }`
+       * as an allOf of object `$ref`s titled with a machine name
+       * ("omitdGFnRichTextWidget&tl@1767-1787"). Merge the members into one form
+       * (via `collectProps` below), like the legacy admin's `resolveRefs`. It
+       * must NOT reach the choice-union branches above: a pure intersection has
+       * no discriminator, so every branch is dropped and the field collapses to
+       * an empty picker rendered as "[object Object]".
+       */
+      type = "object";
+      suppressResolvedTitle = true;
     } else if (typeof v.$ref === "string") {
       // Last-resort: ref points to a def with no type/union we recognize.
       // Treat as object so nested-property recursion has a chance to fill in.
@@ -1029,7 +1042,7 @@ export function resolveSchema(
       title:
         typeof v.title === "string"
           ? v.title
-          : typeof resolved.title === "string"
+          : !suppressResolvedTitle && typeof resolved.title === "string"
             ? resolved.title
             : fromLeaf<string>("title"),
       description:

--- a/apps/web/src/components/sections-editor/resolve-schema.ts
+++ b/apps/web/src/components/sections-editor/resolve-schema.ts
@@ -364,6 +364,19 @@ export function resolveSchema(
   };
 
   /**
+   * deco names anonymous composite defs after their structure — a jsdelivr URL,
+   * pipe-joined branches ("ImageCard|TextCard"), or an intersection
+   * ("omitdGFnRichTextWidget&tl@1767-1787"). Those machine names leak in as
+   * field labels. A human-authored `@title` has spaces or none of these markers,
+   * so it is kept (e.g. "Q&A | Help").
+   */
+  const isMachineGeneratedTitle = (t: unknown): boolean =>
+    typeof t === "string" &&
+    (t.includes("://") ||
+      (!/\s/.test(t) &&
+        (t.includes("|") || t.includes("&") || t.includes("@"))));
+
+  /**
    * Recursively follow $ref / allOf / anyOf / oneOf and merge all
    * `properties` objects found. seenRefs guards against cycles.
    */
@@ -808,10 +821,8 @@ export function resolveSchema(
           const def = resolveBranchDef(branch);
           return def.type === "object" || Boolean(def.properties);
         };
-        const isChoiceUnion =
-          Array.isArray(resolved.anyOf) || Array.isArray(resolved.oneOf);
+        // allOf is merged as an object earlier, so this block only sees choice unions.
         const isPlainDataUnion =
-          isChoiceUnion &&
           depth < MAX_BUILD_PROPERTY_DEPTH &&
           nonNull.every(branchIsPlainDataObject);
 
@@ -894,12 +905,6 @@ export function resolveSchema(
         // plain "A or B" data union (e.g. Location | Map, or a const-tagged
         // union like StaleWhileRevalidate | MaxAge). Render as a branch selector
         // instead of merging every branch's fields into a single form.
-        //
-        // Only `anyOf`/`oneOf` are choices — `allOf` is an intersection meant to
-        // MERGE all branches, so it must fall through to the object-merge path.
-        // `isPlainDataUnion` (computed above) already requires a choice union of
-        // bare object branches (inline or behind a `$ref`) with no module
-        // identity — exactly the `Location | Map` / const-tagged-union shape.
         if (isPlainDataUnion) {
           const constValue = (
             p: RawSchema,
@@ -972,7 +977,7 @@ export function resolveSchema(
        * an empty picker rendered as "[object Object]".
        */
       type = "object";
-      suppressResolvedTitle = true;
+      suppressResolvedTitle = isMachineGeneratedTitle(resolved.title);
     } else if (typeof v.$ref === "string") {
       // Last-resort: ref points to a def with no type/union we recognize.
       // Treat as object so nested-property recursion has a chance to fill in.
@@ -1127,15 +1132,7 @@ export function resolveSchema(
       if (!isChoiceUnion || def.properties) continue;
       const built = buildProperty(def, 0);
       if (built.type === "inline-union" && built.inlineUnionBranches) {
-        // deco names an anonymous union def after its branches
-        // ("A|B|C" / a jsdelivr URL "…@Props"). That machine name leaks in as
-        // the field label — drop it unless the dev gave the type a real @title.
-        // Only treat as machine-generated a URL or pipe-joined identifiers with
-        // no spaces, so a human title like "Q&A | Help" is kept.
-        const t = built.title;
-        const machineTitle =
-          typeof t === "string" &&
-          (t.includes("://") || /^[^\s|]+(\|[^\s|]+)+$/.test(t));
+        const machineTitle = isMachineGeneratedTitle(built.title);
         return {
           ...built,
           title: machineTitle ? undefined : built.title,


### PR DESCRIPTION
## Summary

A section prop typed as an **anonymous TS intersection** rendered in Studio Content as a broken field: a machine-generated label (`omitdGFnRichTextWidget&tl@1767-1787`) over a box showing `[object Object]`, with no editable fields.

Repro: ALS `als-storefront` TabbedShelf, whose `title` prop is:
```ts
title?: Omit<RichTextWidget, "tag"> & { tag?: HeadingTag };
```


### Root cause

deco emits the intersection as a def:
```json
{ "allOf": [{ "$ref": "…@omitdGFnRichTextWidget" }, { "$ref": "…@tl@1767-1787" }],
  "title": "omitdGFnRichTextWidget&tl@1767-1787" }
```
`buildProperty` in `resolve-schema.ts` lumped `allOf` in with `anyOf`/`oneOf` and treated it as a **choice union**. A pure intersection has no discriminator, so it fell into the `allRefs && !isPlainDataUnion` block-ref path, every branch was dropped (`!rt.includes("/") → continue`), and it returned `{ type: "block-ref", anyOfRefs: [], title: "<machine>" }` → an empty picker rendered as `[object Object]`.

The **legacy admin** (`deco-sites/admin`) renders it fine because its `resolveRefs` (`components/editor/JSONSchema/utils.ts`) merges `allOf` members before rendering.

### Fix

`allOf` is an intersection (merge), not a choice union. In `buildProperty`:
- `else if (resolved.anyOf || resolved.oneOf)` keeps the choice-union logic (removed `allOf` from it).
- A new `else if (resolved.allOf)` sets `type = "object"` — the existing `collectProps` already merges every member's `properties` — plus a `suppressResolvedTitle` flag so the machine-generated intersection title is dropped and the field uses its own label.

deco's single-member block-config wrapper (`allOf:[{$ref:Props}], properties:{__resolveType}`) is handled by a separate path and is unaffected.

Fixes every client with anonymous-intersection props, not just ALS.

## Testing

- Ran the resolver against ALS's production `_meta`: **before** → `block-ref` / `anyOfRefs: []` / mangled label; **after** → object with all 9 merged fields (`content`, `color` with `color-input` format, `tag` narrowed to the 6 headings), label falls back to `"Title"`.
- Added 2 regression tests in `resolve-schema.test.ts`.
- `bun test apps/web/src/components/sections-editor/` → 633 pass, 0 fail.
- `bun run --cwd=apps/web check`, `bun run lint` (0 errors), `bun run fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats `allOf` intersections as merges in the sections editor schema resolver. Anonymous TS intersections now render as one object form with merged fields; previously they showed an empty picker labeled with a machine-generated name.

- Maps `allOf` to `type: "object"` and merges member properties via existing logic; deco’s single-member block-config wrapper remains unaffected.
- Suppresses only machine-generated intersection titles; keeps human-authored `@title`s and prop-level titles. Reuses the same heuristic for inline-union labels.
- Leaves `anyOf`/`oneOf` choice-union behavior unchanged and removes a dead `isChoiceUnion` guard.
- Adds tests for merged fields, suppression rules, and title precedence; all existing tests pass.

<sup>Written for commit 16e00d4ca995b846112d5e48b3689de13d50ee82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6171?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

