### PR TITLE
perf(mcp-clients): skip the read-only tool lookup when read caching is disabled

### DIFF
--- a/apps/api/src/mcp-clients/lazy-client.ts
+++ b/apps/api/src/mcp-clients/lazy-client.ts
@@ -251,7 +251,9 @@ export function createLazyClient(
     options,
   ) => {
     const toolName = (params as { name?: unknown })?.name;
+    // Skip the isReadOnlyTool lookup when readCache is null — both uses below are readCache-gated.
     const readOnly =
+      readCache &&
       cacheReads &&
       typeof toolName === "string" &&
       (await isReadOnlyTool(cache, connection.id, toolName));


### PR DESCRIPTION
**Source:** reduction found while auditing `apps/api/src/mcp-clients/lazy-client.ts` (this file has had 3 hardening fixes land this week — #6181, #6189, #6210 — so I read it closely for the next gap).

**The issue:** `callToolInner` computed `readOnly` via `isReadOnlyTool(cache, ...)` unconditionally on every `callTool` invocation. `isReadOnlyTool` does an async `cache.get("tools", connectionId)` lookup against the NATS KV tool-list cache — a real network round-trip. But `readOnly` is only ever consumed inside two `if (readCache && ...)` branches. `readCache` is the *result*-cache, gated per-org by a settings flag (per the comment a few lines above: "null when MCP caching is disabled"), and is a separate/independent flag from the tool-list `cache` used to compute `readOnly`. So for any org/connection with read-result caching turned off, every single tool call was paying for a KV lookup whose result could never be used.

**Fix:** short-circuit on `readCache` before doing the lookup — `readOnly` now evaluates to `false` immediately (no await, no KV call) when `readCache` is null, matching the fact that both of its consumers are already gated on `readCache` being present. Behavior is unchanged: whenever `readCache` is null, `readOnly` was already unused (both `if` branches skip), so this only removes the wasted work, not any behavior. When `readCache` is present, behavior is identical.

**Verify:** `cd apps/api && bunx tsc --noEmit` (green), `bun test apps/api/src/mcp-clients/lazy-client.test.ts` (13 pass / 0 fail, unchanged), `bunx oxlint apps/api/src/mcp-clients/lazy-client.ts` (0 warnings/errors).

Ran locally: `bun run fmt`, targeted `tsc --noEmit` in `apps/api`, the exact test file above, and per-file `oxlint`. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips the `isReadOnlyTool` lookup in `callToolInner` when `readCache` is null, avoiding an unnecessary NATS KV round-trip on every tool call. Old behavior: always queried the tool-list cache; new behavior: only queries when `readCache` is present; no functional change.

- `readOnly` is only used inside `readCache`-gated branches, so the short-circuit preserves behavior while cutting KV reads when result caching is disabled.

<sup>Written for commit 2aea342c793a78e87f526139a90f2d0ae8dec05a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

