### PR TITLE
fix(preview): pull preview images with Always, the tag is mutable

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -323,6 +323,30 @@ jobs:
           [ "$count" -eq 3 ] \
             || fail "expected 3 containers with --skip-migrations, found ${count}"
 
+          # The preview tag is mutable — same tag, different bits, whenever the
+          # base moves — so a cached image must never win.
+          python3 - <<'PULL'
+          import sys, yaml
+          bad = []
+          for d in yaml.safe_load_all(open("/tmp/preview.yaml")):
+              if not d or d.get("kind") not in ("Deployment", "Job", "StatefulSet"):
+                  continue
+              spec = d["spec"]["template"]["spec"]
+              for c in (spec.get("initContainers") or []) + spec["containers"]:
+                  # Only the studio images carry a mutable tag; postgres, minio
+                  # and nats are pinned upstream releases.
+                  if "-preview:" not in c["image"]:
+                      continue
+                  if c.get("imagePullPolicy") != "Always":
+                      bad.append(f'{d["kind"]}/{d["metadata"]["name"]}/{c["name"]}'
+                                 f' = {c.get("imagePullPolicy")}')
+          if bad:
+              print("::error::preview images must use imagePullPolicy: Always — the "
+                    "tag is mutable, so a cached layer serves stale code: " + "; ".join(bad))
+              sys.exit(1)
+          print("every preview image is pulled fresh")
+          PULL
+
           grep -q 'DATABASE_POOL_MAX: "5"' /tmp/preview.yaml \
             || fail "DATABASE_POOL_MAX is not 5"
 

--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,6 +2,12 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
+# 0.14.4: preview images pull with Always. The preview tag is mutable — the
+# build checks out refs/pull/N/merge, so the same pr-<n>-<sha> is rebuilt
+# against whatever main is at the time — and IfNotPresent let a node that had
+# cached an earlier build keep serving it. The tag cannot be made immutable:
+# the Argo pullRequest generator exposes only .number and .head_sha.
+#
 # 0.14.3: the preview renders its own Namespace (preview.manageNamespace).
 # CreateNamespace=true creates one without adopting it, so a cascading delete
 # removed everything inside and left the namespace behind — one per pull request
@@ -38,7 +44,7 @@ type: application
 # when disabled, so existing releases are unaffected.
 # 0.12.4: chart-managed API/worker dispatch roles now use
 # STUDIO_DISPATCH_ROLE; legacy overrides are rejected.
-version: 0.14.3
+version: 0.14.4
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/values-preview.yaml
+++ b/deploy/helm/studio/values-preview.yaml
@@ -50,7 +50,22 @@ autoscaling:
 image:
   repository: ghcr.io/decocms/studio/studio-preview
   # tag injected per PR by the ApplicationSet.
-  pullPolicy: IfNotPresent
+  #
+  # Always, not IfNotPresent, because the preview tag is MUTABLE. It is
+  # `pr-<n>-<7 of head_sha>`, and the head sha does not move when the base does
+  # — but the image content does: the build checks out refs/pull/N/merge, so it
+  # is main ∪ PR, rebuilt against whatever main is at the time. Every push to
+  # the PR, and every label event, overwrites the same tag with different bits.
+  #
+  # The tag cannot be made immutable: the Argo pullRequest generator exposes
+  # only .number and .head_sha, so there is nothing to derive a base sha from.
+  # With IfNotPresent a node that cached an earlier build keeps serving it, and
+  # the symptom is "I fixed it on main and the preview did not change" with
+  # nothing to point at.
+  #
+  # Costs one registry round trip per pod start. On a spot pool that recycles
+  # nodes daily, that is the cheap side of the trade.
+  pullPolicy: Always
   # --skip-migrations is REQUIRED and enforced by validatePreview: the PreSync
   # Job is the single migration writer. Applies to the worker containers too,
   # which share this value.
@@ -58,6 +73,9 @@ image:
 
 nginx:
   # repository/tag injected per PR (studio-nginx-preview).
+  # Always for the same reason as the API image above: same mutable tag.
+  image:
+    pullPolicy: Always
   resources:
     requests:
       cpu: "100m"


### PR DESCRIPTION
The preview image tag is **mutable**, and `IfNotPresent` lets a stale cached image win.

## Why the tag moves

The tag is `pr-<n>-<7 of head_sha>`. The head sha does not change when the base branch does — but the image content does: the build checks out `refs/pull/N/merge`, so the image is `main ∪ PR`, rebuilt against whatever `main` happens to be at that moment. Every push to the PR, and every `labeled` event, overwrites the same tag with different bits. There is no "already exists" guard in `preview-build.yaml`, by design.

So `pr-6205-398ba0c` built yesterday and `pr-6205-398ba0c` built today are different images with the same name.

With `IfNotPresent`, a node that cached the earlier build keeps serving it. The symptom is *"I fixed it on main and the preview did not change"*, with nothing on the pod, the Application, or the image to point at.

## Why not make the tag immutable instead

That would be the better fix, and it is not available. The Argo `pullRequest` generator exposes `.number`, `.branch`, `.target_branch`, `.head_sha`, `.head_short_sha`, `.labels`, `.title`, `.author` — there is no base sha and no merge sha to fold into the tag. The ApplicationSet has to be able to construct the tag from what it knows, so the tag can only be a function of the PR.

## Cost

One registry round trip per pod start. On a spot-only pool that recycles nodes daily and runs four pods per preview, that is the cheap side of the trade.

## Two image blocks

The API image and the nginx front door carry **separate** `pullPolicy` keys. I set the first and missed the second; the assertion added here caught it. It now walks every container in the render, picks out the ones whose image tag is a preview tag, and fails on anything not set to `Always` — leaving `postgres`, `minio` and `nats` alone, since those are pinned upstream releases where `IfNotPresent` is correct.

## Verification

- All five preview containers render with `Always`: `-web`, `-api-0`, `-api-1`, `-worker`, `migrate`.
- Default render outside preview: **0 lines of difference** against `main`.
- `helm lint` clean.

Chart `0.14.3` → `0.14.4`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure preview images always pull fresh to avoid stale caches. Previously `IfNotPresent` let nodes serve old builds because the `pr-<n>-<sha>` preview tag is mutable; now all preview containers use `imagePullPolicy: Always`, trading one registry round trip per pod start for correct behavior.

- Set `image.pullPolicy: Always` for the preview API image and `nginx.image.pullPolicy: Always` in `values-preview.yaml`; leave upstream-pinned `postgres`, `minio`, and `nats` at `IfNotPresent`.
- Add a CI assertion in `.github/workflows/helm-test.yml` that fails if any `*-preview:` container is not `Always`.
- Scope: preview only; default (non-preview) render is unchanged. Bump chart version to `0.14.4`. No migrations required.

<sup>Written for commit 80cd744c5789df39f34af016c19ec80ebf9c7975. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

