### PR TITLE
fix(decopilot): don't settle a run its successor still owns

### DIFF
--- a/apps/api/src/api/routes/decopilot/dispatch-run.test.ts
+++ b/apps/api/src/api/routes/decopilot/dispatch-run.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import type { UIMessageChunk } from "ai";
+import {
+  isRunSuperseded,
+  RunSupersededError,
+} from "@/harnesses/sandbox-dispatch-client";
 import {
   assertHostedDispatchHarness,
   assertSinglePersistedRequestMessage,
@@ -335,5 +341,34 @@ describe("buildAgentSandboxUiStream resume", () => {
     expect(rec.done).toEqual([11]);
     // And the floor keeps advancing, so a THIRD attempt would pick up from 11.
     expect(acked).toEqual([6, 7, 8, 9, 10, 11]);
+  });
+});
+
+describe("stream onError takeover guard", () => {
+  test("checks for a takeover before settling the thread as failed", () => {
+    // Source-text assertion, same technique as
+    // hosted-harness-workflow.test.ts: the real `onError` closure can't run
+    // without a live stream, so this proves the guard sits BEFORE the
+    // failed-FINISH (after it, a takeover would still settle a live run).
+    const src = readFileSync(join(import.meta.dir, "dispatch-run.ts"), "utf8");
+    const hook = src.indexOf("onError: (error) => {");
+    expect(hook).toBeGreaterThan(-1);
+    const body = src.slice(hook);
+    const guard = body.indexOf("isRunSuperseded(error)");
+    const settle = body.indexOf('threadStatus: "failed"');
+    expect(guard).toBeGreaterThan(-1);
+    expect(settle).toBeGreaterThan(guard);
+  });
+
+  test("a takeover error survives the DBOS journal round trip", () => {
+    // The guard reads an own-enumerable marker, not `instanceof`, because DBOS
+    // reconstructs a plain Error on replay. A structured clone stands in.
+    const takeover = new RunSupersededError("a newer dispatch took over");
+    const replayed = Object.assign(new Error(takeover.message), {
+      superseded: (takeover as unknown as { superseded: boolean }).superseded,
+    });
+    expect(isRunSuperseded(takeover)).toBe(true);
+    expect(isRunSuperseded(replayed)).toBe(true);
+    expect(isRunSuperseded(new Error("boom"))).toBe(false);
   });
 });

--- a/apps/api/src/api/routes/decopilot/dispatch-run.ts
+++ b/apps/api/src/api/routes/decopilot/dispatch-run.ts
@@ -41,6 +41,7 @@ import { InProcessSandboxClient } from "@/harnesses/in-process-sandbox-client";
 import { CLAUDE_SUBSCRIPTION_PROVIDER_ID } from "@/harnesses/claude-code-env";
 import {
   harnessRunsInSandbox,
+  isRunSuperseded,
   SandboxDispatchClient,
 } from "@/harnesses/sandbox-dispatch-client";
 import { resolveSandboxBranchForThread } from "@/tools/sandbox/thread-repo";
@@ -1654,6 +1655,13 @@ async function prepareRun(
                   is_resume: input.isResume ?? false,
                 },
               });
+              return;
+            }
+            // A takeover is the successor's terminal to write, not ours.
+            if (isRunSuperseded(error)) {
+              console.log(
+                `[decopilot] attempt superseded by a newer dispatch; leaving the terminal to it thread=${mem.thread.id}`,
+              );
               return;
             }
             console.error("[decopilot] stream error:", stringifyError(error));


### PR DESCRIPTION
## Summary

When a newer dispatch of the same run displaces the current attempt, the sandbox daemon reports a `superseded` terminal and the successor becomes the run's writer — it settles the run under the same fence. The displaced attempt must write nothing.

`hostedHarnessWorkflowFn`'s catch already returns early on `RunSupersededError` for exactly this reason. But `buildAgentSandboxUiStream`'s `onError` hook runs first, and it settled the thread as `failed` for *every* error, takeover included — so the displaced attempt declared a live run failed while the successor was still streaming. The guard has to sit in both places.

The takeover fires on any pod turnover that makes DBOS recover a workflow onto another pod: a rolling deploy, an eviction, a KEDA scale-in.

## What changes

`dispatch-run.ts` — `onError` returns early on `isRunSuperseded(error)`, before the failed-`FINISH`, mirroring the workflow's catch. Everything else still settles exactly as before.

Two side effects go away with it:

- `classifyRunFailure` no longer sees `"a newer dispatch took over this run"`, which matched no pattern and landed in `GENERIC_RUN_FAILURE` (`failure_kind: "error"`, "Run ended with an error — see the run's messages") — a verdict that points at the run's messages, where there is no error to find, because the displaced attempt publishes no terminal.
- The task board no longer spends a retry on a run that never failed.

## Testing

`apps/api/src/api/routes/decopilot/dispatch-run.test.ts`:

- `checks for a takeover before settling the thread as failed` — source-text assertion anchored inside the `onError` body, same technique as `hosted-harness-workflow.test.ts`'s guard test (the real closure needs a live stream). Proves the guard precedes the settle; after it, the guard would be inert.
- `a takeover error survives the DBOS journal round trip` — covers why the check reads the own-enumerable `superseded` marker rather than `instanceof`: DBOS reconstructs a plain `Error` on replay.

`bun test` on the four related files: 86 pass. `bun run fmt`, `bun run lint` (0 errors), `bun run check` clean.

## Not covered here

A displaced attempt whose successor also never writes a terminal still relies on the sweep to settle the thread. Separate concern, separate change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents displaced Decopilot attempts from marking live runs failed. Previously the stream `onError` settled every error as failed; now it returns early on `isRunSuperseded`, leaving the terminal to the successor that owns the run.

- `apps/api/src/api/routes/decopilot/dispatch-run.ts`: add takeover guard in `onError` before the failed-FINISH, mirroring the workflow catch.
- Side effects removed: no generic failure verdict on live runs; the task board no longer burns a retry on takeovers.
- Tests: assert the guard precedes the settle and that the `superseded` marker survives DBOS replay (use own-enumerable check, not `instanceof`).

<sup>Written for commit cda1f1f26200a230298478a303a375764a8cc958. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

