### PR TITLE
fix(decofile): drop invalid-JSON blocks instead of wedging the merge

### DIFF
--- a/apps/api/src/decofile/commit-coalescer.ts
+++ b/apps/api/src/decofile/commit-coalescer.ts
@@ -181,9 +181,10 @@ async function commitBatch(batch: Batch): Promise<string> {
       const { decofile: genContent, skipped } = mergeBlocks(files);
       if (skipped.length > 0) {
         console.warn("decofile gen: dropped blocks that were not valid JSON", {
+          repo: `${client.owner}/${client.repo}`,
           branch,
           packagePath,
-          blocks: skipped.map((s) => ({ key: s.key, error: s.error })),
+          blocks: skipped.map((s) => s.key),
         });
       }
       const genBlobSha = await client.createBlob(genContent);

--- a/apps/api/src/decofile/commit-coalescer.ts
+++ b/apps/api/src/decofile/commit-coalescer.ts
@@ -178,7 +178,15 @@ async function commitBatch(batch: Batch): Promise<string> {
           content: b.content ?? (await client.getBlobText(b.sha as string)),
         })),
       );
-      const genBlobSha = await client.createBlob(mergeBlocks(files));
+      const { decofile: genContent, skipped } = mergeBlocks(files);
+      if (skipped.length > 0) {
+        console.warn("decofile gen: dropped blocks that were not valid JSON", {
+          branch,
+          packagePath,
+          blocks: skipped.map((s) => ({ key: s.key, error: s.error })),
+        });
+      }
+      const genBlobSha = await client.createBlob(genContent);
       writes.push({
         path: genPath,
         mode: "100644",

--- a/apps/api/src/decofile/read-decofile.ts
+++ b/apps/api/src/decofile/read-decofile.ts
@@ -90,6 +90,17 @@ function countColdRead(path: "tarball" | "blobs"): void {
   coldReadsCounter.add(1, { path });
 }
 
+let skippedBlocksCounter: Counter | null = null;
+
+function countSkippedBlocks(n: number): void {
+  skippedBlocksCounter ??= meter.createCounter("decofile_skipped_blocks", {
+    description:
+      "Decofile blocks dropped from a merge for not being valid JSON",
+    unit: "{blocks}",
+  });
+  skippedBlocksCounter.add(n);
+}
+
 export async function mapBounded<T, R>(
   items: T[],
   limit: number,
@@ -179,18 +190,20 @@ export interface DecofileSnapshot {
   decofile: string;
 }
 
+/** Bump when the merge output changes so entries written by an older
+ * `mergeBlocks` miss instead of being served as-is — notably the pre-drop
+ * splice that could cache an INVALID document under a still-current sha. */
+const MERGED_DOC_FORMAT = "2";
+
 /**
- * Disk key for the merged document. The store keys merged entries by a single
- * 40-hex sha; a root project uses the head sha itself, but the merged doc
- * also depends on `packagePath` (two nested projects can share one repo), so
- * nested projects key by a sha1 of (head sha, packagePath) — still
- * deterministic and content-addressed, so restart-warmness is preserved.
- * (Deviation from the spec's `merged/<owner>/<repo>/<headSha>.json` sketch,
- * which ignored packagePath.)
+ * Disk key for the merged document — a sha1 of (format, head sha, packagePath),
+ * so it's deterministic/content-addressed (restart-warm) yet distinct per
+ * nested project (two can share one repo) and per merge-output format.
  */
 function mergedDocSha(sha: string, packagePath: string | null): string {
-  if (!packagePath) return sha;
-  return createHash("sha1").update(`${sha}:${packagePath}`).digest("hex");
+  return createHash("sha1")
+    .update(`${MERGED_DOC_FORMAT}:${sha}:${packagePath ?? ""}`)
+    .digest("hex");
 }
 
 /** Concurrent snapshot reads of the same content share ONE resolution — this
@@ -273,11 +286,12 @@ async function resolveSnapshot(
   );
   const { decofile, skipped } = mergeBlocks(contents);
   if (skipped.length > 0) {
+    countSkippedBlocks(skipped.length);
     console.warn("decofile read: dropped blocks that were not valid JSON", {
       repo: `${owner}/${repo}`,
       sha,
       packagePath,
-      blocks: skipped.map((s) => ({ key: s.key, error: s.error })),
+      blocks: skipped.map((s) => s.key),
     });
   }
   await putMerged(owner, repo, docSha, decofile);

--- a/apps/api/src/decofile/read-decofile.ts
+++ b/apps/api/src/decofile/read-decofile.ts
@@ -271,7 +271,15 @@ async function resolveSnapshot(
       return { stem: e.stem, content };
     },
   );
-  const decofile = mergeBlocks(contents);
+  const { decofile, skipped } = mergeBlocks(contents);
+  if (skipped.length > 0) {
+    console.warn("decofile read: dropped blocks that were not valid JSON", {
+      repo: `${owner}/${repo}`,
+      sha,
+      packagePath,
+      blocks: skipped.map((s) => ({ key: s.key, error: s.error })),
+    });
+  }
   await putMerged(owner, repo, docSha, decofile);
   return { sha, decofile };
 }

--- a/packages/e2e/tests/decofile-api.spec.ts
+++ b/packages/e2e/tests/decofile-api.spec.ts
@@ -427,6 +427,49 @@ test.describe("decofile API", () => {
     }
   });
 
+  test("GET drops a block that is not valid JSON instead of returning an unparseable body", async ({
+    playwright,
+  }) => {
+    const ctx = await newApiContext(playwright);
+    try {
+      const user = await signUpViaApi(ctx);
+      const org = user.orgSlug;
+      const owner = uniqueOwner();
+      const repo = "site";
+
+      const heroBlock = {
+        __resolveType: "site/sections/Hero.tsx",
+        title: "Welcome",
+      };
+      await seedStubRepo(ctx, {
+        owner,
+        repo,
+        defaultBranch: "main",
+        branches: {
+          main: {
+            files: {
+              ".deco/blocks/Hero.json": blockFileContent(heroBlock),
+              // Raw `.tsx` source spliced in would make the whole body unparseable.
+              ".deco/blocks/Broken.json": "import { H } from './x'",
+            },
+          },
+        },
+      });
+
+      const project = await createFastPreviewProject(ctx, org, { owner, repo });
+      const res = await ctx.get(decofileUrl(project, "main"));
+
+      // 200 with a parseable body — not an unparseable 200 that wedges the editor.
+      expect(res.status()).toBe(200);
+      const body = (await res.json()) as DecofileGetBody;
+      // The valid block survives; the corrupt one is dropped, not merged.
+      expect(body.decofile["Hero"]).toEqual(heroBlock);
+      expect(Object.keys(body.decofile)).toEqual(["Hero"]);
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
   test("legacy repo children (repoScope.sourceConnectionId) read through the mint path", async ({
     playwright,
   }) => {

--- a/packages/sandbox/daemon-go/internal/decofile/merge.go
+++ b/packages/sandbox/daemon-go/internal/decofile/merge.go
@@ -45,15 +45,16 @@ func decodeUntilStable(stem string) string {
 // generateFromBlocks rebuilds the merged decofile from the sibling
 // `.deco/blocks/*.json` files so the CMS is readable before the dev server is
 // up. Maps each file to `{ [decodeUntilStable(stem)]: <file contents> }`,
-// sorted by filename for a deterministic, byte-for-byte result.
+// sorted by filename — byte-for-byte identical to the TS mergeBlocks
+// (packages/shared/src/decofile/merge.ts) for well-formed input.
 //
-// The merged text is built by splicing raw file bytes rather than
-// unmarshal/marshal round-tripping through Go values — this payload is
-// routinely multi-MB, and a malformed block isn't caught here; the client's
-// parse fails and falls back to "no snapshot", same as the read/write/edit
-// handlers already gate. The merge is deliberately all-or-nothing: one bad block
-// blanks the whole snapshot rather than silently dropping a block and rendering
-// a partial site.
+// Valid blocks are spliced in raw (no unmarshal/marshal round-trip — the
+// payload is routinely multi-MB). A block that is not valid JSON is DROPPED
+// rather than spliced raw, which would make the whole snapshot unparseable and
+// wedge the CMS; this mirrors the TS side, which dropped it to unwedge Fast
+// Preview. The write/edit/publish handlers still reject invalid blocks up front
+// (see InvalidBlockJSON) — this is the last-resort net for a bad block that
+// arrived some other way (e.g. a direct push).
 //
 // Returns ok=false when there's no blocks dir (nothing to merge) so the caller
 // falls through to its normal "file not found" path.
@@ -86,6 +87,11 @@ func generateFromBlocks(blocksDir string) (string, bool) {
 		content := bytes.TrimSpace(raw)
 		// Skip empty files — `"key":` with no value would break the merged JSON.
 		if len(content) == 0 {
+			continue
+		}
+		// Drop a block that isn't valid JSON — spliced raw it would corrupt the
+		// whole snapshot. json.Valid avoids allocating a discarded value.
+		if !json.Valid(content) {
 			continue
 		}
 		keyJSON, err := json.Marshal(decodeUntilStable(stem))

--- a/packages/sandbox/daemon-go/internal/decofile/merge_test.go
+++ b/packages/sandbox/daemon-go/internal/decofile/merge_test.go
@@ -59,6 +59,24 @@ func TestGenerateFromBlocks(t *testing.T) {
 		}
 	})
 
+	t.Run("drops a block that is not valid JSON", func(t *testing.T) {
+		dir := t.TempDir()
+		writeBlock(t, dir, "good.json", `{"ok":true}`)
+		// A raw `.tsx` source spliced in would make the whole snapshot unparseable.
+		writeBlock(t, dir, "broken.json", `import { H } from './x'`)
+		merged, ok := generateFromBlocks(dir)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if merged != `{"good":{"ok":true}}` {
+			t.Fatalf("merged = %q, want the broken block dropped", merged)
+		}
+		var v any
+		if err := json.Unmarshal([]byte(merged), &v); err != nil {
+			t.Fatalf("merged blob is not valid JSON: %v", err)
+		}
+	})
+
 	t.Run("decodes percent-encoded stems until stable", func(t *testing.T) {
 		dir := t.TempDir()
 		// Double-encoded stem: a single decode would key it `Compre%20Junto`,

--- a/packages/shared/src/decofile/index.ts
+++ b/packages/shared/src/decofile/index.ts
@@ -11,4 +11,6 @@ export {
   GEN_BASENAME,
   mergeBlocks,
   type BlockFile,
+  type MergeResult,
+  type SkippedBlock,
 } from "./merge";

--- a/packages/shared/src/decofile/index.ts
+++ b/packages/shared/src/decofile/index.ts
@@ -11,6 +11,4 @@ export {
   GEN_BASENAME,
   mergeBlocks,
   type BlockFile,
-  type MergeResult,
-  type SkippedBlock,
 } from "./merge";

--- a/packages/shared/src/decofile/merge.test.ts
+++ b/packages/shared/src/decofile/merge.test.ts
@@ -3,47 +3,72 @@ import { BLOCK_PATH_RE, mergeBlocks } from "./merge";
 
 describe("mergeBlocks", () => {
   it("merges files into a flat key -> content document", () => {
-    const out = mergeBlocks([
+    const { decofile, skipped } = mergeBlocks([
       { stem: "b", content: '{"n":2}' },
       { stem: "a", content: '{"n":1}' },
     ]);
-    expect(out).toBe('{"a":{"n":1},"b":{"n":2}}');
+    expect(decofile).toBe('{"a":{"n":1},"b":{"n":2}}');
+    expect(skipped).toEqual([]);
   });
 
   it("preserves pretty-printed content verbatim", () => {
     const pretty = '{\n  "n": 1\n}';
-    const out = mergeBlocks([{ stem: "a", content: pretty }]);
-    expect(out).toBe(`{"a":${pretty}}`);
-    expect(JSON.parse(out)).toEqual({ a: { n: 1 } });
+    const { decofile } = mergeBlocks([{ stem: "a", content: pretty }]);
+    expect(decofile).toBe(`{"a":${pretty}}`);
+    expect(JSON.parse(decofile)).toEqual({ a: { n: 1 } });
   });
 
   it("decodes double-encoded stems to a single key", () => {
-    const out = mergeBlocks([
+    const { decofile } = mergeBlocks([
       { stem: "Compre%2520Junto", content: '{"v":"double"}' },
     ]);
-    expect(JSON.parse(out)).toEqual({ "Compre Junto": { v: "double" } });
+    expect(JSON.parse(decofile)).toEqual({ "Compre Junto": { v: "double" } });
   });
 
   it("skips empty and whitespace-only files", () => {
-    const out = mergeBlocks([
+    const { decofile } = mergeBlocks([
       { stem: "empty", content: "" },
       { stem: "spaces", content: "  \n\t" },
       { stem: "a", content: "{}" },
     ]);
-    expect(out).toBe('{"a":{}}');
+    expect(decofile).toBe('{"a":{}}');
   });
 
   it("sorts by filename, not stem (matches the Go daemon byte-for-byte)", () => {
     // "a-b.json" < "a.json" ("-" sorts before "."), while stem "a" < "a-b".
-    const out = mergeBlocks([
+    const { decofile } = mergeBlocks([
       { stem: "a", content: "1" },
       { stem: "a-b", content: "2" },
     ]);
-    expect(out).toBe('{"a-b":2,"a":1}');
+    expect(decofile).toBe('{"a-b":2,"a":1}');
   });
 
   it("returns an empty document for no files", () => {
-    expect(mergeBlocks([])).toBe("{}");
+    expect(mergeBlocks([])).toEqual({ decofile: "{}", skipped: [] });
+  });
+
+  it("drops a block that is not valid JSON and keeps the document parseable", () => {
+    // A raw `.tsx` source spliced in would make the whole document unparseable.
+    const { decofile, skipped } = mergeBlocks([
+      { stem: "good", content: '{"ok":true}' },
+      { stem: "broken", content: "import { H } from './x'" },
+    ]);
+    expect(JSON.parse(decofile)).toEqual({ good: { ok: true } });
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0]).toMatchObject({ key: "broken", stem: "broken" });
+    expect(skipped[0]?.error).toBeTruthy();
+  });
+
+  it("reports the decoded key for a skipped block with an encoded stem", () => {
+    const { decofile, skipped } = mergeBlocks([
+      { stem: "Compre%20Junto", content: "not json" },
+    ]);
+    expect(decofile).toBe("{}");
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0]).toMatchObject({
+      key: "Compre Junto",
+      stem: "Compre%20Junto",
+    });
   });
 });
 

--- a/packages/shared/src/decofile/merge.test.ts
+++ b/packages/shared/src/decofile/merge.test.ts
@@ -59,6 +59,27 @@ describe("mergeBlocks", () => {
     expect(skipped[0]?.error).toBeTruthy();
   });
 
+  it("drops a broken block between valid ones without breaking the commas", () => {
+    const { decofile, skipped } = mergeBlocks([
+      { stem: "a", content: '{"n":1}' },
+      { stem: "b", content: "oops not json" },
+      { stem: "c", content: '{"n":3}' },
+    ]);
+    expect(JSON.parse(decofile)).toEqual({ a: { n: 1 }, c: { n: 3 } });
+    expect(skipped.map((s) => s.key)).toEqual(["b"]);
+  });
+
+  it("reports every skipped block in filename order", () => {
+    const { decofile, skipped } = mergeBlocks([
+      { stem: "a", content: "nope" },
+      { stem: "b", content: '{"ok":true}' },
+      { stem: "c", content: "also nope" },
+    ]);
+    expect(JSON.parse(decofile)).toEqual({ b: { ok: true } });
+    expect(skipped).toHaveLength(2);
+    expect(skipped.map((s) => s.key)).toEqual(["a", "c"]);
+  });
+
   it("reports the decoded key for a skipped block with an encoded stem", () => {
     const { decofile, skipped } = mergeBlocks([
       { stem: "Compre%20Junto", content: "not json" },

--- a/packages/shared/src/decofile/merge.ts
+++ b/packages/shared/src/decofile/merge.ts
@@ -24,18 +24,30 @@ export interface BlockFile {
   content: string;
 }
 
+/** A block omitted from the merged document because it was not valid JSON. */
+export interface SkippedBlock {
+  /** The decoded key the block would have been emitted under. */
+  key: string;
+  /** Filename stem — NOT decoded (identifies the source file). */
+  stem: string;
+  /** The JSON parse error that disqualified the block. */
+  error: string;
+}
+
+export interface MergeResult {
+  /** The merged decofile document — always valid JSON text. */
+  decofile: string;
+  /** Blocks dropped because their content did not parse as JSON. */
+  skipped: SkippedBlock[];
+}
+
 /**
- * Merge block files into the decofile document:
- * `{ [decodeUntilStable(stem)]: <raw file contents> }`, sorted by filename for
- * a deterministic, byte-for-byte result identical to the Go daemon's merge.
- *
- * The merged text is built by splicing raw contents rather than
- * parse/stringify round-tripping — the payload is routinely multi-MB, and the
- * merge is deliberately all-or-nothing: one malformed block makes the whole
- * document unparseable rather than silently rendering a partial site.
- * Callers that need per-block validity check it at write time instead.
+ * Merge block files into `{ [decodeUntilStable(stem)]: <raw contents> }`, sorted
+ * by filename — byte-for-byte identical to the Go daemon's merge for valid input.
+ * A block that is not valid JSON is dropped (reported in `skipped`) instead of
+ * spliced raw, which would make the whole document unparseable.
  */
-export function mergeBlocks(files: BlockFile[]): string {
+export function mergeBlocks(files: BlockFile[]): MergeResult {
   // Sort by full filename (stem + ".json"), matching the Go implementation's
   // `sort.Strings(names)` — stem order and filename order can differ around
   // characters that sort before ".".
@@ -45,15 +57,27 @@ export function mergeBlocks(files: BlockFile[]): string {
     return an < bn ? -1 : an > bn ? 1 : 0;
   });
 
+  const skipped: SkippedBlock[] = [];
   let out = "{";
   let first = true;
   for (const file of sorted) {
     const content = file.content.trim();
     // Skip empty files — `"key":` with no value would break the merged JSON.
     if (content.length === 0) continue;
+    // Parse only to validate; the raw text (not a re-stringify) is spliced.
+    try {
+      JSON.parse(content);
+    } catch (err) {
+      skipped.push({
+        key: decodeUntilStable(file.stem),
+        stem: file.stem,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      continue;
+    }
     if (!first) out += ",";
     first = false;
     out += `${JSON.stringify(decodeUntilStable(file.stem))}:${content}`;
   }
-  return `${out}}`;
+  return { decofile: `${out}}`, skipped };
 }


### PR DESCRIPTION
## Problem

Fast Preview stays stuck on the "Iniciando seu preview" / "starting preview" pill and never renders the draft.

Root cause: the Fast Preview decofile read (`apps/api/src/decofile/read-decofile.ts`) serves an arbitrary GitHub **branch head** directly, with no write-time validation gate. `mergeBlocks` splices each `.deco/blocks/*.json` in **raw** for performance, so a single corrupt block — e.g. a file that contains raw `.tsx` source (`import { H … }`) instead of a JSON object — makes the **entire** merged document unparseable.

The API then returns `200` with an invalid JSON body. On the client, `fetchDecofile` does `res.json()` → throws `SyntaxError` → retries exhaust → `setDecofileDraft` never runs → `draftPreviewUrl` stays `null` → `fastPreviewReady` is `false` → the preview is wedged on the waking pill forever.

## Fix

`mergeBlocks` now validates each block and **drops** the ones that aren't valid JSON, returning `{ decofile, skipped }`:

- Valid blocks are still spliced **verbatim** (byte-for-byte parity with the Go daemon merge for well-formed input; pretty-printing preserved).
- Invalid blocks are omitted and reported in `skipped` (key, stem, parse error).
- Both callers (`read-decofile.ts` read path and `commit-coalescer.ts` gen path) `console.warn` the dropped blocks, so the loss is observable rather than silent.

Net effect: a corrupt block degrades to a **partial but valid, renderable** document instead of wedging the whole preview.

## Notes / follow-ups

- **Cache:** the merged doc is content-addressed by head sha (`putMerged`). A doc cached under the old code (invalid) is served as-is on a warm hit; it self-heals when the branch head moves (new sha ⇒ fresh valid merge). Removing the corrupt block on the branch is the immediate unblock.
- **Go parity:** the daemon's `generateFromBlocks` (`packages/sandbox/daemon-go/internal/decofile/merge.go`) has the same all-or-nothing design; it's guarded by write-time `InvalidBlockJSON` today. Mirroring this skip there is a sensible parallel follow-up (not in this PR to keep scope on the Fast Preview bug).

## Testing

- `bun test packages/shared/src/decofile/merge.test.ts` — 10 pass (adjusted existing + 2 new: drop-invalid-block, decoded-key reporting).
- `tsc --noEmit` clean for `packages/shared` and `apps/api`.
- `bun run fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Fast Preview and the sandbox from wedging by dropping invalid-JSON blocks during decofile merge. Previously, one corrupt `.deco/blocks/*.json` produced a 200 with an unparseable body and the editor stayed on “starting preview.” Now both merges validate each block, omit invalid ones, and always return valid JSON so previews render (possibly partially).

- Review notes
  - `mergeBlocks` now returns `{ decofile, skipped }`; update any external call sites accordingly. Valid blocks are still spliced verbatim; output is unchanged for well-formed input.
  - Observability: the read path counts dropped blocks via `decofile_skipped_blocks` and logs dropped block keys; the generation path logs keys as well. We do not log raw parse errors.
  - Cache: the merged-doc cache key is versioned, so previously cached invalid documents miss immediately after deploy instead of persisting until the branch head changes.
  - Go parity: the daemon’s `generateFromBlocks` now drops invalid-JSON blocks to match the TypeScript merge.

<sup>Written for commit 09be235b852e8c9e15040c3103f467edf1530384. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

