### PR TITLE
feat(sections-editor): let optional enum selects clear back to empty

### DIFF
--- a/apps/web/ct/harness/fixtures.ts
+++ b/apps/web/ct/harness/fixtures.ts
@@ -27,3 +27,11 @@ export function sectionWithProps(
 ): LiveMeta {
   return metaWithSchema({ type: "object", properties }, defs);
 }
+
+/** Shorthand: a section schema with `properties` and a `required` name list. */
+export function sectionWithRequired(
+  properties: Record<string, unknown>,
+  required: string[],
+): LiveMeta {
+  return metaWithSchema({ type: "object", properties, required });
+}

--- a/apps/web/ct/tests/enum-field.ct.tsx
+++ b/apps/web/ct/tests/enum-field.ct.tsx
@@ -1,6 +1,10 @@
 import { expect, test } from "@playwright/experimental-ct-react";
 import { SchemaFormHarness } from "../harness/schema-form-harness";
-import { sectionWithProps, TEST_RESOLVE_TYPE } from "../harness/fixtures";
+import {
+  sectionWithProps,
+  sectionWithRequired,
+  TEST_RESOLVE_TYPE,
+} from "../harness/fixtures";
 import { hoverFieldDescription, readFormValue } from "../harness/ct-utils";
 
 test("string enum renders a combobox trigger", async ({ mount }) => {
@@ -175,6 +179,42 @@ test("empty-string enum: selecting the empty option yields an empty string", asy
   await page.getByRole("option").first().click();
 
   await expect.poll(() => readFormValue(component)).toEqual({ size: "" });
+});
+
+test("optional enum: offers a None option that clears the value", async ({
+  mount,
+  page,
+}) => {
+  const meta = sectionWithProps({
+    size: { type: "string", enum: ["sm", "md"] },
+  });
+  const component = await mount(
+    <SchemaFormHarness
+      meta={meta}
+      resolveType={TEST_RESOLVE_TYPE}
+      initialValue={{ size: "md" }}
+    />,
+  );
+
+  await component.getByRole("combobox").click();
+  await expect(page.getByRole("option")).toHaveCount(3);
+  await page.getByRole("option", { name: "None" }).click();
+
+  await expect.poll(() => readFormValue(component)).toEqual({});
+});
+
+test("required enum: no None option is offered", async ({ mount, page }) => {
+  const meta = sectionWithRequired(
+    { size: { type: "string", enum: ["sm", "md"] } },
+    ["size"],
+  );
+  const component = await mount(
+    <SchemaFormHarness meta={meta} resolveType={TEST_RESOLVE_TYPE} />,
+  );
+
+  await component.getByRole("combobox").click();
+  await expect(page.getByRole("option")).toHaveCount(2);
+  await expect(page.getByRole("option", { name: "None" })).toHaveCount(0);
 });
 
 test("enum: description is shown as a help tooltip next to the label", async ({

--- a/apps/web/src/components/sections-editor/fields/array-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/array-field.tsx
@@ -477,6 +477,8 @@ export function ArrayField({
             value: item,
             onChange: (val) => updateItem(selectedIndex, val),
             path: `${path}.${selectedIndex}`,
+            // An array item is never optional; clearing would leave a null hole.
+            required: true,
             // A mustache `title` (e.g. "{{{city}}} {{{regionCode}}}") is an
             // item-label template, not a display label — use the resolved item
             // label so the header reads "SP BR" instead of the raw template.

--- a/apps/web/src/components/sections-editor/fields/enum-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/enum-field.tsx
@@ -28,8 +28,8 @@ export function EnumField({
   const t = useT();
   const options = schema.enum ?? [];
   const selectValue = formValueToSelectValue(value, options);
-  // Optional enums offer a "None" entry to clear the selection.
-  const showClearOption = !required;
+  // Suppressed when "" is already an option: that is itself the empty choice.
+  const showClearOption = !required && !options.some((opt) => opt === "");
 
   return (
     <div className="space-y-2">

--- a/apps/web/src/components/sections-editor/fields/enum-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/enum-field.tsx
@@ -8,6 +8,7 @@ import {
 } from "@decocms/ui/components/select.tsx";
 import type { FieldProps } from "./field-props";
 import {
+  ENUM_CLEAR_SELECT_VALUE,
   enumOptionLabel,
   enumOptionToSelectValue,
   formValueToSelectValue,
@@ -21,11 +22,14 @@ export function EnumField({
   onChange,
   path,
   label,
+  required,
   sandbox,
 }: FieldProps) {
   const t = useT();
   const options = schema.enum ?? [];
   const selectValue = formValueToSelectValue(value, options);
+  // Optional enums offer a "None" entry to clear the selection.
+  const showClearOption = !required;
 
   return (
     <div className="space-y-2">
@@ -37,7 +41,13 @@ export function EnumField({
       />
       <Select
         value={selectValue}
-        onValueChange={(v) => onChange(selectValueToEnumOption(v, options))}
+        onValueChange={(v) =>
+          onChange(
+            v === ENUM_CLEAR_SELECT_VALUE
+              ? undefined
+              : selectValueToEnumOption(v, options),
+          )
+        }
       >
         <SelectTrigger id={path} className="h-10">
           <SelectValue
@@ -45,6 +55,14 @@ export function EnumField({
           />
         </SelectTrigger>
         <SelectContent>
+          {showClearOption && (
+            <SelectItem
+              value={ENUM_CLEAR_SELECT_VALUE}
+              className="text-muted-foreground"
+            >
+              {t("sectionsEditor.enumField.clearOption")}
+            </SelectItem>
+          )}
           {options.map((opt) => {
             const itemValue = enumOptionToSelectValue(opt);
             return (

--- a/apps/web/src/components/sections-editor/fields/enum-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/enum-field.tsx
@@ -12,7 +12,7 @@ import {
   enumOptionLabel,
   enumOptionToSelectValue,
   formValueToSelectValue,
-  selectValueToEnumOption,
+  selectValueToFormValue,
 } from "./enum-select-value";
 import { FieldLabel } from "./field-label";
 
@@ -41,13 +41,7 @@ export function EnumField({
       />
       <Select
         value={selectValue}
-        onValueChange={(v) =>
-          onChange(
-            v === ENUM_CLEAR_SELECT_VALUE
-              ? undefined
-              : selectValueToEnumOption(v, options),
-          )
-        }
+        onValueChange={(v) => onChange(selectValueToFormValue(v, options))}
       >
         <SelectTrigger id={path} className="h-10">
           <SelectValue

--- a/apps/web/src/components/sections-editor/fields/enum-select-value.test.ts
+++ b/apps/web/src/components/sections-editor/fields/enum-select-value.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import {
+  ENUM_CLEAR_SELECT_VALUE,
   ENUM_EMPTY_SELECT_VALUE,
   enumOptionLabel,
   enumOptionToSelectValue,
   formValueToSelectValue,
   selectValueToEnumOption,
+  selectValueToFormValue,
 } from "./enum-select-value";
 
 describe("enumOptionToSelectValue", () => {
@@ -42,6 +44,24 @@ describe("formValueToSelectValue", () => {
   test("uses sentinel when unset and empty enum is allowed", () => {
     expect(formValueToSelectValue(null, ["", "custom"])).toBe(
       ENUM_EMPTY_SELECT_VALUE,
+    );
+  });
+});
+
+describe("selectValueToFormValue", () => {
+  test("clear sentinel maps to undefined (unset the field)", () => {
+    expect(
+      selectValueToFormValue(ENUM_CLEAR_SELECT_VALUE, ["a", "b"]),
+    ).toBeUndefined();
+  });
+
+  test("empty-string enum still round-trips as empty, not cleared", () => {
+    expect(selectValueToFormValue(ENUM_EMPTY_SELECT_VALUE, ["", "a"])).toBe("");
+  });
+
+  test("normal value delegates to selectValueToEnumOption", () => {
+    expect(selectValueToFormValue("article", ["website", "article"])).toBe(
+      "article",
     );
   });
 });

--- a/apps/web/src/components/sections-editor/fields/enum-select-value.ts
+++ b/apps/web/src/components/sections-editor/fields/enum-select-value.ts
@@ -22,6 +22,19 @@ export function selectValueToEnumOption(
   return match !== undefined ? match : value;
 }
 
+/**
+ * Maps a Select value to the form value written back. The clear option becomes
+ * `undefined` (unset the field); every other value delegates to
+ * {@link selectValueToEnumOption}.
+ */
+export function selectValueToFormValue(
+  value: string,
+  options: unknown[],
+): unknown {
+  if (value === ENUM_CLEAR_SELECT_VALUE) return undefined;
+  return selectValueToEnumOption(value, options);
+}
+
 export function formValueToSelectValue(
   value: unknown,
   options: unknown[],

--- a/apps/web/src/components/sections-editor/fields/enum-select-value.ts
+++ b/apps/web/src/components/sections-editor/fields/enum-select-value.ts
@@ -1,6 +1,13 @@
 /** Radix Select reserves `""` for clearing; map real empty-string enums to this. */
 export const ENUM_EMPTY_SELECT_VALUE = "__enum_empty__";
 
+/**
+ * Sentinel for the "None" option offered on optional enums. Selecting it clears
+ * the field back to `undefined`. Distinct from {@link ENUM_EMPTY_SELECT_VALUE},
+ * which represents an enum whose allowed value is the empty string `""`.
+ */
+export const ENUM_CLEAR_SELECT_VALUE = "__enum_clear__";
+
 export function enumOptionToSelectValue(opt: unknown): string {
   if (opt === "") return ENUM_EMPTY_SELECT_VALUE;
   return String(opt);

--- a/apps/web/src/components/sections-editor/fields/field-props.ts
+++ b/apps/web/src/components/sections-editor/fields/field-props.ts
@@ -16,6 +16,13 @@ export interface FieldProps {
   onChange: (value: unknown) => void;
   path: string;
   label: string;
+  /**
+   * Whether the parent object marks this field as required. Optional fields
+   * (the default when omitted) let widgets offer a way to clear the value —
+   * e.g. `EnumField` shows a "None" option so an optional select can be left
+   * empty.
+   */
+  required?: boolean;
   breadcrumbPath?: Crumb[];
   onBreadcrumbChange?: (path: Crumb[]) => void;
   /**

--- a/apps/web/src/components/sections-editor/resolve-schema.test.ts
+++ b/apps/web/src/components/sections-editor/resolve-schema.test.ts
@@ -1998,3 +1998,65 @@ describe("resolveSchema – intersection-typed props (allOf) merge into one form
     expect(title?.title).toBe("Layout options");
   });
 });
+
+describe("resolveSchema – required propagation", () => {
+  test("exposes required child names at the root", () => {
+    const meta = metaWithSchema({
+      type: "object",
+      required: ["tag"],
+      properties: {
+        tag: { type: "string", enum: ["Heading 1", "Heading 2"] },
+        subtitle: { type: "string", enum: ["A", "B"] },
+      },
+    });
+
+    const resolved = resolveSchema("site/sections/Test.tsx", meta);
+    expect(resolved?.required).toContain("tag");
+    expect(resolved?.required).not.toContain("subtitle");
+  });
+
+  test("required is undefined when the object declares none", () => {
+    const meta = metaWithSchema({
+      type: "object",
+      properties: {
+        tag: { type: "string", enum: ["Heading 1", "Heading 2"] },
+      },
+    });
+
+    expect(resolveSchema("site/sections/Test.tsx", meta)?.required).toBe(
+      undefined,
+    );
+  });
+
+  test("merges required arrays from allOf members on nested objects", () => {
+    const meta: LiveMeta = {
+      manifest: {
+        blocks: {
+          sections: {
+            "site/sections/Test.tsx": { $ref: "#/definitions/Root" },
+          },
+        },
+      },
+      schema: {
+        definitions: {
+          Root: {
+            type: "object",
+            properties: { nested: { $ref: "#/definitions/Nested" } },
+          },
+          Nested: {
+            type: "object",
+            allOf: [
+              { required: ["a"], properties: { a: { type: "string" } } },
+              { required: ["b"], properties: { b: { type: "string" } } },
+            ],
+          },
+        },
+      },
+    };
+
+    const nested = resolveSchema("site/sections/Test.tsx", meta)?.properties
+      ?.nested;
+    expect(nested?.required).toContain("a");
+    expect(nested?.required).toContain("b");
+  });
+});

--- a/apps/web/src/components/sections-editor/resolve-schema.test.ts
+++ b/apps/web/src/components/sections-editor/resolve-schema.test.ts
@@ -2059,4 +2059,22 @@ describe("resolveSchema – required propagation", () => {
     expect(nested?.required).toContain("a");
     expect(nested?.required).toContain("b");
   });
+
+  test("does not mark a key required from only one anyOf branch", () => {
+    const meta = metaWithSchema({
+      type: "object",
+      required: ["kind"],
+      properties: { kind: { type: "string", enum: ["x", "y"] } },
+      anyOf: [
+        { required: ["a"], properties: { a: { type: "string" } } },
+        { required: ["b"], properties: { b: { type: "string" } } },
+      ],
+    });
+
+    const resolved = resolveSchema("site/sections/Test.tsx", meta);
+    // The object's own required survives; branch-only requireds do not.
+    expect(resolved?.required).toContain("kind");
+    expect(resolved?.required).not.toContain("a");
+    expect(resolved?.required).not.toContain("b");
+  });
 });

--- a/apps/web/src/components/sections-editor/resolve-schema.ts
+++ b/apps/web/src/components/sections-editor/resolve-schema.ts
@@ -144,6 +144,13 @@ function isSectionLoaderArrayBranch(
 // `format` field natively this guard becomes a no-op.
 const VIDEO_WIDGET_REF_KEY = "VideoWidget";
 
+/** Coerce a raw JSON Schema `required`/`__required` value to string names. */
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((k): k is string => typeof k === "string")
+    : [];
+}
+
 /** Base64 encode resolveType keys — browser-safe (btoa), Node fallback in tests. */
 function toBase64(str: string): string {
   if (typeof btoa === "function") return btoa(str);
@@ -410,26 +417,27 @@ export function resolveSchema(
       props = { ...props, ...(s.properties as RawSchema) };
     }
 
-    // Merge required arrays from allOf/anyOf/oneOf members
     if (Array.isArray(s.required)) {
-      const existing = Array.isArray(props.__required)
-        ? (props.__required as string[])
-        : [];
-      props.__required = [...existing, ...(s.required as string[])];
+      props.__required = [
+        ...asStringArray(props.__required),
+        ...asStringArray(s.required),
+      ];
     }
 
     for (const k of ["allOf", "anyOf", "oneOf"] as const) {
       const arr = (s as Record<string, unknown>)[k];
       if (!Array.isArray(arr)) continue;
       for (const part of arr as RawSchema[]) {
+        const carriedRequired = asStringArray(props.__required);
         const partProps = collectProps(part, seenRefs, depth + 1);
-        // Merge required so a later member doesn't overwrite an earlier one's.
-        const mergedRequired = [
-          ...(Array.isArray(props.__required) ? props.__required : []),
-          ...(Array.isArray(partProps.__required) ? partProps.__required : []),
-        ];
         props = { ...props, ...partProps };
-        if (mergedRequired.length > 0) props.__required = mergedRequired;
+        // required is an intersection: only allOf members contribute.
+        const merged =
+          k === "allOf"
+            ? [...carriedRequired, ...asStringArray(partProps.__required)]
+            : carriedRequired;
+        if (merged.length > 0) props.__required = merged;
+        else delete props.__required;
       }
     }
 
@@ -1005,11 +1013,8 @@ export function resolveSchema(
     let requiredKeys: string[] | undefined;
     if (depth < MAX_BUILD_PROPERTY_DEPTH) {
       const nestedRaw = collectProps(resolved);
-      if (Array.isArray(nestedRaw.__required)) {
-        requiredKeys = (nestedRaw.__required as unknown[]).filter(
-          (k): k is string => typeof k === "string",
-        );
-      }
+      const nestedRequired = asStringArray(nestedRaw.__required);
+      if (nestedRequired.length > 0) requiredKeys = nestedRequired;
       const nestedEntries = Object.entries(nestedRaw).filter(
         ([k]) => !k.startsWith("__") && k !== "@type",
       );
@@ -1181,15 +1186,13 @@ export function resolveSchema(
 
   if (Object.keys(properties).length === 0) return null;
 
+  const rootRequired = asStringArray(topRaw.__required);
+
   return {
     type: "object",
     title: typeof schemaRoot.title === "string" ? schemaRoot.title : undefined,
     properties,
-    required: Array.isArray(topRaw.__required)
-      ? (topRaw.__required as unknown[]).filter(
-          (k): k is string => typeof k === "string",
-        )
-      : undefined,
+    required: rootRequired.length > 0 ? rootRequired : undefined,
   };
 }
 

--- a/apps/web/src/components/sections-editor/resolve-schema.ts
+++ b/apps/web/src/components/sections-editor/resolve-schema.ts
@@ -23,6 +23,13 @@ export interface SchemaProperty {
   enum?: unknown[];
   default?: unknown;
   properties?: Record<string, SchemaProperty>;
+  /**
+   * Names of the required child properties (merged from the JSON Schema
+   * `required` arrays of this object and its allOf/anyOf/oneOf members). A
+   * child key absent from this list is optional — the form offers a "clear"
+   * option so the value can be left empty.
+   */
+  required?: string[];
   items?: SchemaProperty;
   titleBy?: string;
   /** Mustache template for array-item thumbnails (from schema `@image`) */
@@ -415,7 +422,14 @@ export function resolveSchema(
       const arr = (s as Record<string, unknown>)[k];
       if (!Array.isArray(arr)) continue;
       for (const part of arr as RawSchema[]) {
-        props = { ...props, ...collectProps(part, seenRefs, depth + 1) };
+        const partProps = collectProps(part, seenRefs, depth + 1);
+        // Merge required so a later member doesn't overwrite an earlier one's.
+        const mergedRequired = [
+          ...(Array.isArray(props.__required) ? props.__required : []),
+          ...(Array.isArray(partProps.__required) ? partProps.__required : []),
+        ];
+        props = { ...props, ...partProps };
+        if (mergedRequired.length > 0) props.__required = mergedRequired;
       }
     }
 
@@ -988,8 +1002,14 @@ export function resolveSchema(
     // deco sections nest images at depth 4+ (`images[].desktop.src`); the
     // old cap left those leaves un-resolved and stripped their `format`.
     let nestedProperties: Record<string, SchemaProperty> | undefined;
+    let requiredKeys: string[] | undefined;
     if (depth < MAX_BUILD_PROPERTY_DEPTH) {
       const nestedRaw = collectProps(resolved);
+      if (Array.isArray(nestedRaw.__required)) {
+        requiredKeys = (nestedRaw.__required as unknown[]).filter(
+          (k): k is string => typeof k === "string",
+        );
+      }
       const nestedEntries = Object.entries(nestedRaw).filter(
         ([k]) => !k.startsWith("__") && k !== "@type",
       );
@@ -1067,6 +1087,7 @@ export function resolveSchema(
             ? resolved.format
             : fromLeaf<string>("format"),
       properties: nestedProperties,
+      required: requiredKeys,
       items: itemsSchema,
       hidden: isSchemaHidden(resolved) || isSchemaHidden(v) ? true : undefined,
       titleBy:
@@ -1164,6 +1185,11 @@ export function resolveSchema(
     type: "object",
     title: typeof schemaRoot.title === "string" ? schemaRoot.title : undefined,
     properties,
+    required: Array.isArray(topRaw.__required)
+      ? (topRaw.__required as unknown[]).filter(
+          (k): k is string => typeof k === "string",
+        )
+      : undefined,
   };
 }
 

--- a/apps/web/src/components/sections-editor/schema-form.tsx
+++ b/apps/web/src/components/sections-editor/schema-form.tsx
@@ -520,6 +520,8 @@ export function SchemaForm({
     (k) => !HIDDEN_PROPS.has(k) && properties[k]?.hidden !== true,
   );
 
+  const requiredKeys = new Set(schema.required ?? []);
+
   if (keys.length === 0) {
     return (
       <div className="px-3 py-6 text-center text-xs text-muted-foreground">
@@ -640,6 +642,7 @@ export function SchemaForm({
           onChange: (val) => updateField(key, val),
           path: fieldPath,
           label,
+          required: requiredKeys.has(key),
           breadcrumbPath: fieldBreadcrumbPath,
           onBreadcrumbChange: fieldOnBreadcrumbChangeForKey,
           hasSiblingDrillDownFields,

--- a/apps/web/src/components/sections-editor/schema-form.tsx
+++ b/apps/web/src/components/sections-editor/schema-form.tsx
@@ -531,6 +531,11 @@ export function SchemaForm({
   }
 
   const updateField = (key: string, fieldValue: unknown) => {
+    if (fieldValue === undefined) {
+      const { [key]: _removed, ...rest } = objValue;
+      onChange(rest);
+      return;
+    }
     onChange({ ...objValue, [key]: fieldValue });
   };
 

--- a/apps/web/src/i18n/en/sections-editor.ts
+++ b/apps/web/src/i18n/en/sections-editor.ts
@@ -41,6 +41,7 @@ export const sectionsEditor = {
   "sectionsEditor.dynamicOptionsField.selectPlaceholder": "Select...",
   "sectionsEditor.dynamicOptionsField.useValue": 'Use "{value}"',
   "sectionsEditor.enumField.selectPlaceholder": "Select...",
+  "sectionsEditor.enumField.clearOption": "None",
   "sectionsEditor.fileField.browseButton": "Browse",
   "sectionsEditor.fileField.dropFileHint": "Drop a file or click to browse",
   "sectionsEditor.fileField.dropToUpload": "Drop to upload",

--- a/apps/web/src/i18n/pt-br/sections-editor.ts
+++ b/apps/web/src/i18n/pt-br/sections-editor.ts
@@ -44,6 +44,7 @@ export const sectionsEditor = {
   "sectionsEditor.dynamicOptionsField.selectPlaceholder": "Selecionar...",
   "sectionsEditor.dynamicOptionsField.useValue": 'Usar "{value}"',
   "sectionsEditor.enumField.selectPlaceholder": "Selecionar...",
+  "sectionsEditor.enumField.clearOption": "Nenhum",
   "sectionsEditor.fileField.browseButton": "Procurar",
   "sectionsEditor.fileField.dropFileHint":
     "Solte um arquivo ou clique para procurar",


### PR DESCRIPTION
## Summary

When an enum prop is **optional**, the Content/block property editor select should let you leave it empty. Today the select only shows the "Selecionar…" placeholder until you pick a value — once chosen, there was no way to clear it back to empty.

This threads the JSON Schema `required` info down to the field and adds a **"None" / "Nenhum"** option on optional enums that clears the value to `undefined`.

## Changes

- **`resolve-schema.ts`** — preserve the schema `required` array as `SchemaProperty.required` (root + nested objects) instead of dropping it. Also fixes a merge bug where `allOf`/`anyOf`/`oneOf` members overwrote each other's `__required` instead of accumulating it.
- **`field-props.ts`** — add `required?: boolean` to `FieldProps`.
- **`schema-form.tsx`** — parent object computes required keys and passes `required` to each field.
- **`enum-field.tsx`** — when not required, render a "None" item that clears to `undefined` (own sentinel, distinct from the empty-string-enum sentinel).
- **i18n** — `enumField.clearOption` in `en` ("None") and `pt-br` ("Nenhum").

Required enums keep requiring one of their options. Since absent-from-`required` = optional per JSON Schema, enums without a declared `required` also become clearable — the correct behavior.

## Testing
- `bun run --cwd=apps/web check` ✅
- `bun test apps/web/src/components/sections-editor/` → 634 pass (3 new tests for `required` propagation) ✅
- `bun run lint` → 0 errors in changed files ✅
- `bun run fmt` ✅

Not yet verified visually in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optional enum selects in the Sections Editor can now be cleared to empty via a “None” option that unsets the field. Previously a chosen value couldn’t be cleared; now clearing removes the key from the object. Required enums stay enforced, array items remain non-clearable, and we suppress “None” when the enum already includes "" as a valid value.

- Propagates JSON Schema `required` to `SchemaProperty.required` (root and nested). Merges only from `allOf`; `anyOf`/`oneOf` branch-required keys do not escalate, fixing the prior overwrite.
- Adds `required?: boolean` to `FieldProps`; `SchemaForm` computes from `schema.required` and passes it to fields. `ArrayField` always passes `required: true` for items.
- Updates `EnumField` to show a clear option only when not required and no empty-string enum exists; selecting it maps to `undefined` via `selectValueToFormValue`. `SchemaForm` deletes a key when a field becomes `undefined`.
- Adds i18n strings for the clear option in `en` (“None”) and `pt-br` (“Nenhum”), plus tests for required propagation (`allOf` vs `anyOf`), select value mapping, and CT coverage for optional vs required and empty-string cases.

<sup>Written for commit f02d0b6aad901db4c9604a772bb9b3ae25ce9ee3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

