### PR TITLE
fix(decofile): don't let a rename-source delete clobber a same-path rename destination in branch-wins merges

### DIFF
--- a/apps/api/src/decofile/git-compat.test.ts
+++ b/apps/api/src/decofile/git-compat.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test";
+import { buildMergeTreeEntries } from "./git-compat";
+
+describe("buildMergeTreeEntries", () => {
+  it("writes a rename as create-destination + delete-source", () => {
+    const entries = buildMergeTreeEntries(
+      [
+        {
+          filename: "Header.json",
+          status: "renamed",
+          sha: "b1",
+          previousFilename: "Hero.json",
+        },
+      ],
+      new Map([["Header.json", { sha: "b1" }]]),
+    );
+    expect(entries).toContainEqual({
+      path: "Header.json",
+      mode: "100644",
+      type: "blob",
+      sha: "b1",
+    });
+    expect(entries).toContainEqual({
+      path: "Hero.json",
+      mode: "100644",
+      type: "blob",
+      sha: null,
+    });
+  });
+
+  it("keeps a path's new content when it is both a rename destination and another file's rename source, regardless of diff order", () => {
+    const files = [
+      {
+        filename: "Header.json",
+        status: "renamed",
+        sha: "b1",
+        previousFilename: "Hero.json",
+      },
+      {
+        filename: "Hero.json",
+        status: "renamed",
+        sha: "b2",
+        previousFilename: "Banner.json",
+      },
+    ];
+    const branchBlobByPath = new Map([
+      ["Header.json", { sha: "b1" }],
+      ["Hero.json", { sha: "b2" }],
+    ]);
+
+    for (const ordered of [files, [...files].reverse()]) {
+      const entries = buildMergeTreeEntries(ordered, branchBlobByPath);
+      const heroEntry = entries.find((e) => e.path === "Hero.json");
+      expect(heroEntry).toEqual({
+        path: "Hero.json",
+        mode: "100644",
+        type: "blob",
+        sha: "b2",
+      });
+      expect(entries).toContainEqual({
+        path: "Banner.json",
+        mode: "100644",
+        type: "blob",
+        sha: null,
+      });
+    }
+  });
+
+  it("deletes a removed file", () => {
+    const entries = buildMergeTreeEntries(
+      [{ filename: "Old.json", status: "removed", sha: "b1" }],
+      new Map(),
+    );
+    expect(entries).toEqual([
+      { path: "Old.json", mode: "100644", type: "blob", sha: null },
+    ]);
+  });
+});

--- a/apps/api/src/decofile/git-compat.ts
+++ b/apps/api/src/decofile/git-compat.ts
@@ -174,6 +174,53 @@ const MERGE_REPLAY_FILE_CAP = 300;
 
 const MERGE_CAS_ATTEMPTS = 3;
 
