### PR TITLE
fix(preview): re-apply the schema on every pod start

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -333,6 +333,34 @@ jobs:
                 f"({len(needs)} references checked)")
           DEPS
 
+          # The preview Postgres is an emptyDir, so any reschedule hands the pod
+          # an empty volume. The Job is a sync hook and will not re-run, so
+          # without an init container the app comes up against zero tables with
+          # every signal reporting healthy. Exactly one pod may migrate — Kysely
+          # locks, DBOS does not.
+          python3 - <<'BOOT'
+          import sys, yaml
+          migrators, waiters = [], []
+          for d in yaml.safe_load_all(open("/tmp/preview.yaml")):
+              if not d or d["kind"] != "Deployment":
+                  continue
+              for c in (d["spec"]["template"]["spec"].get("initContainers") or []):
+                  if c["name"] == "migrate-on-boot":
+                      migrators.append(d["metadata"]["name"])
+                  if c["name"] == "wait-for-schema":
+                      waiters.append(d["metadata"]["name"])
+          if len(migrators) != 1:
+              print(f"::error::exactly one Deployment may migrate on boot, found "
+                    f"{len(migrators)}: {migrators} — DBOS has no lock and parallel "
+                    "launches collide on dbos.dbos_migrations")
+              sys.exit(1)
+          if not waiters:
+              print("::error::the worker has no wait-for-schema init container — it "
+                    "would start against a database the API pod has not migrated yet")
+              sys.exit(1)
+          print(f"schema is re-applied on boot by {migrators[0]}, awaited by {waiters}")
+          BOOT
+
           # Every studio container (api-0, api-1, worker) must skip migrations:
           # the PreSync Job is the single writer. Three, not two.
           # `|| true` — grep exits 1 on zero matches, which under `set -e` would

--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,6 +2,13 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
+# 0.14.6: previews re-apply the schema on every pod start (preview.migrateOnBoot).
+# The preview Postgres is an emptyDir, so a spot reclaim hands the pod an empty
+# volume — and the migration Job is a sync hook that does not re-run, because
+# nothing changed in git. The application then serves against zero tables while
+# pods are Running, the namespace is Active and Argo says Progressing. Observed
+# twice in two days on a spot-only pool.
+#
 # 0.14.5: the ServiceAccount had no sync-wave, so it landed at 0 — after the
 # migration Job at -10 that runs as it. The Job never got a pod at all ("error
 # looking up service account"), sat Running 0/1, and the sync stalled on the
@@ -50,7 +57,7 @@ type: application
 # when disabled, so existing releases are unaffected.
 # 0.12.4: chart-managed API/worker dispatch roles now use
 # STUDIO_DISPATCH_ROLE; legacy overrides are rejected.
