### PR TITLE
fix(task-board): stop re-completing a card a member moved out of Done

### DIFF
--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -1739,6 +1739,31 @@ export class TaskBoardStorage {
     }));
   }
 
+  /** A null actor is a machine path; a `reason` marks a move that meant something
+   *  other than "not done" (Rerun-from-Done stamps `reason: "rerun"`). */
+  async hasHumanRejectedDone(
+    taskBoardItemId: string,
+    organizationId: string,
+  ): Promise<boolean> {
+    const laneLeft = sql<string>`a.data->>'from'`;
+    const moveReason = sql<string>`a.data->>'reason'`;
+    const byMember = "a.actor_id";
+
+    const override = await this.db
+      .selectFrom("task_board_activity as a")
+      .innerJoin("task_board_items as item", "item.id", "a.task_board_item_id")
+      .select("a.id")
+      .where("item.organization_id", "=", organizationId)
+      .where("a.task_board_item_id", "=", taskBoardItemId)
+      .where("a.action", "=", "status_changed")
+      .where(byMember, "is not", null)
+      .where(laneLeft, "=", "done")
+      .where(moveReason, "is", null)
+      .limit(1)
+      .executeTakeFirst();
+    return override !== undefined;
+  }
+
   /** A task's comments, oldest first (thread order). Tenant-scoped through the
    *  task, which is the only thing carrying an org. Flat — the caller nests
    *  roots and replies by `parentId`. */

