### PR TITLE
fix(i18n): translate remaining pt-br auto-tasks billing copy

### DIFF
--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -812,11 +812,11 @@ export const settings = {
   "settings.billing.title": "Cobrança",
   "settings.billing.autoTasksTitle": "Tarefas automáticas",
   "settings.billing.unlimitedDescription":
-    "As execuções de auto tasks são ilimitadas neste deployment. Tasks criadas por você também nunca têm limite.",
+    "As execuções de tarefas automáticas são ilimitadas neste deployment. Tarefas criadas por você também nunca têm limite.",
   "settings.billing.autoTasksDescriptionTrial":
     "3 execuções grátis vitalícias, depois R$ 250/mês para 10 execuções por ciclo de cobrança.",
   "settings.billing.autoTasksDescriptionSubscribed":
-    "10 execuções de auto tasks por ciclo de cobrança. Tasks criadas por você nunca têm limite.",
+    "10 execuções de tarefas automáticas por ciclo de cobrança. Tarefas criadas por você nunca têm limite.",
   "settings.billing.statusTrial": "Teste grátis",
   "settings.billing.statusActive": "Ativa",
   "settings.billing.statusPastDue": "Problema no pagamento",


### PR DESCRIPTION
#6169 fixed the card title ("Auto tasks" -> "Tarefas automáticas") but left the English term in the description body: `settings.billing.unlimitedDescription` and `settings.billing.autoTasksDescriptionSubscribed` still read "execuções de auto tasks"/"Tasks criadas por você" inside otherwise-Portuguese sentences.

Translate both remaining occurrences to match the title fix.

To confirm: open Settings > Billing on a pt-br session with unlimited runs (self-hosted) or a subscribed org — the description under "Tarefas automáticas" now reads entirely in Portuguese.

Checked: `bun run fmt`, `bunx oxlint` on the touched file (0 warnings). `cd apps/web && bunx tsc --noEmit` has one pre-existing unrelated error (missing 'mustache' types in section-title.ts, untouched by this change); pt-br must satisfy `Record<keyof typeof enDomain, string>` so a missing/extra key is already a compile error, and this diff doesn't add or remove keys. CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fully localizes remaining pt-br Billing copy for Tarefas automáticas. Previously, descriptions showed “execuções de auto tasks” and “Tasks criadas por você”; now they read “execuções de tarefas automáticas” and “Tarefas criadas por você” to match the title.

- Updates only `settings.billing.unlimitedDescription` and `settings.billing.autoTasksDescriptionSubscribed` in `apps/web/src/i18n/pt-br/settings.ts`; keys unchanged.
- Verify: switch to pt-br, open Settings > Billing on an unlimited/self-hosted or subscribed org; the Tarefas automáticas card description is entirely in Portuguese.

<sup>Written for commit aa41ca0cebbf3637d69bf10185abf2c7f4707ad6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

