### PR TITLE
fix(oauth): don't drop a refreshed token's expires_in: 0 to never-expiring

### DIFF
--- a/apps/api/src/oauth/refresh-access-token.test.ts
+++ b/apps/api/src/oauth/refresh-access-token.test.ts
@@ -181,6 +181,25 @@ describe("refreshAccessToken", () => {
     expect(result.expiresIn).toBeUndefined();
   });
 
+  it("keeps expires_in: 0 as already-expired, not never-expiring", async () => {
+    installFetch(
+      () =>
+        new Response(
+          JSON.stringify({
+            access_token: "new",
+            token_type: "Bearer",
+            expires_in: 0,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+    );
+
+    const result = await refreshAccessToken(baseToken);
+
+    expect(result.success).toBe(true);
+    expect(result.expiresIn).toBe(0);
+  });
+
   it("ignores a negative expires_in", async () => {
     installFetch(
       () =>

--- a/apps/api/src/oauth/refresh-access-token.ts
+++ b/apps/api/src/oauth/refresh-access-token.ts
@@ -186,13 +186,13 @@ export async function refreshAccessToken(
       };
     }
 
-    // expires_in is untrusted server input — reject non-finite/non-positive values.
+    // expires_in is untrusted server input — reject non-finite/negative values; 0 is valid (already-expired).
     let expiresIn: number | undefined;
     if (data.expires_in !== undefined) {
       const parsed = Number(data.expires_in);
       if (
         Number.isFinite(parsed) &&
-        parsed > 0 &&
+        parsed >= 0 &&
         parsed <= MAX_EXPIRES_IN_SECONDS
       ) {
         expiresIn = parsed;

--- a/apps/api/src/oauth/token-refresh.ts
+++ b/apps/api/src/oauth/token-refresh.ts
@@ -108,9 +108,10 @@ async function refreshAndStoreOnce(
     accessToken: result.accessToken,
     refreshToken: result.refreshToken ?? token.refreshToken,
     scope: result.scope ?? token.scope,
-    expiresAt: result.expiresIn
-      ? new Date(Date.now() + result.expiresIn * 1000)
-      : null,
+    expiresAt:
+      result.expiresIn === undefined
+        ? null
+        : new Date(Date.now() + result.expiresIn * 1000),
     clientId: token.clientId,
     clientSecret: token.clientSecret,
     tokenEndpoint: token.tokenEndpoint,


### PR DESCRIPTION
Follows #6198, which fixed the exact same bug class one call site over — the initial-token route (`downstream-token.ts`) treating `expiresIn: 0` as no-expiry via a falsy check. This PR fixes the same class in the refresh path itself, two spots deep:

1. `refresh-access-token.ts` parsed the token endpoint's `expires_in` and rejected `0` as malformed (`parsed > 0`), even though RFC 6749 §5.1 allows `expires_in: 0` ("already expired") — it silently dropped to `expiresIn: undefined`.
2. `token-refresh.ts` then stored that (or a legitimate `0`) via `result.expiresIn ? new Date(...) : null` — a falsy ternary that turns a real `0` into `expiresAt: null`, which `DownstreamTokenStorage.isExpired()` reads as "never expires".

**Failure scenario:** a downstream OAuth server refreshes a token and returns `expires_in: 0` (some servers do this for single-use/already-consumed tokens). Studio stores `expiresAt: null` for the freshly-refreshed token, so `isExpired()` always returns `false` for it — Studio never proactively refreshes again and keeps handing out a token the upstream server already considers dead.

**Fix:** allow `expires_in: 0` through as `expiresIn: 0` (still rejecting negative/non-finite/absurdly-large values), and use an explicit `undefined` check instead of a falsy one when computing `expiresAt`.

**Regression test:** added `"keeps expires_in: 0 as already-expired, not never-expiring"` to `refresh-access-token.test.ts`, asserting `result.expiresIn` is `0` rather than `undefined`.

**To confirm:** `bun test apps/api/src/oauth/refresh-access-token.test.ts`

**Locally verified:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test file above, and `bunx oxlint` on the three touched files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treats refreshed tokens with expires_in: 0 as already expired instead of never expiring. Previously the refresh path dropped 0 to undefined and stored expiresAt: null, so isExpired() returned false and we kept handing out a dead token.

- Accepts expires_in: 0 in `refresh-access-token.ts` (rejects only negative, non-finite, or overly large values).
- Computes expiresAt using an explicit undefined check in `token-refresh.ts`; 0 now yields a timestamp at “now” instead of null.
- Adds a regression test ensuring expires_in: 0 is preserved as 0.

<sup>Written for commit 07c2c9e85ba67a64edffa4240f6f9d621848aa90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

