### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through a stack trace

### DIFF
--- a/packages/sandbox/daemon-e2e/stub-daemon.mjs
+++ b/packages/sandbox/daemon-e2e/stub-daemon.mjs
@@ -133,7 +133,8 @@ const server = http.createServer(async (req, res) => {
       writeFileSync(target, payload.content ?? "");
       return send(res, 200, { ok: true });
     } catch (e) {
-      return send(res, 400, { error: String(e?.message ?? e) });
+      process.stderr.write(`[stub-daemon] write failed: ${String(e?.stack ?? e)}\n`);
+      return send(res, 400, { error: "invalid request" });
     }
   }
 
@@ -148,7 +149,8 @@ const server = http.createServer(async (req, res) => {
       const content = lines.map((l, i) => `${i + 1}\t${l}`).join("\n");
       return send(res, 200, { kind: "text", content, lineCount: lines.length });
     } catch (e) {
-      return send(res, 400, { error: String(e?.message ?? e) });
+      process.stderr.write(`[stub-daemon] read failed: ${String(e?.stack ?? e)}\n`);
+      return send(res, 400, { error: "invalid request" });
     }
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/decocms/studio/security/code-scanning/4](https://github.com/decocms/studio/security/code-scanning/4)

To fix this without changing functional behavior, keep HTTP status codes and route behavior the same, but replace client-visible error details derived from caught exceptions with a generic message. If debugging detail is still needed, log the caught error on the server (`stderr`) instead of returning it in the response payload.

Best single approach in this file:
- In `packages/sandbox/daemon-e2e/stub-daemon.mjs`, update both `catch (e)` blocks in:
  - `POST /_sandbox/write`
  - `POST /_sandbox/read`
- Replace `return send(res, 400, { error: String(e?.message ?? e) });` with:
  - a server-side log line including the error object (or stack if present), and
  - a generic client message such as `{ error: "invalid request" }`.

No imports or external dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops exposing exception details from the sandbox daemon stub by returning a generic error to clients and logging the stack to stderr. Preserves all route behavior and HTTP status codes to address the information exposure alert.

- Changes limited to `POST /_sandbox/write` and `POST /_sandbox/read`: still return 400 on failure, but payload is `{ error: "invalid request" }`; full error/stack is written to stderr.
- No new imports or dependencies; only two catch blocks modified.
- If any tests or clients assert on previous error strings, update them to expect the generic message.

<sup>Written for commit fc07d5a333e5fe641a56f4761b32c2696045744b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

