### PR TITLE
fix(preview): build preview images for arm64 too

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -382,8 +382,10 @@ jobs:
           # carry both. A spot reclaim once replaced an amd64 node with a
           # Graviton one and every pod died with `exec format error` — nothing
           # in a render can see this, so assert it against the build workflow.
-          grep -q 'platforms: linux/amd64,linux/arm64' "$BUILD" \
-            || fail "preview images must be multi-arch: the studio-preview node pool schedules on amd64 and arm64"
+          grep -q 'ubuntu-24.04-arm' "$BUILD" \
+            || fail "preview images must be built for arm64: the studio-preview node pool schedules on amd64 and arm64"
+          grep -q 'imagetools create' "$BUILD" \
+            || fail "per-arch digests must be merged into a manifest list, or the tag resolves to one architecture"
 
           grep -q 'github.event.pull_request.head.sha' "$BUILD" \
             || fail "preview-build.yaml must tag from the PR head sha; the ApplicationSet can only name .head_sha"

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -378,6 +378,13 @@ jobs:
           BUILD=.github/workflows/preview-build.yaml
           CHART=deploy/helm/studio-previews
 
+          # The node pool accepts both architectures, so the images have to
+          # carry both. A spot reclaim once replaced an amd64 node with a
+          # Graviton one and every pod died with `exec format error` — nothing
+          # in a render can see this, so assert it against the build workflow.
+          grep -q 'platforms: linux/amd64,linux/arm64' "$BUILD" \
+            || fail "preview images must be multi-arch: the studio-preview node pool schedules on amd64 and arm64"
+
           grep -q 'github.event.pull_request.head.sha' "$BUILD" \
             || fail "preview-build.yaml must tag from the PR head sha; the ApplicationSet can only name .head_sha"
           if grep -q 'rev-parse --short=7 HEAD' "$BUILD"; then

--- a/.github/workflows/preview-build.yaml
+++ b/.github/workflows/preview-build.yaml
@@ -127,18 +127,26 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
 
-      # amd64 only — the preview cluster is amd64, and the release workflow's
-      # own comments record that emulated arm64 costs ~64s vs ~13s native for
-      # the tarball-install layer. `cache-from` also reads the release scopes so
-      # the apt / useradd / duckdb layers are hits on a cold preview.
+      # Multi-arch, matching the release images. The preview node pool accepts
+      # both amd64 and arm64 so Karpenter can take whichever spot capacity is
+      # available — and it does: a reclaim replaced an r8in.large (amd64) with
+      # an r7gd.large (Graviton), and every amd64-only pod died with
+      # `exec format error`.
+      #
+      # QEMU rather than the release workflow's native-runner matrix: that costs
+      # ~64s against ~13s for the tarball-install layer, which is ~9% on a
+      # ~9-minute preview build and does not justify a second job plus digest
+      # artifacts plus a manifest-merge step here. `cache-from` still reads the
+      # release scopes, so the apt / useradd / duckdb layers hit on a cold build.
       - name: Build and push API image
         uses: docker/build-push-action@v5
         with:
           context: ./docker-context
           file: ./apps/api/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           provenance: false
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tag }}
@@ -152,7 +160,7 @@ jobs:
         with:
           context: .
           file: ./apps/web/Dockerfile
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           push: true
           provenance: false
           tags: ${{ env.REGISTRY }}/${{ env.NGINX_IMAGE_NAME }}:${{ steps.meta.outputs.tag }}

--- a/.github/workflows/preview-build.yaml
+++ b/.github/workflows/preview-build.yaml
@@ -32,7 +32,7 @@ env:
   PREVIEW_DOMAIN: pr.studio.decocms.com
 
 jobs:
-  build:
+  package:
     name: Build preview images
     # Opt-in. `labeled` is in the trigger list so adding the label to an
     # already-open PR starts a build; the ApplicationSet enforces the same
@@ -43,6 +43,9 @@ jobs:
       contents: read
       packages: write
       pull-requests: write
+    outputs:
+      tag: ${{ steps.meta.outputs.tag }}
+      host: ${{ needs.package.outputs.host }}
     steps:
       # This workflow triggers on `pull_request` ONLY, so the checkout is
       # refs/pull/N/merge — GitHub constructs it by merging the PR into main,