-version: 0.14.5
+version: 0.14.6
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/templates/_helpers.tpl
+++ b/deploy/helm/studio/templates/_helpers.tpl
@@ -357,6 +357,74 @@ and grant the wrong thing.
 {{- end }}
 
 {{/*
+Re-applies the schema every time a pod starts, not only when Argo syncs.
+
+The preview's Postgres is an emptyDir: a spot reclaim, a drain or an OOM gives
+the pod a brand-new empty volume. The migration Job is a sync hook, so it does
+not re-run — nothing changed in git — and the application comes up against a
+database with zero tables. Everything reports healthy: pods Running, namespace
+Active, Argo Progressing. Only the product is broken, with nothing pointing at
+why. Seen twice in two days.
+
+Kysely serialises concurrent runs through kysely_migration_lock, so this is safe
+to race with the Job. DBOS does not — parallel launches collide on
+dbos.dbos_migrations — which is why only ONE pod migrates and the worker waits.
+*/}}
+{{- define "chart-deco-studio.previewMigrateInit" -}}
+{{- if and .Values.preview.enabled .Values.preview.migrateOnBoot }}
+- name: migrate-on-boot
+  image: "{{ .Values.image.repository }}{{- if and .Values.image.tag (hasPrefix "sha256:" .Values.image.tag) }}@{{ .Values.image.tag }}{{- else }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{- end }}"
+  imagePullPolicy: {{ .Values.image.pullPolicy }}
+  envFrom:
+    - configMapRef:
+        name: {{ include "chart-deco-studio.fullname" . }}-config
+    - secretRef:
+        name: {{ include "chart-deco-studio.secretName" . }}
+  command: ["/bin/sh", "-c"]
+  args:
+    - |
+      set -eu
+      bun run node_modules/decocms/dist/server/migrate.js
+      bun run node_modules/decocms/dist/server/migrate-dbos.js
+  resources:
+    {{- toYaml .Values.preview.jobResources | nindent 4 }}
+{{- end }}
+{{- end }}
+
+{{/*
+Blocks the worker until the schema exists, rather than migrating it.
+
+The API pod is the single writer — see previewMigrateInit. Having the worker
+migrate too would race DBOS, which is the collision the migration Job was
+introduced to avoid in the first place.
+*/}}
+{{- define "chart-deco-studio.previewWaitForSchema" -}}
+{{- if and .Values.preview.enabled .Values.preview.migrateOnBoot }}
+- name: wait-for-schema
+  image: "{{ .Values.preview.postgres.image.repository }}:{{ .Values.preview.postgres.image.tag }}"
+  imagePullPolicy: {{ .Values.preview.postgres.image.pullPolicy }}
+  envFrom:
+    - configMapRef:
+        name: {{ include "chart-deco-studio.fullname" . }}-config
+    - secretRef:
+        name: {{ include "chart-deco-studio.secretName" . }}
+  command: ["/bin/sh", "-c"]
+  args:
+    - |
+      set -eu
+      # to_regclass returns NULL rather than erroring on a missing table, so
+      # this polls without a failing exit code muddying the loop.
+      until [ "$(psql "$DATABASE_URL" -tAc "select to_regclass('public.kysely_migration') is not null")" = "t" ]; do
+        echo "waiting for the schema"
+        sleep 3
+      done
+      echo "schema present"
+  resources:
+    {{- toYaml .Values.preview.jobResources | nindent 4 }}
+{{- end }}
+{{- end }}
+
+{{/*
 Validates per-PR preview releases. Every failure here is something that would
 otherwise render a healthy-looking object that silently does nothing: an
 HTTPRoute with no hostname matches no traffic, a pod without --skip-migrations

--- a/deploy/helm/studio/templates/deployment.yaml
+++ b/deploy/helm/studio/templates/deployment.yaml
@@ -62,6 +62,10 @@ spec:
       serviceAccountName: {{ include "chart-deco-studio.serviceAccountName" . }}
       securityContext:
         {{- include "chart-deco-studio.podSecurityContext" . | nindent 8 }}
+      {{- with (include "chart-deco-studio.previewMigrateInit" . | trim) }}
+      initContainers:
+        {{- . | nindent 8 }}
+      {{- end }}
       containers:
         # The front-door / web tier. Runs the nginx image (serves the SPA +
         # proxies to the API sidecars); named "-web" for the user-facing web

--- a/deploy/helm/studio/templates/worker-deployment.yaml
+++ b/deploy/helm/studio/templates/worker-deployment.yaml
@@ -81,6 +81,10 @@ spec:
       serviceAccountName: {{ include "chart-deco-studio.serviceAccountName" . }}
       securityContext:
         {{- include "chart-deco-studio.podSecurityContext" . | nindent 8 }}
+      {{- with (include "chart-deco-studio.previewWaitForSchema" . | trim) }}
+      initContainers:
+        {{- . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-worker
           {{- with .Values.securityContext }}

--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -147,6 +147,15 @@ preview:
       limits:
         memory: "768Mi"
 
+  # Re-apply the schema on every pod start, not only when Argo syncs.
+  #
+  # The preview's Postgres is an emptyDir, so a spot reclaim, a drain or an OOM
+  # hands the pod an empty volume. The migration Job is a sync hook and does not
+  # re-run — nothing changed in git — so the application comes up against zero
+  # tables while every signal says healthy. Turn off only if something else
+  # guarantees the schema.
+  migrateOnBoot: true
+
   # Render the preview's namespace as part of the release.
   #
   # Argo's CreateNamespace=true creates a namespace without adopting it: no


### PR DESCRIPTION
Caught live on decocms/studio#6227 a few minutes ago.

```
Job de migração:  Complete   1/1   (18m ago)
Tables in public: 0
```

## What happens

The preview Postgres is an `emptyDir`. A spot reclaim — or a drain, or an OOM — hands the rescheduled pod a brand-new empty volume. The migration Job is a **sync hook**, so it does not re-run: nothing changed in git, so Argo has no reason to sync.

The application then comes up against a database with **zero tables**.

The dangerous part is that nothing reports a fault:

| signal | says |
|---|---|
| pods | `Running` |
| namespace | `Active` |
| Argo | `Progressing` |
| migration Job | `Complete` |
| the product | broken |

Whoever opens the URL sees an application error and concludes the preview is buggy. There is nothing to point at.

This is not rare. It happened **twice in two days** — both times on the only previews left running for more than half an hour, on a pool that is spot-only by design.

## Fix

An init container makes the schema a property of *a pod starting* rather than of *Argo syncing*. A reschedule then costs a restart, not a dead environment.

**Exactly one pod migrates.** Kysely serialises concurrent runs through `kysely_migration_lock`, so racing the Job is safe — but DBOS has no lock, and parallel launches collide on `dbos.dbos_migrations`. That collision is precisely why the Job exists. So:

- the **API pod** runs `migrate.js` + `migrate-dbos.js` in `migrate-on-boot`;
- the **worker** blocks in `wait-for-schema`, polling `to_regclass(public.kysely_migration)` until the schema is there.

`to_regclass` returns NULL instead of erroring on a missing table, so the loop polls cleanly without a failing exit code.

The Job stays. It is still the single writer on a first sync, before any pod exists to run an init container.

## Assertion

`helm-test.yml` now fails if more than one Deployment carries `migrate-on-boot` — the DBOS collision — or if the worker has no `wait-for-schema`. Both embedded scripts are `sh -n`-checked alongside the existing hook scripts.

## Verification

- Render: API pod has `migrate-on-boot`, worker has `wait-for-schema`, nothing else changed.
- Default render outside preview: **0 lines of difference** against `main`.
- `helm lint` clean.

Chart `0.14.5` → `0.14.6`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Previews now re-apply the database schema on every pod start to avoid empty Postgres after reschedules. Previously, migrations ran only on Argo sync via a Job; a rescheduled pod could start against zero tables while all signals looked healthy.

- API Deployment gains a `migrate-on-boot` init container that runs the standard schema and DBOS migrations; the worker gains a `wait-for-schema` init container that blocks until `public.kysely_migration` exists.
- Exactly one Deployment may migrate on boot; the worker never migrates. A new `helm-test` check enforces one migrator and the worker waiter, preventing DBOS collisions.
- Adds `preview.migrateOnBoot` (default true). Non-preview renders are unchanged. Chart version bumps to 0.14.6.

<sup>Written for commit b656541bda2ea8ac73418be80f0348a7a7a85b05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6229?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

