### PR TITLE
feat(preview): optional hosted sandboxes, off by default

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -496,6 +496,18 @@ jobs:
             --set preview.postgres.enabled=false \
             --set externalSecret.enabled=false
 
+          # Binding sandbox access to the namespace's `default` ServiceAccount
+          # would hand it to every pod in the preview — Postgres and MinIO
+          # included — and the render would look perfectly healthy.
+          expect_fail "sandbox without a named ServiceAccount" "requires serviceAccount.create=true" \
+            --set preview.host=h.example.com \
+            --set preview.sandbox.enabled=true \
+            --set preview.sandbox.roleName=some-role
+          expect_fail "sandbox without a role" "preview.sandbox.roleName is required" \
+            --set preview.host=h.example.com \
+            --set preview.sandbox.enabled=true \
+            --set serviceAccount.create=true
+
           # image.command is a list, which --set cannot express cleanly.
           printf 'image:\n  command: ["bun","run","deco"]\n' > /tmp/no-skip.yaml
           expect_fail "missing --skip-migrations" "requires --skip-migrations" \

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -499,10 +499,13 @@ jobs:
           # Binding sandbox access to the namespace's `default` ServiceAccount
           # would hand it to every pod in the preview — Postgres and MinIO
           # included — and the render would look perfectly healthy.
+          # values-preview.yaml turns serviceAccount.create on, so this case has
+          # to turn it back off — the point is the guard, not the default.
           expect_fail "sandbox without a named ServiceAccount" "requires serviceAccount.create=true" \
             --set preview.host=h.example.com \
             --set preview.sandbox.enabled=true \
-            --set preview.sandbox.roleName=some-role
+            --set preview.sandbox.roleName=some-role \
+            --set serviceAccount.create=false
           expect_fail "sandbox without a role" "preview.sandbox.roleName is required" \
             --set preview.host=h.example.com \
             --set preview.sandbox.enabled=true \

--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,6 +2,12 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
+# 0.14.2: optional hosted sandboxes for previews (preview.sandbox.enabled,
+# default false). Renders one RoleBinding when on, nothing when off. Read the
+# note in templates/preview-sandbox-rbac.yaml before enabling: the namespace it
+# binds into is shared with production sandboxes and RBAC has no label scoping.
+# Previews now also run under a named ServiceAccount rather than `default`.
+#
 # 0.14.1: the preview ConfigMap had no sync-wave, so it landed at 0 — after the
 # migrate Job at -10 that consumes it via envFrom. The Job sat in
 # CreateContainerConfigError and the sync stalled on the hook with nothing on
@@ -26,7 +32,7 @@ type: application
 # when disabled, so existing releases are unaffected.
 # 0.12.4: chart-managed API/worker dispatch roles now use
 # STUDIO_DISPATCH_ROLE; legacy overrides are rejected.
-version: 0.14.1
+version: 0.14.2
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/templates/_helpers.tpl
+++ b/deploy/helm/studio/templates/_helpers.tpl
@@ -342,6 +342,21 @@ Service/Deployment name for the preview's own MinIO.
 {{- end }}
 
 {{/*
+Guards the sandbox binding. Both checks stop a render that would look correct
+and grant the wrong thing.
+*/}}
+{{- define "chart-deco-studio.validatePreviewSandbox" -}}
+{{- if and .Values.preview.enabled .Values.preview.sandbox.enabled }}
+{{- if not .Values.serviceAccount.create }}
+{{- fail "chart-deco-studio: preview.sandbox.enabled=true requires serviceAccount.create=true — otherwise the binding lands on the namespace's `default` ServiceAccount, handing sandbox access to every pod in the preview, Postgres and MinIO included" -}}
+{{- end }}
+{{- if not .Values.preview.sandbox.roleName }}
+{{- fail "chart-deco-studio: preview.sandbox.roleName is required when preview.sandbox.enabled=true" -}}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 Validates per-PR preview releases. Every failure here is something that would
 otherwise render a healthy-looking object that silently does nothing: an
 HTTPRoute with no hostname matches no traffic, a pod without --skip-migrations

