### PR TITLE
fix(preview): the config ConfigMap is created after the Job that mounts it

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -251,6 +251,46 @@ jobs:
           print("every preview pod is pinned to the preview node pool")
           POOL
 
+          # Ordering between waves is not enough: a resource also has to come
+          # AFTER everything it consumes. The migrate Job takes both the
+          # ConfigMap and the Secret via envFrom, and the ConfigMap had no wave
+          # at all — so it landed at 0, after the Job at -10, and the Job sat in
+          # CreateContainerConfigError while the whole sync stalled waiting on
+          # the hook. Nothing on the object said anything was wrong, and
+          # `helm template` cannot see it because it never sequences.
+          python3 - <<'DEPS'
+          import sys, yaml
+          waves, needs = {}, []
+          for d in yaml.safe_load_all(open("/tmp/preview.yaml")):
+              if not d:
+                  continue
+              kind, name = d["kind"], d["metadata"]["name"]
+              w = int((d["metadata"].get("annotations") or {})
+                      .get("argocd.argoproj.io/sync-wave", 0))
+              waves[name] = w
+              if kind not in ("Job", "Deployment", "StatefulSet"):
+                  continue
+              spec = d["spec"]["template"]["spec"]
+              for c in (spec.get("initContainers") or []) + spec["containers"]:
+                  for ref in (c.get("envFrom") or []):
+                      for key in ("configMapRef", "secretRef"):
+                          if key in ref:
+                              needs.append((kind, name, w, ref[key]["name"]))
+          bad = []
+          for kind, name, w, dep in needs:
+              # Only things this chart renders; anything else is pre-existing.
+              if dep not in waves:
+                  continue
+              if waves[dep] > w:
+                  bad.append(f"{kind}/{name} (wave {w}) consumes {dep} (wave {waves[dep]})")
+          if bad:
+              print("::error::a resource is sequenced before something it mounts: "
+                    + "; ".join(bad))
+              sys.exit(1)
+          print(f"every envFrom source is created no later than its consumer "
+                f"({len(needs)} references checked)")
+          DEPS
+
           # Every studio container (api-0, api-1, worker) must skip migrations:
           # the PreSync Job is the single writer. Three, not two.
           # `|| true` — grep exits 1 on zero matches, which under `set -e` would

--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,6 +2,13 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
+# 0.14.1: the preview ConfigMap had no sync-wave, so it landed at 0 — after the
+# migrate Job at -10 that consumes it via envFrom. The Job sat in
+# CreateContainerConfigError and the sync stalled on the hook with nothing on
+# any object reporting a problem. Found on the first real preview; `helm
+# template` cannot see it, so helm-test now asserts that every envFrom source
+# is created no later than what mounts it.
+#
 # 0.14.0: per-PR preview releases (preview.enabled, default false). Adds an
 # HTTPRoute, an ephemeral in-namespace Postgres and a single PreSync migration
 # Job — the database lives and dies with the namespace, so there is no shared
@@ -19,7 +26,7 @@ type: application
 # when disabled, so existing releases are unaffected.
 # 0.12.4: chart-managed API/worker dispatch roles now use
 # STUDIO_DISPATCH_ROLE; legacy overrides are rejected.
-version: 0.14.0
+version: 0.14.1
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/templates/configmap.yaml
+++ b/deploy/helm/studio/templates/configmap.yaml
@@ -4,6 +4,15 @@ metadata:
   name: {{ include "chart-deco-studio.fullname" . }}-config
   labels:
     {{- include "chart-deco-studio.labels" . | nindent 4 }}
+  {{- if .Values.preview.enabled }}
+  annotations:
+    # Same wave as the ExternalSecret, and for the same reason: the migrate Job
+    # (-10) and the app Deployments (0) both take this via envFrom, and a
+    # missing configMapRef leaves the container in CreateContainerConfigError —
+    # which stalls the whole sync on the hook, with no error on the object
+    # itself. Only a real sync surfaces this; `helm template` cannot.
+    argocd.argoproj.io/sync-wave: "-30"
+  {{- end }}
 data:
   {{- toYaml .Values.configMap.meshConfig | nindent 2 }}
   {{- $autoNatsUrl := "" }}

