### PR TITLE
fix(task-board): newest activity first, no in-progress spinner

### DIFF
--- a/apps/web/src/layouts/task-board/config.test.ts
+++ b/apps/web/src/layouts/task-board/config.test.ts
@@ -84,8 +84,8 @@ describe("statusIconClassName", () => {
     threads: [{ status: "requires_action" }],
   } as TaskBoardItem;
 
-  test("an in-progress task spins", () => {
-    expect(statusIconClassName(working)).toContain("animate-spin");
+  test("an in-progress task does not spin", () => {
+    expect(statusIconClassName(working)).not.toContain("animate-spin");
   });
 
   test("one waiting on input pulses in warning instead", () => {

--- a/apps/web/src/layouts/task-board/config.tsx
+++ b/apps/web/src/layouts/task-board/config.tsx
@@ -165,7 +165,7 @@ export const STATUS_CONFIG: Record<
   in_progress: {
     labelKey: "taskBoard.config.statusInProgress",
     icon: Loading02,
-    iconClassName: "text-primary animate-spin",
+    iconClassName: "text-primary",
   },
   in_review: {
     labelKey: "taskBoard.config.statusInReview",

--- a/apps/web/src/layouts/task-board/config.tsx
+++ b/apps/web/src/layouts/task-board/config.tsx
@@ -54,9 +54,9 @@ export function isTaskHandedToHuman(item: TaskBoardItem): boolean {
 }
 
 /**
- * Status-icon classes for a task card/row. An in-progress task's spinner spins,
- * but one waiting on input stops spinning and pulses in `warning` — same token
- * as its "Needs input" badge, so a stalled task doesn't look like it's working.
+ * Status-icon classes for a task card/row. A task waiting on input pulses in
+ * `warning` — same token as its "Needs input" badge, so a stalled task doesn't
+ * look like it's still progressing.
  */
 export function statusIconClassName(item: TaskBoardItem): string {
   return item.status === "in_progress" && isTaskBlocked(item)

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -1462,7 +1462,7 @@ function LinksSection({
 
 /**
  * Activity feed: the task's change timeline (created, moved, (re)assigned), its
- * linked agent sessions and its comment threads, interleaved oldest-first.
+ * linked agent sessions and its comment threads, interleaved most-recent-first.
  * Consecutive timeline events render as one run joined by a rail; a thread or a
  * comment renders as a card. A composer at the bottom starts a new thread.
  */
@@ -1550,7 +1550,7 @@ function ActivitySection({
         comment,
       }),
     ),
-  ].sort((a, b) => a.at - b.at);
+  ].sort((a, b) => b.at - a.at);
 
   // Group consecutive timeline events so their avatars connect with a rail.
   const blocks: (


### PR DESCRIPTION
## What is this contribution about?
The task card's activity feed appended new entries at the bottom of the timeline, so as agents log more steps the thread grows and reviewing it means scrolling to the end every time. This flips the sort to most-recent-first. It also removes the constant `animate-spin` on the "In progress" status icon, which users found distracting.

## How did you verify your code works?
Verified manually: formatted the changed files with Biome. No automated tests were added since these are presentational/ordering tweaks to existing UI with no new logic branches.

## Screenshots/Demonstration
N/A (no screenshots taken this session; visual diff is a reordering of existing timeline items and removal of a spin animation).

## How to Test
1. Open a task card with several agent activity events.
2. Confirm the most recent activity appears at the top of the Activity feed instead of the bottom.
3. Move a task to "In progress" and confirm its status icon no longer spins.

## Review Checklist
- [x] PR title is clear and descriptive
- [ ] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [x] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows newest activity first in task cards and removes the constant spin on the in-progress status icon. Old: activity feed sorted oldest-first and the in-progress icon used `animate-spin`; New: most-recent-first and a static icon, reducing scrolling and distraction.

- Activity feed now sorts by descending timestamp; timeline grouping and composer placement are unchanged.
- "In progress" status uses the same icon without `animate-spin`; updates the `statusIconClassName` test to expect no spin. Other statuses are unaffected.

<sup>Written for commit 951b5990a79e57bf8a1acbb28c49dbb39b975d23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