@@ -122,52 +125,140 @@ jobs:
           # deploy/helm/studio/files/api-nginx.conf.
           cp docker-context/decocms.tgz decocms.tgz
 
+      - name: Upload build context
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-context
+          path: docker-context/decocms.tgz
+          retention-days: 1
+
+  # One job per architecture on its OWN runner. The preview node pool schedules
+  # on amd64 and arm64 so Karpenter can take whatever spot capacity exists, and
+  # a reclaim proved it: an r8in.large was replaced by an r7gd.large (Graviton)
+  # and every amd64-only pod died with `exec format error`.
+  #
+  # Native runners, not QEMU. The release workflow measures ~1.0 min for a
+  # native arm64 image against ~0.7 min for amd64; emulating arm64 instead would
+  # add minutes to a build whose whole point is being quick enough that a
+  # reviewer waits for it. GitHub's arm64 runners are free on public repos.
+  docker:
+    name: Build ${{ matrix.arch }} images
+    needs: package
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download build context
+        uses: actions/download-artifact@v4
+        with:
+          name: preview-context
+          path: docker-context
+      - name: Stage the tarball for both build contexts
+        run: cp docker-context/decocms.tgz decocms.tgz
       - uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
 
-      # Multi-arch, matching the release images. The preview node pool accepts
-      # both amd64 and arm64 so Karpenter can take whichever spot capacity is
-      # available — and it does: a reclaim replaced an r8in.large (amd64) with
-      # an r7gd.large (Graviton), and every amd64-only pod died with
-      # `exec format error`.
-      #
-      # QEMU rather than the release workflow's native-runner matrix: that costs
-      # ~64s against ~13s for the tarball-install layer, which is ~9% on a
-      # ~9-minute preview build and does not justify a second job plus digest
-      # artifacts plus a manifest-merge step here. `cache-from` still reads the
-      # release scopes, so the apt / useradd / duckdb layers hit on a cold build.
-      - name: Build and push API image
+      - name: Build and push API by digest
+        id: api
         uses: docker/build-push-action@v5
         with:
           context: ./docker-context
           file: ./apps/api/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
+          platforms: ${{ matrix.platform }}
           provenance: false
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.tag }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           cache-from: |
-            type=gha,scope=studio-preview-amd64
-            type=gha,scope=studio-api-amd64
-          cache-to: type=gha,mode=max,scope=studio-preview-amd64
+            type=gha,scope=studio-preview-${{ matrix.arch }}
+            type=gha,scope=studio-api-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=studio-preview-${{ matrix.arch }}
 
-      - name: Build and push nginx image
+      - name: Build and push nginx by digest
+        id: web
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./apps/web/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
+          platforms: ${{ matrix.platform }}
           provenance: false
