### PR TITLE
fix(thread): stop an in-flight run before deleting its thread

### DIFF
--- a/apps/api/src/tools/thread/delete.ts
+++ b/apps/api/src/tools/thread/delete.ts
@@ -17,6 +17,10 @@ import {
   requireOrganization,
 } from "../../core/studio-context";
 import { normalizeThreadForResponse } from "./helpers";
+import { broadcastRunCancel } from "@/api/routes/decopilot/cancel-registry";
+import { cancelHostedHarness } from "@/dispatch-queue";
+import { cancelThreadGateHead } from "@/dispatch-queue/thread-gate-queue";
+import { cancelThreadBackgroundJobs } from "@/harnesses/decopilot/background-tool-workflow";
 
 export const COLLECTION_THREADS_DELETE = defineTool({
   name: "COLLECTION_THREADS_DELETE",
@@ -40,6 +44,29 @@ export const COLLECTION_THREADS_DELETE = defineTool({
     const thread = await ctx.storage.threads.get(input.id);
     if (!thread) {
       throw new Error(`Thread not found: ${input.id}`);
+    }
+
+    // Stop an in-flight run before deleting its thread, or it keeps running orphaned.
+    if (thread.status === "in_progress") {
+      const onError = (step: string) => (err: unknown) =>
+        console.error("[thread] delete-time run cancel step failed", {
+          threadId: input.id,
+          step,
+          err,
+        });
+      await cancelThreadBackgroundJobs(input.id).catch(
+        onError("background-jobs"),
+      );
+      await cancelThreadGateHead(input.id).catch(onError("gate-head"));
+      const fence = await ctx.storage.threads
+        .getRunFence(input.id)
+        .catch(() => null);
+      if (fence) {
+        await cancelHostedHarness(input.id, fence).catch(
+          onError("hosted-harness"),
+        );
+      }
+      broadcastRunCancel(input.id);
     }
 
     await ctx.storage.threads.delete(input.id);


### PR DESCRIPTION
**Bug**: `COLLECTION_THREADS_DELETE` (the generic thread-collection delete tool, invoked from any MCP client) deletes the `threads` row without touching a still-running agent loop behind it. If the thread's status is `in_progress` when it's deleted, the run's in-memory `AbortController`, any queued background-tool job (image gen / subtask), the gate head holding the thread's dispatch partition, and the hosted-harness child keep executing against a `thread_id` whose row no longer exists — invisible to the user and no longer cancellable via the normal cancel path (there's no thread left to read a fence token from).

**Why a maintainer wants this**: same failure class `rerun.ts`'s `stopSupersededRun` was written to fix (see its doc comment citing a real prod incident where an unstoppped run opened a duplicate PR) — a destructive action on a thread's row must stop the run behind it, or the run keeps burning tokens/quota and can still take real side-effecting actions (tool calls, GitHub pushes) with no way for the user to see or stop it.

**Fix**: in `delete.ts`, when the fetched thread's `status === "in_progress"`, run the same best-effort cancel sequence `stopSupersededRun` uses (minus the durable `setCancelRequested`/DB write, since the row is about to be deleted anyway) — cancel background-tool jobs, cancel the gate head, cancel the hosted-harness child via its current fence token, and broadcast a cross-pod run cancel — before deleting the row. Terminal-status threads are unaffected (the guard is skipped entirely).

**Verification**: `cd apps/api && bunx tsc --noEmit` is clean; `bunx oxlint apps/api/src/tools/thread/delete.ts` reports 0 warnings/errors. I did not add a new test: exercising this handler needs a full `StudioContext` + DB (an integration test, per this repo's testing philosophy), and this environment has no Postgres/NATS to run one against — each cancel primitive reused here (`cancelThreadBackgroundJobs`, `cancelThreadGateHead`, `cancelHostedHarness`, `broadcastRunCancel`) is already exercised by its own module's tests and by `rerun.ts`'s existing coverage of the same sequence. CI's integration/e2e tiers will validate the full path.

**Reviewer check**: call `COLLECTION_THREADS_DELETE` on a thread with `status: "in_progress"` and confirm the run's gate head / background jobs are cancelled before the row disappears (or just read the diff — it's a straight, gated port of `stopSupersededRun`'s sequence).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop in-flight runs before deleting their threads to prevent orphaned execution. Previously, `COLLECTION_THREADS_DELETE` removed the thread row while the run continued; now, if the thread is `in_progress`, we cancel background jobs, the gate head, and the hosted harness (via current fence) and broadcast a cross-pod cancel before deleting. Terminal threads behave the same as before.

**Review notes**
- Reuses the `stopSupersededRun` cancel sequence, minus the durable “cancel requested” DB write since the row is being removed.
- Best-effort: failures in individual cancel steps are logged; deletion proceeds after attempts.
- To verify: delete an `in_progress` thread and confirm background jobs, gate head, and hosted harness stop before the row disappears.

<sup>Written for commit 2fdb5c4b2e0e1e5653907ade7bf94e74edd8ccc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

