### PR TITLE
perf(storage): cut a DB round trip on connection create/update

### DIFF
--- a/apps/api/src/storage/connection.ts
+++ b/apps/api/src/storage/connection.ts
@@ -222,17 +222,17 @@ export class ConnectionStorage implements ConnectionStoragePort {
       created_at: now,
       updated_at: now,
     });
-    await this.db
+    // returningAll() avoids a second round trip to re-fetch the inserted row.
+    const row = await this.db
       .insertInto("connections")
       .values(serialized as Insertable<Database["connections"]>)
-      .execute();
-
-    const connection = await this.findById(id);
-    if (!connection) {
+      .returningAll()
+      .executeTakeFirst();
+    if (!row) {
       throw new Error(`Failed to create connection with id: ${id}`);
     }
 
-    return connection;
+    return this.deserializeConnection(row as RawConnectionRow);
   }
 
   async createNew(data: Partial<ConnectionEntity>): Promise<ConnectionEntity> {
@@ -248,11 +248,13 @@ export class ConnectionStorage implements ConnectionStoragePort {
       updated_at: now,
     });
 
+    let row: RawConnectionRow | undefined;
     try {
-      await this.db
+      row = (await this.db
         .insertInto("connections")
         .values(serialized as Insertable<Database["connections"]>)
-        .execute();
+        .returningAll()
+        .executeTakeFirst()) as RawConnectionRow | undefined;
     } catch (error) {
       if (
         error instanceof Error &&
@@ -264,12 +266,11 @@ export class ConnectionStorage implements ConnectionStoragePort {
       throw error;
     }
 
-    const connection = await this.findById(id);
-    if (!connection) {
+    if (!row) {
       throw new Error(`Failed to create connection with id: ${id}`);
     }
 
-    return connection;
+    return this.deserializeConnection(row);
   }
 
   async findById(
@@ -396,18 +397,17 @@ export class ConnectionStorage implements ConnectionStoragePort {
       updated_at: new Date().toISOString(),
     });
 
-    await this.db
+    const row = await this.db
       .updateTable("connections")
       .set(serialized)
       .where("id", "=", id)
-      .execute();
-
-    const connection = await this.findById(id);
-    if (!connection) {
+      .returningAll()
+      .executeTakeFirst();
+    if (!row) {
       throw new Error("Connection not found after update");
     }
 
-    return connection;
+    return this.deserializeConnection(row as RawConnectionRow);
   }
 
   /**


### PR DESCRIPTION
Follows #2995 ("DB latency amplifies significantly across MCP tool calls") — `ConnectionStorage` backs every MCP connection lookup/create/update, so its round-trip count is directly on the critical path of tool calls.

`create()`, `createNew()`, and `update()` each did an `INSERT`/`UPDATE` followed by a *separate* `findById()` `SELECT` just to return the row that was already written. That's one avoidable DB round trip per connection create/update, paid on every request that provisions or edits a connection (registry install, OAuth callback, MCP settings save, etc.) — real latency added to a hot path, not a micro-opt on a tiny input.

Fix: use Kysely's `.returningAll()` on the INSERT/UPDATE to get the row back in the same statement, and deserialize it directly instead of issuing a follow-up `SELECT`.

Behavior-preserving: `deserializeConnection()` (decrypt + JSON-field parsing) is unchanged and now runs on the row Postgres returns from the same statement, which is byte-identical to what the old `findById()` SELECT would have fetched immediately after. `update()` still does its pre-update `findById()` read for slug recomputation (unavoidable — it needs the existing row's fields merged with the incoming patch before building the UPDATE), it's only the *post*-write fetch that's removed.

How to verify: `git diff apps/api/src/storage/connection.ts` — one round-trip removed from each of the three write paths, no schema/type changes. Existing coverage: `apps/api/src/storage/connection.integration.test.ts` exercises create/update round-trips (needs Postgres, so it's for CI to run, not this sandbox).

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), `bunx oxlint apps/api/src/storage/connection.ts` (0 warnings/errors). Full CI (including the Postgres integration test) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cuts one DB round trip on connection create and update by using `kysely` `.returningAll()` to return the written row in the same statement. This reduces latency on the MCP connection hot path with no behavior change.

- Affected methods: `create()`, `createNew()`, `update()` now deserialize the row returned by the write instead of calling `findById()` after.
- `update()` still does a pre-update `findById()` for slug recomputation; only the post-write fetch is removed.
- No schema/type changes; `deserializeConnection()` is unchanged and processes the Postgres-returned row.

<sup>Written for commit 9f04ab60e7089434e6f99784db05ecd8ce998861. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