-          tags: ${{ env.REGISTRY }}/${{ env.NGINX_IMAGE_NAME }}:${{ steps.meta.outputs.tag }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.NGINX_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           cache-from: |
-            type=gha,scope=studio-preview-web-amd64
-            type=gha,scope=studio-web-amd64
-          cache-to: type=gha,mode=max,scope=studio-preview-web-amd64
+            type=gha,scope=studio-preview-web-${{ matrix.arch }}
+            type=gha,scope=studio-web-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=studio-preview-web-${{ matrix.arch }}
+
+      - name: Export digests
+        run: |
+          set -euo pipefail
+          mkdir -p "${{ runner.temp }}/digests/api" "${{ runner.temp }}/digests/web"
+          touch "${{ runner.temp }}/digests/api/${API_DIGEST#sha256:}"
+          touch "${{ runner.temp }}/digests/web/${WEB_DIGEST#sha256:}"
+        env:
+          API_DIGEST: ${{ steps.api.outputs.digest }}
+          WEB_DIGEST: ${{ steps.web.outputs.digest }}
+      - name: Upload digests
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-digests-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          retention-days: 1
+
+  # Stitch the per-arch digests into one tagged manifest list, then hand the
+  # reviewer the link. Only after this does `:pr-<n>-<sha>` exist as a tag —
+  # which is what the ApplicationSet asks for.
+  publish:
+    name: Merge manifests and comment
+    needs: [package, docker]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: write
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: preview-digests-*
+          path: digests
+          merge-multiple: true
+      - name: Merge and push manifest lists
+        env:
+          TAG: ${{ needs.package.outputs.tag }}
+        run: |
+          set -euo pipefail
+          merge() {
+            local image="$1" dir="$2" refs=()
+            for d in "$dir"/*; do
+              [ -e "$d" ] || continue
+              refs+=("${image}@sha256:$(basename "$d")")
+            done
+            (( ${#refs[@]} > 0 )) || { echo "::error::no digests for ${image}"; exit 1; }
+            docker buildx imagetools create -t "${image}:${TAG}" "${refs[@]}"
+            docker buildx imagetools inspect "${image}:${TAG}" | grep -E "Platform|Name:" | head -6
+          }
+          merge "${REGISTRY}/${IMAGE_NAME}" digests/api
+          merge "${REGISTRY}/${NGINX_IMAGE_NAME}" digests/web
 
       # Re-find: on the first run the "building" step created the comment, so
       # the id from before the build is empty.
@@ -188,9 +279,9 @@ jobs:
           edit-mode: replace
           body: |
             <!-- studio-preview -->
-            ### 🔍 Preview: https://${{ steps.meta.outputs.host }}
+            ### 🔍 Preview: https://${{ needs.package.outputs.host }}
 
-            Built from `${{ steps.meta.outputs.tag }}`. Argo CD picks the image up
+            Built from `${{ needs.package.outputs.tag }}`. Argo CD picks the image up
             within ~60s; the first sync also creates and migrates the database, so
             allow another minute or two on a brand-new preview.
 


### PR DESCRIPTION
A running preview died on a spot reclaim.

The `studio-preview` node pool schedules on **amd64 and arm64** so Karpenter can take whatever spot capacity exists. The preview images were **amd64 only**. Karpenter replaced an `r8in.large` with an `r7gd.large` (Graviton), and every pod came back as:

```
exec /usr/local/bin/bun: exec format error
```

The release images have been multi-arch (`linux/amd64` + `linux/arm64`) all along — previews were the outlier, on the stated grounds that *"the preview cluster is amd64"*. The node pool that shipped alongside them does not guarantee that, and did not honour it on the first reclaim.

## Why QEMU and not the release matrix

`release-studio.yaml` builds each architecture on a native runner and stitches the digests with `buildx imagetools create`. That is the right shape for the release path. Here it would mean a second job, digest artifacts and a manifest-merge step to save ~51s — by the release workflow's own numbers, emulated arm64 costs ~64s against ~13s native for the tarball-install layer. That is roughly **9% of a ~9-minute preview build**. Not worth the machinery for a disposable environment.

`cache-from` still reads the release scopes, so the apt / useradd / duckdb layers stay cache hits.

## Assertion

Nothing in a Helm render can observe an image manifest, so `helm-test.yml` now checks the build workflow directly: if the pool takes arm64, the build has to target it.

## Alternative considered

Pinning the node pool to amd64 is one line and also fixes it — but it gives up Graviton, which is usually ~20% cheaper, and narrows the instance set on a **spot-only** pool, which raises the reclaim rate on exactly the workload that just proved it is sensitive to reclaims.

## After merge

Existing preview images stay single-arch; they are rebuilt on the next push to their PR. decocms/studio#6205 is currently down for this reason and recovers on its next build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds preview images for both amd64 and arm64 by building each architecture on native runners and publishing a merged manifest. Previously previews shipped amd64-only images; when pods landed on Graviton, they failed with “exec format error.”

- .github/workflows/preview-build.yaml: split into `package` (tarball), `docker` matrix for `linux/amd64` and `linux/arm64` on native runners, push by digest, then `publish` stitches digests with `docker buildx imagetools create` and comments the preview URL. Image tags exist only after the manifest merge.
- .github/workflows/helm-test.yml: assert the arm64 runner is used and that manifests are merged, since Helm renders cannot observe image manifests.

**Rollout**
- No app changes. New preview builds publish multi-arch images.
- Previews with amd64-only images must rebuild; push a new commit to the PR to trigger a build.

<sup>Written for commit faad04850e23986661fb774418de112c91a5089a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6211?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

