### PR TITLE
fix(mcp-clients): don't let an unrelated circuit trip kill an already-connected lazy client

### DIFF
--- a/apps/api/src/mcp-clients/lazy-client.test.ts
+++ b/apps/api/src/mcp-clients/lazy-client.test.ts
@@ -132,6 +132,28 @@ describe("lazy-client with circuit breaker", () => {
     expect(lazy4.listTools()).rejects.toThrow(CircuitOpenError);
   });
 
+  it("an already-connected instance keeps working after the circuit trips for its connection ID", async () => {
+    const realClient = await createWorkingClient();
+    clientFromConnectionMock.mockResolvedValueOnce(realClient);
+
+    const lazy1 = createLazyClient(fakeConnection, fakeCtx, false);
+    const first = await lazy1.listTools();
+    expect(first.tools).toHaveLength(1);
+
+    // Trip the circuit via other instances for the same connection ID.
+    clientFromConnectionMock.mockRejectedValue(new Error("timeout"));
+    for (let i = 0; i < 3; i++) {
+      const lazy = createLazyClient(fakeConnection, fakeCtx, false);
+      expect(lazy.listTools()).rejects.toThrow("timeout");
+    }
+    const tripped = createLazyClient(fakeConnection, fakeCtx, false);
+    expect(tripped.listTools()).rejects.toThrow(CircuitOpenError);
+
+    // The already-connected instance must still serve its cached real client.
+    const second = await lazy1.listTools();
+    expect(second.tools).toHaveLength(1);
+  });
+
   it("different connections have independent circuits", async () => {
     clientFromConnectionMock.mockRejectedValue(new Error("timeout"));
 

--- a/apps/api/src/mcp-clients/lazy-client.ts
+++ b/apps/api/src/mcp-clients/lazy-client.ts
@@ -116,10 +116,10 @@ export function createLazyClient(
       );
     }
 
-    // Fast-fail if the circuit breaker is open for this connection
-    assertCircuitClosed(connection.id);
-
     if (!realClientPromise) {
+      // Fast-fail only gates new connection attempts — an already-live client must survive an unrelated circuit trip.
+      assertCircuitClosed(connection.id);
+
       const pending: Promise<Client> = clientFromConnection(
         connection,
         ctx,


### PR DESCRIPTION
Found while hunting for edge-case bugs in the lazy client after #6181 (stop lazy client from reconnecting after its own close()).

`getRealClient()` called `assertCircuitClosed(connection.id)` unconditionally on every invocation, even when `realClientPromise` was already resolved to a live, working client. The circuit-breaker map in `circuit-breaker.ts` is process-wide and keyed only by connection id — so if *any other* request/lazy-client instance for the same connection racks up 3 consecutive reconnect failures and trips the circuit open, every already-connected instance for that same connection immediately starts throwing `CircuitOpenError` on its next call too, even though its own cached client is perfectly healthy and isn't attempting to reconnect at all.

Why this matters: the circuit breaker's stated purpose (see its own doc comment) is to fail fast on *new* connection attempts instead of blocking ~60s per attempt — not to sever calls on a connection that's already established and working.

Fix: move the `assertCircuitClosed` check inside the `if (!realClientPromise)` branch, so it only gates the creation of a *new* connection. Reuse of an already-resolved (or already in-flight) real client is unaffected by a circuit tripping from unrelated failures.

Regression test added: `lazy-client.test.ts` — "an already-connected instance keeps working after the circuit trips for its connection ID" — connects one lazy client successfully, trips the circuit via three other instances failing on the same connection id, then asserts the original instance's second call still succeeds (previously it would throw `CircuitOpenError`).

To verify: `bun test apps/api/src/mcp-clients/lazy-client.test.ts` (10/10 pass, including the new test).

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean on this file), `bunx oxlint apps/api/src/mcp-clients/lazy-client.ts apps/api/src/mcp-clients/lazy-client.test.ts` (0 warnings/errors), and the targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a circuit breaker trip from unrelated requests from blocking calls on an already-connected lazy client. Previously, `getRealClient()` asserted the circuit was closed on every call and could throw `CircuitOpenError` even when using a healthy cached client; now the assertion runs only when opening a new connection, so existing clients keep working.

- Moves the `assertCircuitClosed(connection.id)` check inside the `if (!realClientPromise)` branch to gate only new connections.
- Keeps reuse of a resolved or in-flight `realClientPromise` unaffected by later circuit trips for the same connection ID.
- Adds a regression test that connects one client, trips the circuit via other instances, and verifies the original client still succeeds.
- No API changes; new connection attempts still fast-fail when the circuit is open.

<sup>Written for commit a1f957be5569c198a077c5afd17fa3d1e83febb9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

