### PR TITLE
fix(decofile): drop a block whose decoded key collides with another instead of silently splicing a duplicate JSON key

### DIFF
--- a/packages/shared/src/decofile/merge.test.ts
+++ b/packages/shared/src/decofile/merge.test.ts
@@ -108,6 +108,20 @@ describe("mergeBlocks", () => {
       stem: "Compre%20Junto",
     });
   });
+
+  it("drops a later file whose decoded key collides with an earlier one", () => {
+    // Both stems decode to the same key — splicing both would emit a duplicate JSON key.
+    const { decofile, skipped } = mergeBlocks([
+      { stem: "Compre Junto", content: '{"v":"literal"}' },
+      { stem: "Compre%20Junto", content: '{"v":"encoded"}' },
+    ]);
+    expect(JSON.parse(decofile)).toEqual({ "Compre Junto": { v: "literal" } });
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0]).toMatchObject({
+      key: "Compre Junto",
+      stem: "Compre%20Junto",
+    });
+  });
 });
 
 describe("BLOCK_PATH_RE", () => {

--- a/packages/shared/src/decofile/merge.ts
+++ b/packages/shared/src/decofile/merge.ts
@@ -61,26 +61,38 @@ export function mergeBlocks(files: BlockFile[]): MergeResult {
     .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
 
   const skipped: SkippedBlock[] = [];
+  const seenKeys = new Set<string>();
   let out = "{";
   let first = true;
   for (const { file } of sorted) {
     const content = file.content.trim();
     // Skip empty files — `"key":` with no value would break the merged JSON.
     if (content.length === 0) continue;
+    const key = decoBlockKeyFromFileStem(file.stem);
+    // Two distinct filenames can decode to the same key; splicing both would silently drop one via JSON.parse's last-key-wins.
+    if (seenKeys.has(key)) {
+      skipped.push({
+        key,
+        stem: file.stem,
+        error: `duplicate block key "${key}" (another file already maps to it)`,
+      });
+      continue;
+    }
     // Parse only to validate; the raw text (not a re-stringify) is spliced.
     try {
       JSON.parse(content);
     } catch (err) {
       skipped.push({
-        key: decoBlockKeyFromFileStem(file.stem),
+        key,
         stem: file.stem,
         error: err instanceof Error ? err.message : String(err),
       });
       continue;
     }
+    seenKeys.add(key);
     if (!first) out += ",";
     first = false;
-    out += `${JSON.stringify(decoBlockKeyFromFileStem(file.stem))}:${content}`;
+    out += `${JSON.stringify(key)}:${content}`;
   }
   return { decofile: `${out}}`, skipped };
 }


### PR DESCRIPTION
Bug found while reading `packages/shared/src/decofile/merge.ts` (recently hardened by #6183/#6194/#6203).

`mergeBlocks` splices each block under `decoBlockKeyFromFileStem(stem)` without checking for collisions. Two distinct filenames can decode to the same key — e.g. `.deco/blocks/Compre Junto.json` (a literal space) and `.deco/blocks/Compre%20Junto.json` (its single-encoded twin) both decode to the key `"Compre Junto"`. Splicing both produces a merged document with a duplicate JSON key: `{"Compre Junto":{...},"Compre Junto":{...}}`. `JSON.parse` silently resolves duplicate keys by keeping the last one — so the first block is dropped from the runtime's view with no error, no entry in `skipped`, and no log line, unlike every other block-drop path this file already handles (invalid JSON, empty file).

**Failure scenario:** a repo ends up with two block files whose stems decode to the same key (a stale copy left after a rename, or a manual edit), the reader silently loses one block's data every time it re-merges, and nobody is told why a change didn't take effect.

**Fix:** track keys already emitted in a `Set`; a later file (in the same sort order the merge already uses) whose decoded key collides with one already emitted is dropped and reported via the existing `skipped` array instead of being spliced.

**Regression test:** `packages/shared/src/decofile/merge.test.ts` — "drops a later file whose decoded key collides with an earlier one" reproduces the two-stems-one-key case and asserts the merged doc has one entry and the loser shows up in `skipped`.

Reviewer check: `bun test packages/shared/src/decofile/merge.test.ts` (15 pass, includes the new case).

Locally ran: `bun run fmt`, `cd packages/shared && bunx tsc --noEmit` (clean), `bunx oxlint packages/shared/src/decofile/merge.ts packages/shared/src/decofile/merge.test.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops silent data loss in Decofile merges by skipping a later block file when its decoded key collides with an earlier one and recording the skip in `skipped`. Previously `mergeBlocks` spliced both, and `JSON.parse` kept the last value, silently dropping the first.

- Old behavior: duplicate decoded keys produced duplicate JSON keys; the first block’s data was lost without a `skipped` entry.
- New behavior: track emitted keys; on collision, skip the later file, add a `skipped` entry with an error, and keep the earlier file. Precedence follows the existing filename sort order.
- Test: adds a regression case in `packages/shared/src/decofile/merge.test.ts`; run `bun test packages/shared/src/decofile/merge.test.ts` to verify.

<sup>Written for commit 5ad1b372d3d9f3d00d9047277af33a37e0f25c58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

