### PR TITLE
fix(mcp): repair invalid tool-call arguments instead of only hinting

### DIFF
--- a/apps/api/src/mcp-clients/lazy-client.test.ts
+++ b/apps/api/src/mcp-clients/lazy-client.test.ts
@@ -269,3 +269,107 @@ describe("lazy-client with circuit breaker", () => {
     expect(clientFromConnectionMock).toHaveBeenCalledTimes(1);
   });
 });
+
+/**
+ * The MCP SDK's server returns an argument-validation failure as an
+ * `isError: true` result, not a thrown JSON-RPC error, so the proxy's repair
+ * has to read the result. Exercised against a real `McpServer` for that reason.
+ */
+describe("lazy-client argument repair", () => {
+  const toolsCache = {
+    get: async (_type: string, _connectionId: string) => [
+      {
+        name: "edit",
+        inputSchema: {
+          type: "object",
+          required: ["patch", "save"],
+          properties: { patch: { type: "object" }, save: { type: "boolean" } },
+        },
+      },
+    ],
+    set: async () => {},
+    invalidate: async () => {},
+    teardown: () => {},
+  };
+
+  async function createEditClient(): Promise<Client> {
+    const server = new McpServer({ name: "test-downstream", version: "1.0.0" });
+    server.tool(
+      "edit",
+      { patch: z.object({ sections: z.array(z.number()) }), save: z.boolean() },
+      async ({ patch, save }) => ({
+        content: [
+          { type: "text", text: `saved=${save} n=${patch.sections.length}` },
+        ],
+      }),
+    );
+    const { client: clientTransport, server: serverTransport } =
+      createBridgeTransportPair();
+    await server.connect(serverTransport);
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    await client.connect(clientTransport);
+    return client;
+  }
+
+  beforeEach(() => {
+    resetAll();
+    clientFromConnectionMock.mockReset();
+  });
+
+  it("re-types JSON-string arguments and retries", async () => {
+    clientFromConnectionMock.mockResolvedValue(await createEditClient());
+
+    const lazy = createLazyClient(fakeConnection, fakeCtx, false, toolsCache);
+    const result = (await lazy.callTool({
+      name: "edit",
+      arguments: { patch: '{"sections":[1,2]}', save: "true" },
+    })) as { isError?: boolean; content: Array<{ text: string }> };
+
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]!.text).toBe("saved=true n=2");
+  });
+
+  it("appends a hint when the arguments cannot be repaired", async () => {
+    clientFromConnectionMock.mockResolvedValue(await createEditClient());
+
+    const lazy = createLazyClient(fakeConnection, fakeCtx, false, toolsCache);
+    const result = (await lazy.callTool({
+      name: "edit",
+      arguments: { patch: "not json", save: "true" },
+    })) as { isError?: boolean; content: Array<{ text: string }> };
+
+    expect(result.isError).toBe(true);
+    // The upstream text is kept; the correction names the one argument that
+    // could not be repaired (`save: "true"` was, and the retry still failed).
+    expect(result.content[0]!.text).toContain("Input validation error");
+    expect(result.content[0]!.text).toContain(
+      'Invalid arguments for "edit". Required: patch (object), save (boolean).',
+    );
+    expect(result.content[0]!.text).toContain(
+      "Wrong type: patch (expected object, got string)",
+    );
+  });
+
+  it("leaves an ordinary tool error untouched", async () => {
+    const server = new McpServer({ name: "test-downstream", version: "1.0.0" });
+    server.tool("edit", { save: z.boolean() }, async () => ({
+      content: [{ type: "text", text: "post not found" }],
+      isError: true,
+    }));
+    const { client: clientTransport, server: serverTransport } =
+      createBridgeTransportPair();
+    await server.connect(serverTransport);
+    const client = new Client({ name: "test-client", version: "1.0.0" });
+    await client.connect(clientTransport);
+    clientFromConnectionMock.mockResolvedValue(client);
+
+    const lazy = createLazyClient(fakeConnection, fakeCtx, false, toolsCache);
+    const result = (await lazy.callTool({
+      name: "edit",
+      arguments: { save: true },
+    })) as { isError?: boolean; content: Array<{ text: string }> };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0]!.text).toBe("post not found");
+  });
+});

