### PR TITLE
fix(mcp): don't flag a correctly-sent integer as wrong-typed in the repair hint

### DIFF
--- a/apps/api/src/mcp-clients/validation-hint.test.ts
+++ b/apps/api/src/mcp-clients/validation-hint.test.ts
@@ -40,6 +40,20 @@ describe("buildValidationHint", () => {
     );
   });
 
+  it("does not flag a correctly-sent integer as wrong-typed", () => {
+    // `typeof 5` is "number", never "integer" — must not read as a mismatch.
+    const hint = buildValidationHint(
+      "t",
+      {
+        required: ["limit", "name"],
+        properties: { limit: { type: "integer" }, name: { type: "string" } },
+      },
+      { limit: 5 },
+    );
+    expect(hint).not.toContain("Wrong type");
+    expect(hint).toContain("Missing required: name.");
+  });
+
   it("omits missing/required clauses when schema has no required fields", () => {
     const hint = buildValidationHint("t", { properties: {} }, { a: 1 });
     expect(hint).toBe('Invalid arguments for "t". You sent: a.');

--- a/apps/api/src/mcp-clients/validation-hint.ts
+++ b/apps/api/src/mcp-clients/validation-hint.ts
@@ -31,6 +31,19 @@ function jsonTypeOf(value: unknown): string {
 }
 
 /**
+ * Whether `value` satisfies a declared JSON Schema `type`. JSON Schema's
+ * "integer" is a whole-number `number`, not a distinct JS runtime type —
+ * `jsonTypeOf` alone would call a correctly-sent `5` a type mismatch because
+ * `typeof 5 === "number"` never equals the declared string `"integer"`.
+ */
+function matchesDeclaredType(value: unknown, declared: string): boolean {
+  if (declared === "integer") {
+    return typeof value === "number" && Number.isInteger(value);
+  }
+  return jsonTypeOf(value) === declared;
+}
+
+/**
  * Re-type a single string argument to the type its schema declares. Returns
  * `undefined` when the string can't be read as that type, so the caller leaves
  * the original value alone and the upstream rejection stands.
@@ -114,7 +127,7 @@ export function buildValidationHint(
   const mistyped = sent
     .filter((k) => {
       const declared = schema?.properties?.[k]?.type;
-      return declared != null && jsonTypeOf(args?.[k]) !== declared;
+      return declared != null && !matchesDeclaredType(args?.[k], declared);
     })
     .map(
       (k) =>


### PR DESCRIPTION
Follows #6210 (the tool-call argument repair feature) — a bug that slipped through review in that merged PR's `buildValidationHint`.

**The bug:** `buildValidationHint`'s mistyped-argument detector compared `jsonTypeOf(value)` (which uses `typeof`) directly against the schema's declared JSON Schema type string. `typeof 5` is `"number"` in JS, but JSON Schema's `"integer"` type is a distinct declared type from `"number"` — so any tool argument declared `type: "integer"` that was sent as a perfectly valid integer (e.g. `limit: 5`) was always reported as `Wrong type: limit (expected integer, got number)`, even though nothing was wrong with it.

**Failure scenario:** a tool call fails validation because of an unrelated missing/wrong field, but the tool also has an `integer`-typed parameter that was sent correctly. The repair hint appended to the error tells the agent the correct integer argument is "wrong type", which is false and can send the agent chasing/mangling a field that was already fine, wasting a retry round-trip.

**Fix:** added `matchesDeclaredType`, which treats `"integer"` as `typeof value === "number" && Number.isInteger(value)` instead of a raw string-equality check against `jsonTypeOf`. `buildValidationHint`'s mistyped filter now uses it.

**Regression test:** `apps/api/src/mcp-clients/validation-hint.test.ts` — "does not flag a correctly-sent integer as wrong-typed", asserting the hint reports the real missing field but not a false `Wrong type` for the integer arg.

To confirm: `bun test apps/api/src/mcp-clients/validation-hint.test.ts`

Locally verified: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test file above, and `bunx oxlint` on both touched files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a false positive in MCP repair hints that labeled correctly-sent integer arguments as “Wrong type”. Previously, `buildValidationHint` compared `typeof` to the JSON Schema type, so `5` (“number”) mismatched `"integer"`; now we recognize integers as whole-number numbers. This only affects the hint text and reduces wasted retries.

- `buildValidationHint` uses `matchesDeclaredType` to treat `"integer"` as `number` with `Number.isInteger`.
- Adds a regression test ensuring the hint reports the real missing field and does not include a false “Wrong type” for integers.

<sup>Written for commit ad508c7a70b46403fdf1838a448b5cbdb89aca80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

