### PR TITLE
fix(automations): stop trigger-fired runs from parking human chat turns

### DIFF
--- a/apps/api/src/api/app.ts
+++ b/apps/api/src/api/app.ts
@@ -1351,10 +1351,7 @@ export async function createApp(options: CreateAppOptions = {}) {
   // gate-parked runs are already DEQUEUED (PENDING) and pinned to this pod, so
   // queue depth can't see them (see hosted-run-concurrency.ts). Per-pod, so the
   // trigger must aggregate across worker pods.
-  app.get(SYSTEM_PATHS.HOSTED_RUN_PENDING, (c) => {
-    const { active, pending, max } = hostedRunStats();
-    return c.json({ pending, active, max });
-  });
+  app.get(SYSTEM_PATHS.HOSTED_RUN_PENDING, (c) => c.json(hostedRunStats()));
 
   // ============================================================================
   // Public Configuration (no auth required)

--- a/apps/api/src/automations/build-stream-request.test.ts
+++ b/apps/api/src/automations/build-stream-request.test.ts
@@ -1,4 +1,9 @@
 import { describe, expect, it } from "bun:test";
+import {
+  RUN_CLASS_METADATA_KEY,
+  RUN_PRIORITY,
+  runPriority,
+} from "@/dispatch-queue/run-priority";
 import type { Automation } from "@/storage/types";
 import {
   buildStreamRequest,
@@ -250,6 +255,56 @@ describe("buildStreamRequest", () => {
       makeResolvedModel(),
     );
     expect(result.maxAgentSteps).toBe(50);
+  });
+
+  it("marks a trigger-fired run so it queues behind a human's chat turn", () => {
+    const result = buildStreamRequest(
+      makeAutomation(),
+      "trig_1",
+      "thrd_1",
+      makeResolvedModel(),
+    );
+    expect(runPriority(result.runMetadata)).toBe(RUN_PRIORITY.new_task);
+    expect(runPriority(result.runMetadata)).toBeGreaterThan(
+      RUN_PRIORITY.interactive,
+    );
+  });
+
+  it("keeps a manual run (no triggerId) interactive", () => {
+    const result = buildStreamRequest(
+      makeAutomation(),
+      null,
+      "thrd_1",
+      makeResolvedModel(),
+    );
+    expect(result.runMetadata).toBeUndefined();
+    expect(runPriority(result.runMetadata)).toBe(RUN_PRIORITY.interactive);
+  });
+
+  it("preserves a webhook's other run_metadata keys alongside the class", () => {
+    const result = buildStreamRequest(
+      makeAutomation(),
+      "trig_1",
+      "thrd_1",
+      makeResolvedModel(),
+      { tenant: "acme", source: "webhook" },
+    );
+    expect(result.runMetadata).toMatchObject({
+      tenant: "acme",
+      source: "webhook",
+    });
+    expect(runPriority(result.runMetadata)).toBe(RUN_PRIORITY.new_task);
+  });
+
+  it("does not let a webhook payload outrank a person at the keyboard", () => {
+    const result = buildStreamRequest(
+      makeAutomation(),
+      "trig_1",
+      "thrd_1",
+      makeResolvedModel(),
+      { [RUN_CLASS_METADATA_KEY]: "interactive" },
+    );
+    expect(runPriority(result.runMetadata)).toBe(RUN_PRIORITY.new_task);
   });
 });
 

--- a/apps/api/src/automations/build-stream-request.ts
+++ b/apps/api/src/automations/build-stream-request.ts
@@ -9,7 +9,26 @@
  */
 
 import type { DispatchRunInput } from "@/api/routes/decopilot/dispatch-run";
+import {
+  RUN_CLASS_METADATA_KEY,
+  type RunClass,
+} from "@/dispatch-queue/run-priority";
 import type { Automation } from "@/storage/types";
+
+/**
+ * The admission class of a trigger-fired automation run.
+ *
+ * Nobody is watching a cron/webhook/event fire's stream, so it must not compete
+ * for a pod's in-process slot at `interactive` — which is exactly what an
+ * unmarked run defaults to (see `run-priority.ts`). Typed as `RunClass` so
+ * renaming a class is a compile error here, not a silent priority regression.
+ *
+ * Applied only when a `triggerId` is present: `triggerId === null` is the manual
+ * AUTOMATION_RUN path, where a person clicked Run and is watching that stream.
+ * It also overrides the key from a webhook's `run_metadata` — that payload is
+ * trusted as tool context, never as a way to outrank a person at the keyboard.
+ */
+const TRIGGERED_RUN_CLASS: RunClass = "new_task";
 
 type ModelShape = {
   id: string;
@@ -88,6 +107,10 @@ export function buildStreamRequest(
     }),
   );
 
