### PR TITLE
fix(mcp-clients): reconnect after a pooled MCP client is closed mid-run

### DIFF
--- a/apps/api/src/mcp-clients/lazy-client.test.ts
+++ b/apps/api/src/mcp-clients/lazy-client.test.ts
@@ -210,4 +210,23 @@ describe("lazy-client with circuit breaker", () => {
     const lazy4 = createLazyClient(fakeConnection, fakeCtx, false);
     expect(lazy4.listTools()).rejects.toThrow(CircuitOpenError);
   });
+
+  it("reconnects after the pooled client is closed by someone else", async () => {
+    const first = await createWorkingClient();
+    clientFromConnectionMock.mockResolvedValue(first);
+
+    const lazy = createLazyClient(fakeConnection, fakeCtx, false);
+    expect((await lazy.listTools()).tools).toHaveLength(1);
+
+    // A sibling holder of the SAME pooled client closes it (what a finished
+    // subtask's passthrough does to the parent run's connection).
+    await first.close();
+
+    const second = await createWorkingClient();
+    clientFromConnectionMock.mockResolvedValue(second);
+
+    // Without invalidation this throws "Not connected" forever.
+    expect((await lazy.listTools()).tools).toHaveLength(1);
+    expect(clientFromConnectionMock).toHaveBeenCalledTimes(2);
+  });
 });

--- a/apps/api/src/mcp-clients/lazy-client.ts
+++ b/apps/api/src/mcp-clients/lazy-client.ts
@@ -112,9 +112,25 @@ export function createLazyClient(
     assertCircuitClosed(connection.id);
 
     if (!realClientPromise) {
-      realClientPromise = clientFromConnection(connection, ctx, superUser)
+      const pending: Promise<Client> = clientFromConnection(
+        connection,
+        ctx,
+        superUser,
+      )
         .then((client) => {
           recordSuccess(connection.id);
+          // The underlying client is POOLED per StudioContext and shared with
+          // every sibling client for the same connection — a subtask's
+          // passthrough closes the very instance the parent run is still using.
+          // Once closed, the SDK throws "Not connected" on every later request,
+          // so a cached closed client breaks the connection for the rest of the
+          // run. Drop it on close; the next call reconnects.
+          // Chain the pool's own handler (it evicts the pool entry).
+          const poolOnClose = client.onclose;
+          client.onclose = () => {
+            if (realClientPromise === pending) realClientPromise = null;
+            poolOnClose?.();
+          };
           return client;
         })
         .catch((err) => {
@@ -124,6 +140,7 @@ export function createLazyClient(
           recordFailure(connection.id);
           throw err;
         });
+      realClientPromise = pending;
     }
     return realClientPromise;
   }


### PR DESCRIPTION
## Problem

Every tool call on a connection starts failing with **`Not connected.`** partway through a run, and never recovers — for the rest of the thread.

Prod, last 21 days: **~350 occurrences across 25+ orgs and every connection kind** (GitHub, VTEX, custom apps) — it is not app-specific.

Reproduced in a real thread (`aviator`, VTEX agent): VTEX tool calls succeed at steps 2–12, the agent calls `subtask` twice at steps 15/17, and from step 26 onward *every* VTEX call returns `Not connected.` until the thread ends.

## Cause

`createLazyClient` caches the resolved MCP client in `realClientPromise` and only clears it when the *connect* fails — never when the client closes.

The client it caches is not private: `createOutboundClient` returns `ctx.getOrCreateClient(transport, connectionId)`, a pool **shared across the whole StudioContext**. `GatewayClient` keeps one lazy client per connection for the life of the run, and `subtask` closes its subagent passthrough in a `finally`, which walks down to `real.close()` on that same pooled instance.

So a finished subtask closes the parent run's live connection. The pool evicts its entry (a *new* lazy client would reconnect), but the parent's existing lazy client keeps handing out the dead one, and `Protocol.request` throws `Not connected` from then on. (`sanitizeStreamError` adds the trailing period, which is why the chat shows `Not connected.`)

## Fix

Invalidate the cached client on `onclose`, chaining the pool's own handler. The next call reconnects.

Self-healing for any cause of a closed transport, not just this one.

## Test

`bun test apps/api/src/mcp-clients/lazy-client.test.ts` — new case fails with the literal prod error (`Not connected`) without the fix, passes with it.

## Known residual

A request already in flight when a subtask closes the connection still fails once. The deeper fix — a borrower must not close a pooled client — needs a lifetime decision on the per-ctx pool (nothing disposes it today), so it is left out of this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconnects lazy MCP clients after their pooled underlying client is closed mid-run, preventing persistent "Not connected." failures. Previously `createLazyClient` cached a closed client; now it clears the cache on `client.onclose` so the next call reconnects.

**Reviewer notes**
- In `createLazyClient`, wrap the connection promise and set `client.onclose` to clear `realClientPromise` if it’s the same pending promise, then chain the pool’s original `onclose`.
- Adds a test that closes a shared pooled client and verifies the lazy client reconnects (second call to `clientFromConnection`).
- Known residual: a single in-flight request may still fail when the close happens. No API changes or migrations.

<sup>Written for commit 657a4e7ce83ce96418875305c73ca929352709b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6173?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

