### PR TITLE
Potential fix for code scanning alert no. 10: DOM text reinterpreted as HTML

### DIFF
--- a/apps/web/src/views/registry/image-upload.tsx
+++ b/apps/web/src/views/registry/image-upload.tsx
@@ -21,6 +21,22 @@ interface ImageUploadProps {
   isUploading?: boolean;
 }
 
+const sanitizeImageUrl = (raw: string): string => {
+  const trimmed = raw.trim();
+  if (!trimmed) return "";
+
+  try {
+    const parsed = new URL(trimmed, window.location.origin);
+    if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+      return parsed.href;
+    }
+  } catch {
+    // Invalid URL, fall through and reject.
+  }
+
+  return "";
+};
+
 export function ImageUpload({
   value,
   onChange,
@@ -83,7 +99,7 @@ export function ImageUpload({
           <div className="flex items-center gap-3 p-3 h-full">
             <div className="size-20 rounded-lg border border-border bg-muted/20 overflow-hidden shrink-0">
               <img
-                src={value}
+                src={sanitizeImageUrl(value)}
                 alt={t("registry.imageUpload.previewAlt")}
                 className="w-full h-full object-cover"
               />
@@ -189,7 +205,7 @@ export function ImageUpload({
                 placeholder={t("registry.imageUpload.urlPlaceholder")}
                 value={value}
                 className="text-xs h-8"
-                onChange={(event) => onChange(event.target.value)}
+                onChange={(event) => onChange(sanitizeImageUrl(event.target.value))}
                 onBlur={onBlur}
               />
             </div>

--- a/apps/web/src/views/registry/image-upload.tsx
+++ b/apps/web/src/views/registry/image-upload.tsx
@@ -205,7 +205,9 @@ export function ImageUpload({
                 placeholder={t("registry.imageUpload.urlPlaceholder")}
                 value={value}
                 className="text-xs h-8"
-                onChange={(event) => onChange(sanitizeImageUrl(event.target.value))}
+                onChange={(event) =>
+                  onChange(sanitizeImageUrl(event.target.value))
+                }
                 onBlur={onBlur}
               />
             </div>


### PR DESCRIPTION
Potential fix for [https://github.com/decocms/studio/security/code-scanning/10](https://github.com/decocms/studio/security/code-scanning/10)

The best fix is to validate and sanitize image URLs at the point they enter state (input change) and at render time before assigning to `img.src`, using a strict allowlist of protocols (`http:`/`https:`) plus optional relative URLs. This preserves existing functionality (users can still paste normal image URLs and upload images) while preventing unsafe schemes from ever being rendered.

Concretely:
- **File:** `apps/web/src/views/registry/image-upload.tsx`
- Add a small helper function in this file to normalize/validate URL values.
- Use it in the URL input `onChange` handler so `onChange` receives only safe values (or empty string if unsafe).
- Use the same helper when rendering `<img src=...>` as defense in depth.

No new package is required; use built-in `URL`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes image URLs in the registry image upload to address code scanning alert #10 (DOM text reinterpreted as HTML). Previously raw input was assigned to img.src; now only http/https (including relative) are accepted and normalized to absolute, otherwise cleared, preventing unsafe schemes from rendering and affecting how values display/store.

- Adds `sanitizeImageUrl` in `apps/web/src/views/registry/image-upload.tsx`; used in URL input `onChange` and when rendering `<img src>`.
- Allows only `http:`/`https:`; trims input; invalid or disallowed schemes return an empty string. Relative inputs render as absolute. `data:`, `file:`, and `javascript:` are rejected; update any callers that relied on those schemes.
- Wraps the `onChange` handler for formatting only; no behavior change.

<sup>Written for commit e429ddd1e3f6610a930f6d8ac040e5f6743a45e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