--- a/apps/api/src/tools/task-board/human-rejected-done.integration.test.ts
+++ b/apps/api/src/tools/task-board/human-rejected-done.integration.test.ts
@@ -1,0 +1,154 @@
+/** The gate is entirely SQL over `actor_id` and two jsonb keys — an in-memory fake
+ *  would not reproduce it, so this runs against real Postgres. */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { sql } from "kysely";
+import type { StudioDatabase } from "../../database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../../database/test-db-pg";
+import { TaskBoardStorage } from "../../storage/task-board";
+
+const ORG = "org_rejectdone_1";
+const OTHER_ORG = "org_rejectdone_2";
+const USER = "user_rd1";
+
+describe("hasHumanRejectedDone", () => {
+  let database: StudioDatabase;
+  let taskBoard: TaskBoardStorage;
+
+  const seed = async (): Promise<string> => {
+    const item = await taskBoard.create({
+      organizationId: ORG,
+      title: `card-${Math.random()}`,
+      status: "in_review",
+      by: USER,
+    });
+    return item.id;
+  };
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    const now = new Date().toISOString();
+    await database.db
+      .insertInto("organization")
+      .values([
+        { id: ORG, name: ORG, slug: "org-rejectdone-1", createdAt: now },
+        {
+          id: OTHER_ORG,
+          name: OTHER_ORG,
+          slug: "org-rejectdone-2",
+          createdAt: now,
+        },
+      ])
+      .execute();
+    // Raw SQL: real Postgres has a BOOLEAN emailVerified the typed shape disagrees with.
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES (${USER}, ${"rd1@rejectdone.test"}, false, ${USER}, ${now}, ${now})
+    `.execute(database.db);
+    taskBoard = new TaskBoardStorage(database.db);
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  it("is false for a card nobody has pulled out of Done", async () => {
+    const id = await seed();
+    expect(await taskBoard.hasHumanRejectedDone(id, ORG)).toBe(false);
+  });
+
+  it("is true once a member moves the card out of Done", async () => {
+    const id = await seed();
+    await taskBoard.recordActivity({
+      taskBoardItemId: id,
+      action: "status_changed",
+      actorId: USER,
+      data: { from: "done", to: "in_review" },
+    });
+    expect(await taskBoard.hasHumanRejectedDone(id, ORG)).toBe(true);
+  });
+
+  it("ignores a machine move out of Done", async () => {
+    const id = await seed();
+    await taskBoard.recordActivity({
+      taskBoardItemId: id,
+      action: "status_changed",
+      actorId: null,
+      data: { from: "done", to: "in_progress" },
+    });
+    expect(await taskBoard.hasHumanRejectedDone(id, ORG)).toBe(false);
+  });
+
+  it("ignores a member's moves that don't leave Done", async () => {
+    const id = await seed();
+    await taskBoard.recordActivity({
+      taskBoardItemId: id,
+      action: "status_changed",
+      actorId: USER,
+      data: { from: "in_review", to: "done" },
+    });
+    await taskBoard.recordActivity({
+      taskBoardItemId: id,
+      action: "priority_changed",
+      actorId: USER,
+      data: { from: "done", to: "in_review" },
+    });
+    expect(await taskBoard.hasHumanRejectedDone(id, ORG)).toBe(false);
+  });
+
+  it("ignores Rerun on a Done card — that asks for more work, not a reopen", async () => {
+    const id = await seed();
+    await taskBoard.recordActivity({
+      taskBoardItemId: id,
+      action: "status_changed",
+      actorId: USER,
+      data: { from: "done", to: "in_progress", reason: "rerun" },
+    });
+    expect(await taskBoard.hasHumanRejectedDone(id, ORG)).toBe(false);
+  });
+
+  it("leaves an untouched card free to auto-complete", async () => {
+    const id = await seed();
+    await taskBoard.recordActivity({
+      taskBoardItemId: id,
+      action: "status_changed",
+      actorId: null,
+      data: { from: "in_progress", to: "in_review" },
+    });
+    await taskBoard.recordActivity({
+      taskBoardItemId: id,
+      action: "title_changed",
+      actorId: USER,
+      data: { from: "old", to: "new" },
+    });
+    expect(await taskBoard.hasHumanRejectedDone(id, ORG)).toBe(false);
+  });
+
+  it("stays true after the card is completed again", async () => {
+    const id = await seed();
+    await taskBoard.recordActivity({
+      taskBoardItemId: id,
+      action: "status_changed",
+      actorId: USER,
+      data: { from: "done", to: "in_review" },
+    });
+    await taskBoard.update(id, ORG, { status: "done" }, USER);
+    expect(await taskBoard.hasHumanRejectedDone(id, ORG)).toBe(true);
+  });
+
+  it("does not leak across orgs", async () => {
+    const id = await seed();
+    await taskBoard.recordActivity({
+      taskBoardItemId: id,
+      action: "status_changed",
+      actorId: USER,
+      data: { from: "done", to: "in_review" },
+    });
+    expect(await taskBoard.hasHumanRejectedDone(id, OTHER_ORG)).toBe(false);
+  });
+});

--- a/apps/api/src/tools/task-board/prs-get.ts
+++ b/apps/api/src/tools/task-board/prs-get.ts
@@ -1239,7 +1239,15 @@ export const TASK_BOARD_ITEM_PRS_GET = defineTool({
     // failure must never break the read. Forward-only: never un-does Done or Archived.
     if (prs.some((p) => p.merged)) {
       try {
-        if (item && item.status !== "done" && item.status !== "archived") {
+        if (
+          item &&
+          item.status !== "done" &&
+          item.status !== "archived" &&
+          !(await ctx.storage.taskBoard.hasHumanRejectedDone(
+            taskBoardItemId,
+            organizationId,
+          ))
+        ) {
           const updated = await ctx.storage.taskBoard.update(
             taskBoardItemId,
             organizationId,

--- a/apps/api/src/tools/task-board/review-decision.ts
+++ b/apps/api/src/tools/task-board/review-decision.ts
@@ -338,7 +338,12 @@ export const TASK_BOARD_REVIEW_DECISION = defineTool({
     }
 
     const settings = await ctx.storage.organizationSettings.get(organizationId);
-    const autoMerge = settings?.flags?.auto_merge === true;
+    const autoMergeEnabled = settings?.flags?.auto_merge === true;
+    const humanRejectedDone = await ctx.storage.taskBoard.hasHumanRejectedDone(
+      taskBoardItemId,
+      organizationId,
+    );
+    const autoMerge = autoMergeEnabled && !humanRejectedDone;
     const outcome = autoMerge
       ? await mergeLinkedPr(ctx, organizationId, taskBoardItemId)
       : null;

--- a/apps/api/src/tools/task-board/update.test.ts
+++ b/apps/api/src/tools/task-board/update.test.ts
@@ -8,7 +8,11 @@
 import { describe, expect, it } from "bun:test";
 import type { TaskBoardItem } from "@/storage/types";
 import { SUPER_AGENT_ASSIGNEE_ID } from "./schema";
-import { delegatesToSuperAgent, diffTaskActivityEntries } from "./update";
+import {
+  closesOwnReview,
+  delegatesToSuperAgent,
+  diffTaskActivityEntries,
+} from "./update";
 
 function item(overrides: Partial<TaskBoardItem> = {}): TaskBoardItem {
   return {
@@ -135,5 +139,24 @@ describe("delegatesToSuperAgent", () => {
 
   it("does not delegate without a pre-update item", () => {
     expect(delegatesToSuperAgent(SUPER_AGENT_ASSIGNEE_ID, null)).toBe(false);
+  });
+});
+
+describe("closesOwnReview", () => {
+  it("catches a run completing a task under review", () => {
+    expect(closesOwnReview("done", "in_review", true)).toBe(true);
+  });
+
+  it("allows a run to complete a task that needed no code change", () => {
+    expect(closesOwnReview("done", "in_progress", true)).toBe(false);
+  });
+
+  it("allows a run to move a task under review anywhere but Done", () => {
+    expect(closesOwnReview("in_progress", "in_review", true)).toBe(false);
+    expect(closesOwnReview(undefined, "in_review", true)).toBe(false);
+  });
+
+  it("never catches a person", () => {
+    expect(closesOwnReview("done", "in_review", false)).toBe(false);
   });
 });

--- a/apps/api/src/tools/task-board/update.ts
+++ b/apps/api/src/tools/task-board/update.ts
@@ -1,7 +1,11 @@
 import { z } from "zod";
 import { defineTool } from "@/core/define-tool";
 import { getUserId, requireAuth } from "@/core/studio-context";
-import type { TaskBoardActivityAction, TaskBoardItem } from "@/storage/types";
+import type {
+  TaskBoardActivityAction,
+  TaskBoardItem,
+  TaskBoardItemStatus,
+} from "@/storage/types";
 import {
   SUPER_AGENT_ASSIGNEE_ID,
   TaskBoardItemPrioritySchema,
@@ -11,6 +15,7 @@ import {
 import { assertValidAssignee } from "./validate-assignee";
 import { reactToSuperAgentDelegation } from "./enqueue-super-agent";
 import { recordTaskActivities } from "./activity";
+import { taskRunContextStore } from "./task-run-context";
 import { emitTaskBoardUpdated } from "./run-reactions";
 import {
   ensureTaskExecutionAllowed,
@@ -101,6 +106,18 @@ export function delegatesToSuperAgent(
     : previous.status === "todo";
 }
 
+/** `task-run-context` withholds REVIEW_DECISION and PROMOTE_TO_PRODUCTION for this
+ *  invariant; this tool sets `status` freely, so it needs the same guard. */
+export function closesOwnReview(
+  inputStatus: TaskBoardItemStatus | undefined,
+  previousStatus: TaskBoardItemStatus | undefined,
+  isTaskRun: boolean,
+): boolean {
+  const completesTask = inputStatus === "done";
+  const awaitingReview = previousStatus === "in_review";
+  return isTaskRun && completesTask && awaitingReview;
+}
+
 export const TASK_BOARD_ITEM_UPDATE = defineTool({
   name: "TASK_BOARD_ITEM_UPDATE",
   description:
@@ -188,6 +205,15 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
     // longer org-scoped itself (the join table has no organization_id).
     if (hasFieldUpdate && !previous) {
       throw new Error(`Task board item not found: ${input.id}`);
+    }
+
+    const isTaskRun = taskRunContextStore.getStore() !== undefined;
+    if (closesOwnReview(input.status, previous?.status, isTaskRun)) {
+      throw new Error(
+        "This task is In Review — a run can't move it to Done. Leave it in " +
+          "in_review for the reviewer; only a person, or TASK_BOARD_REVIEW_DECISION " +
+          "on a reviewer's own run, completes a task under review.",
+      );
     }
 
     const assigneeChanged =


### PR DESCRIPTION
## Problem

Reported by a client: a card kept jumping back to **Concluído** after they moved it to **Em Revisão** and asked for changes in a comment. "Super Agent" did it twice, without touching the page or the repo.

It wasn't an agent decision. `TASK_BOARD_ITEM_PRS_GET` reconciles merge→Done on read (there's no GitHub `pull_request` webhook), and a merged PR stays merged — so it re-fired every time anyone opened the board, logging `actorId: null`, which the UI renders as "Super Agent". Its only guard was forward-only (`status !== "done" && !== "archived"`): no memory that a human had already disagreed.

## Fix

`TaskBoardStorage.hasHumanRejectedDone` — the card's memory of an override, read off activity rows we already write. Three legs:

- `action = 'status_changed'` and `data->>'from' = 'done'` — the card left Done
- `actor_id IS NOT NULL` — a member did it, not one of the machine paths (they all log a null actor)
- `data->>'reason' IS NULL` — the move meant "this isn't done", not something else

Sticky, not time-windowed: one override means the automation was wrong about *this* card. A later Done still has to come from a person, or from `PROMOTE_TO_PRODUCTION`, which is a person pressing a button.

Both auto-completing paths consult it: the `prs-get` reconcile, and `review-decision`'s auto-merge on approval.

### Auto-merge still works on untouched cards

That's what the `reason` leg is for. Clicking **Rerun** on a Done card logs a *member's* `done → in_progress` with `reason: "rerun"` (`rerun.ts:376`) — a request for more work, not a reopen. Counting it would have silently switched auto-merge off for every rerun card. A card nobody dragged has no qualifying row at all, so `auto_merge` ships it exactly as before. Both directions are pinned by tests.

## Also: an agent could close its own review

`task-run-context` withholds `TASK_BOARD_REVIEW_DECISION` and `TASK_BOARD_PROMOTE_TO_PRODUCTION` from a run's own endpoint because "an agent must not approve or merge its own work" — then grants `TASK_BOARD_ITEM_UPDATE`, which sets `status` to anything. A run could write `done` directly and skip review entirely; the only thing discouraging it was a sentence in the `task-manager` prompt, which the task-run surface doesn't even get.

`agentMayCompleteTask` blocks exactly `in_review → done` when the call arrives through the task-run MCP endpoint (detected via the existing `taskRunContextStore` ALS — no new plumbing). A run legitimately completing a task that needed no code change is In Progress, not In Review, so that path is untouched. Humans are never affected.

## Testing

- `bun test apps/api/src/tools/task-board/` — **355 pass, 0 fail**
- 8 new real-Postgres tests (`human-rejected-done.integration.test.ts`): human drag out of Done trips the gate; machine move, Rerun, non-status move, and untouched card do not; sticky across re-completion; no cross-org leak. Picked up by the `*.integration.test.ts` convention in `storage-integration.yml`.
- 4 new unit tests for `agentMayCompleteTask`.
- `bun run fmt`, `bun run lint` (0 errors), `bunx knip` (clean), `tsc --noEmit` in `apps/api` all pass.

Note: `bun run check` fails on `check:readmes` for an untracked local `apps/mesh/` directory — pre-existing, unrelated to this branch.

## Not in scope

The underlying attribution gap: an agent calling `TASK_BOARD_ITEM_UPDATE` on the task-run endpoint records `actorId = getUserId(ctx)`, which resolves to the human who owns the per-run API key — so agent moves through that path are indistinguishable from human drags in the timeline. `actor_id IS NULL` is the only machine signal today and that path never produces it. Worth a follow-up (an actor-kind stamp); it doesn't affect this fix, whose trigger was a genuinely machine-authored row.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops auto-recompletion when a member pulls a card out of Done, and prevents a run from closing its own review. Previously, the merge→Done reconcile re-set cards to Done on every board read and appeared as “Super Agent”; now we honor a human override and block the in_review→done transition on task-run endpoints.

- Remember a human override via activity rows: a non-null actor changed status from done and provided no reason; sticky and org-scoped.
- Check this guard in `TASK_BOARD_ITEM_PRS_GET` (merge→Done reconcile) and in `TASK_BOARD_REVIEW_DECISION` (auto-merge on approval). Untouched cards still auto-merge.
- Ignore Rerun-from-Done (`reason: "rerun"`), so reruns keep auto-merge behavior.
- Disallow task-run calls to set in_review→done (detected via `taskRunContextStore`); humans unaffected and in_progress→done remains allowed.
- Added integration and unit tests. No migrations or config changes.

<sup>Written for commit 33a3e4ffda413ab5b13bae6f1770fcb233d6210d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

