### PR TITLE
fix(sandbox): cap the Go daemon's /grep result limit

### DIFF
--- a/packages/sandbox/daemon-go/internal/routes/fs.go
+++ b/packages/sandbox/daemon-go/internal/routes/fs.go
@@ -470,6 +470,11 @@ func Edit(deps FsDeps) http.HandlerFunc {
 	}
 }
 
+const (
+	grepDefaultResultLimit = 250
+	grepMaxResultLimit     = 10000
+)
+
 func Grep(deps FsDeps) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var body struct {
@@ -520,9 +525,12 @@ func Grep(deps FsDeps) http.HandlerFunc {
 		}
 		args = append(args, "--", body.Pattern, searchPath)
 
-		limit := 250
+		limit := grepDefaultResultLimit
 		if body.Limit > 0 {
 			limit = body.Limit
+			if limit > grepMaxResultLimit {
+				limit = grepMaxResultLimit
+			}
 		}
 
 		cmd := exec.Command("rg", args...)

--- a/packages/sandbox/daemon-go/internal/routes/fs_test.go
+++ b/packages/sandbox/daemon-go/internal/routes/fs_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -55,6 +56,44 @@ func TestDecodeBodyRejectsOversizedRequest(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "exceeded") {
 		t.Fatalf("expected a size-limit error, got: %v", err)
+	}
+}
+
+// Without an upper bound, a caller-supplied `limit` let /grep buffer an
+// unbounded number of match lines into memory — the same crash-the-daemon
+// class the request-body cap above closes for the request side.
+func TestGrepCapsCallerSuppliedLimit(t *testing.T) {
+	if _, err := exec.LookPath("rg"); err != nil {
+		t.Skip("ripgrep not installed")
+	}
+	repoDir := t.TempDir()
+	var content strings.Builder
+	for i := 0; i < grepMaxResultLimit+500; i++ {
+		content.WriteString("needle\n")
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "haystack.txt"), []byte(content.String()), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	deps := FsDeps{AppRoot: repoDir, RepoDir: repoDir}
+	body, _ := json.Marshal(map[string]any{
+		"pattern":     "needle",
+		"output_mode": "content",
+		"limit":       grepMaxResultLimit * 10,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/grep", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	Grep(deps)(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("expected 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+	var out struct {
+		MatchCount int `json:"matchCount"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.MatchCount > grepMaxResultLimit {
+		t.Fatalf("expected matchCount capped at %d, got %d", grepMaxResultLimit, out.MatchCount)
 	}
 }
 


### PR DESCRIPTION
Follows #6176 (which capped fs route request bodies): auditing `packages/sandbox/daemon-go/internal/routes/fs.go` for remaining size-limit loopholes found that `/grep`'s caller-supplied `limit` had no upper bound, unlike `/glob`'s `resultLimit` which is clamped to `globMaxResultLimit`.

Why it matters: a caller passing a very large `limit` makes the handler buffer that many `rg` match lines into memory before the daemon ever caps it, the same class of unbounded-memory-growth issue #6176 fixed for request bodies. Both close variants of the daemon getting killed mid-run by a missed health probe.

Fix: add `grepMaxResultLimit` (10000, matching Glob's cap) and clamp the effective limit to it, same pattern already used by `Glob`.

Regression test: `TestGrepCapsCallerSuppliedLimit` in `fs_test.go` seeds a file with more matching lines than the cap, requests a `limit` far above it, and asserts the response's `matchCount` never exceeds `grepMaxResultLimit`. It skips locally if `rg` isn't installed but runs for real in CI (`sandbox-daemon.yml` installs ripgrep).

Reviewer command: `cd packages/sandbox/daemon-go && go test ./internal/routes/... -run TestGrepCapsCallerSuppliedLimit -v` (needs ripgrep installed to actually exercise the cap; otherwise it self-skips).

Locally verified: `go build ./...`, `go vet ./internal/routes/...`, `go test ./internal/routes/...`, `gofmt -l` (clean) in `packages/sandbox/daemon-go`. Full CI (including the ripgrep-backed test run) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps the Go sandbox daemon’s `/grep` results at 10,000 and clamps caller-supplied `limit` to prevent unbounded memory usage. Previously `/grep` accepted any `limit` and could buffer arbitrarily many `rg` match lines; now it uses min(requested, 10,000), matching `/glob`.

- Introduces `grepMaxResultLimit` (10000) and `grepDefaultResultLimit` (250); default behavior is unchanged, large limits are now clamped in `packages/sandbox/daemon-go/internal/routes/fs.go`.
- Responses with more than 10,000 matches are truncated; clients should not rely on receiving more than 10,000 results.
- Adds `TestGrepCapsCallerSuppliedLimit` in `fs_test.go`; run with: `cd packages/sandbox/daemon-go && go test ./internal/routes/... -run TestGrepCapsCallerSuppliedLimit -v` (requires ripgrep installed).

<sup>Written for commit ebd7eea08034f9295bb2b9d10f275044e91f5616. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