--- a/apps/api/src/mcp-clients/lazy-client.ts
+++ b/apps/api/src/mcp-clients/lazy-client.ts
@@ -37,7 +37,14 @@ import {
   REVALIDATE_MIN_INTERVAL_MS,
 } from "./mcp-list-cache";
 import { getMcpReadCache, type ReadCacheScope } from "./mcp-read-cache";
-import { enrichInvalidParams, type ToolInputSchema } from "./validation-hint";
+import {
+  appendHintToResult,
+  buildValidationHint,
+  coerceArgsToSchema,
+  enrichInvalidParams,
+  invalidParamsResultText,
+  type ToolInputSchema,
+} from "./validation-hint";
 
 /**
  * A read-only tool is eligible for result caching. We trust the upstream's
@@ -292,36 +299,68 @@ export function createLazyClient(
     return real.callTool(params, resultSchema, options);
   };
 
-  // On a -32602 (InvalidParams) rejection, append a schema-derived correction
-  // so the agent can fix its arguments instead of retrying the same bad shape.
-  // Only the error path pays the cached tool-list lookup.
+  // An upstream rejection for -32602 (InvalidParams) happens while validating
+  // the arguments, before the tool runs, so it is safe to repair and retry:
+  // re-type what the model plainly got wrong and call again, and if it still
+  // fails, append a schema-derived correction. Both the thrown and the
+  // `isError`-result shapes are handled — see validation-hint.ts. Only the
+  // rejection path pays the cached tool-list lookup.
   placeholder.callTool = async (params, resultSchema, options) => {
+    const rawName = (params as { name?: unknown })?.name;
+    const toolName = typeof rawName === "string" ? rawName : null;
+    const args = (params as { arguments?: Record<string, unknown> })?.arguments;
+
+    const inputSchema = async (): Promise<ToolInputSchema | undefined> => {
+      const tools = await cache!.get("tools", connection.id).catch(() => null);
+      return tools?.find(
+        (t): t is { name: string; inputSchema?: ToolInputSchema } =>
+          typeof t === "object" &&
+          t !== null &&
+          (t as { name?: unknown }).name === toolName,
+      )?.inputSchema;
+    };
+
+    const retryCoerced = async (schema: ToolInputSchema | undefined) => {
+      const coerced = coerceArgsToSchema(schema, args);
+      if (!coerced) return null;
+      return await callToolInner(
+        { ...params, arguments: coerced },
+        resultSchema,
+        options,
+      ).catch(() => null);
+    };
+
+    let result: Awaited<ReturnType<Client["callTool"]>>;
     try {
-      return await callToolInner(params, resultSchema, options);
+      result = await callToolInner(params, resultSchema, options);
     } catch (err) {
-      const toolName = (params as { name?: unknown })?.name;
       if (
-        err instanceof McpError &&
-        err.code === ErrorCode.InvalidParams &&
-        typeof toolName === "string" &&
-        cache
+        !toolName ||
+        !cache ||
+        !(err instanceof McpError) ||
+        err.code !== ErrorCode.InvalidParams
       ) {
-        const tools = await cache.get("tools", connection.id).catch(() => null);
-        const tool = tools?.find(
-          (t): t is { name: string; inputSchema?: ToolInputSchema } =>
-            typeof t === "object" &&
-            t !== null &&
-            (t as { name?: unknown }).name === toolName,
-        );
-        throw enrichInvalidParams(
-          err,
-          toolName,
-          tool?.inputSchema,
-          (params as { arguments?: Record<string, unknown> })?.arguments,
-        );
+        throw err;
       }
-      throw err;
+      const schema = await inputSchema();
+      const retried = await retryCoerced(schema);
+      if (retried) return retried;
+      throw enrichInvalidParams(err, toolName, schema, args);
     }
+
+    if (!toolName || !cache || !invalidParamsResultText(result)) return result;
+
+    const schema = await inputSchema();
+    // Accept the retry unless it failed validation again — an ordinary tool
+    // error means the coerced arguments were accepted and the tool itself
+    // failed, which is the truthful result to return.
+    const retried = await retryCoerced(schema);
+    if (retried && !invalidParamsResultText(retried)) return retried;
+
+    return appendHintToResult(
+      result,
+      buildValidationHint(toolName, schema, args),
+    );
   };
 
   placeholder.getPrompt = async (params, options) => {

--- a/apps/api/src/mcp-clients/validation-hint.test.ts
+++ b/apps/api/src/mcp-clients/validation-hint.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "bun:test";
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
-import { buildValidationHint, enrichInvalidParams } from "./validation-hint";
+import {
+  appendHintToResult,
+  buildValidationHint,
+  coerceArgsToSchema,
+  enrichInvalidParams,
+  invalidParamsResultText,
+} from "./validation-hint";
 
 describe("buildValidationHint", () => {
   const schema = {
@@ -21,6 +27,17 @@ describe("buildValidationHint", () => {
     const hint = buildValidationHint("t", schema, undefined);
     expect(hint).toContain("You sent: (none).");
     expect(hint).toContain("Missing required: startDate, endDate.");
+  });
+
+  it("names arguments that are present but wrong-typed", () => {
+    const hint = buildValidationHint(
+      "POST_EDIT",
+      { properties: { patch: { type: "object" }, save: { type: "boolean" } } },
+      { patch: '{"sections":[]}', save: "true" },
+    );
+    expect(hint).toContain(
+      "Wrong type: patch (expected object, got string), save (expected boolean, got string).",
+    );
   });
 
   it("omits missing/required clauses when schema has no required fields", () => {
@@ -58,5 +75,107 @@ describe("enrichInvalidParams", () => {
   it("passes through when the tool name is unknown", () => {
     const original = new McpError(ErrorCode.InvalidParams, "bad");
     expect(enrichInvalidParams(original, undefined, schema, {})).toBe(original);
+  });
+});
+
+describe("coerceArgsToSchema", () => {
+  const schema = {
+    properties: {
+      postName: { type: "string" },
+      patch: { type: "object" },
+      sections: { type: "array" },
+      save: { type: "boolean" },
+      limit: { type: "integer" },
+      ratio: { type: "number" },
+    },
+  };
+
+  it("parses a JSON string into the declared object/array", () => {
+    const out = coerceArgsToSchema(schema, {
+      patch: '{"sections":[1]}',
+      sections: "[1,2]",
+    });
+    expect(out).toEqual({ patch: { sections: [1] }, sections: [1, 2] });
+  });
+
+  it('reads "true"/"false" and numeric strings', () => {
+    expect(coerceArgsToSchema(schema, { save: "true" })).toEqual({
+      save: true,
+    });
+    expect(coerceArgsToSchema(schema, { save: "false" })).toEqual({
+      save: false,
+    });
+    expect(coerceArgsToSchema(schema, { limit: "10", ratio: "1.5" })).toEqual({
+      limit: 10,
+      ratio: 1.5,
+    });
+  });
+
+  it("never reinterprets a string-typed parameter", () => {
+    expect(coerceArgsToSchema(schema, { postName: '{"a":1}' })).toBeNull();
+  });
+
+  it("leaves values it cannot read as the declared type", () => {
+    // unparseable, wrong parsed type, non-boolean word, non-integer number
+    expect(coerceArgsToSchema(schema, { patch: "not json" })).toBeNull();
+    expect(coerceArgsToSchema(schema, { patch: "[1,2]" })).toBeNull();
+    expect(coerceArgsToSchema(schema, { save: "yes" })).toBeNull();
+    expect(coerceArgsToSchema(schema, { limit: "1.5" })).toBeNull();
+  });
+
+  it("returns null when nothing changed, and keeps untouched keys", () => {
+    expect(
+      coerceArgsToSchema(schema, { patch: { a: 1 }, save: true }),
+    ).toBeNull();
+    expect(coerceArgsToSchema(undefined, { save: "true" })).toBeNull();
+    expect(coerceArgsToSchema(schema, undefined)).toBeNull();
+    expect(
+      coerceArgsToSchema(schema, { postName: "p", save: "true", other: 1 }),
+    ).toEqual({ postName: "p", save: true, other: 1 });
+  });
+});
+
+describe("invalidParamsResultText", () => {
+  const errorResult = (text: string) => ({
+    isError: true,
+    content: [{ type: "text", text }],
+  });
+
+  it("returns the text of an argument-validation failure", () => {
+    expect(
+      invalidParamsResultText(
+        errorResult("MCP error -32602: Input validation error: ..."),
+      ),
+    ).toContain("-32602");
+  });
+
+  it("ignores results from a tool that ran and failed on its own terms", () => {
+    expect(invalidParamsResultText(errorResult("Post not found"))).toBeNull();
+    expect(
+      invalidParamsResultText({
+        isError: false,
+        content: [{ type: "text", text: "MCP error -32602" }],
+      }),
+    ).toBeNull();
+    expect(invalidParamsResultText(null)).toBeNull();
+    expect(invalidParamsResultText({ isError: true })).toBeNull();
+  });
+});
+
+describe("appendHintToResult", () => {
+  it("appends to the first text block and leaves the rest alone", () => {
+    const result = {
+      isError: true,
+      content: [
+        { type: "text", text: "bad args" },
+        { type: "text", text: "trailing" },
+      ],
+    };
+    const out = appendHintToResult(result, "hint");
+    expect(out.content[0]!.text).toBe("bad args\n\nhint");
+    expect(out.content[1]!.text).toBe("trailing");
+    expect(out.isError).toBe(true);
+    // input is not mutated
+    expect(result.content[0]!.text).toBe("bad args");
   });
 });

--- a/apps/api/src/mcp-clients/validation-hint.ts
+++ b/apps/api/src/mcp-clients/validation-hint.ts
@@ -1,11 +1,19 @@
 /**
- * Corrective hints for invalid tool-call arguments.
+ * Repair and explain invalid tool-call arguments.
  *
- * When an upstream MCP server rejects a `tools/call` with JSON-RPC -32602
- * (InvalidParams), the raw error is often terse ("startDate: Required") and the
- * agent keeps retrying with the same bad shape. Since the proxy already holds
- * the tool's advertised `inputSchema`, we append a concrete correction so the
- * model can fix the arguments on the next attempt.
+ * When an upstream MCP server rejects a `tools/call` for -32602 (InvalidParams),
+ * the raw error is terse ("startDate: Required") and the agent keeps retrying
+ * the same bad shape. The proxy holds the tool's advertised `inputSchema`, so it
+ * can do better: re-type the arguments the model plainly got wrong
+ * (`coerceArgsToSchema`) and retry, and failing that append a concrete
+ * correction (`buildValidationHint`) so the next attempt can fix them.
+ *
+ * A rejection arrives in one of two shapes, and both must be handled:
+ *  - a thrown JSON-RPC error   → `enrichInvalidParams`
+ *  - an `isError: true` result → `invalidParamsResultText` / `appendHintToResult`
+ * The MCP SDK's own server (>= 1.29) catches the validation `McpError` in its
+ * `tools/call` handler and returns the second shape, so the throw path alone
+ * misses every server built on it.
  */
 
 import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
