### PR TITLE
fix(preview): wait for the DBOS schema too before starting the worker

### DIFF
--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,6 +2,14 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
+# 0.14.7: wait-for-schema now gates the worker on BOTH public.kysely_migration
+# and dbos.dbos_migrations. 0.14.6's migrate-on-boot init container runs
+# migrate.js then migrate-dbos.js as two sequential steps; gating on the
+# kysely table alone let the worker start — and call DBOS.launch() — while
+# migrate-dbos.js was still running, racing inserts into dbos.dbos_migrations
+# exactly like the multi-pod collision the split into two migrate scripts was
+# meant to prevent.
+#
 # 0.14.6: previews re-apply the schema on every pod start (preview.migrateOnBoot).
 # The preview Postgres is an emptyDir, so a spot reclaim hands the pod an empty
 # volume — and the migration Job is a sync hook that does not re-run, because
@@ -57,7 +65,7 @@ type: application
 # when disabled, so existing releases are unaffected.
 # 0.12.4: chart-managed API/worker dispatch roles now use
 # STUDIO_DISPATCH_ROLE; legacy overrides are rejected.
-version: 0.14.6
+version: 0.14.7
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/templates/_helpers.tpl
+++ b/deploy/helm/studio/templates/_helpers.tpl
@@ -414,7 +414,14 @@ introduced to avoid in the first place.
       set -eu
       # to_regclass returns NULL rather than erroring on a missing table, so
       # this polls without a failing exit code muddying the loop.
-      until [ "$(psql "$DATABASE_URL" -tAc "select to_regclass('public.kysely_migration') is not null")" = "t" ]; do
+      #
+      # Both tables must exist: migrate-on-boot runs migrate.js (creates
+      # public.kysely_migration) THEN migrate-dbos.js (creates dbos.dbos_migrations)
+      # as two sequential steps. Gating on kysely_migration alone lets this
+      # container return while migrate-dbos.js is still running, so the worker's
+      # own DBOS.launch() races the API's migrate-dbos.js on dbos.dbos_migrations —
+      # the exact collision this init container exists to prevent.
+      until [ "$(psql "$DATABASE_URL" -tAc "select to_regclass('public.kysely_migration') is not null and to_regclass('dbos.dbos_migrations') is not null")" = "t" ]; do
         echo "waiting for the schema"
         sleep 3
       done


### PR DESCRIPTION
Follows #6229 ("fix(preview): re-apply the schema on every pod start").

#6229's `migrate-on-boot` init container runs `migrate.js` then `migrate-dbos.js` as two **sequential** steps in the API pod, and gates the worker's `wait-for-schema` init container on `public.kysely_migration` existing — which `migrate.js` creates first. That leaves a window where the worker passes the gate and starts its own `DBOS.launch()` (see `apps/api/src/index.ts`) while the API's `migrate-dbos.js` is still applying the `dbos` schema. Both processes then race on inserts into `dbos.dbos_migrations` — the exact multi-pod collision `migrate-dbos.js` was split out into its own script to prevent (see the comment in `apps/api/src/database/migrate-dbos.ts`).

**Fix**: gate the worker on both `public.kysely_migration` and `dbos.dbos_migrations` existing, so it only starts once the API's init container has fully finished both migration steps.

**Failure scenario**: a preview pod reschedule (spot reclaim, drain, OOM) resets the emptyDir Postgres to empty. `migrate-on-boot` starts re-applying the schema; `migrate.js` finishes and creates `kysely_migration` while `migrate-dbos.js` is still running. If the worker pod is also (re)starting at that moment, its `wait-for-schema` gate opens early, `DBOS.launch()` fires, and it can hit a unique-constraint violation on `dbos.dbos_migrations` racing the API's still-in-flight migration — the same failure class `tests/multi-pod/docker-compose.yml` documents.

**How to verify**: `helm template deploy/helm/studio -f deploy/helm/studio/values-preview.yaml --set preview.enabled=true --set preview.host=x.example.com --set preview.prNumber=123 --set externalSecret.enabled=false --show-only templates/worker-deployment.yaml` and check the `wait-for-schema` init container's SQL now checks both tables.

**Checks run locally**: `helm lint` and `helm template` against `values-preview.yaml` (both pass, rendered `wait-for-schema` container confirmed). Full CI (`helm-test`) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Waits for the DBOS schema before starting the preview worker to remove a migration race. The worker used to gate on `public.kysely_migration` only; it now requires both `public.kysely_migration` and `dbos.dbos_migrations`, preventing `DBOS.launch()` from racing the API’s `migrate-dbos.js`.

**Review / rollout**
- Scope: preview worker `wait-for-schema` init container; no API changes.
- Behavior: worker may start slightly later until both tables exist.
- Chart: `0.14.7`; no values changes and no data migration.
- Verify: the init loop in `templates/_helpers.tpl` checks both tables.

<sup>Written for commit 251a7f6a8a21e306ca98c05235eeb1cc173cc167. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

