### PR TITLE
fix(native): reject an empty virtualMcpId on SANDBOX_START/DELETE

### DIFF
--- a/apps/native/crates/local-api/src/routes/intercept/sandbox_lifecycle.rs
+++ b/apps/native/crates/local-api/src/routes/intercept/sandbox_lifecycle.rs
@@ -514,7 +514,11 @@ async fn delete(state: &AppState, body: &Bytes) -> Response {
         Ok(value) => value,
         Err(error) => return error.into_response(),
     };
-    let Some(virtual_mcp_id) = input.get("virtualMcpId").and_then(Value::as_str) else {
+    let Some(virtual_mcp_id) = input
+        .get("virtualMcpId")
+        .and_then(Value::as_str)
+        .filter(|id| !id.is_empty())
+    else {
         return ApiError::bad_request("virtualMcpId is required").into_response();
     };
     let Some(branch) = input
@@ -559,7 +563,11 @@ async fn start(state: &AppState, org: &str, body: &Bytes) -> Response {
         Ok(value) => value,
         Err(error) => return error.into_response(),
     };
-    let Some(virtual_mcp_id) = input.get("virtualMcpId").and_then(Value::as_str) else {
+    let Some(virtual_mcp_id) = input
+        .get("virtualMcpId")
+        .and_then(Value::as_str)
+        .filter(|id| !id.is_empty())
+    else {
         return ApiError::bad_request("virtualMcpId is required").into_response();
     };
     let branch = input.get("branch").and_then(Value::as_str);
@@ -897,6 +905,21 @@ mod tests {
             assert_eq!(status, StatusCode::OK);
             assert_eq!(answer, json!({ "success": true }));
         }
+    }
+
+    /// An empty `virtualMcpId` is not a valid id — it must be rejected the
+    /// same way a missing one is, not treated as present. `branch` already got
+    /// this treatment; `virtualMcpId` didn't, which let an empty id flow
+    /// through to `ensure()` while `branch_for_virtual_mcp` (empty id ==
+    /// "no agent") reported a disagreeing `EPHEMERAL_BRANCH` for the sandbox
+    /// that had actually just been started.
+    #[tokio::test]
+    async fn delete_rejects_an_empty_virtual_mcp_id() {
+        let root = tempfile::tempdir().unwrap();
+        let state = super::super::test_state(root.path());
+        let (status, _) =
+            delete_body(&state, json!({ "virtualMcpId": "", "branch": "feature-x" })).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
     }
 
     #[test]


### PR DESCRIPTION
Bug found while auditing `apps/native/crates/local-api/src/routes/intercept/sandbox_lifecycle.rs` for error-handling/state-consistency gaps.

**The gap:** `start()` and `delete()` both validate `virtualMcpId` with `input.get("virtualMcpId").and_then(Value::as_str)` — an empty string `""` passes this check (it's `Some("")`, not `None`). The sibling `branch` field in the same two functions is already filtered for emptiness (`.filter(|b| !b.is_empty())`), so this is an inconsistency, not a deliberate choice.

**Failure scenario:** a caller sends `SANDBOX_START` with `virtualMcpId: ""`. The empty id flows through `config_from_virtual_mcp`/`compute_handle`/`ensure()` and a real sandbox gets provisioned and registered under that empty key. But `branch_for_virtual_mcp` — called right after `ensure()` to fill the response's `branch` field — treats an empty id as "no agent" by design and returns the `EPHEMERAL_BRANCH` sentinel. So the response reports a live `previewUrl`/`sandboxHandle` for a just-started sandbox alongside `branch: "ephemeral"`, a state the rest of the module treats as "no sandbox exists" (see the doc comments on `EPHEMERAL_BRANCH` and `branch_for_virtual_mcp`). That's exactly the kind of default-masking-a-real-value bug this file's own comments call out as having bitten it before with `branch`.

**Fix:** apply the same `.filter(|id| !id.is_empty())` treatment already used for `branch` to `virtualMcpId` in both `start()` and `delete()`, so an empty id is rejected as "required" instead of silently treated as present.

**Regression test:** `delete_rejects_an_empty_virtual_mcp_id` — asserts `SANDBOX_DELETE` with `virtualMcpId: ""` now returns 400 instead of the prior no-op success. (`start()`'s path needs a live upstream call so isn't unit-testable here, but shares the identical validation line.)

**To verify:** `cd apps/native && cargo test -p local-api sandbox_lifecycle`

**Checks run locally:** `cargo test -p local-api sandbox_lifecycle` (14/14 pass) and `cargo fmt --check` (clean). Full CI covers the rest of the crate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects an empty virtualMcpId on SANDBOX_START and SANDBOX_DELETE to prevent provisioning a sandbox under an empty key and returning an “ephemeral” branch. Previously, "" was accepted and treated as present; now it is treated as missing and returns 400.

**Review notes**
- Applies `.filter(|id| !id.is_empty())` to virtualMcpId extraction in both `start()` and `delete()` in `apps/native/crates/local-api/src/routes/intercept/sandbox_lifecycle.rs`, matching existing branch handling.
- Adds regression test `delete_rejects_an_empty_virtual_mcp_id`; run with `cargo test -p local-api sandbox_lifecycle`.

<sup>Written for commit f5b4319deeab976480a8df4d371ffbe17d05ab1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

