### PR TITLE
fix(preview): the ServiceAccount is created after the Job that runs as it

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -291,27 +291,45 @@ jobs:
               kind, name = d["kind"], d["metadata"]["name"]
               w = int((d["metadata"].get("annotations") or {})
                       .get("argocd.argoproj.io/sync-wave", 0))
-              waves[name] = w
+              waves[(kind, name)] = w
               if kind not in ("Job", "Deployment", "StatefulSet"):
                   continue
               spec = d["spec"]["template"]["spec"]
+              # Everything a pod names and the kubelet must resolve before it
+              # can start. envFrom was the first one to bite (the ConfigMap at
+              # 0.14.1); serviceAccountName was the second, and produced a
+              # stranger failure — the Job never even got a pod, so there were
+              # no logs and no events on anything except the Job itself.
+              if spec.get("serviceAccountName"):
+                  needs.append((kind, name, w, "ServiceAccount", spec["serviceAccountName"]))
               for c in (spec.get("initContainers") or []) + spec["containers"]:
                   for ref in (c.get("envFrom") or []):
-                      for key in ("configMapRef", "secretRef"):
+                      for key, k8s in (("configMapRef", "ConfigMap"), ("secretRef", "Secret")):
                           if key in ref:
-                              needs.append((kind, name, w, ref[key]["name"]))
+                              needs.append((kind, name, w, k8s, ref[key]["name"]))
+              for v in (spec.get("volumes") or []):
+                  for key, k8s in (("configMap", "ConfigMap"), ("secret", "Secret")):
+                      if key in v:
+                          n = v[key].get("name") or v[key].get("secretName")
+                          if n:
+                              needs.append((kind, name, w, k8s, n))
           bad = []
-          for kind, name, w, dep in needs:
-              # Only things this chart renders; anything else is pre-existing.
-              if dep not in waves:
-                  continue
-              if waves[dep] > w:
-                  bad.append(f"{kind}/{name} (wave {w}) consumes {dep} (wave {waves[dep]})")
+          for kind, name, w, dep_kind, dep in needs:
+              # An ExternalSecret produces a Secret of the same name; credit its
+              # wave to the Secret it targets.
+              key = (dep_kind, dep)
+              if key not in waves and dep_kind == "Secret":
+                  key = ("ExternalSecret", dep)
+              if key not in waves:
+                  continue  # not rendered by this chart
+              if waves[key] > w:
+                  bad.append(f"{kind}/{name} (wave {w}) needs "
+                             f"{dep_kind}/{dep} (wave {waves[key]})")
           if bad:
-              print("::error::a resource is sequenced before something it mounts: "
+              print("::error::a resource is sequenced before something it needs: "
                     + "; ".join(bad))
               sys.exit(1)
-          print(f"every envFrom source is created no later than its consumer "
+          print(f"every referenced object is created no later than what needs it "
                 f"({len(needs)} references checked)")
           DEPS
 

--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,6 +2,12 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
+# 0.14.5: the ServiceAccount had no sync-wave, so it landed at 0 — after the
+# migration Job at -10 that runs as it. The Job never got a pod at all ("error
+# looking up service account"), sat Running 0/1, and the sync stalled on the
+# hook. Same shape as the ConfigMap at 0.14.1; helm-test now checks every object
+# a pod names, not just envFrom sources.
+#
 # 0.14.4: preview images pull with Always. The preview tag is mutable — the
 # build checks out refs/pull/N/merge, so the same pr-<n>-<sha> is rebuilt
 # against whatever main is at the time — and IfNotPresent let a node that had
@@ -44,7 +50,7 @@ type: application
 # when disabled, so existing releases are unaffected.
 # 0.12.4: chart-managed API/worker dispatch roles now use
 # STUDIO_DISPATCH_ROLE; legacy overrides are rejected.
-version: 0.14.4
+version: 0.14.5
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/templates/serviceaccount.yaml
+++ b/deploy/helm/studio/templates/serviceaccount.yaml
@@ -12,6 +12,15 @@ metadata:
   {{- if and .Values.s3Sync .Values.s3Sync.roleArn }}
   {{- $_ := set $annotations "eks.amazonaws.com/role-arn" .Values.s3Sync.roleArn }}
   {{- end }}
+  {{- /* Previews sequence with sync waves, and the migration Job at -10 runs as
+  this account. Without a wave the ServiceAccount lands at 0 — after the Job —
+  and the Job never gets a pod: the kubelet refuses with "error looking up
+  service account", the Job sits Running 0/1, and the sync stalls on the hook
+  with nothing on any object reporting a fault. Same shape as the ConfigMap at
+  0.14.1, one identifier further out. */}}
+  {{- if .Values.preview.enabled }}
+  {{- $_ := set $annotations "argocd.argoproj.io/sync-wave" "-30" }}
+  {{- end }}
   {{- if $annotations }}
   annotations:
     {{- toYaml $annotations | nindent 4 }}


### PR DESCRIPTION
Second run of decocms/studio#6205 end to end. It stalled in the same place as yesterday, for a different reason.

```
Error creating: pods "studio-pr-6205-preview-migrate-" is forbidden:
  error looking up service account studio-pr-6205/studio-pr-6205: not found
```

## The same mistake, one identifier further out

0.14.1 gave the `-config` ConfigMap a sync-wave because the migration Job mounts it via `envFrom`. The ServiceAccount the Job **runs as** never got one, so it landed at the default `0` — after the Job at `-10`.

| resource | wave |
|---|---|
| Namespace | -40 |
| ConfigMap, ExternalSecret | -30 |
| Postgres, MinIO | -20 |
| migrate Job | **-10** |
| **ServiceAccount** | **0** ← the Job runs as it |

## It fails more quietly than the ConfigMap did

With a missing ConfigMap the pod at least exists and reports `CreateContainerConfigError`. Here the kubelet refuses to create the pod at all, so there is nothing to inspect: no pod, no container logs, no events on anything but the Job. Just `Running 0/1` and an Application stuck on `waiting for completion of hook`.

Postgres and MinIO come up fine, so the namespace looks half-alive indefinitely.

## Why the existing assertion missed it

The check added alongside the ConfigMap fix only walked `envFrom` sources. `serviceAccountName` is not an `envFrom`.

It now covers everything a pod names that the kubelet must resolve before it can start:

- `serviceAccountName`
- `envFrom` → `configMapRef` / `secretRef`
- volumes → `configMap` / `secret`

and credits an `ExternalSecret`'s wave to the `Secret` it produces, since the Secret does not exist as a rendered object.

Verified against `main`: it flags the exact pair.

```
::error::a resource is sequenced before something it needs:
  Job/studio-pr-42-preview-migrate (wave -10) needs ServiceAccount/studio-pr-42 (wave 0)
```

12 references checked on the fixed chart, all in order.

## Note on how this class of bug behaves

Neither instance is visible to `helm template` — rendering never sequences. Both were found by a real sync, and both looked like something else at first glance. That is the argument for the assertion covering the whole class rather than the two cases we happen to have hit.

## Verification

- Default render outside preview: **0 lines of difference** against `main`.
- `helm lint` clean.
- The wave is gated on `preview.enabled`, so nothing outside previews changes.

Chart `0.14.4` → `0.14.5`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the ServiceAccount is created before the preview migration Job that runs as it. Previously the ServiceAccount had no sync-wave (0) and applied after the Job (-10), so the kubelet refused to create the pod and the sync stalled.

- Add preview-only sync-wave `-30` to the ServiceAccount.
- Extend the CI ordering check in `helm-test` to cover `serviceAccountName`, `envFrom` configMap/secret, volume configMap/secret, and credit an `ExternalSecret`’s wave to its `Secret`.
- Gate changes behind `.Values.preview.enabled`; no effect outside previews. Bump chart to 0.14.5.

<sup>Written for commit 6e872107a11b9bb1d390cb8ffe6752c6569a9b06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

