### PR TITLE
fix(sandbox): hold the claim open while a hosted harness drives the sandbox

### DIFF
--- a/packages/sandbox/daemon-go/internal/routes/fs.go
+++ b/packages/sandbox/daemon-go/internal/routes/fs.go
@@ -36,6 +36,14 @@ type FsDeps struct {
 	AllowSameHostDev bool
 }
 
+// escapesRoot is the 400 for a path SafePath rejected. It names what IS
+// reachable: an agent that guessed `/tmp` (which its own `bash` tool can write,
+// unlike these routes) otherwise retries the same path instead of correcting it.
+func (d FsDeps) escapesRoot() string {
+	return "Path escapes app root — paths must resolve inside " + d.AppRoot +
+		"; a relative path resolves against " + d.RepoDir
+}
+
 func (d FsDeps) notifyWrite(path string) {
 	if d.OnWorkingTreeWrite != nil {
 		d.OnWorkingTreeWrite(path)
@@ -212,7 +220,7 @@ func Write(deps FsDeps) http.HandlerFunc {
 		}
 		filePath, ok := paths.SafePath(deps.AppRoot, deps.RepoDir, body.Path)
 		if !ok {
-			httpx.Error(w, 400, "Path escapes app root")
+			httpx.Error(w, 400, deps.escapesRoot())
 			return
 		}
 		if jsonErr := decofile.InvalidBlockJSON(body.Path, *body.Content); jsonErr != "" {
@@ -268,7 +276,7 @@ func Unlink(deps FsDeps) http.HandlerFunc {
 		}
 		filePath, ok := paths.SafePath(deps.AppRoot, deps.RepoDir, body.Path)
 		if !ok {
-			httpx.Error(w, 400, "Path escapes app root")
+			httpx.Error(w, 400, deps.escapesRoot())
 			return
 		}
 		existed := true
@@ -324,7 +332,7 @@ func Mkdir(deps FsDeps) http.HandlerFunc {
 		}
 		dirPath, ok := paths.SafePath(deps.AppRoot, deps.RepoDir, body.Path)
 		if !ok {
-			httpx.Error(w, 400, "Path escapes app root")
+			httpx.Error(w, 400, deps.escapesRoot())
 			return
 		}
 		if err := os.MkdirAll(dirPath, 0o755); err != nil {
@@ -363,7 +371,7 @@ func Rename(deps FsDeps) http.HandlerFunc {
 		fromPath, okFrom := paths.SafePath(deps.AppRoot, deps.RepoDir, body.From)
 		toPath, okTo := paths.SafePath(deps.AppRoot, deps.RepoDir, body.To)
 		if !okFrom || !okTo {
-			httpx.Error(w, 400, "Path escapes app root")
+			httpx.Error(w, 400, deps.escapesRoot())
 			return
 		}
 		if _, err := os.Stat(fromPath); err != nil {
@@ -404,7 +412,7 @@ func Edit(deps FsDeps) http.HandlerFunc {
 		}
 		filePath, ok := paths.SafePath(deps.AppRoot, deps.RepoDir, body.Path)
 		if !ok {
-			httpx.Error(w, 400, "Path escapes app root")
+			httpx.Error(w, 400, deps.escapesRoot())
 			return
 		}
 		if body.OldString == "" {
@@ -478,7 +486,7 @@ func Grep(deps FsDeps) http.HandlerFunc {
 		if body.Path != "" {
 			resolved, ok := paths.SafePath(deps.AppRoot, deps.RepoDir, body.Path)
 			if !ok {
-				httpx.Error(w, 400, "Path escapes app root")
+				httpx.Error(w, 400, deps.escapesRoot())
 				return
 			}
 			searchPath = resolved
@@ -671,7 +679,7 @@ func Glob(deps FsDeps) http.HandlerFunc {
 		if body.Path != "" {
 			resolved, ok := paths.SafePath(deps.AppRoot, deps.RepoDir, body.Path)
 			if !ok {
-				httpx.Error(w, 400, "Path escapes app root")
+				httpx.Error(w, 400, deps.escapesRoot())
 				return
 			}
 			searchPath = resolved
@@ -775,7 +783,7 @@ func WriteFromUrl(deps FsDeps) http.HandlerFunc {
 		}
 		filePath, ok := paths.SafePath(deps.AppRoot, deps.RepoDir, body.Path)
 		if !ok {
-			httpx.Error(w, 400, "Path escapes app root")
+			httpx.Error(w, 400, deps.escapesRoot())
 			return
 		}
 		if err := urlallow.Assert(body.URL, deps.AllowedHosts, deps.AllowSameHostDev); err != nil {

--- a/packages/sandbox/daemon-go/internal/routes/fs_test.go
+++ b/packages/sandbox/daemon-go/internal/routes/fs_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -73,5 +74,25 @@ func TestReadDecofileFallbackRefusesAbsolute(t *testing.T) {
 	rec := readReq(t, deps, abs)
 	if rec.Code != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400 (no merge for absolute path); body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+// The 400 an out-of-root write returns must name the root it wants. A model
+// that guessed `/tmp` (writable from its own bash tool, not from here) has to
+// be able to correct itself from the message alone — prod thread 38147122
+// burned several steps retrying the same rejected path.
+func TestWriteEscapesRootNamesTheRoot(t *testing.T) {
+	deps := seedBlocks(t)
+	body, _ := json.Marshal(map[string]any{"path": "/tmp/toolrun/x.ts", "content": "x"})
+	req := httptest.NewRequest(http.MethodPost, "/write", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	Write(deps)(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400; body = %s", rec.Code, rec.Body.String())
+	}
+	msg := rec.Body.String()
+	if !strings.Contains(msg, deps.AppRoot) || !strings.Contains(msg, deps.RepoDir) {
+		t.Fatalf("error must name AppRoot %q and RepoDir %q; got %s", deps.AppRoot, deps.RepoDir, msg)
 	}
 }

--- a/packages/sandbox/server/provider/sandbox-fs-hooks.test.ts
+++ b/packages/sandbox/server/provider/sandbox-fs-hooks.test.ts
@@ -36,6 +36,41 @@ const lifecycle = {
   canAutoRestart: false,
 };
 
+describe("claim TTL renewal", () => {
+  test("renews on the first op, then throttles", async () => {
+    const renewed: string[] = [];
+    const provider = {
+      kind: "agent-sandbox",
+      proxyDaemonRequest: async () =>
+        new Response(JSON.stringify({ ok: true, bytesWritten: 1 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      renewTtl: async (handle: string) => {
+        renewed.push(handle);
+      },
+    } as unknown as SandboxProvider;
+
+    const hooks = createSandboxFsHooks(provider, lifecycle);
+    // Without this a hosted-harness run holds no claim at all and the operator
+    // reaps the pod 15 minutes in, mid-run (prod thread 38147122, 2026-08-16).
+    await hooks.onWrite("/app/a.ts", "a");
+    await hooks.onWrite("/app/b.ts", "b");
+    await hooks.onWrite("/app/c.ts", "c");
+    expect(renewed).toEqual(["handle-1"]);
+  });
+
+  test("is inert for a provider that has no renewTtl", async () => {
+    const captured: { path?: string; body?: unknown } = {};
+    const hooks = createSandboxFsHooks(
+      fakeProvider(captured, { ok: true, bytesWritten: 1 }),
+      lifecycle,
+    );
+    await hooks.onWrite("/app/a.ts", "a");
+    expect(captured.path).toBe("/_sandbox/write");
+  });
+});
+
 describe("createSandboxFsHooks", () => {
   test("onRead proxies /_sandbox/read and returns content", async () => {
     const captured: { path?: string; body?: unknown } = {};

--- a/packages/sandbox/server/provider/sandbox-fs-hooks.ts
+++ b/packages/sandbox/server/provider/sandbox-fs-hooks.ts
@@ -146,6 +146,14 @@ const DAEMON_BASH_MAX_TIMEOUT_MS = 120_000; // daemon clamp (daemon/routes/bash.
 const DAEMON_DEFAULT_TIMEOUT_MS = 30_000; // daemon default (daemon/routes/bash.ts)
 const OP_GRACE_MS = 15_000;
 
+/**
+ * Floor on how often sandbox activity re-arms the claim's shutdown deadline.
+ * Same cadence (and reasoning) as the dispatch path's `TTL_RENEW_MS`:
+ * comfortably inside the 15-minute claim TTL, so a missed renewal still leaves
+ * two more chances before the operator reaps the pod.
+ */
+const TTL_RENEW_MS = 5 * 60_000;
+
 export function opDeadlineMs(input: Record<string, unknown>): number {
   const budget =
     typeof input.timeout === "number" && input.timeout > 0
@@ -339,6 +347,32 @@ export function createSandboxFsHooks(
 ): SandboxFsHooks {
   const { ensureHandle, invalidateHandle, canAutoRestart } = lifecycle;
 
+  // Hold the claim open while a HOSTED harness is driving this sandbox.
+  //
+  // A claim dies at `spec.lifecycle.shutdownTime` (now + 15min) unless
+  // something pushes it out. The two things that did were the preview SSE
+  // handler (a browser attached to the sandbox iframe) and `/dispatch`
+  // streaming (a harness running INSIDE the pod). A hosted harness — decopilot
+  // driving the sandbox over these fs/exec routes — is neither, so nothing
+  // renewed it: at minute 15 the operator deleted the claim mid-run and the pod
+  // came back reset, losing the working tree and `.deco/tools/` under a run that
+  // was still going.
+  //
+  // Activity-driven rather than a timer: no interval to leak or dispose, and a
+  // run that stops touching the sandbox correctly stops holding it.
+  let lastRenewAt = 0;
+  const renewTtl = (handle: string): void => {
+    if (!provider.renewTtl) return;
+    const now = Date.now();
+    if (now - lastRenewAt < TTL_RENEW_MS) return;
+    lastRenewAt = now;
+    void provider.renewTtl(handle).catch((err) => {
+      console.warn(
+        `[sandbox-fs-hooks] TTL renew failed for ${handle}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+  };
+
   const formatUnreachableMessage = (cause: unknown): string => {
     const detail = cause instanceof Error ? cause.message : String(cause);
     return canAutoRestart
@@ -359,6 +393,7 @@ export function createSandboxFsHooks(
         threadId: lifecycle.threadId,
       });
     const firstHandle = await ensureHandle();
+    renewTtl(firstHandle);
     try {
       return await tryOnce(firstHandle);
     } catch (firstErr) {


### PR DESCRIPTION
## Problem

A long chat run loses its sandbox mid-turn: the working tree is wiped, `.deco/tools/.endpoint.json` disappears and never comes back, so `@decocms/typegen` can no longer authenticate and every batch-scripting path dies — while the run keeps going.

Observed in prod (`aviator`, thread `38147122`, 2026-08-16). One 36-minute run, started 13:55. At 14:14 the workspace is fresh and empty; the agent's own probe at 14:41 finds the daemon back on *"waiting for workload configuration"*. It spends the rest of the turn trying to get `.deco` back and eventually gives up:

> "o reset do workspace apagou o `.deco/tools/.endpoint.json` e o daemon não o regenera (perdeu o claim)"

## Cause

A `SandboxClaim` is created with `spec.lifecycle.shutdownTime = now + 15min` and the operator deletes claim + pod at that instant unless `renewTtl` pushes it out.

`renewTtl` had exactly two callers:

| caller | renews when |
|---|---|
| `sandbox-events-handler.ts` | a **browser** is attached to the preview SSE stream |
| `sandbox-dispatch-client.ts` → `renewWhileStreaming` | a harness is running **inside** the pod via `/dispatch` |

A **hosted** harness is neither. Decopilot runs in Studio and drives the sandbox over the fs/exec routes (`cluster-sandbox-fs` → `createSandboxFsHooks` → `proxyDaemonRequest`) — no `/dispatch` envelope, and the user is in the chat, not the preview iframe. So nothing renewed the claim and every hosted run had a hard 15-minute wall. 13:55 + ~15min lands right on the 14:14 reset.

This is the same blind spot #4575-era work fixed one path down; the dispatch-path comment even says *"until now its ONLY caller was the preview SSE handler"*.

Note the run does **not** die — `ensureSandbox` hands back a live (recycled) pod — which is why this reads as "the sandbox mysteriously reset itself" rather than as a failure.

## Fix

Renew from **activity** in the fs-hooks `call` path — the single choke point every hosted-harness daemon op goes through — throttled to the same 5-minute cadence as the dispatch path.

Activity-driven rather than a timer on purpose: no interval to leak or dispose (these hooks have no teardown), and a run that stops touching the sandbox correctly stops holding it. Inert for providers without `renewTtl`.

## Also in this PR

The fs routes' out-of-root 400 now names the root. In the same thread the model tried `write` to `/tmp/toolrun/step1.ts` — a path its own **`bash`** tool had just successfully `mkdir -p`'d — and got only `Path escapes app root`, with nothing saying that `/app` is the boundary and that relative paths resolve against `/app/repo`. It burned several steps retrying variants.

## Tests

- `bun test packages/sandbox/server/provider/sandbox-fs-hooks.test.ts` — renews on first op, throttles the next two, inert without `renewTtl`.
- `go test ./internal/routes/` (in `packages/sandbox/daemon-go`) — the 400 names both roots.

## Not fixed here

Once a claim *is* lost, the catalog only comes back on the next `ensureHandle()` (`syncToolsCatalog` is wired to fresh handle resolution). A recycled pod that keeps the same handle mid-run never re-syncs. Worth a follow-up, but with the claim held it stops being reachable this way.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps hosted-harness runs from losing their sandbox mid-turn by renewing the `SandboxClaim` on fs/exec activity. Previously only preview SSE and in-pod `/dispatch` renewed TTL, so hosted runs hit the 15‑minute shutdown and the pod was recycled, wiping the working tree and `.deco/tools/`.

- Renews TTL from activity in `createSandboxFsHooks` on the first op, throttled to 5 minutes; no timer; inert if the provider lacks `renewTtl`. Adds a warning log on renew failures.
- Improves fs route 400s to name the roots: “Path escapes app root — paths must resolve inside <AppRoot>; a relative path resolves against <RepoDir>.”

**Tests**
- `packages/sandbox/server/provider/sandbox-fs-hooks.test.ts`: renews on first op, throttles later ops; no-op without `renewTtl`.
- `packages/sandbox/daemon-go/internal/routes/fs_test.go`: out-of-root write error names both roots.

<sup>Written for commit acbf1fbd30e6ed459810b971577d5dd97590d8fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

