### PR TITLE
fix(fast-preview): publish syncs with base using branch-wins, never 409s

### DIFF
--- a/apps/web/src/components/thread/github/cms-header-actions.tsx
+++ b/apps/web/src/components/thread/github/cms-header-actions.tsx
@@ -362,6 +362,7 @@ export function CmsHeaderActions({ virtualMcpId }: Props) {
           openPullRequest={pr?.state === "open" ? pr : null}
           onPullRequestChanged={refreshPrState}
           onPublished={() => publishCompletion.mutateAsync()}
+          rebaseOnConflict="branch-wins"
         />
       ) : null}
     </>

--- a/apps/web/src/components/thread/github/header-actions.tsx
+++ b/apps/web/src/components/thread/github/header-actions.tsx
@@ -570,6 +570,9 @@ export function HeaderActions({ virtualMcpId }: Props) {
           openPullRequest={pr?.state === "open" ? pr : null}
           onPullRequestChanged={refreshPrState}
           onPublished={switchToFreshBranch}
+          {...(fastPreviewActive
+            ? { rebaseOnConflict: "branch-wins" as const }
+            : {})}
         />
       )}
     </>

--- a/apps/web/src/components/thread/github/publish-dialog.tsx
+++ b/apps/web/src/components/thread/github/publish-dialog.tsx
@@ -97,6 +97,14 @@ export interface PublishDialogProps {
   onPullRequestChanged?: () => void | Promise<void>;
   /** Called after a successful publish (squash-merge to base). */
   onPublished?: () => void | Promise<void>;
+  /**
+   * Conflict strategy for the publish flow's sync-with-base step. Fast Preview
+   * passes "branch-wins" so a conflicting base never 409s the publish — the
+   * server auto-merges with the branch's content winning for every path it
+   * touched (same strategy as the header's "Get latest"). Unset = fail on
+   * conflict, the sandboxed vibecoding default.
+   */
+  rebaseOnConflict?: "branch-wins";
 }
 
 export function PublishDialog(props: PublishDialogProps) {
@@ -137,6 +145,7 @@ function PublishDialogBody({
   openPullRequest = null,
   onPullRequestChanged,
   onPublished,
+  rebaseOnConflict,
 }: PublishDialogProps) {
   const t = useT();
   const githubClient = useMCPClient({
@@ -370,7 +379,13 @@ function PublishDialogBody({
       }
 
       try {
-        await rebaseGitBranch(orgSlug, virtualMcpId, branch, baseBranch);
+        await rebaseGitBranch(
+          orgSlug,
+          virtualMcpId,
+          branch,
+          baseBranch,
+          rebaseOnConflict ? { onConflict: rebaseOnConflict } : undefined,
+        );
       } catch (error) {
         throw new PublishFlowError(
           error instanceof Error


### PR DESCRIPTION
## Summary

Fast Preview's publish flow could still 409 on a merge conflict with base, despite #6054's intent that conflicts never reach the editor. A user hit exactly this: publish failed with GitHub's 409 and only recovered after clicking **Get latest**.

Root cause: the publish flow's sync-with-base step (`publish-dialog.tsx`) called `rebaseGitBranch` **without** an `onConflict` strategy, so the server route defaulted to `"fail"` and `githubGitRebase` rethrew GitHub's `POST /merges` 409 ("resolve on GitHub"). The `branch-wins` strategy — introduced in #5951 and wired by #6054 — was only ever sent by the **Get latest** button (`cms-header-actions.tsx`) and the vibecoding Sync button (`header-actions.tsx`), never by publish itself. And with no open PR there is no `mergeableState === "dirty"` signal, so the header offers **Review & Publish** on a conflicting branch with no warning.

## Change

- `PublishDialog` gains an optional `rebaseOnConflict?: "branch-wins"` prop, threaded into the publish flow's `rebaseGitBranch` call.
- `CmsHeaderActions` (Fast Preview only) passes it unconditionally.
- `HeaderActions` passes it only when `fastPreviewActive` — consistent with its Sync button, which already used `branch-wins` in that mode.
- Sandboxed vibecoding publishes are untouched and keep the fail-on-conflict default.

No server change: the `/git/rebase` route already accepts the flag and maps it to the branch-favoured merge (base's tree with every branch-touched path replayed on top, both parents recorded). This ships the same content the user would get from Get latest → publish, without the error round-trip.

## Testing

- `bun run fmt` · `bun run lint` (0 errors; 18 pre-existing warnings, none in touched files) · `bun run --cwd=apps/web check`
- `bun test` on `apps/web/src/components/thread/github/`: 225 pass, 0 fail
- No new unit test: the change is prop threading through a DOM component (excluded from the unit tier — no mocks), and no e2e coverage of the publish-conflict contract exists yet. Follow-up candidate: a `packages/e2e` scenario seeding a conflicting base commit and asserting publish succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fast Preview publish now syncs with base using a branch-wins strategy, so publish no longer fails with GitHub 409s on merge conflicts. Previously, publish rebased without an onConflict strategy and surfaced a 409; users had to click Get latest to continue.

**Review notes**
- Add optional `rebaseOnConflict?: "branch-wins"` to `PublishDialog` and pass it through to `rebaseGitBranch`.
- `CmsHeaderActions` always sets `rebaseOnConflict="branch-wins"`; `HeaderActions` sets it only when `fastPreviewActive`.
- No server changes; the `/git/rebase` route already supports `onConflict`.
- Sandboxed vibecoding publishes keep the fail-on-conflict default.
- Result matches the Get latest → publish path, but without the error round-trip.

<sup>Written for commit 11e9d108e6e361acae3397801f790ab7a673970c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