@@ -13,6 +21,74 @@ import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 export interface ToolInputSchema {
   required?: string[];
   properties?: Record<string, { type?: string }>;
+}
+
+/** The JSON Schema `type` name for a runtime value. */
+function jsonTypeOf(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}
+
+/**
+ * Re-type a single string argument to the type its schema declares. Returns
+ * `undefined` when the string can't be read as that type, so the caller leaves
+ * the original value alone and the upstream rejection stands.
+ */
+function coerceString(raw: string, declared: string): unknown {
+  if (declared === "object" || declared === "array") {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return undefined;
+    }
+    return jsonTypeOf(parsed) === declared ? parsed : undefined;
+  }
+  if (declared === "boolean") {
+    if (raw === "true") return true;
+    if (raw === "false") return false;
+    return undefined;
+  }
+  if (declared === "number" || declared === "integer") {
+    if (raw.trim() === "") return undefined;
+    const n = Number(raw);
+    if (!Number.isFinite(n)) return undefined;
+    if (declared === "integer" && !Number.isInteger(n)) return undefined;
+    return n;
+  }
+  return undefined;
+}
+
+/**
+ * Models routinely send a JSON *string* where the schema declares an object or
+ * array (`patch: "{\"sections\":[…]}"`) and `"true"` where it declares a
+ * boolean. The upstream server rejects the call before executing it and the
+ * agent burns steps retrying the same shape.
+ *
+ * Returns a copy with those arguments re-typed, or `null` when nothing could be
+ * coerced. Only string values whose declared type is object/array/boolean/
+ * number/integer are touched — a `string`-typed parameter is never reinterpreted,
+ * and an unparseable value is left as sent.
+ */
+export function coerceArgsToSchema(
+  schema: ToolInputSchema | undefined,
+  args: Record<string, unknown> | undefined,
+): Record<string, unknown> | null {
+  if (!schema?.properties || !args) return null;
+
+  let changed = false;
+  const out: Record<string, unknown> = { ...args };
+  for (const [key, value] of Object.entries(args)) {
+    if (typeof value !== "string") continue;
+    const declared = schema.properties[key]?.type;
+    if (!declared || declared === "string") continue;
+    const coerced = coerceString(value, declared);
+    if (coerced === undefined) continue;
+    out[key] = coerced;
+    changed = true;
+  }
+  return changed ? out : null;
 }
 
 /**
@@ -33,11 +109,24 @@ export function buildValidationHint(
     return type ? `${name} (${type})` : name;
   };
 
+  // A present-but-wrong-typed argument is the common failure when nothing is
+  // missing — say so, otherwise the hint reads as "everything is fine".
+  const mistyped = sent
+    .filter((k) => {
+      const declared = schema?.properties?.[k]?.type;
+      return declared != null && jsonTypeOf(args?.[k]) !== declared;
+    })
+    .map(
+      (k) =>
+        `${k} (expected ${schema?.properties?.[k]?.type}, got ${jsonTypeOf(args?.[k])})`,
+    );
+
   const parts = [
     `Invalid arguments for "${toolName}".`,
     required.length ? `Required: ${required.map(describe).join(", ")}.` : "",
     `You sent: ${sent.length ? sent.join(", ") : "(none)"}.`,
     missing.length ? `Missing required: ${missing.join(", ")}.` : "",
+    mistyped.length ? `Wrong type: ${mistyped.join(", ")}.` : "",
   ];
 
   return parts.filter(Boolean).join(" ");
@@ -64,4 +153,37 @@ export function enrichInvalidParams(
   // the one already on err.message to avoid a doubled header.
   const raw = err.message.replace(/^MCP error -?\d+: /, "");
   return new McpError(ErrorCode.InvalidParams, `${raw}\n\n${hint}`, err.data);
+}
+
+interface ToolResultLike {
+  isError?: boolean;
+  content?: Array<{ type?: string; text?: string }>;
+}
+
+/**
+ * The error text of a `tools/call` result that failed argument validation, or
+ * `null` for anything else — including an `isError` result from a tool that ran
+ * and failed on its own terms, which must not be retried.
+ */
+export function invalidParamsResultText(result: unknown): string | null {
+  const r = result as ToolResultLike | null;
+  if (!r || r.isError !== true || !Array.isArray(r.content)) return null;
+  const text = r.content
+    .map((c) => (c?.type === "text" ? c.text : null))
+    .filter((t): t is string => typeof t === "string")
+    .join("\n");
+  return /MCP error -32602|Input validation error/.test(text) ? text : null;
+}
+
+/** Copy of an errored `tools/call` result with the hint appended to its text. */
+export function appendHintToResult<T>(result: T, hint: string): T {
+  const r = result as ToolResultLike;
+  return {
+    ...r,
+    content: (r.content ?? []).map((c, i) =>
+      i === 0 && c?.type === "text"
+        ? { ...c, text: `${c.text}\n\n${hint}` }
+        : c,
+    ),
+  } as T;
 }


