### PR TITLE
test: smoke-check the per-PR preview pipeline

### DIFF
--- a/deploy/preview/README.md
+++ b/deploy/preview/README.md
@@ -10,6 +10,8 @@ designer, a PM, another engineer — click a link instead of cloning the monorep
 
 ## Using one
 
+<!-- smoke: first end-to-end validation of the preview pipeline. -->
+
 1. Add the `preview` label to your PR.
 2. Wait ~8–10 minutes for the image build, then ~1–2 more for the first sync
    (which creates and migrates the database). The bot comment updates itself.


### PR DESCRIPTION
First end-to-end run of per-PR preview environments, landed earlier today in #6125 and decocms/deco-apps-cd#244.

**Do not merge.** The only change is a comment in `deploy/preview/README.md`; this PR exists to exercise the pipeline and will be closed once verified.

## What this is checking

| Stage | Expected |
|---|---|
| `preview-build.yaml` | two images tagged `pr-<n>-<7 of head sha>`, sticky comment with the URL |
| ApplicationSet generator | picks the PR up within ~60s of the label |
| Sync waves | ExternalSecret (-30) → Postgres + MinIO (-20) → migrate Job (-10) → app (0) |
| Pods | six, all on the `studio-preview` spot node pool |
| Storage | `DATABASE_URL` and `S3_ENDPOINT` pointing at the in-namespace Postgres and MinIO |
| Routing | HTTPRoute attaches, `attachedRoutes` on the shared Gateway goes 0 → 1 |
| Teardown | closing this PR removes the namespace, and the database and bucket with it |

## Known gaps at this point

Nothing gates the preview URL yet — no oauth2-proxy or `AuthorizationPolicy`, and the record is DNS-only, so Cloudflare is not in front either. Fine for a short-lived smoke test that gets closed; not fine for sharing the link around.

Hosted agent sandboxes, Google sign-in, billing, monitoring and outbound email are all out of scope for a preview by design — see `deploy/preview/README.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Smoke-tests the per-PR preview pipeline with a no-op comment in `deploy/preview/README.md` and rebuilds preview images as multi-arch; amd64-only images previously failed when pods rescheduled onto ARM (Graviton) nodes. Do not merge; close after verification.

- Builds two multi-arch images tagged `pr-<n>-<7-of-head-sha>` and posts a sticky preview URL comment.
- ApplicationSet picks the labeled PR within ~60s; sync order: ExternalSecret → Postgres/MinIO → migrate Job → app.
- Runs six pods on the `studio-preview` spot pool; `DATABASE_URL` and `S3_ENDPOINT` point to in-namespace Postgres/MinIO.
- HTTPRoute attaches to the shared Gateway; closing the PR deletes the namespace, database, and bucket.

**Caveats**
- No auth on the preview URL; DNS-only routing (no Cloudflare).
- Hosted sandboxes, Google sign-in, billing, monitoring, and outbound email are out of scope.

<sup>Written for commit 0f763b7bd430e1a1d51fb57b9605c58c50be4397. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

