### PR TITLE
fix(mcp-clients): stop lazy client from reconnecting after its own close()

### DIFF
--- a/apps/api/src/mcp-clients/lazy-client.test.ts
+++ b/apps/api/src/mcp-clients/lazy-client.test.ts
@@ -229,4 +229,21 @@ describe("lazy-client with circuit breaker", () => {
     expect((await lazy.listTools()).tools).toHaveLength(1);
     expect(clientFromConnectionMock).toHaveBeenCalledTimes(2);
   });
+
+  it("does not reconnect after its own close()", async () => {
+    const first = await createWorkingClient();
+    clientFromConnectionMock.mockResolvedValue(first);
+
+    const lazy = createLazyClient(fakeConnection, fakeCtx, false);
+    expect((await lazy.listTools()).tools).toHaveLength(1);
+
+    await lazy.close();
+
+    const second = await createWorkingClient();
+    clientFromConnectionMock.mockResolvedValue(second);
+
+    // A call after explicit close must not silently open a new connection.
+    expect(lazy.listTools()).rejects.toThrow("is closed");
+    expect(clientFromConnectionMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/api/src/mcp-clients/lazy-client.ts
+++ b/apps/api/src/mcp-clients/lazy-client.ts
@@ -106,8 +106,16 @@ export function createLazyClient(
 
   // Shared promise for the real client (single-flight)
   let realClientPromise: Promise<Client> | null = null;
+  // True once this wrapper's own close() ran — must not reconnect after that.
+  let closed = false;
 
   function getRealClient(): Promise<Client> {
+    if (closed) {
+      return Promise.reject(
+        new Error(`MCP client for connection ${connection.id} is closed`),
+      );
+    }
+
     // Fast-fail if the circuit breaker is open for this connection
     assertCircuitClosed(connection.id);
 
@@ -369,6 +377,7 @@ export function createLazyClient(
   // Close the real client if it was ever created
   const originalClose = placeholder.close.bind(placeholder);
   placeholder.close = async () => {
+    closed = true;
     if (realClientPromise) {
       const real = await realClientPromise.catch(() => null);
       if (real) await real.close().catch(() => {});


### PR DESCRIPTION
Follows #6173, which fixed a pooled MCP client getting permanently stuck on "Not connected" after a sibling (e.g. a finished subtask's passthrough) closes the shared pooled client — it now nulls the lazy wrapper's cached client promise on close so the next call transparently reconnects.

**The gap:** that same nulling fires when the wrapper's OWN `close()` runs too, since `close()` calls the real client's `.close()`, which triggers the same `onclose` hook. So a lazy client that was explicitly shut down (its owning run/request finished and called `close()`) would silently open a brand-new downstream connection if anything still called it afterward — a stray in-flight background revalidation, or a caller invoking a method after close by mistake — and nothing will ever close that new connection again, since `close()` already ran. That's a connection leak on every such path.

**Fix:** add a `closed` flag set in `close()` and checked in `getRealClient()`. Once a wrapper is explicitly closed it stays closed and fails loudly (`MCP client for connection <id> is closed`) instead of silently reconnecting. A sibling closing the shared pooled client is unaffected — that still just resets the promise, since each `PassthroughClient`/subtask holds its own wrapper instance with its own `closed` flag.

**Regression test:** `apps/api/src/mcp-clients/lazy-client.test.ts` — "does not reconnect after its own close()": creates a lazy client, uses it, calls `close()`, then calls `listTools()` again and asserts it rejects instead of opening a second connection (`clientFromConnectionMock` called only once).

Reviewer command: `bun test apps/api/src/mcp-clients/lazy-client.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops a lazy MCP client from silently reconnecting after its own close(), preventing downstream connection leaks. Previously, calls made after `close()` reopened a new connection due to the shared `onclose` nulling; now, the client marks itself closed and rejects further calls with a clear error, while sibling-driven pool closes still allow transparent reconnects.

- Adds a `closed` flag set in `close()` and checked in `getRealClient()`; subsequent calls reject with “MCP client for connection <id> is closed.”
- Keeps the behavior from #6173: if a sibling closes the pooled client, we null the cached promise so the next call reconnects.
- Adds a regression test at `apps/api/src/mcp-clients/lazy-client.test.ts` (“does not reconnect after its own close()”); run with `bun test apps/api/src/mcp-clients/lazy-client.test.ts`.
- No migration required; callers must not invoke a closed client and should handle the explicit error.

<sup>Written for commit 5d001c4a79935a3e6eaeb071122ec0a283671f40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