### PR DESCRIPTION
## Summary

Debugging a stuck prod thread (`bagaggio`, Blog Manager agent) surfaced a dead code path in the MCP proxy.

The agent called `POST_EDIT` with `patch` as a JSON *string* and `save: "true"`. The upstream rejected both for -32602. The agent retried the identical shape, gave up on the tool, and re-implemented the call as a sandbox script — ~4M input tokens and several minutes to work around one type mismatch.

Two things were wrong:

**1. The existing hint never fires.** `enrichInvalidParams` only wraps the *throw* path, but the MCP SDK's own server (>= 1.29) catches the validation `McpError` inside its `tools/call` handler and returns an `isError: true` result instead. Every server built on the SDK therefore lands in the shape we don't inspect. Confirmed in prod: no rejection anywhere carries a hint — not in that thread, not in the `spire-agent` logs, which are full of bare `MCP error -32602: Input validation error: …` lines.

**2. Hinting is the wrong ceiling anyway.** -32602 is raised while validating arguments, *before* the tool runs, so a retry is side-effect free. The proxy already holds the tool's advertised `inputSchema` — it can just fix the arguments.

## Changes

- Handle the `isError`-result shape alongside the thrown one (`invalidParamsResultText`, `appendHintToResult`).
- On a -32602 rejection, re-type the arguments against the schema and retry once (`coerceArgsToSchema`). A JSON string for an `object`/`array` parameter, `"true"` for a `boolean`, `"10"` for an `integer`.
- The hint, now only reached when the repair fails, names present-but-wrong-typed arguments. Previously it listed required keys and what was sent — with nothing missing it read as "everything is fine", which is exactly the case that produced this bug.

