### PR TITLE
perf(decofile): stop recomputing sort filenames per comparison in mergeBlocks

### DIFF
--- a/packages/shared/src/decofile/merge.ts
+++ b/packages/shared/src/decofile/merge.ts
@@ -48,19 +48,15 @@ export interface MergeResult {
  * spliced raw, which would make the whole document unparseable.
  */
 export function mergeBlocks(files: BlockFile[]): MergeResult {
-  // Sort by full filename (stem + ".json"), matching the Go implementation's
-  // `sort.Strings(names)` — stem order and filename order can differ around
-  // characters that sort before ".".
-  const sorted = [...files].sort((a, b) => {
-    const an = `${a.stem}.json`;
-    const bn = `${b.stem}.json`;
-    return an < bn ? -1 : an > bn ? 1 : 0;
-  });
+  // Sort by full filename (stem + ".json"), matching the Go daemon; computed once per file, not per comparison.
+  const sorted = files
+    .map((file) => ({ file, name: `${file.stem}.json` }))
+    .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
 
   const skipped: SkippedBlock[] = [];
   let out = "{";
   let first = true;
-  for (const file of sorted) {
+  for (const { file } of sorted) {
     const content = file.content.trim();
     // Skip empty files — `"key":` with no value would break the merged JSON.
     if (content.length === 0) continue;


### PR DESCRIPTION
Bounded optimization inside `packages/shared/src/decofile/merge.ts` — this tick's assigned focus area (decofile merge engine audit), found while auditing the file just hardened by #6183.

`mergeBlocks`'s sort comparator rebuilt `${stem}.json` from scratch on both sides of every comparison — O(n log n) string concatenations for an n-block merge. Real content-heavy repos can have thousands of `.deco/blocks/*.json` files, so this isn't a micro-opt on a 3-element array. The Go daemon counterpart (`generateFromBlocks` in `packages/sandbox/daemon-go/internal/decofile/merge.go`) avoids this entirely because `os.ReadDir` already returns full filenames it sorts directly — the TS side had to reconstruct the filename from `stem` every time instead.

Fix: decorate-sort-undecorate — compute each file's `${stem}.json` once via `.map()`, sort on the precomputed `name`, then iterate the decorated `file`. No behavior change: same comparator logic (`<`/`>` on the identical string), same output ordering.

Verification:
- `bun test packages/shared/src/decofile/merge.test.ts` — 12/12 pass, including the byte-for-byte-with-Go ordering test ("sorts by filename, not stem").
- `cd packages/shared && bunx tsc --noEmit` — clean.
- `bunx oxlint packages/shared/src/decofile/merge.ts` — 0 warnings/errors.
- `bun run fmt` — no changes needed beyond the edit itself.

Reviewer check: `bun test packages/shared/src/decofile/merge.test.ts`. Full CI validates the rest.

Net diff: -9/+5 lines, one file, one concern.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Precomputes `${stem}.json` once in `mergeBlocks` to avoid rebuilding it during each sort comparison. Previously the comparator recalculated the filename per comparison; now it decorates items with a precomputed name, reducing allocations with no behavior change and preserving Go-parity ordering.

**Review notes**
- Implements decorate-sort-undecorate in `packages/shared/src/decofile/merge.ts`; order and merge output are unchanged.
- To verify: run `bun test packages/shared/src/decofile/merge.test.ts`.

<sup>Written for commit 1334712ba0e84d74f4e6b6058bc12ea834a2f3d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