+  const resolvedRunMetadata = triggerId
+    ? { ...runMetadata, [RUN_CLASS_METADATA_KEY]: TRIGGERED_RUN_CLASS }
+    : runMetadata;
+
   const request: DispatchRunInput = {
     messages,
     models: {
@@ -115,7 +138,7 @@ export function buildStreamRequest(
     harnessId: "decopilot",
     sandboxProviderKind: "agent-sandbox",
     triggerId: triggerId ?? undefined,
-    ...(runMetadata ? { runMetadata } : {}),
+    ...(resolvedRunMetadata ? { runMetadata: resolvedRunMetadata } : {}),
     taskId,
   };
 

--- a/apps/api/src/dispatch-queue/hosted-run-concurrency.test.ts
+++ b/apps/api/src/dispatch-queue/hosted-run-concurrency.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import {
+  acquireHostedRunSlot,
+  HOSTED_RUN_CAPS,
+  hostedRunStats,
+} from "./hosted-run-concurrency";
+
+describe("hostedRunStats", () => {
+  test("reports each gate's own cap, not the summed one", async () => {
+    // A saturated in-process gate used to report `active: 3, max: 15`.
+    const releases = await Promise.all(
+      Array.from({ length: HOSTED_RUN_CAPS.inProcess }, () =>
+        acquireHostedRunSlot({ harnessId: "decopilot" }),
+      ),
+    );
+    try {
+      const stats = hostedRunStats();
+      expect(stats.in_process.active).toBe(HOSTED_RUN_CAPS.inProcess);
+      expect(stats.in_process.max).toBe(HOSTED_RUN_CAPS.inProcess);
+      // Saturation is only visible per gate — the sandbox budget is untouched.
+      expect(stats.sandboxed.active).toBe(0);
+      expect(stats.sandboxed.max).toBe(HOSTED_RUN_CAPS.sandboxed);
+    } finally {
+      for (const release of releases) release();
+    }
+  });
+
+  test("keeps the summed triple the KEDA trigger reads", async () => {
+    const release = await acquireHostedRunSlot({ harnessId: "decopilot" });
+    try {
+      const stats = hostedRunStats();
+      expect(stats.active).toBe(
+        stats.in_process.active + stats.sandboxed.active,
+      );
+      expect(stats.pending).toBe(
+        stats.in_process.pending + stats.sandboxed.pending,
+      );
+      expect(stats.max).toBe(stats.in_process.max + stats.sandboxed.max);
+    } finally {
+      release();
+    }
+  });
+});

--- a/apps/api/src/dispatch-queue/hosted-run-concurrency.ts
+++ b/apps/api/src/dispatch-queue/hosted-run-concurrency.ts
@@ -89,20 +89,46 @@ meter
   })
   .addCallback((r) => r.observe(gate.pending + sandboxGate.pending));
 
+/** One gate's live occupancy. */
+export interface GateStats {
+  active: number;
+  pending: number;
+  max: number;
+}
+
 /**
  * Live gate stats for the `/hosted-run-pending` metrics-api endpoint (KEDA).
  * `pending` is the scale signal: parked runs are DBOS-PENDING (dequeued), so
  * they're invisible to the ENQUEUED-only queue-depth endpoint.
+ *
+ * The top-level triple sums both gates (the KEDA trigger's contract — do not
+ * change its shape), but summing the CAPS makes a saturated pod look idle: 3/3
+ * in-process with 6 parked reported as `active: 3, max: 15`, which reads as 80%
+ * free. `in_process` / `sandboxed` break the same numbers out per gate, since
+ * only a per-gate ratio can show which budget is actually exhausted.
  */