+/**
+ * Tree write entries for the branch-wins replay, deduped by path. A path can
+ * be BOTH a rename destination for one file and a rename source for another
+ * in the same diff (e.g. `Hero.json`→`Header.json` while `Banner.json`→
+ * `Hero.json`) — GitHub's tree write applies the LAST entry for a duplicate
+ * path, so pushing both a create and a stale-source delete for the same path
+ * let iteration order decide whether the renamed-in content survived. A
+ * destination entry always describes the path's real final content, so it
+ * always wins; a source delete only applies when nothing else claims that
+ * path as its destination.
+ */
+export function buildMergeTreeEntries(
+  files: Array<{
+    filename: string;
+    status: string;
+    sha: string;
+    previousFilename?: string;
+  }>,
+  branchBlobByPath: Map<string, { sha: string }>,
+): TreeWriteEntry[] {
+  const byPath = new Map<string, TreeWriteEntry>();
+  for (const f of files) {
+    const blob = branchBlobByPath.get(f.filename);
+    byPath.set(f.filename, {
+      path: f.filename,
+      mode: "100644",
+      type: "blob",
+      sha: f.status === "removed" || !blob ? null : blob.sha,
+    });
+  }
+  for (const f of files) {
+    if (
+      f.previousFilename &&
+      f.previousFilename !== f.filename &&
+      !byPath.has(f.previousFilename)
+    ) {
+      byPath.set(f.previousFilename, {
+        path: f.previousFilename,
+        mode: "100644",
+        type: "blob",
+        sha: null,
+      });
+    }
+  }
+  return [...byPath.values()];
+}
+
 async function mergeBranchWins(
   client: GitDataClient,
   branch: string,
@@ -203,34 +250,7 @@ async function mergeBranchWins(
       branchTree.filter((e) => e.type === "blob").map((e) => [e.path, e]),
     );
 
-    const entries: TreeWriteEntry[] = [];
-    for (const f of files) {
-      const blob = branchBlobByPath.get(f.filename);
-      if (f.status === "removed" || !blob) {
-        entries.push({
-          path: f.filename,
-          mode: "100644",
-          type: "blob",
-          sha: null,
-        });
-      } else {
-        entries.push({
-          path: f.filename,
-          mode: "100644",
-          type: "blob",
-          sha: blob.sha,
-        });
-      }
-      // A rename on the branch must also delete the old path from base's tree.
-      if (f.previousFilename && f.previousFilename !== f.filename) {
-        entries.push({
-          path: f.previousFilename,
-          mode: "100644",
-          type: "blob",
-          sha: null,
-        });
-      }
-    }
+    const entries = buildMergeTreeEntries(files, branchBlobByPath);
 
     const treeSha = await client.createTree(
       await client.getCommitTreeSha(baseHead),


### PR DESCRIPTION
Bug found while auditing decofile merge robustness (my focus area this tick — the e2e decofile suite and its recently-touched merge code, adjacent to #6226's merge-key dedup fix).

**The bug**: `githubGitRebase(..., onConflict: "branch-wins")` (apps/api/src/decofile/git-compat.ts) replays every file the branch changed on top of base, favoring the branch's edits. For each changed file it pushed TWO tree-write entries: a create for `f.filename` and (for renames) a delete for `f.previousFilename`. If one file's rename DESTINATION is another file's rename SOURCE in the same diff — e.g. `Hero.json`→`Header.json` and `Banner.json`→`Hero.json` land in the same commit — both a create-`Hero.json` entry and a delete-`Hero.json` entry end up in the same `createTree` call. GitHub's Git Trees API applies the LAST entry for a duplicate path, so which one wins depended on the compare API's file ordering — a coin flip that could silently delete the block that was supposed to survive at that path (real data loss on an already branch-favored merge, whose whole point is to never lose the editor's own edits).

**Fix**: extracted the entry-assembly loop into a pure `buildMergeTreeEntries` and deduped by path with destination-wins semantics — a path that is any file's rename destination always keeps that file's content; a rename-source delete is only applied when nothing else claims that path as its destination. This is order-independent by construction.

**Regression test**: `apps/api/src/decofile/git-compat.test.ts` — asserts the swap-like rename scenario resolves the same way regardless of input order (a pure, previously-untested function extracted specifically to make this testable without a live GitDataClient). This qualifies as the destructive-safety-net trust boundary (guards real data loss in a git merge/rebase op).

**To verify**: `bun test apps/api/src/decofile/git-compat.test.ts`

**Checks run locally**: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents branch-wins merges from deleting the surviving file when a rename destination is also another file’s rename source. Previously we wrote both a create and a delete for the same path and GitHub applied the last entry; now we dedupe by path with destination-wins semantics, making the result order-independent.

- Extracts a pure `buildMergeTreeEntries` to assemble tree entries and ensures a rename-source delete applies only if no file targets that path.
- Updates branch-wins replay to use the new builder.
- Adds a unit test covering swap-like renames and verifies identical results regardless of diff order (run: bun test apps/api/src/decofile/git-compat.test.ts).

<sup>Written for commit b27676e48c2b9df9a939e6c6cb53242b28441a44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6230?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

