### PR TITLE
fix(previews): bump to 0.1.1 so namespaceLabels actually ships

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -174,6 +174,7 @@ jobs:
             --set externalSecret.secretPath=preview/studio/application \
             --set externalSecret.secretStoreName=aws-secrets-manager \
             --set externalSecret.secretStoreKind=ClusterSecretStore \
+            --set 'preview.namespaceLabels.decocms\.com/preview=true' \
             --api-versions gateway.networking.k8s.io/v1 \
             > /tmp/preview.yaml
 

--- a/deploy/helm/studio-previews/Chart.yaml
+++ b/deploy/helm/studio-previews/Chart.yaml
@@ -14,4 +14,9 @@ description: |
   ApplicationSet that generates previews, and preview policy must be able to
   change without bumping — and therefore rolling — the application chart.
 type: application
-version: 0.1.0
+# 0.1.1: pass namespaceLabels through to the studio chart, which renders the
+# preview's Namespace itself as of chart-deco-studio 0.14.3. Without this the
+# namespace is created with no gateway selector label and the HTTPRoute
+# attaches to nothing.
+
+version: 0.1.1


### PR DESCRIPTION
#6213 added `namespaceLabels` to the ApplicationSet template but bumped only the studio chart. `release-sandbox-charts.yaml` checks whether the version is already published and skips the push if so — correct behaviour, OCI tags should be immutable — so `chart-deco-studio-previews:0.1.0` in the registry is still the build without it:

```
$ helm pull chart-deco-studio-previews --version 0.1.0
$ grep -c namespaceLabels templates/applicationset.yaml
0
```

## Why it matters

`chart-deco-studio` 0.14.3 renders the preview Namespace itself, with `preview.namespaceLabels` supplying the label the Gateway admits routes by. If the ApplicationSet never passes that value, the namespace renders **without** the label and the HTTPRoute attaches to nothing — a 404 with a green Argo, which is precisely the failure #6213 exists to remove.

`managedNamespaceMetadata` still labels the namespace on the first sync, so this is not guaranteed to break — but it makes correctness depend on apply ordering between two writers of the same object, which is not something to rely on.

## Rollout

Publishing 0.1.1 is not enough on its own: `apps/studio-preview/values.yaml` in `decocms/deco-apps-cd` pins `chart-deco-studio-previews`, and also still pins `studioChart.version: "0.14.1"` — two versions behind. Both need bumping there before any of this reaches a preview.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes `namespaceLabels` by bumping `chart-deco-studio-previews` to 0.1.1 and fixes CI to render previews with those labels. Previously 0.1.0 omitted the field (immutable tag), so preview Namespaces lacked the gateway selector label and HTTPRoutes attached to nothing; now labels flow to `chart-deco-studio` 0.14.3 which renders the Namespace with the selector, removing reliance on `managedNamespaceMetadata` ordering. CI Helm template now sets `preview.namespaceLabels` so the namespace assertion validates a real render.

- Rollout
  - Update `decocms/deco-apps-cd` `apps/studio-preview/values.yaml`: set `chart-deco-studio-previews.version: "0.1.1"` and `studioChart.version: "0.14.3"`.
  - After deploy, verify a preview Namespace has the gateway selector label and routes resolve.

<sup>Written for commit f74e0374de1c58ccffa9e3ad68dac1238e7cfe0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

