### PR TITLE
fix(monitoring): authorize MONITORING_LOGS_LIST before reading logs

### DIFF
--- a/apps/api/src/tools/monitoring/list.test.ts
+++ b/apps/api/src/tools/monitoring/list.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, mock } from "bun:test";
+import { ForbiddenError } from "@/core/access-control";
+
+// The real module pulls in the whole OpenTelemetry provider graph; the flush is
+// a no-op when no exporter is configured, so stub it out.
+const flushMonitoringData = mock(async () => {});
+mock.module("@/observability", () => ({ flushMonitoringData }));
+
+const { MONITORING_LOGS_LIST } = await import("./list");
+
+type Handler = typeof MONITORING_LOGS_LIST.handler;
+type Ctx = Parameters<Handler>[1];
+
+function makeCtx(check: () => Promise<void>) {
+  const query = mock(async (_filters: { organizationId: string }) => ({
+    logs: [],
+    total: 0,
+  }));
+  const ctx = {
+    organization: { id: "org-1" },
+    access: { check: mock(check) },
+    storage: { monitoring: { query } },
+  } as unknown as Ctx;
+  return { ctx, query };
+}
+
+const INPUT = { limit: 20, offset: 0 } as Parameters<Handler>[0];
+
+describe("MONITORING_LOGS_LIST", () => {
+  it("authorizes before reading, so a denied caller never sees another org's logs", async () => {
+    // `POST /api/:org/tools/:toolName` carries no auth middleware and
+    // `resolveOrgFromPath` sets `ctx.organization` even for anonymous callers,
+    // so the handler's own `access.check()` is the whole gate here.
+    const { ctx, query } = makeCtx(async () => {
+      throw new ForbiddenError("Access denied to: MONITORING_LOGS_LIST");
+    });
+
+    await expect(MONITORING_LOGS_LIST.handler(INPUT, ctx)).rejects.toThrow(
+      ForbiddenError,
+    );
+
+    expect(ctx.access.check).toHaveBeenCalled();
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it("queries scoped to the caller's organization once authorized", async () => {
+    const { ctx, query } = makeCtx(async () => {});
+
+    const result = await MONITORING_LOGS_LIST.handler(INPUT, ctx);
+
+    expect(result).toEqual({ logs: [], total: 0, offset: 0, limit: 20 });
+    expect(query).toHaveBeenCalledTimes(1);
+    expect(query.mock.calls[0]![0]).toMatchObject({
+      organizationId: "org-1",
+    });
+  });
+});

--- a/apps/api/src/tools/monitoring/list.ts
+++ b/apps/api/src/tools/monitoring/list.ts
@@ -100,6 +100,13 @@ export const MONITORING_LOGS_LIST = defineTool({
     limit: z.number().describe("Current limit for pagination"),
   }),
   handler: async (input, ctx) => {
+    // Authorize BEFORE any IO. `POST /api/:org/tools/:toolName` has no auth
+    // middleware of its own and `resolveOrgFromPath` populates
+    // `ctx.organization` for unauthenticated callers too (so OAuth discovery
+    // works), so this check is the only thing standing between an anonymous
+    // request and another org's tool-call history.
+    await ctx.access.check();
+
     // Flush buffered spans so the query sees the latest data (local mode).
     await flushMonitoringData();
 


### PR DESCRIPTION
## Problem

`MONITORING_LOGS_LIST` was the only read tool in the codebase whose handler never called `ctx.access.check()` (`apps/api/src/tools/monitoring/list.ts`). It called `requireOrganization(ctx)` and went straight to `storage.monitoring.query`.

Three things combine to make that a live, unauthenticated cross-tenant read rather than a lint nit:

1. **`POST /api/:org/tools/:toolName` has no auth middleware.** `apps/api/src/api/routes/tools-rest.ts` states this explicitly in its header comment — the tool name in the path *is* the permission identifier, "enforced by the tool handler's own `ctx.access.check()`". Unlike the MCP mounts, there is no `mcpAuth` in front of it.
2. **`resolveOrgFromPath` populates `ctx.organization` for unauthenticated callers.** That's deliberate (`apps/api/src/api/middleware/resolve-org-from-path.ts`) so OAuth-capable MCP clients can reach protected-resource discovery and start their flow; the middleware's own comment defers to "routes that need an authenticated principal still reject via their own `ctx.access.check()`". So `requireOrganization` succeeds for an anonymous request against any org slug.
3. **Nothing enforces `granted()`.** `AccessControl`'s module docs claim "Middleware verifies that access was granted," but `AccessControl.granted()` has zero non-test callers. A forgotten check fails **open**.

Net effect: `POST /api/<org-slug>/tools/MONITORING_LOGS_LIST` with no credentials returned that organization's full tool-call history — tool names, connection ids, virtual-MCP ids, user ids, request ids, error messages, durations, and the custom `properties` bag (which carries values like `user_tags`).

Every other tool with a `check()` fails closed for an anonymous principal: `boundAuth` exists on every request, so `checkResource` falls through to `hasPermission`, which returns `false` (no role, no stored permissions, and Better Auth answers 401).

## Fix

Add `await ctx.access.check()` as the first statement of the handler — before `flushMonitoringData()`, so an unauthorized caller can't drive telemetry flushes either. This matches the ordering already used by `MONITORING_LOG_GET` next door.

## Test

`apps/api/src/tools/monitoring/list.test.ts` pins both halves:

- a denied caller rejects with `ForbiddenError` and **never** reaches `storage.monitoring.query`;
- an authorized caller queries with `organizationId` scoped to its own org.

Verified the first test fails against the unpatched handler (it resolved instead of rejecting) and passes with the fix, so it's a real regression guard rather than a tautology.

## Verification

- `bun test apps/api/src/tools/monitoring/list.test.ts` — 2 pass.
- `bun test apps/api/src/tools/` — 614 pass, 19 fail. Every failure is `connect ECONNREFUSED 127.0.0.1:5432` from integration tests that need Postgres; pre-existing and unrelated.
- `biome format` — clean, no fixes.
- `oxlint` on the two changed files — 0 warnings, 0 errors. Note: the repo-wide `bun run lint` aborts with `memory allocation of 4294967280 bytes failed` in the experimental JS-plugin loader on this machine, on `main` as well as this branch; I linted the changed files with the default rule set instead.
- `tsc --noEmit -p apps/api/tsconfig.json` — no errors in `monitoring/`. Remaining output is a pre-existing duplicate-`ajv` (8.18 vs 8.20) type conflict in `node_modules`.

## Scope

This PR fixes only the missing check. Found while auditing all 172 `defineTool` definitions for cross-tenant read access; four related findings are **not** addressed here and want their own PRs:

- `/mcp/:connectionId/call-tool/:toolName` (`api/routes/proxy.ts`) is uncovered by `mcpAuth` (registered as the single-segment `/mcp/:connectionId?`) and passes `ctx.organization?.id` into `connections.findById`, which drops the org predicate when it's `undefined`.
- `virtualMcps.findById(id, organizationId)` (`storage/virtual.ts`) accepts `organizationId` but never applies it to the query; ~6 call sites treat the result as org-scoped.
- Decopilot run dispatch takes `agent.id` from the request body and never checks it belongs to the path org.
- Enforcing `access.granted()` in `defineTool`, which would turn this whole class of bug into a hard failure instead of a silent bypass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Authorize MONITORING_LOGS_LIST before reading logs to close an unauthenticated cross-tenant read via POST /api/:org/tools/:toolName. Previously the handler skipped ctx.access.check(), allowing anonymous callers to list another org’s tool-call history; now it checks first and rejects unauthorized callers, and the check runs before any IO (including flushMonitoringData).

- Adds tests that assert a denied caller throws ForbiddenError without hitting storage and that an authorized caller’s query is scoped to its org.

<sup>Written for commit 9d81a2c7277db55e5f727d67d7fceefec2463129. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

