### PR TITLE
fix(decofile): key merged blocks by single-decode, matching the deco runtime

### DIFF
--- a/apps/api/src/decofile/read-decofile.test.ts
+++ b/apps/api/src/decofile/read-decofile.test.ts
@@ -45,18 +45,24 @@ describe("blockEntriesInTree", () => {
 });
 
 describe("aliasPathsForKey", () => {
-  it("finds every encoding alias of a key, sorted", () => {
+  it("finds every spelling that single-decodes to the key, sorted", () => {
     const entries = [
+      // A single-decode: %2520 keeps its %20; %20 becomes a space — distinct keys.
       { stem: "Compre%2520Junto", path: ".deco/blocks/Compre%2520Junto.json" },
       { stem: "Compre%20Junto", path: ".deco/blocks/Compre%20Junto.json" },
-      { stem: "Other", path: ".deco/blocks/Other.json" },
+      // Case-varied hex both decode to "A/B" — genuine twins.
+      { stem: "A%2FB", path: ".deco/blocks/A%2FB.json" },
+      { stem: "A%2fB", path: ".deco/blocks/A%2fB.json" },
     ];
     expect(aliasPathsForKey(entries, "Compre Junto")).toEqual([
       ".deco/blocks/Compre%20Junto.json",
+    ]);
+    expect(aliasPathsForKey(entries, "Compre%20Junto")).toEqual([
       ".deco/blocks/Compre%2520Junto.json",
     ]);
-    expect(aliasPathsForKey(entries, "Other")).toEqual([
-      ".deco/blocks/Other.json",
+    expect(aliasPathsForKey(entries, "A/B")).toEqual([
+      ".deco/blocks/A%2FB.json",
+      ".deco/blocks/A%2fB.json",
     ]);
     expect(aliasPathsForKey(entries, "missing")).toEqual([]);
   });

--- a/apps/api/src/decofile/read-decofile.ts
+++ b/apps/api/src/decofile/read-decofile.ts
@@ -1,6 +1,9 @@
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
-import { decodeUntilStable, mergeBlocks } from "@decocms/shared/decofile";
+import {
+  decoBlockKeyFromFileStem,
+  mergeBlocks,
+} from "@decocms/shared/decofile";
 import type { Counter } from "@opentelemetry/api";
 import { meter } from "../observability";
 import {
@@ -156,17 +159,19 @@ export function blockEntriesInTree(
 }
 
 /**
- * All tree paths whose stem decodes (until stable) to `blockKey` — the alias
- * set. Real repos carry single- and double-encoded twins of the same key; a
- * write must land on the existing spelling (not create a sibling) and a
- * delete must remove every alias or the survivor keeps rendering.
+ * All tree paths whose stem single-decodes to `blockKey` — the alias set. A
+ * key maps to `blockKeyToFileStem(key)` on disk, but a repo can hold more than
+ * one spelling that decodes to the same key (e.g. differing `%2f`/`%2F` case);
+ * a write must land on the existing spelling (not create a sibling) and a
+ * delete must remove every alias or the survivor keeps rendering. Single-decode
+ * (not decode-until-stable) so it matches the key the merge and runtime use.
  */
 export function aliasPathsForKey(
   entries: Array<{ stem: string; path: string }>,
   blockKey: string,
 ): string[] {
   return entries
-    .filter((e) => decodeUntilStable(e.stem) === blockKey)
+    .filter((e) => decoBlockKeyFromFileStem(e.stem) === blockKey)
     .map((e) => e.path)
     .sort();
 }
@@ -193,7 +198,7 @@ export interface DecofileSnapshot {
 /** Bump when the merge output changes so entries written by an older
  * `mergeBlocks` miss instead of being served as-is — notably the pre-drop
  * splice that could cache an INVALID document under a still-current sha. */
-const MERGED_DOC_FORMAT = "2";
+const MERGED_DOC_FORMAT = "3";
 
 /**
  * Disk key for the merged document — a sha1 of (format, head sha, packagePath),

--- a/packages/e2e/tests/decofile-api.spec.ts
+++ b/packages/e2e/tests/decofile-api.spec.ts
@@ -345,7 +345,7 @@ test.describe("decofile API", () => {
               // Pretty-printed block: the merge splices raw contents, so the
               // merged document must still parse.
               ".deco/blocks/Hero.json": blockFileContent(heroBlock),
-              // Double-encoded stem: the key must decode until stable.
+              // Double-encoded stem: single-decode keeps its `%20` in the key.
               ".deco/blocks/Compre%2520Junto.json": JSON.stringify(compreBlock),
               // Non-block file: must not leak into the decofile.
               "README.md": "# hi\n",
@@ -366,9 +366,10 @@ test.describe("decofile API", () => {
       // build a draft pointer that works from the native app too.
       expect(body.apiHost).toMatch(/^[\w.-]+(:\d+)?$/);
       expect(body.decofile["Hero"]).toEqual(heroBlock);
-      expect(body.decofile["Compre Junto"]).toEqual(compreBlock);
+      // Double-encoded stem → single-decode key keeps the `%20` (the runtime's form).
+      expect(body.decofile["Compre%20Junto"]).toEqual(compreBlock);
       expect(Object.keys(body.decofile).sort()).toEqual([
-        "Compre Junto",
+        "Compre%20Junto",
         "Hero",
       ]);
       expect(res.headers()["etag"]).toBe(`"${body.version}"`);
@@ -465,6 +466,45 @@ test.describe("decofile API", () => {
       // The valid block survives; the corrupt one is dropped, not merged.
       expect(body.decofile["Hero"]).toEqual(heroBlock);
       expect(Object.keys(body.decofile)).toEqual(["Hero"]);
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
+  test("GET exposes a %20-bearing key under the form the runtime resolves", async ({
+    playwright,
+  }) => {
+    const ctx = await newApiContext(playwright);
+    try {
+      const user = await signUpViaApi(ctx);
+      const org = user.orgSlug;
+      const owner = uniqueOwner();
+      const repo = "site";
+
+      const homePage = { __resolveType: "website/pages/Page.tsx" };
+      await seedStubRepo(ctx, {
+        owner,
+        repo,
+        defaultBranch: "main",
+        branches: {
+          main: {
+            files: {
+              // Key `pages-Home%20Page-40404`, stored double-encoded on disk.
+              ".deco/blocks/pages-Home%2520Page-40404.json":
+                blockFileContent(homePage),
+            },
+          },
+        },
+      });
+
+      const project = await createFastPreviewProject(ctx, org, { owner, repo });
+      const res = await ctx.get(decofileUrl(project, "main"));
+
+      expect(res.status()).toBe(200);
+      const body = (await res.json()) as DecofileGetBody;
+      // Single-decode key = the runtime's form; not over-decoded to a space.
+      expect(Object.keys(body.decofile)).toEqual(["pages-Home%20Page-40404"]);
+      expect(body.decofile["pages-Home%20Page-40404"]).toEqual(homePage);
     } finally {
       await ctx.dispose();
     }
@@ -649,9 +689,9 @@ test.describe("decofile API", () => {
           draft: {
             files: {
               ".deco/blocks/Gone.json": '{"old":true}',
-              // Single- and double-encoded twins of the key "A B".
-              ".deco/blocks/A%20B.json": '{"variant":"single"}',
-              ".deco/blocks/A%2520B.json": '{"variant":"double"}',
+              // Case-varied hex twins that both single-decode to the key "A/B".
+              ".deco/blocks/A%2FB.json": '{"variant":"upper"}',
+              ".deco/blocks/A%2fB.json": '{"variant":"lower"}',
             },
           },
         },
@@ -686,15 +726,15 @@ test.describe("decofile API", () => {
       );
       expect(filesAfterBatch[".deco/blocks/Gone.json"]).toBeUndefined();
 
-      // Deleting "A B" must remove BOTH encoded spellings.
-      const deleteRes = await ctx.patch(url, { data: { delete: ["A B"] } });
+      // Deleting "A/B" must remove BOTH hex spellings that decode to it.
+      const deleteRes = await ctx.patch(url, { data: { delete: ["A/B"] } });
       expect(deleteRes.status()).toBe(200);
 
       inspected = await inspectStubRepo(ctx, owner, repo);
       expect(inspected.commits.length).toBe(commitsBefore + 2);
       const filesAfterDelete = inspected.branches["draft"]?.files ?? {};
-      expect(filesAfterDelete[".deco/blocks/A%20B.json"]).toBeUndefined();
-      expect(filesAfterDelete[".deco/blocks/A%2520B.json"]).toBeUndefined();
+      expect(filesAfterDelete[".deco/blocks/A%2FB.json"]).toBeUndefined();
+      expect(filesAfterDelete[".deco/blocks/A%2fB.json"]).toBeUndefined();
       // The unrelated blocks survive.
       expect(filesAfterDelete[".deco/blocks/Banner.json"]).toBe(
         blockFileContent(banner),

--- a/packages/sandbox/daemon-e2e/daemon.decofile.e2e.test.ts
+++ b/packages/sandbox/daemon-e2e/daemon.decofile.e2e.test.ts
@@ -71,17 +71,14 @@ describe("GET /_sandbox/decofile", () => {
     expect(body["pages-home"]).toEqual({ path: "/", sections: [] });
   });
 
-  test("decodes double-encoded filenames to the real block key", async () => {
-    // Real repos carry both encodings: `Compre%20Junto.json` (single) and
-    // `Compre%2520Junto.json` (double). Both must merge under "Compre Junto" —
-    // a single decode leaves the double-encoded one keyed "Compre%20Junto",
-    // which no `__resolveType` reference resolves.
+  test("single-decodes filenames to the runtime's block key", async () => {
+    // Double-encoded stem keeps its `%20`; single-encoded stem decodes to a space.
     await writeBlock(d!, "Compre%2520Junto", { curated: true });
     await writeBlock(d!, "Card%20config", { plain: true });
 
     const res = await fetch(url(d!, "/_sandbox/decofile"));
     const body = (await res.json()) as Record<string, unknown>;
-    expect(Object.keys(body).sort()).toEqual(["Card config", "Compre Junto"]);
+    expect(Object.keys(body).sort()).toEqual(["Card config", "Compre%20Junto"]);
   });
 
   test("is unauthenticated — the fetcher is a site, not the cluster", async () => {
@@ -293,12 +290,12 @@ describe("daemon e2e: decofile /read fallback", () => {
     });
   });
 
-  it("decodes percent-encoded block stems until stable", async () => {
+  it("single-decodes a double-encoded block stem to its %20 key", async () => {
     await writeBlock(d!, "Compre%2520Junto", { x: 1 });
     const res = await readFallback(d!, ".deco/blocks.gen.json");
     expect(res.status).toBe(200);
     const body = (await res.json()) as { content: string };
-    expect(JSON.parse(body.content)).toEqual({ "Compre Junto": { x: 1 } });
+    expect(JSON.parse(body.content)).toEqual({ "Compre%20Junto": { x: 1 } });
   });
 
   it("still 400s for a genuinely absent file with no blocks dir", async () => {

--- a/packages/sandbox/daemon-go/internal/decofile/merge.go
+++ b/packages/sandbox/daemon-go/internal/decofile/merge.go
@@ -22,30 +22,23 @@ const (
 	BlocksDirname = "blocks"
 )
 
-// decodeUntilStable repeatedly percent-decodes a filename stem until it stops
-// changing. Real repos carry both single- and double-encoded stems
-// (`Compre%20Junto.json`, `Compre%2520Junto.json`); a single decode leaves the
-// double-encoded one keyed `Compre%20Junto`, a key no `__resolveType`
-// reference resolves. Mirrors the frontend's documented decoBlockKeyFromFileStem
-// fallback: an invalid-encoding stem keeps its last successfully decoded form.
-// url.PathUnescape (not QueryUnescape) so a literal `+` in a block name is left
-// alone, matching JS decodeURIComponent. Terminates: PathUnescape only collapses
-// `%XX` triples, so each pass strictly shortens the string until stable or errs.
-func decodeUntilStable(stem string) string {
-	key := stem
-	for {
-		decoded, err := url.PathUnescape(key)
-		if err != nil || decoded == key {
-			return key
-		}
-		key = decoded
+// decodeOnce percent-decodes a stem exactly once — the true inverse of
+// blockKeyToFileStem's single encodeURIComponent (mirrors the frontend's
+// decoBlockKeyFromFileStem), and the form the deco runtime derives block keys
+// by. url.PathUnescape (not QueryUnescape) leaves a literal `+` alone, matching
+// JS decodeURIComponent. An invalid encoding keeps the raw stem.
+func decodeOnce(stem string) string {
+	decoded, err := url.PathUnescape(stem)
+	if err != nil {
+		return stem
 	}
+	return decoded
 }
 
 // generateFromBlocks rebuilds the merged decofile from the sibling
 // `.deco/blocks/*.json` files so the CMS is readable before the dev server is
-// up. Maps each file to `{ [decodeUntilStable(stem)]: <file contents> }`,
-// sorted by filename — byte-for-byte identical to the TS mergeBlocks
+// up. Maps each file to `{ [decodeOnce(stem)]: <file contents> }`, sorted by
+// filename — byte-for-byte identical to the TS mergeBlocks
 // (packages/shared/src/decofile/merge.ts) for well-formed input.
 //
 // Valid blocks are spliced in raw (no unmarshal/marshal round-trip — the
@@ -55,6 +48,11 @@ func decodeUntilStable(stem string) string {
 // Preview. The write/edit/publish handlers still reject invalid blocks up front
 // (see InvalidBlockJSON) — this is the last-resort net for a bad block that
 // arrived some other way (e.g. a direct push).
+//
+// The key is a SINGLE decode: a key that legitimately contains `%20` (a page
+// "Home Page" → `pages-Home%20Page-<id>`) is stored `…%2520….json`, and single-
+// decode gives back `%20` — the form the runtime uses. Decoding until stable
+// would over-decode to a space and the `%20` reference would dangle.
 //
 // Returns ok=false when there's no blocks dir (nothing to merge) so the caller
 // falls through to its normal "file not found" path.
@@ -94,7 +92,7 @@ func generateFromBlocks(blocksDir string) (string, bool) {
 		if !json.Valid(content) {
 			continue
 		}
-		keyJSON, err := json.Marshal(decodeUntilStable(stem))
+		keyJSON, err := json.Marshal(decodeOnce(stem))
 		if err != nil {
 			continue
 		}

--- a/packages/sandbox/daemon-go/internal/decofile/merge_test.go
+++ b/packages/sandbox/daemon-go/internal/decofile/merge_test.go
@@ -77,17 +77,40 @@ func TestGenerateFromBlocks(t *testing.T) {
 		}
 	})
 
-	t.Run("decodes percent-encoded stems until stable", func(t *testing.T) {
+	t.Run("single-decodes a single-encoded stem (space in the key)", func(t *testing.T) {
 		dir := t.TempDir()
-		// Double-encoded stem: a single decode would key it `Compre%20Junto`,
-		// which no __resolveType reference resolves.
-		writeBlock(t, dir, "Compre%2520Junto.json", `{"x":1}`)
+		writeBlock(t, dir, "Compre%20Junto.json", `{"x":1}`)
 		merged, ok := generateFromBlocks(dir)
 		if !ok {
 			t.Fatal("expected ok=true")
 		}
 		if merged != `{"Compre Junto":{"x":1}}` {
-			t.Fatalf("merged = %q, want key decoded to `Compre Junto`", merged)
+			t.Fatalf("merged = %q, want the space key", merged)
+		}
+	})
+
+	t.Run("single-decodes a double-encoded stem to its %20 key, not a space", func(t *testing.T) {
+		dir := t.TempDir()
+		writeBlock(t, dir, "Compre%2520Junto.json", `{"x":1}`)
+		merged, ok := generateFromBlocks(dir)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if merged != `{"Compre%20Junto":{"x":1}}` {
+			t.Fatalf("merged = %q, want the single-decoded %%20 key", merged)
+		}
+	})
+
+	t.Run("keys a %20-bearing page the way the runtime resolves it", func(t *testing.T) {
+		dir := t.TempDir()
+		// "Home Page" is keyed `pages-Home%20Page-<id>`, stored `…%2520….json`.
+		writeBlock(t, dir, "pages-Home%2520Page-40404.json", `{"t":1}`)
+		merged, ok := generateFromBlocks(dir)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if merged != `{"pages-Home%20Page-40404":{"t":1}}` {
+			t.Fatalf("merged = %q, want the runtime's %%20 key", merged)
 		}
 	})
 

--- a/packages/shared/src/decofile/block-key.test.ts
+++ b/packages/shared/src/decofile/block-key.test.ts
@@ -4,32 +4,7 @@ import {
   blockKeyToFileStem,
   decoBlockFilePath,
   decoBlockKeyFromFileStem,
-  decodeUntilStable,
 } from "./block-key";
-
-describe("decodeUntilStable", () => {
-  it("returns plain stems unchanged", () => {
-    expect(decodeUntilStable("Header")).toBe("Header");
-  });
-
-  it("decodes a single-encoded stem", () => {
-    expect(decodeUntilStable("Compre%20Junto")).toBe("Compre Junto");
-  });
-
-  it("decodes a double-encoded stem to the same key", () => {
-    expect(decodeUntilStable("Compre%2520Junto")).toBe("Compre Junto");
-  });
-
-  it("leaves a literal + alone (matches decodeURIComponent, not query decoding)", () => {
-    expect(decodeUntilStable("a+b")).toBe("a+b");
-  });
-
-  it("keeps the last valid form when decoding hits an invalid sequence", () => {
-    expect(decodeUntilStable("bad%zz")).toBe("bad%zz");
-    // %2525 -> %25 -> % ; a bare "%" fails the next decode and is kept.
-    expect(decodeUntilStable("%2525")).toBe("%");
-  });
-});
 
 describe("blockKeyToFileStem / decoBlockKeyFromFileStem", () => {
   it("round-trips keys with spaces and percent signs", () => {
@@ -41,6 +16,12 @@ describe("blockKeyToFileStem / decoBlockKeyFromFileStem", () => {
     ]) {
       expect(decoBlockKeyFromFileStem(blockKeyToFileStem(key))).toBe(key);
     }
+  });
+
+  it("single-decodes a double-encoded stem to its %20 key (not a space)", () => {
+    expect(decoBlockKeyFromFileStem("pages-Home%2520Page-123")).toBe(
+      "pages-Home%20Page-123",
+    );
   });
 
   it("escapes slashes so keys never create path segments", () => {

--- a/packages/shared/src/decofile/block-key.ts
+++ b/packages/shared/src/decofile/block-key.ts
@@ -45,29 +45,6 @@ export function assertSafeDecoBlockKey(blockKey: string): void {
   }
 }
 
-/**
- * Repeatedly percent-decode a filename stem until it stops changing. Real
- * repos carry both single- and double-encoded stems (`Compre%20Junto.json`,
- * `Compre%2520Junto.json`); a single decode leaves the double-encoded one
- * keyed `Compre%20Junto`, a key no `__resolveType` reference resolves. An
- * invalid-encoding stem keeps its last successfully decoded form. Terminates:
- * decoding only collapses `%XX` triples, so each pass strictly shortens the
- * string until stable or throws.
- */
-export function decodeUntilStable(stem: string): string {
-  let key = stem;
-  for (;;) {
-    let decoded: string;
-    try {
-      decoded = decodeURIComponent(key);
-    } catch {
-      return key;
-    }
-    if (decoded === key) return key;
-    key = decoded;
-  }
-}
-
 /** Block key from an on-disk `.deco/blocks/<stem>.json` filename stem. */
 export function decoBlockKeyFromFileStem(stem: string): string {
   try {

--- a/packages/shared/src/decofile/index.ts
+++ b/packages/shared/src/decofile/index.ts
@@ -3,7 +3,6 @@ export {
   blockKeyToFileStem,
   decoBlockFilePath,
   decoBlockKeyFromFileStem,
-  decodeUntilStable,
 } from "./block-key";
 export {
   BLOCK_PATH_RE,

--- a/packages/shared/src/decofile/merge.test.ts
+++ b/packages/shared/src/decofile/merge.test.ts
@@ -18,11 +18,28 @@ describe("mergeBlocks", () => {
     expect(JSON.parse(decofile)).toEqual({ a: { n: 1 } });
   });
 
-  it("decodes double-encoded stems to a single key", () => {
+  it("single-decodes a single-encoded stem (space in the key)", () => {
+    const { decofile } = mergeBlocks([
+      { stem: "Compre%20Junto", content: '{"v":"single"}' },
+    ]);
+    expect(decofile).toBe('{"Compre Junto":{"v":"single"}}');
+  });
+
+  it("single-decodes a double-encoded stem to its %20 key, not a space", () => {
+    // Decoding the key's own `%20` to a space would dangle the runtime reference.
     const { decofile } = mergeBlocks([
       { stem: "Compre%2520Junto", content: '{"v":"double"}' },
     ]);
-    expect(JSON.parse(decofile)).toEqual({ "Compre Junto": { v: "double" } });
+    expect(decofile).toBe('{"Compre%20Junto":{"v":"double"}}');
+  });
+
+  it("keys a %20-bearing page the way the deco runtime resolves it", () => {
+    // "Home Page" is keyed `pages-Home%20Page-<id>`, stored `…%2520….json`.
+    const page = { __resolveType: "website/pages/Page.tsx" };
+    const { decofile } = mergeBlocks([
+      { stem: "pages-Home%2520Page-40404", content: JSON.stringify(page) },
+    ]);
+    expect(JSON.parse(decofile)).toEqual({ "pages-Home%20Page-40404": page });
   });
 
   it("skips empty and whitespace-only files", () => {

--- a/packages/shared/src/decofile/merge.ts
+++ b/packages/shared/src/decofile/merge.ts
@@ -1,4 +1,4 @@
-import { decodeUntilStable } from "./block-key";
+import { decoBlockKeyFromFileStem } from "./block-key";
 
 /**
  * On-disk name of the merged decofile artifact and its sibling source
@@ -42,10 +42,17 @@ export interface MergeResult {
 }
 
 /**
- * Merge block files into `{ [decodeUntilStable(stem)]: <raw contents> }`, sorted
- * by filename — byte-for-byte identical to the Go daemon's merge for valid input.
- * A block that is not valid JSON is dropped (reported in `skipped`) instead of
- * spliced raw, which would make the whole document unparseable.
+ * Merge block files into `{ [decoBlockKeyFromFileStem(stem)]: <raw contents> }`,
+ * sorted by filename — byte-for-byte identical to the Go daemon's merge for valid
+ * input. A block that is not valid JSON is dropped (reported in `skipped`) instead
+ * of spliced raw, which would make the whole document unparseable.
+ *
+ * The key is a SINGLE `decodeURIComponent` — the exact inverse of
+ * `blockKeyToFileStem`'s single `encodeURIComponent`, and the form the deco
+ * runtime derives block keys by. A key that legitimately contains `%20` (a page
+ * "Home Page" → `pages-Home%20Page-<id>`) is stored `…%2520….json`; single-decode
+ * gives back `%20`, matching the runtime, whereas decoding until stable would
+ * over-decode to a literal space and the runtime's `%20` reference would dangle.
  */
 export function mergeBlocks(files: BlockFile[]): MergeResult {
   // Sort by full filename (stem + ".json"), matching the Go daemon; computed once per file, not per comparison.
@@ -65,7 +72,7 @@ export function mergeBlocks(files: BlockFile[]): MergeResult {
       JSON.parse(content);
     } catch (err) {
       skipped.push({
-        key: decodeUntilStable(file.stem),
+        key: decoBlockKeyFromFileStem(file.stem),
         stem: file.stem,
         error: err instanceof Error ? err.message : String(err),
       });
@@ -73,7 +80,7 @@ export function mergeBlocks(files: BlockFile[]): MergeResult {
     }
     if (!first) out += ",";
     first = false;
-    out += `${JSON.stringify(decodeUntilStable(file.stem))}:${content}`;
+    out += `${JSON.stringify(decoBlockKeyFromFileStem(file.stem))}:${content}`;
   }
   return { decofile: `${out}}`, skipped };
 }


### PR DESCRIPTION
## Problem

A deco storefront (als-storefront) Fast Preview draft rendered a 500 / **"Dangling reference of: pages-Home%20Page-22921"**, though the decofile was intact and the page block existed.

Root cause — the merge used the **wrong inverse** for the filename↔key mapping:

- `blockKeyToFileStem` encodes a key with a **single** `encodeURIComponent`, so the one true inverse is a **single** `decodeURIComponent` (`decoBlockKeyFromFileStem`) — which is also how the **deco runtime** derives block keys from filenames.
- The merge instead used `decodeUntilStable` (decode-until-stable), which **over-decodes** any key that legitimately contains `%20`. A page "Home Page" is keyed `pages-Home%20Page-<id>`, stored `pages-Home%2520Page-<id>.json`; the merge produced `pages-Home Page-<id>` (a literal space), so the runtime's `pages-Home%20Page-<id>` reference dangled.

## Why `decodeUntilStable` was wrong (verified on real stores)

Checked **als-storefront** and **farmrio** (both store page files double-encoded):
- Named blocks (pages, curated sections) are resolved by the runtime's **filename-derived, single-decode** key — **zero** `__resolveType` values reference an encoded/spaced key in either repo. So `decodeUntilStable`'s stated justification ("a key no `__resolveType` reference resolves") does not hold in real data.
- `decodeUntilStable` only diverges from single-decode on **double-encoded** files — which it silently broke. Single-decode matches the runtime for **both** single- and double-encoded files (identical to the old output for single-encoded, correct for double-encoded).

## Fix

Key the merge by `decoBlockKeyFromFileStem` (single decode) in both `mergeBlocks` and the Go daemon's `generateFromBlocks`, and switch write/delete grouping (`aliasPathsForKey`) to the same single-decode. Consequences:

- **One key per file** → no phantom duplicate page/section listings in the CMS.
- **Distinct encodings stay distinct** → the `decodeUntilStable` twin-collapse (duplicate key → `JSON.parse` last-wins → silent data loss) is gone.
- The key **matches the runtime**, so `%20`-bearing pages resolve — fixing als-storefront and every site with a space-named page (farmrio's 684 double-encoded pages were latently broken too).
- `decodeUntilStable` is now unused and **removed** (TS + Go).
- **Bumped `MERGED_DOC_FORMAT`** so warm-cached shas re-merge under the new key (otherwise the fix no-ops on a persistent cache).

Supersedes the earlier additive-alias approach on this branch — review (5 critics) showed the alias duplicated keys into the CMS on the common space-in-name case; single-decode is the correct one-key model.

## Testing

- `merge.test.ts` / `merge_test.go`: double-encoded stem → single `%20` key (not a space); single-encoded unchanged; `pages-Home%2520Page-…` round-trip.
- `block-key.test.ts`: removed `decodeUntilStable` tests; `decoBlockKeyFromFileStem` single-decode asserted.
- `read-decofile.test.ts`: `aliasPathsForKey` now groups by single-decode (case-varied `%2F`/`%2f` twins).
- `daemon.decofile.e2e.test.ts` + `decofile-api.spec.ts`: black-box + wire assertions updated to the single-decode key; delete-by-key twin test reframed.
- Full daemon suite **221 pass**; `tsc` clean (shared/api/e2e); `go vet` clean; `bun run lint` 0 errors; `knip` clean (decodeUntilStable removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)