### PR TITLE
fix(home): don't surface a foreign org's agent from default_home_agents.ids

### DIFF
--- a/apps/api/src/api/routes/home-next-actions.integration.test.ts
+++ b/apps/api/src/api/routes/home-next-actions.integration.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import type { StudioContext } from "../../core/studio-context";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+  seedCommonTestPgFixtures,
+} from "../../database/test-db-pg";
+import type { StudioDatabase } from "../../database";
+import { VirtualMCPStorage } from "../../storage/virtual";
+import { OrganizationSettingsStorage } from "../../storage/organization-settings";
+import { defaultHomeAgentNextActions } from "./home-next-actions";
+
+describe("defaultHomeAgentNextActions — cross-org id", () => {
+  let database: StudioDatabase;
+  let ctx: StudioContext;
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    await seedCommonTestPgFixtures(database);
+
+    const now = new Date().toISOString();
+    await database.db
+      .insertInto("connections")
+      .values({
+        id: "conn_foreign_agent",
+        organization_id: "org_123",
+        created_by: "user_123",
+        updated_by: null,
+        title: "Org 123's Agent",
+        description: null,
+        icon: null,
+        app_name: null,
+        app_id: null,
+        slug: null,
+        connection_type: "VIRTUAL",
+        connection_url: "virtual://conn_foreign_agent",
+        connection_token: null,
+        connection_headers: null,
+        oauth_config: null,
+        configuration_state: null,
+        configuration_scopes: null,
+        metadata: null,
+        bindings: null,
+        status: "active",
+        pinned: false,
+        created_at: now,
+        updated_at: now,
+      })
+      .execute();
+
+    const settings = new OrganizationSettingsStorage(database.db);
+    // Stands in for a stale/foreign id in org_1's own settings row.
+    await settings.upsert("org_1", {
+      default_home_agents: { ids: ["conn_foreign_agent"] },
+    });
+
+    ctx = {
+      storage: {
+        virtualMcps: new VirtualMCPStorage(database.db),
+        organizationSettings: settings,
+      },
+    } as unknown as StudioContext;
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  it("does not surface an agent id owned by a different org", async () => {
+    const result = await defaultHomeAgentNextActions("org_1", ctx, new Set());
+    expect(result.prompts).toEqual([]);
+    expect(result.tiles).toEqual([]);
+  });
+});

--- a/apps/api/src/api/routes/home-next-actions.ts
+++ b/apps/api/src/api/routes/home-next-actions.ts
@@ -88,7 +88,7 @@ function indexPromptsByName() {
  * no prompts (or an unreachable gateway) still get one fallback card so every
  * configured default home agent shows up on the home row.
  */
-async function defaultHomeAgentNextActions(
+export async function defaultHomeAgentNextActions(
   orgId: string,
   ctx: StudioContext,
   skipAgentIds: Set<string>,
@@ -101,7 +101,10 @@ async function defaultHomeAgentNextActions(
     uniqueIds.map(
       async (id): Promise<{ prompts: PromptEntry[]; tiles: TileEntry[] }> => {
         const virtualMcp = await ctx.storage.virtualMcps.findById(id);
-        if (!virtualMcp) return { prompts: [], tiles: [] };
+        // findById has no org filter — a foreign id must not leak that org's agent.
+        if (!virtualMcp || virtualMcp.organization_id !== orgId) {
+          return { prompts: [], tiles: [] };
+        }
 
         const tiles: TileEntry[] = getHomeTiles(virtualMcp.metadata?.ui)
           .filter((t) => t?.resourceUri && t.connectionId)


### PR DESCRIPTION
A bug found while hardening-following-up on #6201 (which fixed the same 'findById has no org filter' class on the thread virtual-mcp lookup).

`ORGANIZATION_SETTINGS_UPDATE` accepts `default_home_agents.ids` (an array of virtual-MCP ids) with no check that each id belongs to the caller's own org. `GET /api/:org/home-next-actions` then reads each id via `ctx.storage.virtualMcps.findById(id)` with no org param — for a real (non-synthetic) row `findById` does not filter by org at all — and only checked `!virtualMcp`, not ownership. A stale or mistakenly-entered foreign id in that settings array would leak another org's agent title, icon, description, live prompts (via an MCP `listPrompts()` call to that agent's gateway), and tile `connectionId`/`resourceUri` onto the caller org's home page.

Fix: after `findById`, also check `virtualMcp.organization_id !== orgId` and skip the agent — matching the ownership-check pattern every other `virtualMcps.findById` call site in the codebase already applies (e.g. `sandbox/helpers.ts`, `virtual/get.ts`, `decofile.ts`).

Failure scenario: org A's settings row ends up with a virtual-MCP id belonging to org B (e.g. copy-pasted, or a leftover from an org that previously owned that id) in `default_home_agents.ids`. Before the fix, org A's home page would render org B's agent's name/icon/prompts. After the fix, that id is silently skipped, same as any other not-found id.

Regression test: `apps/api/src/api/routes/home-next-actions.integration.test.ts` seeds a virtual MCP owned by `org_123`, points `org_1`'s `default_home_agents.ids` at it, and asserts `defaultHomeAgentNextActions("org_1", ...)` returns no prompts/tiles for it. This needs the real-Postgres `storage-integration` CI job (no Docker available locally to run it here).

To confirm: `cd apps/api && bunx tsc --noEmit` (passes), `bunx oxlint apps/api/src/api/routes/home-next-actions.ts apps/api/src/api/routes/home-next-actions.integration.test.ts` (0 warnings/errors), `bun run fmt`. Full CI (including the new integration test) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents cross‑org agent leakage on Home by validating ownership of `default_home_agents.ids`. Previously, `GET /api/:org/home-next-actions` read ids via `virtualMcps.findById` without org scoping and surfaced foreign agents; now we skip ids not owned by the requesting org.

- Adds an ownership check (`virtualMcp.organization_id === orgId`) in `defaultHomeAgentNextActions`; exports the function for testing.
- Adds a Postgres-backed integration test that ensures foreign ids yield no prompts or tiles.
- No API changes. Orgs with stale foreign ids will stop seeing those agents on Home.

<sup>Written for commit 09639ec1485f609cc2442c4da7fbd4868ca37684. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

