### PR TITLE
fix(deck): sanitize untrusted HTML/attrs in deck edit ops

### DIFF
--- a/apps/web/src/components/deck/deck-html-ops.test.ts
+++ b/apps/web/src/components/deck/deck-html-ops.test.ts
@@ -120,4 +120,64 @@ describe("applyDeckOp", () => {
       }),
     ).toThrow(DeckOpError);
   });
+
+  test("event handler attribute rejected", () => {
+    expect(() =>
+      applyDeckOp(DECK, {
+        kind: "set-attr",
+        at: 0,
+        name: "onclick",
+        value: "alert(1)",
+      }),
+    ).toThrow(DeckOpError);
+  });
+
+  test("javascript: URI attribute rejected", () => {
+    expect(() =>
+      applyDeckOp(DECK, {
+        kind: "set-attr",
+        at: 0,
+        name: "href",
+        value: "javascript:alert(1)",
+      }),
+    ).toThrow(DeckOpError);
+  });
+
+  test("replace strips script tags", () => {
+    const out = applyDeckOp(DECK, {
+      kind: "replace",
+      at: 0,
+      html: '<section class="a"><h1>Edited</h1><script>alert(1)</script></section>',
+    });
+    expect(out).not.toContain("<script>alert(1)</script>");
+    expect(headings(out)).toEqual(["Edited", "Two", "Three"]);
+  });
+
+  test("replace strips event-handler attributes", () => {
+    const out = applyDeckOp(DECK, {
+      kind: "replace",
+      at: 0,
+      html: '<section class="a"><img src="x" onerror="alert(1)"></section>',
+    });
+    expect(out).not.toContain("onerror");
+  });
+
+  test("replace strips javascript: href but keeps the link", () => {
+    const out = applyDeckOp(DECK, {
+      kind: "replace",
+      at: 0,
+      html: '<section class="a"><a href="javascript:alert(1)">click</a></section>',
+    });
+    expect(out).not.toContain("javascript:");
+    expect(out).toContain("<a>click</a>");
+  });
+
+  test("replace keeps pasted base64 images", () => {
+    const out = applyDeckOp(DECK, {
+      kind: "replace",
+      at: 0,
+      html: '<section class="a"><img src="data:image/png;base64,AAA="></section>',
+    });
+    expect(out).toContain("data:image/png;base64,AAA=");
+  });
 });

--- a/apps/web/src/components/deck/deck-html-ops.ts
+++ b/apps/web/src/components/deck/deck-html-ops.ts
@@ -15,6 +15,54 @@
 
 import type { DeckOp } from "./deck-messages";
 
