### PR TITLE
fix(task-board): derive the preview url from the Workers Builds version

### DIFF
--- a/apps/api/src/tools/task-board/checks-status.test.ts
+++ b/apps/api/src/tools/task-board/checks-status.test.ts
@@ -13,6 +13,7 @@ import {
   headShaFromPrGet,
   headShaFromStatus,
   isRateLimitError,
+  extractPreviewUrlFromCheckRuns,
   extractPreviewUrlFromComments,
   isTrustedPreviewHost,
   mergeChecksStatus,
@@ -303,6 +304,59 @@ describe("isTrustedPreviewHost", () => {
     expect(isTrustedPreviewHost("https://decocdn.com.evil.com/")).toBe(false);
     expect(isTrustedPreviewHost("https://not-deco.site.evil.com/")).toBe(false);
     expect(isTrustedPreviewHost("not a url")).toBe(false);
+  });
+});
+
+describe("extractPreviewUrlFromCheckRuns", () => {
+  // Real Workers Builds check-run shape (deco-sites/demo-storefront#93) — the
+  // bot's PR comment for this Worker carries NO preview link, only this does.
+  const workersRun = {
+    name: "Workers Builds: demo-storefront",
+    output: {
+      title: "Workers Builds: demo-storefront",
+      summary:
+        "\nBuild ID: [85b63568-6bf1-45d6-9d3b-57a558dee041](https://dash.cloudflare.com/x)\n" +
+        "Script: [demo-storefront](https://dash.cloudflare.com/y)\n" +
+        "Version ID: 1fe1ee18-b8d0-46ea-bdf1-45cef0cd6e4d\n",
+    },
+  };
+
+  it("derives the version preview url from the Workers Builds summary", () => {
+    expect(extractPreviewUrlFromCheckRuns({ check_runs: [workersRun] })).toBe(
+      "https://1fe1ee18-demo-storefront.deco-cx.workers.dev",
+    );
+    expect(extractPreviewUrlFromCheckRuns([workersRun])).toBe(
+      "https://1fe1ee18-demo-storefront.deco-cx.workers.dev",
+    );
+  });
+
+  it("ignores runs that are not Workers Builds, or have no version yet", () => {
+    expect(
+      extractPreviewUrlFromCheckRuns([
+        {
+          name: "cubic · AI code reviewer",
+          output: { summary: "Version ID: deadbeef-1" },
+        },
+        {
+          name: "Workers Builds: demo-storefront",
+          output: { summary: "Build queued" },
+        },
+        { name: "Workers Builds: demo-storefront" },
+      ]),
+    ).toBeNull();
+    expect(extractPreviewUrlFromCheckRuns(null)).toBeNull();
+    expect(extractPreviewUrlFromCheckRuns({})).toBeNull();
+  });
+
+  it("rejects a worker name that would forge a host outside workers.dev", () => {
+    expect(
+      extractPreviewUrlFromCheckRuns([
+        {
+          name: "Workers Builds: evil.example.com/x",
+          output: { summary: "Version ID: 1fe1ee18-b8d0" },
+        },
+      ]),
+    ).toBeNull();
   });
 });
 

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -342,25 +342,6 @@ export function extractPreviewUrl(
  *  ponytail: hardcoded; make it configurable if sites land in another account. */
 const WORKERS_DEV_SUBDOMAIN = "deco-cx";
 
-/** Pull the preview URL out of a `get_check_runs` result, derived from
- *  Cloudflare Workers Builds' uploaded version.
- *
- *  Why this is its OWN source: on some Workers the
- *  `cloudflare-workers-and-pages[bot]` PR comment renders with NO "Preview URL"
- *  column at all (deco-sites/demo-storefront does this; deco-sites/decocms-tanstack
- *  does not — same account, same `preview_urls: true`). The version is uploaded
- *  and reachable either way, and its id is always in the check run's summary:
- *
- *      Build ID:   85b63568-6bf1-45d6-9d3b-57a558dee041
- *      Version ID: 1fe1ee18-b8d0-46ea-bdf1-45cef0cd6e4d
- *
- *  → `https://1fe1ee18-demo-storefront.deco-cx.workers.dev`.
- *
- *  Tried FIRST, ahead of the comment scan: it comes from the build that
- *  actually ran for this commit, so it cannot lose to another provider's stale
- *  or dead comment link — demo-storefront's board card pointed at a decobot
- *  `*.decocdn.com` url that times out. `null` when no Workers Builds run has
- *  uploaded a version yet. Exported for the pure-logic unit test. */
 export function extractPreviewUrlFromCheckRuns(raw: unknown): string | null {
   const runs = Array.isArray(raw)
     ? raw

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -337,6 +337,54 @@ export function extractPreviewUrl(
   );
 }
 
+/** deco's Cloudflare account subdomain — the middle label of every
+ *  `*.workers.dev` preview host these sites deploy to.
+ *  ponytail: hardcoded; make it configurable if sites land in another account. */
+const WORKERS_DEV_SUBDOMAIN = "deco-cx";
+
+/** Pull the preview URL out of a `get_check_runs` result, derived from
+ *  Cloudflare Workers Builds' uploaded version.
+ *
+ *  Why this is its OWN source: on some Workers the
+ *  `cloudflare-workers-and-pages[bot]` PR comment renders with NO "Preview URL"
+ *  column at all (deco-sites/demo-storefront does this; deco-sites/decocms-tanstack
+ *  does not — same account, same `preview_urls: true`). The version is uploaded
+ *  and reachable either way, and its id is always in the check run's summary:
+ *
+ *      Build ID:   85b63568-6bf1-45d6-9d3b-57a558dee041
+ *      Version ID: 1fe1ee18-b8d0-46ea-bdf1-45cef0cd6e4d
+ *
+ *  → `https://1fe1ee18-demo-storefront.deco-cx.workers.dev`.
+ *
+ *  Tried FIRST, ahead of the comment scan: it comes from the build that
+ *  actually ran for this commit, so it cannot lose to another provider's stale
+ *  or dead comment link — demo-storefront's board card pointed at a decobot
+ *  `*.decocdn.com` url that times out. `null` when no Workers Builds run has
+ *  uploaded a version yet. Exported for the pure-logic unit test. */
+export function extractPreviewUrlFromCheckRuns(raw: unknown): string | null {
+  const runs = Array.isArray(raw)
+    ? raw
+    : Array.isArray((raw as { check_runs?: unknown })?.check_runs)
+      ? (raw as { check_runs: unknown[] }).check_runs
+      : [];
+  for (const r of runs) {
+    if (!r || typeof r !== "object") continue;
+    const o = r as { name?: unknown; output?: { summary?: unknown } };
+    const worker =
+      typeof o.name === "string"
+        ? /^Workers Builds:\s*([a-z0-9][a-z0-9-]*)\s*$/i.exec(o.name)?.[1]
+        : null;
+    if (!worker) continue;
+    const summary = o.output?.summary;
+    if (typeof summary !== "string") continue;
+    const version = /Version ID:\s*([0-9a-f]{8})/i.exec(summary)?.[1];
+    if (!version) continue;
+    const url = `https://${version}-${worker}.${WORKERS_DEV_SUBDOMAIN}.workers.dev`;
+    if (isTrustedPreviewHost(url)) return url;
+  }
+  return null;
+}
+
 /**
  * Pull the preview URL out of a PR's comments — where the deploy bot
  * actually posts it. Known shapes: Cloudflare Workers'
@@ -756,9 +804,13 @@ async function fetchPrStatusExtras(
     toChecksStatus(statusObj),
     toCheckRunsStatus(runsRaw),
   );
-  // Preview: a status `target_url` (rare) else the deploy bot's PR comment.
+  // Preview: the Workers Builds version (exact, and present even when
+  // Cloudflare's PR comment omits its Preview URL column), else a status
+  // `target_url` (rare), else the deploy bot's PR comment.
   let previewUrl =
-    extractPreviewUrl(statusObj) ?? extractPreviewUrlFromComments(commentsRaw);
+    extractPreviewUrlFromCheckRuns(runsRaw) ??
+    extractPreviewUrl(statusObj) ??
+    extractPreviewUrlFromComments(commentsRaw);
   // TODO(e2e): cover the miss-path gate + head-sha threading below (only the pure extractors are unit-tested).
   if (!previewUrl) {
     // Last resort: a GitHub Deployment env url (VTEX FastStore posts it only there), scanned only on the miss path once the head sha is known.


### PR DESCRIPTION
## Summary

The board's **Preview** button on a `deco-sites/demo-storefront` task points at a dead `https://envs-demo-storefront--wquv2x.decocdn.com` (times out after 20s), while the working Cloudflare preview for that same commit sits unlinked.

Cause: `fetchPrStatusExtras` resolves the preview from *status target_url → PR comments*. On this repo the `cloudflare-workers-and-pages[bot]` comment renders with **no Preview URL column at all**, so the only trusted url in any comment is `decobot`'s deco.cx one — which is what wins, and it is dead.

The Cloudflare preview does exist. Its id is in the Workers Builds *check run*, which we already fetch:

```
Build ID:   85b63568-6bf1-45d6-9d3b-57a558dee041
Version ID: 1fe1ee18-b8d0-46ea-bdf1-45cef0cd6e4d
```

→ `https://1fe1ee18-demo-storefront.deco-cx.workers.dev`

## Changes

- `extractPreviewUrlFromCheckRuns()` — pure extractor that reads `Version ID` off a `Workers Builds: <worker>` check run and composes `https://<first-8>-<worker>.deco-cx.workers.dev`. Worker name is anchored to `[a-z0-9-]+` and the result still goes through `isTrustedPreviewHost`, so a forged check name can't produce an off-host url.
- Tried **first** in `fetchPrStatusExtras`, ahead of status and comments: it comes from the build that actually ran for this commit, so it can't lose to another provider's stale or dead comment link. No extra round-trip — `get_check_runs` is already one of the three concurrent reads.

## Testing notes

- 3 new cases in `checks-status.test.ts` (real #93 payload, non-Workers/no-version runs, forged worker name). `bun test apps/api/src/tools/task-board/checks-status.test.ts` → 59 pass / 0 fail.
- `bun run --cwd=apps/api check` clean; `bun run fmt` run.
- Verified live: `https://1fe1ee18-demo-storefront.deco-cx.workers.dev/midea-demo` → 200, `<title>Midea × FC Barcelona — Uma viagem por Barcelona</title>`, 11 `/midea-demo/*.jpg`. Production (`demo-storefront.deco-cx.workers.dev`) serves `main` from Aug 10 and has no such route.

## Known limits

- `WORKERS_DEV_SUBDOMAIN` is hardcoded to `deco-cx` (marked with a `ponytail:` comment). Fine while every site lives in that Cloudflare account.
- This prefers the per-commit version url over Cloudflare's per-branch alias, which is intentional — the version url is pinned to the reviewed commit — but it does mean the url changes on every push.

## Not addressed here

- The `decobot` deco.cx preview (`envs-demo-storefront--wquv2x.decocdn.com`) timing out is a separate problem; this change routes around it rather than fixing it.
- deco-sites/demo-storefront#94 adds a workflow that comments the same url on the PR itself.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Derives the task board Preview URL from Cloudflare Workers Builds check runs and prefers it over status or PR comment links. Replaces dead `*.decocdn.com` links with the per-commit `*.workers.dev` preview that matches the reviewed commit.

- Adds `extractPreviewUrlFromCheckRuns()` to parse the worker name and Version ID and compose `https://<version8>-<worker>.deco-cx.workers.dev`; validates with `isTrustedPreviewHost` and restricts worker names to `[a-z0-9][a-z0-9-]*`.
- Uses it first in `fetchPrStatusExtras`, then falls back to a status `target_url`, then PR comments. No extra API calls; reuses fetched check runs.
- Adds unit tests for real payloads, non-matches, and forged names.
- Limit: `WORKERS_DEV_SUBDOMAIN` is hardcoded to `deco-cx`.

<sup>Written for commit 888210c0628c406367d19477fe69970219527757. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