-export const hostedRunStats = (): {
-  active: number;
-  pending: number;
-  max: number;
-} => ({
-  active: gate.active + sandboxGate.active,
-  pending: gate.pending + sandboxGate.pending,
-  max: MAX + SANDBOX_MAX,
-});
+export const hostedRunStats = (): GateStats & {
+  in_process: GateStats;
+  sandboxed: GateStats;
+} => {
+  const inProcess = {
+    active: gate.active,
+    pending: gate.pending,
+    max: MAX,
+  };
+  const sandboxed = {
+    active: sandboxGate.active,
+    pending: sandboxGate.pending,
+    max: SANDBOX_MAX,
+  };
+  return {
+    active: inProcess.active + sandboxed.active,
+    pending: inProcess.pending + sandboxed.pending,
+    max: inProcess.max + sandboxed.max,
+    in_process: inProcess,
+    sandboxed,
+  };
+};
 
 /** The two caps, separately — for diagnostics and for tests that need to
  *  saturate one specific gate. `hostedRunStats` reports the pod's total


### PR DESCRIPTION
## Problem

Users saw "Waiting for a free runner" for about 2 minutes before a chat turn
started, outside peak hours.

That copy is the `waiting-capacity` stage, published from exactly one place
(`hosted-harness-workflow.ts`), when a run parks on the pod's in-process
concurrency gate (`hosted-run-concurrency.ts`, cap
`DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS`, default 3). Admission order comes from
`runClass` (`run-priority.ts`).

Only the task-board paths set that key (`enqueue-task-run.ts`,
`enqueue-reviewer.ts`, `review-sweeper.ts`). An automation fire sets no
`runMetadata` at all, so it fell through to `runPriority`'s default of
`interactive`, the same class as a person watching a stream. A run already
holding a slot is never preempted.

Automation runs are long. Measured on prod over 6h: 134 in-process runs, mean
212s, max 1402s, and most were `fireAutomationWorkflow` children rather than
human turns. At one sampled instant, three trigger-fired runs of 20m, 12m and
11m held all three slots on a worker pod, with three `threadGateWorkflow` (human
chat) runs parked behind them. Worker logs at that moment:
`run parked at concurrency cap { active: 3, pending: 6, max: 3 }`. Cron fires
also burst, several landing on the same second at the top of the hour.

The queue was not caused by user load. Background work was holding
interactive-priority slots.

## Change

- A fire carrying a `triggerId` (cron, webhook, event) is marked `new_task`, so
  it queues behind interactive turns, reviewers and retries. Set once in
  `buildStreamRequest`, which every fire path routes through. Both `runPriority`
  call sites (thread gate and hosted harness) read it.
- A manual `AUTOMATION_RUN` passes `triggerId: null`. A person clicked Run and is
  watching that stream, so it stays `interactive`.
- The class overrides the same key arriving in a webhook's `run_metadata`. That
  payload is trusted as tool context, not as a way for an external caller to
  outrank a person at the keyboard.
- `/hosted-run-pending` now reports the two gates separately. It summed the caps
  (3 in-process plus 12 sandbox), so a pod at 3/3 in-process with 6 parked
  reported `active: 3, max: 15`, which reads as 80% free. The summed
  `active`/`pending`/`max` triple the KEDA trigger reads is unchanged.

Priority starves nothing. An automation waits behind in-flight interactive work
and then runs, the same behavior `run-priority.ts` already describes for new task
cards.

## Testing

- `bun test apps/api/src/dispatch-queue/ apps/api/src/automations/`: 75 pass, 0 fail.
- 4 new cases in `build-stream-request.test.ts`: trigger-fired is demoted, manual
  stays interactive, other `run_metadata` keys survive, a payload-supplied
  `runClass` cannot outrank a human.
- New `hosted-run-concurrency.test.ts` saturates the in-process gate through the
  real `acquireHostedRunSlot` and asserts the per-gate caps plus the summed KEDA
  triple.
- `bun run --cwd=apps/api check`, `bun run lint` (0 errors), `bun run knip` and
  `bun run fmt` are clean.

## Not in this PR

These need the infra repo, since ArgoCD owns the ScaledObject and the configmap.
They add capacity rather than fix the ordering, so this PR stands on its own:

1. `DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS` is unset in prod, so the cap is the
   default 3 per pod. Worker pods measure 322Mi and 423Mi against a 2Gi limit
   with zero restarts, while the cap is sized against an assumed 450MB per-run
   p90. That number is worth re-measuring before raising the cap.
2. KEDA barely sees this backlog. The four `metrics-api` triggers read `ENQUEUED`
   only, and a parked run is already dequeued (`PENDING`), so they report 0. The
   `hosted_runs_pending` Prometheus trigger does see it, but its threshold of 3
   is an average, so it needs roughly 3x replicas pending before adding a pod,
   and `minReplicaCount: 1` lets capacity drop to 3 runs cluster-wide. Scaling up
   cannot rescue runs already parked either, because they are pinned to the pod
   that dequeued them.

One follow-up worth a separate look: cancelling while parked logs
`could not publish terminal error`, because a cancelled DBOS workflow cannot
start the publish step. The ghost-run force-fail in `cancelActiveThreadRun`
appears to cover the user-visible outcome, so this is probably just
`console.error` noise on an expected path. I did not confirm that end to end.
