### PR TITLE
fix(native): don't treat a 429 refresh response as invalid_grant

### DIFF
--- a/apps/native/crates/upstream/src/refresh.rs
+++ b/apps/native/crates/upstream/src/refresh.rs
@@ -125,7 +125,9 @@ async fn refresh_access_token(
     let status = res.status();
     if !status.is_success() {
         let text = res.text().await.unwrap_or_default();
-        if status.is_client_error() {
+        // 429 is throttling, not a rejected token — never mark it
+        // invalid_grant. Byte-parity with `refresh-session.ts`.
+        if status.is_client_error() && status.as_u16() != 429 {
             return Err(RefreshError::invalid_grant(format!("HTTP {status} {text}")));
         }
         return Err(RefreshError::transient(format!("HTTP {status} {text}")));
@@ -489,6 +491,41 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(err.kind, RefreshErrorKind::InvalidGrant);
+    }
+
+    #[tokio::test]
+    async fn rate_limited_refresh_is_transient_not_invalid_grant() {
+        // A 429 means the token endpoint is throttling us, not that the
+        // refresh token itself was rejected — treating it as invalid_grant
+        // would hard-sign-out a user for asking too fast.
+        let app = Router::new().route(
+            "/api/auth/mcp/token",
+            post(|| async {
+                (
+                    axum::http::StatusCode::TOO_MANY_REQUESTS,
+                    Json(serde_json::json!({"error": "rate_limited"})),
+                )
+            }),
+        );
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+
+        let store = MemoryTokenStore::new();
+        store
+            .save("host", expired_session(&format!("http://{addr}"), "old"))
+            .await
+            .unwrap();
+
+        let coordinator = RefreshCoordinator::new();
+        let http = reqwest::Client::new();
+        let err = coordinator
+            .ensure_fresh(&http, &store, "host")
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind, RefreshErrorKind::Transient);
     }
 
     #[tokio::test]


### PR DESCRIPTION
The desktop app's Rust upstream-session refresh (`apps/native/crates/upstream/src/refresh.rs`) classifies a non-2xx token-endpoint response with `status.is_client_error()`, which is `true` for HTTP 429. `RefreshErrorKind::InvalidGrant` triggers `hard_sign_out(...)` in `session.rs`, so a rate-limited `/api/auth/mcp/token` response would wrongly sign the desktop user out, as if their refresh token itself had been rejected.

This module is a documented byte-parity port of `apps/api/src/cli/lib/refresh-session.ts`, which already special-cases this: `// 429 is throttling, not a rejected token — never mark it invalid_grant.` (`res.status >= 400 && res.status < 500 && res.status !== 429`). The Rust port had drifted from that source and lost the 429 carve-out.

Failure scenario: token endpoint returns 429 during a burst of concurrent requests (e.g. multiple sandboxes refreshing near-simultaneously) → `refresh_access_token` returns `InvalidGrant` → `session.rs`'s status/ensure-fresh paths call `hard_sign_out("refresh token was rejected...")` → user is logged out of the desktop app for no real auth reason.

Fix: exclude 429 from the client-error branch so it falls through to `Transient`, matching the TS source. Added `rate_limited_refresh_is_transient_not_invalid_grant`, mirroring the existing `rejected_refresh_token_is_invalid_grant` test but asserting `Transient` (not `InvalidGrant`) on a 429 response — this is the regression test; it fails against the old code (`is_client_error()` alone) and passes with the fix.

Reviewer check: `cd apps/native && cargo test -p upstream --lib refresh::`

Locally verified: `cargo test -p upstream --lib refresh::` (9/9 pass, including the new test) and `cargo fmt -p upstream -- --check` (clean). `cargo clippy` isn't installed in this sandbox toolchain; full CI runs it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat HTTP 429 from the token endpoint during session refresh as transient, not invalid_grant. Previously all 4xx were treated as invalid_grant, which hard-signed users out under rate limiting; this aligns the Rust port with the TS source and avoids unnecessary logouts.

**Review notes**
- Update in `apps/native/crates/upstream/src/refresh.rs`: exclude 429 from the client-error branch so it returns `RefreshError::Transient` instead of `RefreshError::InvalidGrant`.
- Add `rate_limited_refresh_is_transient_not_invalid_grant` test to prevent regressions.
- Validate with `cd apps/native && cargo test -p upstream --lib refresh::`; formatting check via `cargo fmt -p upstream -- --check`.

<sup>Written for commit 93d832a1657b3724b35207184fada960bc250993. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

