### PR TITLE
refactor(thread): dedupe the owned-virtual-mcp lookup in create/update

### DIFF
--- a/apps/api/src/tools/thread/create.ts
+++ b/apps/api/src/tools/thread/create.ts
@@ -28,7 +28,11 @@ import {
   requireAuth,
   requireOrganization,
 } from "../../core/studio-context";
-import { normalizeThreadForResponse, type GithubRepoMeta } from "./helpers";
+import {
+  normalizeThreadForResponse,
+  requireOwnedVirtualMcp,
+  type GithubRepoMeta,
+} from "./helpers";
 import {
   ThreadCreateDataSchema,
   ThreadEntitySchema,
@@ -111,17 +115,11 @@ export const COLLECTION_THREADS_CREATE = defineTool({
     const { data } = input;
     const taskId = data.id ?? generatePrefixedId("thrd");
 
-    const vmcp = await ctx.storage.virtualMcps.findById(
+    const vmcp = await requireOwnedVirtualMcp(
+      ctx.storage.virtualMcps,
       data.virtual_mcp_id,
       organization.id,
     );
-    // `findById`'s organizationId param only resolves well-known synthetic
-    // ids (decopilot, brand-context-setup) — for a normal row it does NOT
-    // filter by org, so existence alone doesn't prove the vMCP is ours. Must
-    // check explicitly, same as COLLECTION_VIRTUAL_MCP_UPDATE does.
-    if (!vmcp || vmcp.organization_id !== organization.id) {
-      throw new Error(`Virtual MCP not found: ${data.virtual_mcp_id}`);
-    }
 
     const metadata = vmcp.metadata as
       | (GithubRepoMeta & SandboxMapMeta)

--- a/apps/api/src/tools/thread/helpers.ts
+++ b/apps/api/src/tools/thread/helpers.ts
@@ -6,6 +6,8 @@
  */
 
 import type { Thread, ThreadStatus } from "../../storage/types";
+import type { VirtualMCPStoragePort } from "../../storage/ports";
+import type { VirtualMCPEntity } from "@decocms/shared/sdk/types/virtual-mcp";
 import type { ThreadEntity } from "@decocms/shared/thread/schema";
 
 /** Shape of the `githubRepo` field on a virtual MCP's `metadata` column. */
@@ -16,6 +18,26 @@ export type GithubRepoMeta = {
     connectionId?: string;
   } | null;
 };
+
+/**
+ * Look up a virtual MCP by id and confirm it belongs to `organizationId`.
+ * `findById`'s organizationId param only resolves well-known synthetic ids
+ * (decopilot, brand-context-setup) — for a normal row it does NOT filter by
+ * org, so existence alone doesn't prove the vMCP is ours. Throws (rather than
+ * returning null) so a thread create/update can't silently no-op against a
+ * missing vMCP.
+ */
+export async function requireOwnedVirtualMcp(
+  virtualMcps: VirtualMCPStoragePort,
+  virtualMcpId: string,
+  organizationId: string,
+): Promise<VirtualMCPEntity> {
+  const vmcp = await virtualMcps.findById(virtualMcpId, organizationId);
+  if (!vmcp || vmcp.organization_id !== organizationId) {
+    throw new Error(`Virtual MCP not found: ${virtualMcpId}`);
+  }
+  return vmcp;
+}
 
 /**
  * Threads stuck in "in_progress" longer than this are surfaced as "expired".

--- a/apps/api/src/tools/thread/update.ts
+++ b/apps/api/src/tools/thread/update.ts
@@ -12,7 +12,11 @@ import {
   requireAuth,
   requireOrganization,
 } from "../../core/studio-context";
-import { normalizeThreadForResponse, type GithubRepoMeta } from "./helpers";
+import {
+  normalizeThreadForResponse,
+  requireOwnedVirtualMcp,
+  type GithubRepoMeta,
+} from "./helpers";
 import {
   ThreadEntitySchema,
   ThreadUpdateDataSchema,
@@ -65,17 +69,12 @@ export const COLLECTION_THREADS_UPDATE = defineTool({
     }
 
     if (data.virtual_mcp_id !== undefined) {
-      const targetVmcp = await ctx.storage.virtualMcps.findById(
+      // Guards against re-pointing a thread at another org's agent.
+      await requireOwnedVirtualMcp(
+        ctx.storage.virtualMcps,
         data.virtual_mcp_id,
         organization.id,
       );
-      // `findById`'s organizationId param only resolves well-known synthetic
-      // ids — for a normal row it does NOT filter by org, so existence alone
-      // doesn't prove the vMCP is ours. Without this, re-pointing a thread
-      // (data.virtual_mcp_id) could target another organization's agent.
-      if (!targetVmcp || targetVmcp.organization_id !== organization.id) {
-        throw new Error(`Virtual MCP not found: ${data.virtual_mcp_id}`);
-      }
     }
 
     if (data.branch === null && existing.virtual_mcp_id) {


### PR DESCRIPTION
**Source:** C1 code reduction found while auditing `apps/api/src/tools/thread/**` (my W3 focus area). No linked issue.

**What:** `COLLECTION_THREADS_CREATE` and `COLLECTION_THREADS_UPDATE` each had their own copy of the same "look up a virtual MCP by id and confirm it belongs to the caller's org" block (findById + `organization_id !== organization.id` check + throw), each with its own multi-line comment explaining why the org param on `findById` alone isn't enough. Extracted the shared logic into `requireOwnedVirtualMcp()` in `thread/helpers.ts` and call it from both tools.

**Why a maintainer wants it:** one copy of this security-sensitive check means a future fix (e.g. a stricter lookup) only needs to change in one place instead of two call sites staying in sync by convention.

**Net line delta:** -18 / +22 in create.ts+update.ts, +22 in helpers.ts (the extracted helper + its doc comment) — net +4 lines total, but two duplicate un-DRY checks collapse to one canonical implementation.

**Behavior preserved:** `requireOwnedVirtualMcp` throws the exact same `Virtual MCP not found: <id>` error as before, on the exact same condition (`!vmcp || vmcp.organization_id !== organizationId`). I intentionally left `update.ts`'s second vMCP lookup (the `branch === null` / githubRepo check on `existing.virtual_mcp_id`) untouched — that one tolerates a missing vMCP (`vmcp?.metadata`) rather than throwing, so folding it into the throwing helper would have been a behavior change, not a pure dedup.

**Verify:** `cd apps/api && bunx tsc --noEmit` (clean) and `bun test apps/api/src/tools/thread/helpers.test.ts` (11 pass). `bunx oxlint` on the three touched files: 0 warnings/errors. Did not run the DB-backed `create.integration.test.ts`/`update.integration.test.ts` locally (needs embedded Postgres) — full CI covers those.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dedupes the virtual MCP ownership check in thread create/update into a shared helper to keep a single, consistent security check. Behavior is unchanged: attempts to use a missing or foreign vMCP still throw “Virtual MCP not found: <id>”.

- Introduces `requireOwnedVirtualMcp` in `thread/helpers.ts` and uses it in `COLLECTION_THREADS_CREATE` and `COLLECTION_THREADS_UPDATE`; it calls `findById` and explicitly verifies `organization_id`.
- Leaves `update.ts`’s second vMCP lookup (the tolerant `existing.virtual_mcp_id` path used with `branch === null`) untouched to avoid changing behavior.
- Rationale: `findById`’s org parameter only resolves synthetic IDs and does not filter normal rows, so explicit ownership validation remains necessary.

<sup>Written for commit 806afac833bdf45c9c671af48a74159d18e2ce10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

