### PR TITLE
fix(task-board): don't count unpriced runs in the task-cost run count

### DIFF
--- a/apps/web/src/layouts/task-board/task-cost.test.ts
+++ b/apps/web/src/layouts/task-board/task-cost.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { summarizeTaskCost } from "./task-cost";
+import type { TaskBoardItemThread } from "./config";
+
+function thread(costUsd: number | null): TaskBoardItemThread {
+  return { costUsd } as TaskBoardItemThread;
+}
+
+describe("summarizeTaskCost", () => {
+  test("returns null when no thread recorded usage", () => {
+    expect(summarizeTaskCost([thread(null), thread(null)])).toBeNull();
+    expect(summarizeTaskCost(undefined)).toBeNull();
+  });
+
+  test("excludes unpriced threads from both the total and the run count", () => {
+    const summary = summarizeTaskCost([thread(1.5), thread(null), thread(2)]);
+    expect(summary).toEqual({ total: 3.5, runCount: 2 });
+  });
+});

--- a/apps/web/src/layouts/task-board/task-cost.ts
+++ b/apps/web/src/layouts/task-board/task-cost.ts
@@ -1,0 +1,19 @@
+import type { TaskBoardItemThread } from "./config";
+
+/**
+ * What a task has cost, summed over the runs that recorded usage.
+ *
+ * `runCount` is the number of runs `total` actually sums — a thread with no
+ * `finish` part yet (still running, or crashed before one) has `costUsd:
+ * null` and is excluded, so it must not inflate the count either.
+ */
+export function summarizeTaskCost(
+  threads: TaskBoardItemThread[] | undefined,
+): { total: number; runCount: number } | null {
+  const priced = (threads ?? []).filter((thread) => thread.costUsd !== null);
+  if (priced.length === 0) return null;
+  return {
+    total: priced.reduce((sum, thread) => sum + (thread.costUsd ?? 0), 0),
+    runCount: priced.length,
+  };
+}

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -76,6 +76,7 @@ import {
   type TaskBoardItemStatus,
   type TaskBoardItemThread,
 } from "./config";
+import { summarizeTaskCost } from "./task-cost";
 import { toast } from "sonner";
 import { useTaskBoardItemPrs } from "@/hooks/use-task-board-item-prs";
 import {
@@ -149,10 +150,9 @@ const PROPERTY_BUTTON =
  */
 function TaskCost({ threads }: { threads?: TaskBoardItemThread[] }) {
   const t = useT();
-  const priced = (threads ?? []).filter((thread) => thread.costUsd !== null);
-  if (priced.length === 0) return null;
-  const total = priced.reduce((sum, thread) => sum + (thread.costUsd ?? 0), 0);
-  const runCount = (threads ?? []).length;
+  const summary = summarizeTaskCost(threads);
+  if (!summary) return null;
+  const { total, runCount } = summary;
   const isSingular = runCount === 1;
   return (
     <div


### PR DESCRIPTION
Follows #6154/#6159 (the task-cost chip and its plural fix).

**Bug:** `TaskCost` in `task-dialog.tsx` summed cost only over threads with a non-null `costUsd`, but reported the run count as `(threads ?? []).length` — every linked thread, including ones with no `finish` part yet (still running, or crashed before completing one, per `parseCostUsd`/the cost lateral join in `apps/api/src/storage/task-board.ts`). A task with one priced run and one still-running thread showed "$X in 2 runs", but the total only ever covered the one priced run — the tooltip explicitly claims the total is "across all {runs} of its runs", which was false.

**Fix:** extracted the count/total logic into a pure `summarizeTaskCost()` helper (`task-cost.ts`) and made the run count `priced.length` instead of the full thread list, so the displayed count always matches what the total actually sums.

**Regression test:** `task-cost.test.ts` — `summarizeTaskCost([priced, unpriced, priced])` now asserts `runCount: 2`, not 3.

**To confirm:** `bun test apps/web/src/layouts/task-board/task-cost.test.ts`

**Locally verified:** `bun run fmt`, `bunx tsc --noEmit` in `apps/web` (one pre-existing, unrelated `mustache` type error on main, nothing in the touched files), `bunx oxlint` on the three changed files (0 warnings/errors), and the targeted test above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the task board cost chip to count only runs that recorded `costUsd`, so the run count matches the summed total. Previously it summed priced threads but reported the count of all threads, including still-running or crashed ones.

- Extracts `summarizeTaskCost()` in `task-cost.ts` and uses it in `TaskCost`; the chip is hidden when no priced runs exist.
- Adds `task-cost.test.ts` to cover exclusion of unpriced threads and null cases; `task-dialog.tsx` is refactored to consume the helper.

<sup>Written for commit 7615a9a2d9894d048f5dc6b1048fb04ee85aec9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

