### PR TITLE
fix(sandbox): recover from panics in the tool-catalog coalescer's background sync

### DIFF
--- a/packages/sandbox/daemon-go/internal/toolscatalog/coalescer.go
+++ b/packages/sandbox/daemon-go/internal/toolscatalog/coalescer.go
@@ -70,6 +70,13 @@ func (c *Coalescer) Sync(ep Endpoint) {
 			c.lastRun[ep.URL] = time.Now()
 			c.mu.Unlock()
 		}()
+		// Fire-and-forget: a panic here (e.g. from a malformed catalog
+		// response) must not take down the whole daemon process.
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Error("catalog sync panicked", "err", r)
+			}
+		}()
 		if err := c.sync(ep); err != nil {
 			slog.Error("catalog sync failed", "err", err)
 		}

--- a/packages/sandbox/daemon-go/internal/toolscatalog/coalescer_test.go
+++ b/packages/sandbox/daemon-go/internal/toolscatalog/coalescer_test.go
@@ -84,6 +84,25 @@ func TestCoalescerKeysByEndpoint(t *testing.T) {
 	waitFor(t, runs, 2)
 }
 
+func TestCoalescerSurvivesPanicInSync(t *testing.T) {
+	c := NewCoalescer(Opts{}, time.Millisecond)
+	ep := Endpoint{URL: "https://mcp.example/x"}
+	var runs atomic.Int32
+	c.sync = func(Endpoint) error {
+		runs.Add(1)
+		panic("boom")
+	}
+
+	// A panic inside the background sync must not crash the test process, and
+	// must still clear in-flight state so a later sync isn't wedged forever.
+	c.Sync(ep)
+	waitFor(t, &runs, 1)
+
+	time.Sleep(2 * time.Millisecond)
+	c.Sync(ep)
+	waitFor(t, &runs, 2)
+}
+
 func TestCoalescerIgnoresEmptyEndpoint(t *testing.T) {
 	c := NewCoalescer(Opts{}, time.Hour)
 	runs := stub(c, nil)


### PR DESCRIPTION
**Source:** bug found while auditing `packages/sandbox/daemon-go/internal/toolscatalog/coalescer.go` (assigned focus area: sandbox daemon-go tool catalog) — not tied to an issue.

**Payoff:** `Coalescer.Sync()` runs the actual catalog fetch/write (`FetchCatalog`/`WriteCatalog`, which parse an HTTP response from the Virtual MCP endpoint) in a fire-and-forget goroutine with no panic recovery. Every other fire-and-forget background goroutine in this daemon (`internal/proc/taskmanager.go`, `internal/setup/orchestrator.go`, `internal/config/store.go`) recovers from panics for exactly this reason — this one didn't. A panic here (e.g. a malformed/unexpected catalog response tripping a nil-map access or bad type assertion) would crash the whole daemon process, taking down every sandbox on that pod, not just the one dispatch that triggered the sync.

**Fix:** wrap the goroutine body in a `recover()` that logs instead of propagating, matching the existing pattern elsewhere in this package.

**Regression test:** `TestCoalescerSurvivesPanicInSync` (`coalescer_test.go`) stubs `sync` to panic, asserts the panic doesn't crash the test process, that in-flight state still clears (via the deferred stamp), and that a later `Sync()` call still runs — i.e. no wedged endpoint after a panicking sync.

**To verify:** `cd packages/sandbox/daemon-go && go test ./internal/toolscatalog/...`

**Checks run locally:** `go test ./internal/toolscatalog/...` (green), `gofmt -l` on both touched files (clean), `go vet ./internal/toolscatalog/...` (clean). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents daemon-wide crashes by adding panic recovery to the tool-catalog coalescer’s background sync. Before, a panic inside the fire‑and‑forget sync crashed the process; now the goroutine defers a recover, logs the panic, and clears in‑flight state so later syncs run.

- Wraps the background sync goroutine with `recover()` and `slog.Error`, matching other daemon workers.
- Adds `TestCoalescerSurvivesPanicInSync` to assert non-crash, in-flight cleanup, and subsequent sync execution.
- Verify with: `cd packages/sandbox/daemon-go && go test ./internal/toolscatalog/...`

<sup>Written for commit 2e812231588e04f08ccca97c554ec279ab9e9433. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6188?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