--- a/deploy/helm/studio/templates/secret.yaml
+++ b/deploy/helm/studio/templates/secret.yaml
@@ -5,6 +5,15 @@ metadata:
   name: {{ include "chart-deco-studio.fullname" . }}-secrets
   labels:
     {{- include "chart-deco-studio.labels" . | nindent 4 }}
+  {{- if .Values.preview.enabled }}
+  annotations:
+    # Same wave as the ExternalSecret, and for the same reason: the migrate Job
+    # (-10) and the app Deployments (0) both take this via envFrom, and a
+    # missing configMapRef leaves the container in CreateContainerConfigError —
+    # which stalls the whole sync on the hook, with no error on the object
+    # itself. Only a real sync surfaces this; `helm template` cannot.
+    argocd.argoproj.io/sync-wave: "-30"
+  {{- end }}
 type: Opaque
 stringData:
   BETTER_AUTH_SECRET: {{ .Values.secret.BETTER_AUTH_SECRET | quote }}


### PR DESCRIPTION
Found on the first real preview, [#6205](https://github.com/decocms/studio/pull/6205). The environment never came up.

## What happens

The migrate Job takes **both** the ConfigMap and the Secret via `envFrom`. The `ExternalSecret` sits at wave `-30` for exactly that reason, and its own comment says so — *"ahead of everything that mounts it: the migrate Job (-10) and the app Deployments (0) both consume this Secret via envFrom"*. The ConfigMap in the same `envFrom` had no wave at all, so it landed at the default `0`.

| resource | wave |
|---|---|
| ExternalSecret | -30 |
| Postgres, MinIO | -20 |
| migrate Job | **-10** |
| `-config` ConfigMap | **0** ← after the Job that mounts it |

The Job is scheduled, the kubelet cannot resolve `configMapRef`, and the pod parks in `CreateContainerConfigError`. Because the Job is a sync hook, the entire Application stalls on it:

```
sync=OutOfSync health=Missing
phase=Running message=waiting for completion of hook batch/Job/studio-pr-6205-preview-migrate

Error: configmap "studio-pr-6205-config" not found
```

Nothing on any object reports a fault. Postgres and MinIO come up fine and stay `Running`, so the namespace looks half-healthy indefinitely.

## Why no test caught it

`helm template` renders; it never sequences. Every existing assertion checks what the manifests *say* — that waves are ordered `postgres < migrate < app`, that the six `S3_*` keys are present, that pods carry the node-pool selector. None of them could observe that a consumer is scheduled before something it mounts, because that only exists at sync time.

So this adds the assertion that generalises it: walk every Job, Deployment and StatefulSet, resolve each `envFrom` source rendered by this chart, and fail when the source has a **higher** wave than its consumer. Verified against the pre-fix chart — it flags exactly the offending pair:

```
::error::a resource is sequenced before something it mounts:
  Job/studio-pr-42-preview-migrate (wave -10) consumes studio-pr-42-config (wave 0)
```

and passes on the fixed one, checking 8 references.

## Also

The chart-managed `Secret` (rendered when `externalSecret.enabled=false`) had the same gap, so non-ESO installs would hit this too. Fixed alongside.

## Verification

- `helm template` of the default render against `main`: **0 lines of difference**. The wave annotation is gated on `preview.enabled`.
- `helm lint` clean.
- The new assertion fails on the old chart and passes on the new one.

Chart `0.14.0` → `0.14.1`.

## Rollout

Merging publishes `0.14.1`. The previews chart in `decocms/deco-apps-cd` pins `studioChart.version`, so that pin needs bumping before any preview picks the fix up — [#6205](https://github.com/decocms/studio/pull/6205) is stalled until then.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents preview syncs from stalling by sequencing the config ConfigMap (and chart-managed Secret) before the migrate Job. Previously, the Job ran at wave -10 while the ConfigMap defaulted to 0, so pods hit CreateContainerConfigError; now both resources get wave -30 when `preview.enabled`, ensuring they exist before the Job (-10) and app Deployments (0). Adds a CI check that fails if any workload is sequenced before an `envFrom` source.

- Chart v0.14.1; the wave annotation is gated on `preview.enabled`, so the default render is unchanged. Required action: bump `studioChart.version` in `decocms/deco-apps-cd` to `0.14.1` for previews to pick up the fix.

<sup>Written for commit adfc1ac79130ecb3771eb028d39c56fbb69b4127. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

