### PR TITLE
fix(sections-editor): don't let the general SEO type field clear to empty

### DIFF
--- a/apps/web/src/components/sections-editor/general-seo-form.tsx
+++ b/apps/web/src/components/sections-editor/general-seo-form.tsx
@@ -109,6 +109,8 @@ export function GeneralSeoForm({
                 },
                 path: key,
                 label,
+                // `type` always needs a concrete value — no "None" clear option.
+                required: key === "type",
                 breadcrumbPath: [],
                 onBreadcrumbChange: () => {},
               })}


### PR DESCRIPTION
Follow-up hardening after #6172 ("let optional enum selects clear back to empty").

**Bug:** `EnumField` now shows a "None" option and clears to `undefined` whenever its `required` prop is falsy. `general-seo-form.tsx` renders every General SEO field (including the OpenGraph `type` select — website/article/etc.) through a direct `renderField()` call that never sets `required`, so `type` now silently gained the same "None" clear option as genuinely optional fields.

This form already treats `type` specially: `generalSeoFieldsWithDefaultToggle()` excludes it from the "use default"/inherit toggle, and `handleUseDefaultChange` seeds it back to `"website"` whenever inheritance is turned off — both signal that `type` is meant to always hold a concrete value. Letting a user pick "None" on it produces a value the rest of the form's own logic doesn't expect (a `type: undefined` key that isn't produced by any other path here).

**Fix:** pass `required: key === "type"` in the `renderField` call so `EnumField` doesn't offer the clear option for this one field, matching the form's existing intent. Every other General SEO field is untouched.

**To verify:** open a page's General SEO form, click the `type` select — no "None" entry should appear (the other curated SEO fields with the "use default" switch are unaffected).

**Checks run locally:** `bun run fmt`, `bunx oxlint` on the changed file (0 errors), `bunx tsc --noEmit` in `apps/web` (only a pre-existing, unrelated `mustache` module error surfaces; nothing new). This is a one-line prop-wiring fix onto `EnumField`'s existing, already-tested `required` behavior (see `enum-field.ct.tsx`'s "required enum: no None option is offered" test), so no new Playwright CT infra was added — full CI covers the CT suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents clearing the General SEO OpenGraph `type` select to empty by marking it required. Previously, `type` inherited the "optional enum" behavior and offered a "None" option that set it to undefined; now it always requires a concrete value, aligning with existing form logic.

**Review notes**
- Scope: one-line change passing `required: key === "type"` to `renderField` in `general-seo-form.tsx`; all other SEO fields are unchanged.
- Verify: in a page’s General SEO form, the `type` select shows no "None" option; other fields still allow clearing when intended.

<sup>Written for commit 1afc7b34a48f418930a5d3fc0eb60f01968b2044. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

