### PR TITLE
test: measure the preview cycle end to end

### DIFF
--- a/deploy/preview/README.md
+++ b/deploy/preview/README.md
@@ -10,6 +10,8 @@ designer, a PM, another engineer — click a link instead of cloning the monorep
 
 ## Using one
 
+<!-- timing: second end-to-end run, measuring the full cycle. -->
+
 1. Add the `preview` label to your PR.
 2. Wait ~8–10 minutes for the image build, then ~1–2 more for the first sync
    (which creates and migrates the database). The bot comment updates itself.


### PR DESCRIPTION
Second end-to-end run, now that every fix from the first one has shipped.

**Do not merge.** One comment in a README; closing it is part of the test.

## Measuring

| stage | first run | this run |
|---|---|---|
| build | ~2.1 min | |
| generator pickup | | |
| sync to Healthy | | |
| teardown on close | 85s | |

## What shipped between the two runs

| chart | fix |
|---|---|
| 0.14.1 | `-config` ConfigMap had no sync-wave, landing after the Job that mounts it |
| 0.14.3 | namespace was created by `CreateNamespace=true` and never deleted |
| 0.14.4 | preview tag is mutable, so `IfNotPresent` could serve a cached build |
| 0.14.5 | ServiceAccount had no sync-wave, so the Job never got a pod |
| previews 0.1.1 | pass `namespaceLabels` through |
| build workflow | images были amd64-only; a Graviton node killed a running preview |

## Known gaps

Nothing gates the URL — DNS-only, no authorization policy. Hosted sandboxes are off. A stuck sync operation still blocks teardown, including the 48h TTL.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a README HTML comment to trigger a second end-to-end preview run and record timings for the full preview cycle. No product or runtime behavior changes.

**Review plan**
- Use this PR only to run build → generator pickup → sync to Healthy → teardown on close and capture timings.
- Do not merge; close the PR to trigger teardown and complete the test.
- Validates fixes since the first run (sync-wave ordering, namespace cleanup, image pull policy, multi-arch images, `namespaceLabels` pass-through).

<sup>Written for commit f70105b989d1954d309b394ce188b6167a2e161f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6227?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

