### PR TITLE
fix(oauth): treat expiresIn: 0 as expired, not never-expiring

### DIFF
--- a/apps/api/src/api/routes/downstream-token.integration.test.ts
+++ b/apps/api/src/api/routes/downstream-token.integration.test.ts
@@ -103,4 +103,36 @@ describe("Downstream Token Routes", () => {
     expect(body.success).toBe(true);
     expect(body.expiresAt).toBeTruthy();
   });
+
+  it("stores expiresIn: 0 as already-expired, not never-expiring", async () => {
+    const res = await app.request("/connections/conn_1/oauth-token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        accessToken: "at",
+        expiresIn: 0,
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { success: boolean; expiresAt: string };
+    expect(body.success).toBe(true);
+    expect(body.expiresAt).toBeTruthy();
+    expect(new Date(body.expiresAt).getTime()).toBeLessThanOrEqual(Date.now());
+  });
+
+  it("rejects a non-finite expiresIn", async () => {
+    const res = await app.request("/connections/conn_1/oauth-token", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        accessToken: "at",
+        expiresIn: "not-a-number",
+      }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("expiresIn must be a finite number");
+  });
 });

--- a/apps/api/src/api/routes/downstream-token.ts
+++ b/apps/api/src/api/routes/downstream-token.ts
@@ -80,10 +80,18 @@ export const createDownstreamTokenRoutes = () => {
       }
     }
 
-    // Calculate expiry time
-    const expiresAt = body.expiresIn
-      ? new Date(Date.now() + body.expiresIn * 1000)
-      : null;
+    // Calculate expiry time. Check absence explicitly, not falsy — 0 is a valid "already expired" value.
+    if (
+      body.expiresIn !== undefined &&
+      body.expiresIn !== null &&
+      (typeof body.expiresIn !== "number" || !Number.isFinite(body.expiresIn))
+    ) {
+      return c.json({ error: "expiresIn must be a finite number" }, 400);
+    }
+    const expiresAt =
+      body.expiresIn === undefined || body.expiresIn === null
+        ? null
+        : new Date(Date.now() + body.expiresIn * 1000);
 
     // If tokenEndpoint is a proxy URL (goes through /oauth-proxy/), resolve the
     // origin's actual token endpoint so server-side refresh calls origin directly


### PR DESCRIPTION
A bug found while scrutinizing recently-changed OAuth token-refresh code (the `canRefresh` fix in #6160 touched this same file).

The `POST /connections/:connectionId/oauth-token` handler computed `expiresAt` with a falsy check: `body.expiresIn ? new Date(...) : null`. A downstream OAuth server returning `expires_in: 0` (a legitimate "already expired" value per the OAuth spec) falls into the `null` branch. `DownstreamTokenStorage.isExpired()` reads `expiresAt: null` as "no expiry = never expires" — so the token is treated as permanently valid and never proactively refreshed; it only fails once actually used against the downstream MCP server, at which point there's no automatic recovery path.

The same falsy check also let a non-numeric `expiresIn` (a malformed/malicious body — this route takes untrusted client input) silently compute `new Date(NaN)` (Invalid Date) and persist it, instead of failing loudly.

Fix: check for explicit `undefined`/`null` instead of falsy, and reject a non-finite `expiresIn` with 400.

Failure scenario: a client posts `{ accessToken, expiresIn: 0 }` -> old code stores `expiresAt: null` -> `isExpired()` returns `false` forever -> token is never refreshed even though it's dead on arrival.

Regression test: added two cases to `downstream-token.integration.test.ts` — `expiresIn: 0` now round-trips to an `expiresAt` in the past, and a non-numeric `expiresIn` now 400s with `"expiresIn must be a finite number"`.

Reviewer check: `bun test apps/api/src/api/routes/downstream-token.integration.test.ts` (needs local Postgres, same as the existing tests in that file).

Locally verified: `bun run fmt`, `bunx tsc --noEmit` in `apps/api` (clean on both touched files), `bunx oxlint` on both touched files (0 warnings/errors). The integration test itself needs Postgres, which this environment doesn't have — full CI runs it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats `expiresIn: 0` in `POST /connections/:connectionId/oauth-token` as already expired and validates `expiresIn` input. Previously, `0` stored `expiresAt: null` (interpreted as never-expiring), so dead tokens were never refreshed; now `0` yields an `expiresAt` in the past and non‑finite values return 400.

- Clients that send `expiresIn` must provide a finite number; strings, NaN, or Infinity now return 400.
- To review, run: bun test apps/api/src/api/routes/downstream-token.integration.test.ts (requires local Postgres).

<sup>Written for commit ddf011dac3dcfbdcbf7694871abbe1f9c19ed37e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