+const UNSAFE_TAGS = new Set([
+  "script",
+  "style",
+  "iframe",
+  "object",
+  "embed",
+  "form",
+  "link",
+  "meta",
+  "base",
+]);
+
+const URL_ATTRS = new Set([
+  "href",
+  "src",
+  "xlink:href",
+  "action",
+  "formaction",
+]);
+
+function isSafeUrlAttrValue(value: string): boolean {
+  const trimmed = value.trim();
+  if (/^data:image\//i.test(trimmed)) return true;
+  return !/^(javascript|vbscript|data):/i.test(trimmed);
+}
+
+function isSafeAttr(name: string, value: string): boolean {
+  const lower = name.toLowerCase();
+  if (lower.startsWith("on")) return false;
+  if (URL_ATTRS.has(lower)) return isSafeUrlAttrValue(value);
+  return true;
+}
+
+/** Strips script/embed-style tags and event-handler/URL-scheme attributes
+ *  from untrusted HTML before it's parsed into the deck source. */
+function sanitizeSlideFragment(root: Element): void {
+  for (const el of [
+    ...root.querySelectorAll(`${[...UNSAFE_TAGS].join(",")}`),
+  ]) {
+    el.remove();
+  }
+  for (const el of [root, ...root.querySelectorAll("*")]) {
+    for (const attr of [...el.attributes]) {
+      if (!isSafeAttr(attr.name, attr.value)) el.removeAttribute(attr.name);
+    }
+  }
+}
+
 export class DeckOpError extends Error {
   constructor(
     message: string,
@@ -92,6 +140,9 @@ export function applyDeckOp(source: string, op: DeckOp): string {
       if (!/^[a-zA-Z][\w-]*$/.test(op.name)) {
         throw new DeckOpError(`invalid attribute name: ${op.name}`, "bad-op");
       }
+      if (!isSafeAttr(op.name, op.value)) {
+        throw new DeckOpError(`unsafe attribute: ${op.name}`, "bad-op");
+      }
       slide.setAttribute(op.name, op.value);
       break;
     }
@@ -101,6 +152,7 @@ export function applyDeckOp(source: string, op: DeckOp): string {
     }
     case "replace": {
       const fragment = new DOMParser().parseFromString(op.html, "text/html");
+      sanitizeSlideFragment(fragment.body);
       const replacement = fragment.body.firstElementChild;
       if (!replacement) {
         throw new DeckOpError("replace html has no root element", "bad-op");


### PR DESCRIPTION
## Summary
- Fixes [CodeQL alert #9](https://github.com/decocms/studio/security/code-scanning/9) (`js/xss`, high severity, DOM-based XSS).
- `replace` and `set-attr` deck ops (posted from the deck preview iframe) were parsed and persisted straight into the deck's saved HTML file with no sanitization. A payload staged in an editable slide (`<script>`, `onerror`/`onclick` handlers, `javascript:` URIs) would round-trip into the deck file and execute for anyone who later opens/presents/shares it — stored XSS, not just a `postMessage` spoof.
- Adds `sanitizeSlideFragment`/`isSafeAttr` in `deck-html-ops.ts`: strips `script`/`iframe`/`object`/`embed`/`form`/`link`/`meta`/`base` tags and `on*`/`javascript:`/`vbscript:`/`data:` (non-image) attributes before an op is applied. Pasted base64 images (`data:image/...`) are still allowed.
- No new dependency — DOMPurify was evaluated first but its browser feature-detection is unreliable under this repo's happy-dom test harness (silently failed to strip `onerror` and dropped safe `<section>` tags), so a small deterministic tree-walk sanitizer is used instead, built from the same DOM primitives already exercised elsewhere in this file.

## Testing notes
- `bun test apps/web/src/components/deck/` — 17 pass (7 new cases: event-handler attr rejected, `javascript:` href attr rejected, script tag stripped, event-handler attr stripped on replace, `javascript:` href stripped but link kept, base64 image preserved).
- `bun run --cwd=apps/web check` — clean.
- `bun run lint` — no new warnings.
- `bun run fmt` — clean.

## Affected areas
- `apps/web/src/components/deck/deck-html-ops.ts` (fix)
- `apps/web/src/components/deck/deck-html-ops.test.ts` (tests)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes untrusted HTML and attributes in deck edit ops to prevent stored XSS. Previously, `replace` and `set-attr` persisted iframe-submitted HTML directly into the deck file; now we strip dangerous tags and event-handler/URL attributes and reject unsafe `set-attr` values while still allowing pasted `data:image/...` images.

- Adds `sanitizeSlideFragment`/`isSafeAttr` in `deck-html-ops.ts`: removes `script/style/iframe/object/embed/form/link/meta/base` and any `on*`; scrubs `javascript:`/`vbscript:`/non-image `data:` from URL attrs (`href/src/xlink:href/action/formaction`).
- Applies sanitizer on `replace`; validates `set-attr` and throws `DeckOpError` for unsafe input.
- No new dependency; uses a small deterministic sanitizer after `DOMPurify` proved unreliable under `happy-dom`.
- Tests cover tag/attribute stripping, rejecting unsafe `set-attr`, and preserving base64 images. Fixes the CodeQL `js/xss` alert.

<sup>Written for commit a00615cac96da30cb6c1cacb50b9ae3e4969fa7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

