### PR TITLE
fix(subtask): surface the real failure instead of "No output generated"

### DIFF
--- a/apps/api/src/harnesses/decopilot/built-in-tools/subtask.test.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/subtask.test.ts
@@ -9,6 +9,7 @@ import { describe, expect, test } from "bun:test";
 import {
   createSubtaskTool,
   isTransientStreamError,
+  settled,
   resolveSubtaskCodingWorkspace,
   SubtaskInputSchema,
   type SubtaskParams,
@@ -62,6 +63,22 @@ const mockWriter = {
   write: () => {},
   merge: () => {},
 } as never;
+
+describe("settled", () => {
+  test("passes a resolved value through", async () => {
+    expect(await settled(Promise.resolve("stop"), "error")).toBe("stop");
+  });
+
+  test("swallows the AI SDK's NoOutputGeneratedError rejection", async () => {
+    // streamText rejects finishReason/steps/usage when no step ever finished.
+    // Throwing that out of the subtask generator replaced the real cause with
+    // the SDK's placeholder text (prod thread 38147122, 2026-08-16).
+    const rejected = Promise.reject(
+      new Error("No output generated. Check the stream for errors."),
+    );
+    expect(await settled(rejected, "error")).toBe("error");
+  });
+});
 
 describe("SubtaskInputSchema", () => {
   describe("valid input", () => {

--- a/apps/api/src/harnesses/decopilot/built-in-tools/subtask.ts
+++ b/apps/api/src/harnesses/decopilot/built-in-tools/subtask.ts
@@ -65,6 +65,36 @@ export function isTransientStreamError(message: string): boolean {
 }
 
 /**
+ * A `streamText` result promise that rejected (the AI SDK rejects
+ * finishReason/steps/usage with `NoOutputGeneratedError` when no step ever
+ * finished), reduced to a fallback. The real failure is on `handle.error`.
+ *
+ * Exported for its unit test; the drain loop below is the only caller.
+ */
+export async function settled<T>(
+  promise: PromiseLike<T>,
+  fallback: T,
+): Promise<T> {
+  try {
+    return await promise;
+  } catch {
+    return fallback;
+  }
+}
+
+const EMPTY_USAGE: LanguageModelUsage = {
+  inputTokens: undefined,
+  outputTokens: undefined,
+  totalTokens: undefined,
+  inputTokenDetails: {
+    noCacheTokens: undefined,
+    cacheReadTokens: undefined,
+    cacheWriteTokens: undefined,
+  },
+  outputTokenDetails: { textTokens: undefined, reasoningTokens: undefined },
+};
+
+/**
  * How many times a subagent may resume after a transient stream failure.
  *
  * ponytail: fixed at 2 — a third attempt against a provider that dropped twice
@@ -469,11 +499,19 @@ export function createSubtaskTool(
           commitPending();
 
           // 4. Collect this attempt's results from the resolved promises.
+          //
+          // When the subagent produced no step at all (its first model call
+          // errored), the AI SDK REJECTS finishReason/steps/usage with
+          // `NoOutputGeneratedError`. Awaiting them bare threw that out of this
+          // generator, so the parent got the SDK's placeholder "No output
+          // generated. Check the stream for errors." instead of the real cause
+          // `handle.error` already holds — and the resume path below never ran.
+          // Settle them instead; `handle.error` carries the actual failure.
           error = await handle.error;
-          finishReason = await handle.result.finishReason;
-          const attemptSteps = await handle.result.steps;
+          finishReason = await settled(handle.result.finishReason, "error");
+          const attemptSteps = await settled(handle.result.steps, []);
           steps.push(...attemptSteps);
-          const attemptUsage = await handle.result.usage;
+          const attemptUsage = await settled(handle.result.usage, EMPTY_USAGE);
           usage = {
             ...attemptUsage,
             inputTokens:


### PR DESCRIPTION
## Problem

Repeated `subtask` calls fail with the opaque `No output generated. Check the stream for errors.` and the parent agent has nothing to act on. Seen 5× in one prod thread (`aviator`, thread `38147122`, 2026-08-16), after which the agent gave up on delegation entirely.

## Cause

`streamText`'s flush rejects `finishReason`, `steps` and `usage` with `NoOutputGeneratedError` whenever **no step ever finished** — i.e. the subagent's first model call errored (provider 5xx, 429, credits, …):

```js
if (recordedSteps.length === 0 || recordedNoOutputError != null) {
  self._finishReason.reject(error); self._steps.reject(error); ...
```

`subtask`'s drain loop awaited all three bare, right after `await handle.error` had already resolved with the **real** cause:

```ts
error = await handle.error;                       // e.g. "Provider returned error 502"
finishReason = await handle.result.finishReason;  // ← throws NoOutputGeneratedError
```

That throw escaped the generator, so:
- the carefully-built `Subtask failed: <cause>` + partial-result path in `toModelOutput` never ran,
- the transient-stream **resume** path (`isTransientStreamError`) never ran either — a 502 that the loop is designed to resume from just killed the subtask.

The parent only ever saw the SDK's placeholder string.

## Fix

Settle those three promises against a fallback. `handle.error` already carries the actual failure (`runNativeAgentLoopCore` catches the same rejection into it), so the existing error/resume logic works again.

## Test

`bun test apps/api/src/harnesses/decopilot/built-in-tools/subtask.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces the real subtask failure when a subagent’s first model call errors, restoring resume behavior. Previously subtasks ended with “No output generated. Check the stream for errors.” and aborted; now they report the provider error and can resume on transient failures.

**Details**
- Settles `handle.result.finishReason`, `steps`, and `usage` with fallbacks to prevent `NoOutputGeneratedError` from masking the cause when no step finished.
- Continues to read the failure from `handle.error`, enabling “Subtask failed: <cause>” and the `isTransientStreamError` resume path.
- Adds an `EMPTY_USAGE` fallback and exports `settled` (unit-tested). No migration required.

<sup>Written for commit bbb089b01c1a149389417a8d387e94abe889e8d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

