### PR TITLE
fix(sandbox): cap the Go daemon's fs route request bodies

### DIFF
--- a/packages/sandbox/daemon-go/internal/routes/fs.go
+++ b/packages/sandbox/daemon-go/internal/routes/fs.go
@@ -42,10 +42,17 @@ func (d FsDeps) notifyWrite(path string) {
 	}
 }
 
+// decodeBody caps the request body at maxTransferBytes: without a limit, a
+// misbehaving or malicious caller could stream an unbounded body into memory
+// and crash the daemon, tearing down the sandbox pod on the next missed
+// health probe. The cap matches the daemon's other file-transfer bound.
 func decodeBody(r *http.Request, out any) error {
-	raw, err := io.ReadAll(r.Body)
+	raw, err := io.ReadAll(io.LimitReader(r.Body, maxTransferBytes+1))
 	if err != nil {
 		return fmt.Errorf("Failed to parse body: %s", err.Error())
+	}
+	if len(raw) > maxTransferBytes {
+		return fmt.Errorf("Request body exceeded %d bytes", maxTransferBytes)
 	}
 	if err := json.Unmarshal(raw, out); err != nil {
 		return fmt.Errorf("Failed to parse body: %s", err.Error())

--- a/packages/sandbox/daemon-go/internal/routes/fs_test.go
+++ b/packages/sandbox/daemon-go/internal/routes/fs_test.go
@@ -3,10 +3,12 @@ package routes
 import (
 	"bytes"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -28,6 +30,32 @@ func seedBlocks(t *testing.T) FsDeps {
 		}
 	}
 	return FsDeps{AppRoot: filepath.Dir(repoDir), RepoDir: repoDir}
+}
+
+// infiniteReader never hits EOF; it lets a test drive decodeBody's cap
+// without pre-allocating the oversized body it's rejecting.
+type infiniteReader struct{}
+
+func (infiniteReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 'a'
+	}
+	return len(p), nil
+}
+
+// Without a cap, decodeBody's io.ReadAll(r.Body) would buffer an unbounded
+// request body into memory and could crash the daemon, tearing down the
+// sandbox pod on the next missed health probe.
+func TestDecodeBodyRejectsOversizedRequest(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/write", io.NopCloser(infiniteReader{}))
+	var out map[string]any
+	err := decodeBody(req, &out)
+	if err == nil {
+		t.Fatal("expected decodeBody to reject an oversized body, got nil error")
+	}
+	if !strings.Contains(err.Error(), "exceeded") {
+		t.Fatalf("expected a size-limit error, got: %v", err)
+	}
 }
 
 func readReq(t *testing.T, deps FsDeps, path string) *httptest.ResponseRecorder {


### PR DESCRIPTION
**Source:** a real resource-bound gap, in the same lane as #6162 (which capped the daemon's *outbound* MCP JSON-RPC response body) — this caps the daemon's *inbound* fs request body, which was still unbounded.

**Why a maintainer wants this:** `decodeBody` in `packages/sandbox/daemon-go/internal/routes/fs.go` backs every `/fs/*` route (read, write, edit, mkdir, unlink, mv, list, write_from_url, upload_to_url) and read the request body with a plain `io.ReadAll(r.Body)` — no size cap. A caller sending an oversized body could buffer it entirely into the daemon's memory and crash it. Per this repo's own docs, the daemon's health probe is unforgiving: Studio marks the sandbox dead on a single missed probe and tears the pod down mid-session, so an OOM here is a real availability hit, not just a slow request.

**Fix:** cap the body at `maxTransferBytes` (500MB) — the bound the daemon already uses for its other file-transfer path (`write_from_url`/`upload_to_url`) — via the same `io.LimitReader` + explicit length check pattern #6162 used for the JSON-RPC response cap.

**Regression test:** `TestDecodeBodyRejectsOversizedRequest` in `fs_test.go` drives `decodeBody` with an `infiniteReader` (never hits EOF, no upfront allocation) and asserts it returns a size-limit error instead of buffering forever.

**To verify:** `cd packages/sandbox/daemon-go && go test ./internal/routes/... -run TestDecodeBodyRejectsOversizedRequest -v`

**Checks run locally:** `go build ./...`, `go vet ./internal/routes/...`, `gofmt -l` (clean), and the targeted test above (passes, ~0.5s). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the Go daemon’s /fs/* request bodies at 500MB to prevent OOM and sandbox teardown. Previously `decodeBody` read an unbounded body with `io.ReadAll`; now it wraps the body with `io.LimitReader(maxTransferBytes+1)` and rejects payloads over `maxTransferBytes`.

- Applies to all /fs/* routes (read, write, edit, mkdir, unlink, mv, list, write_from_url, upload_to_url); returns a size-limit error. Valid payloads are unaffected.
- Matches the existing 500MB transfer bound and mirrors the limit + explicit length check pattern from #6162.
- Adds `TestDecodeBodyRejectsOversizedRequest` using an infinite reader to verify rejection without buffering.

<sup>Written for commit 11683c7564f28df3ff29b80e166fa62d591d7855. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