Coercion is deliberately conservative and fails closed: only string values whose declared type is object/array/boolean/number/integer, only when the string reads cleanly as that type. A `string`-typed parameter is never reinterpreted, an unparseable value is left exactly as sent and the upstream rejection stands, and an `isError` result from a tool that actually ran is never retried.

## Testing

`bun test apps/api/src/mcp-clients/` — 114 pass.

- Unit coverage for `coerceArgsToSchema` (each type, each refusal), `invalidParamsResultText`, `appendHintToResult`, and the new hint clause.
- Three tests in `lazy-client.test.ts` against a **real** `McpServer` over the bridge transport, since the `isError` shape is the SDK server's behavior and a hand-rolled fake would not reproduce it: repair-and-retry succeeds, an unrepairable call gets the hint appended, and an ordinary tool error passes through untouched. The unrepairable case reproduces the exact `POST_EDIT` error text from the thread.

`bun run fmt`, `bun run lint`, and `bun run --cwd apps/api check` are clean.

## Not in scope

The thread's other failures live outside this repo and are noted here so they don't get lost:

- **The actual publish blocker was Perplexity.** `POST_PUBLISH` is gated on a fact-check that returned `skipped_error` on every attempt. That call happens inside `spire-agent`, it is swallowed with no log line, and `factCheckStatus` has not been `ok` anywhere in prod since 2026-07-13 — the failure is invisible until it blocks a publish, and it reads to the user like a content problem. Needs an owner on the Spire side.
- `spire-agent` logs show the mirror-image mismatch on its own outbound calls (`VTEX_IS_GET_PRODUCT_SEARCH`, `query` expected string, got object) — 14 occurrences in 200 minutes. This PR's repair does not cover it: that path sends an object where a string is declared, which is not safely coercible.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Repairs invalid MCP tool-call arguments and retries once using the tool’s `inputSchema`; only add a hint when repair fails. Previously we only hinted on thrown -32602 errors, but SDK servers return `isError` results, so hints never appeared and agents retried the same bad shape.

- Handle both rejection shapes: thrown `McpError` and `isError: true` result; detect validation failures via result text and enrich or append in place.
- Coerce string arguments to declared types and retry once: JSON strings → object/array, "true"/"false" → boolean, numeric strings → integer/number. Accept retried result only if it passes validation; leave ordinary tool errors untouched.
- Fail closed: never reinterpret `string`-typed params; ignore unparseable values; do nothing without a matching schema.
- Improve hints to name present-but-wrong-typed args, avoiding the “everything is fine” read when nothing is missing.
- Tests add coverage for coercion and result handling, including integration against a real `McpServer`.

<sup>Written for commit b56556b3e34a71b29abbf5850633d69c0e51d694. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