--- a/deploy/helm/studio/templates/preview-sandbox-rbac.yaml
+++ b/deploy/helm/studio/templates/preview-sandbox-rbac.yaml
@@ -1,0 +1,49 @@
+{{- if and .Values.preview.enabled .Values.preview.sandbox.enabled }}
+{{- /*
+Lets a preview drive hosted agent sandboxes.
+
+READ THIS BEFORE ENABLING. The Role bound here lives in the sandbox namespace,
+and that namespace holds the sandboxes of EVERY environment on the cluster —
+production included. Kubernetes RBAC has no label scoping, so this grants reach
+over all of them, not only the ones a preview creates. The housekeeper's
+CLAIM_SELECTOR separates what it sweeps; it does not separate what a
+ServiceAccount can touch.
+
+A preview runs un-merged code from any pull request carrying the preview label.
+Binding it here means a label on a PR is enough to obtain pods/portforward and
+HTTPRoute delete against production sandboxes.
+
+It is written this way because the sandbox namespace is not configurable — it is
+hardcoded in the application and throughout the sandbox-env chart, on the stated
+premise that "multiple envs share agent-sandbox-system". Until that changes, or
+until the application talks to a controller API instead of the Kubernetes API
+(which would replace this with a scoped token), there is no way to give previews
+sandboxes without also giving them this reach.
+
+Off by default. Turn it on deliberately, and for as long as you actually need it.
+*/ -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "chart-deco-studio.fullname" . }}-sandbox
+  namespace: {{ required "preview.sandbox.namespace is required when preview.sandbox.enabled=true" .Values.preview.sandbox.namespace }}
+  labels:
+    {{- include "chart-deco-studio.labels" . | nindent 4 }}
+  annotations:
+    # Ahead of the pods, so the ServiceAccount can already claim by the time
+    # anything tries to.
+    argocd.argoproj.io/sync-wave: "-30"
+    # Deliberately loud: this object is the one place where a preview reaches
+    # outside its own namespace, and into a shared production one.
+    decocms.com/grants-access-to: {{ .Values.preview.sandbox.namespace | quote }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "chart-deco-studio.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  # An existing Role, not one this chart defines: the sandbox-env chart owns the
+  # verb set, and a copy here would drift from it silently.
+  name: {{ required "preview.sandbox.roleName is required when preview.sandbox.enabled=true" .Values.preview.sandbox.roleName }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/deploy/helm/studio/templates/validations.yaml
+++ b/deploy/helm/studio/templates/validations.yaml
@@ -9,3 +9,4 @@ This file only runs chart-level validations and renders no resources.
 {{- include "chart-deco-studio.validateClickhouse" . -}}
 {{- include "chart-deco-studio.validateIngress" . -}}
 {{- include "chart-deco-studio.validatePreview" . -}}
+{{- include "chart-deco-studio.validatePreviewSandbox" . -}}

--- a/deploy/helm/studio/values-preview.yaml
+++ b/deploy/helm/studio/values-preview.yaml
@@ -164,6 +164,12 @@ topologySpreadConstraints: []
 # Spot is safe here in a way it is nowhere else on this cluster: the database
 # is an emptyDir Postgres that the PreSync Job re-migrates on the next sync,
 # and a preview holds no PVC at all. A reclaim costs a reviewer a restart.
+# A named ServiceAccount rather than the namespace's `default`. Costs nothing
+# when sandboxes are off, and is required when they are on: binding sandbox
+# access to `default` would hand it to every pod here, Postgres and MinIO too.
+serviceAccount:
+  create: true
+
 nodeSelector:
   decocms.com/nodepool: studio-preview
 tolerations:
@@ -207,8 +213,25 @@ configMap:
     AUTH_EMAIL_PASSWORD_ENABLED: "true"
     # Several reviewers behind one office IP trip the auth limiter otherwise.
     DISABLE_RATE_LIMIT: "true"
-    # No hosted sandboxes in a preview. Agent dispatch returns 409 link_offline
+    # No hosted sandboxes by default. Agent dispatch returns 409 link_offline
     # with no local daemon attached — a documented limitation, not a bug.
+    #
+    # To test agent behaviour in a preview, set preview.sandbox.enabled=true
+    # (see values.yaml — it grants reach over a shared production namespace) and
+    # replace this block with the settings below, pointed at an existing
+    # environment whose templates and warm pool the preview borrows:
+    #
+    #   STUDIO_SANDBOX_PROVIDER: "cluster"
+    #   STUDIO_SANDBOX_RUNNER: "agent-sandbox"
+    #   STUDIO_SANDBOX_TEMPLATE_NAME: "<existing template, e.g. studio-sandbox-stg>"
+    #   STUDIO_ENV: "<matching env suffix, e.g. stg>"
+    #   STUDIO_SANDBOX_PREVIEW_GATEWAY_NAME: "<that env's sandbox gateway>"
+    #   STUDIO_SANDBOX_PREVIEW_GATEWAY_NAMESPACE: "agent-sandbox-system"
+    #   STUDIO_SANDBOX_PREVIEW_URL_PATTERN: "https://{handle}.<that env's domain>/"
+    #
+    # Without STUDIO_SANDBOX_SENTINEL_TOKEN the claim takes the cold-start path
+    # instead of the warm pool — slower per sandbox, and it borrows no capacity
+    # from the environment being shared.
     STUDIO_SANDBOX_PROVIDER: "user-desktop"
     DISABLE_ORGFS_MOUNTS: "true"
     # Never let a preview provision real gateway keys. STUDIO_PROVISION_SECRET_KEY

--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -147,6 +147,23 @@ preview:
       limits:
         memory: "768Mi"
 
+  # Hosted agent sandboxes for a preview. OFF by default, and it should stay off
+  # unless someone is actively testing agent behaviour.
+  #
+  # Enabling binds this release's ServiceAccount to a Role in a namespace shared
+  # with production sandboxes — see templates/preview-sandbox-rbac.yaml for why
+  # that cannot currently be narrowed, and what would remove the need.
+  #
+  # The application also needs the matching STUDIO_SANDBOX_* configuration
+  # (provider, runner, template name, preview gateway) pointed at an existing
+  # environment; enabling this alone grants permission but changes no behaviour.
+  sandbox:
+    enabled: false
+    # Namespace holding the SandboxTemplates, warm pools and claims.
+    namespace: agent-sandbox-system
+    # An existing Role in that namespace, owned by the sandbox-env chart.
+    roleName: ""
+
   # Resources for the short-lived migration Job.
   jobResources:
     requests:


### PR DESCRIPTION
A preview cannot drive agents today. `SANDBOX_START` creates a `SandboxClaim` through the Kubernetes API, and the preview's ServiceAccount has no rights in the sandbox namespace:

```
KubeHttpError: sandboxclaims.extensions.agents.x-k8s.io "..." is forbidden
  status: 403, reason: "Forbidden"
[lifecycle-watcher] pod/... stopped: watch denied
```

Observed on decocms/studio#6205.

## What this grants, plainly

The Role being bound lives in `agent-sandbox-system`, which holds the sandboxes of **every environment on the cluster, production included**:

```
studio-sandbox-runner-prod → ServiceAccount/deco-studio/deco-studio
studio-sandbox-runner-stg  → ServiceAccount/deco-studio-stg/deco-studio-stg
```

Kubernetes RBAC has no label scoping. A preview bound there gets `pods/portforward`, and `delete`/`patch` on HTTPRoutes, across **all** sandboxes in that namespace — not only the ones it creates. The housekeeper's `CLAIM_SELECTOR` separates what it *sweeps*; it does not separate what a ServiceAccount can *touch*.

A preview runs un-merged code from any PR carrying the `preview` label. So enabling this makes a label on a PR sufficient to reach production sandboxes. That is the trade, and it is stated at the top of the template rather than buried in a values comment.

**Default is `false`.** Nothing changes unless someone turns it on.

## Why it cannot be narrowed today

The sandbox namespace is hardcoded — in the application, and across 16 files of the `sandbox-env` chart — on the premise recorded in `lifecycle.ts`:

> *template name with envName so multiple envs share `agent-sandbox-system`*

A `sandbox-env` installed into its own namespace would need application changes, not just a different `helm install`. The move to a controller API instead of the Kubernetes API removes the need entirely, by replacing cluster RBAC with a tenant-scoped token.

## Two guards

Both cover a render that would look healthy and grant the wrong thing:

| guard | why |
|---|---|
| `serviceAccount.create` must be true | otherwise the binding lands on the namespace's `default` SA, giving sandbox access to **every** pod in the preview — Postgres and MinIO included |
| `roleName` must be set | an empty `roleRef` binds nothing, silently |

Asserted in `helm-test.yml` on the message text, not just the exit code.

## Permission and configuration are separate

Enabling `preview.sandbox.enabled` grants rights and changes no behaviour. The preview still needs the `STUDIO_SANDBOX_*` block pointed at an existing environment — `values-preview.yaml` now spells out exactly which settings, and notes that without `STUDIO_SANDBOX_SENTINEL_TOKEN` the claim takes the cold-start path rather than borrowing the shared warm pool.

## Side effect worth having

Previews now run under a named ServiceAccount instead of `default`. Postgres and MinIO stay on `default`, so even with sandboxes enabled they hold no sandbox rights — only the app, the worker and the migrate Job do.

## Verification

- Default render outside preview: **0 lines of difference** against `main`.
- Preview render with sandboxes off: no RoleBinding, ServiceAccount present.
- Preview render with sandboxes on: binding targets the release SA in the release namespace.
- Both guards fail with the intended message.
- `helm lint` clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional hosted agent sandboxes for previews. Previously `SANDBOX_START` failed with 403; now, when enabled, previews can claim and drive sandboxes. Default stays off to avoid giving preview code reach into production sandboxes.

- Binds the preview ServiceAccount to an existing Role in `agent-sandbox-system`, granting `pods/portforward` and HTTPRoute delete/patch across that namespace.
- Validations require `serviceAccount.create=true` and a non-empty `preview.sandbox.roleName`; CI asserts both failure paths.
- Permission is separate from app config: `preview.sandbox.enabled=true` only grants rights; the app must still set `STUDIO_SANDBOX_*` (provider, runner, template, gateway) to a real environment.
- Previews now run under a named ServiceAccount; Postgres and MinIO remain on `default`.

**Rollout**
- Off by default; no change unless you opt in.
- To enable: set `preview.sandbox.enabled=true`, `preview.sandbox.namespace` (defaults to `agent-sandbox-system`), and `preview.sandbox.roleName` to a Role from the `sandbox-env` chart; also configure the `STUDIO_SANDBOX_*` block.

<sup>Written for commit 4cdbe21c9374a7f6439952f8a8a7522677281642. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

