### PR TITLE
docs(self-hosting): remove stale auth-config.json references

### DIFF
--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/authentication.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/authentication.mdx
@@ -17,7 +17,7 @@ deco Studio uses Better Auth and supports:
 
 ## Configure auth (self-hosting)
 
-Self-hosted deployments load an `auth-config.json` file at startup (see your deployment guides for mounting details).
+Self-hosted deployments configure auth entirely through `AUTH_*` environment variables — there's no config file to mount. See the variables below.
 
 <Callout type="warning">
   Keep provider secrets out of Git. In production, use Secrets management (Kubernetes Secrets, External Secrets Operator, etc.).
@@ -89,8 +89,7 @@ so only users from your domain can sign in.
 ### Social login vs. SSO
 
 These env vars wire up **OIDC SSO** (the `@better-auth/sso` plugin). They are
-separate from the **social login** buttons configured via `auth-config.json`
-(`socialProviders.google`, `socialProviders.github`) or via
+separate from the **social login** buttons configured via
 `AUTH_GOOGLE_CLIENT_ID` / `AUTH_GITHUB_CLIENT_ID`. Social login lets users
 authenticate with their personal account; deployment-wide SSO routes everyone
 matching `AUTH_SSO_DOMAIN` through the corporate IdP.

--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/docker-compose.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/docker-compose.mdx
@@ -99,7 +99,7 @@ AUTH_GITHUB_CLIENT_ID=...
 AUTH_GITHUB_CLIENT_SECRET=...
 ```
 
-For richer configuration (SAML/SSO, email providers, magic links), mount an `auth-config.json` into the container at `/app/apps/api/auth-config.json` by adding a volume to the `studio` service, using [`apps/api/auth-config.example.json`](https://github.com/decocms/studio/blob/main/apps/api/auth-config.example.json) as a starting point. See [Authentication](/en/studio/self-hosting/authentication) for the full reference.
+For richer configuration (deployment-wide SSO, email providers, magic links), set the corresponding `AUTH_*` variables in the compose `environment` block — there's no config file to mount. See [Authentication](/en/studio/self-hosting/authentication) for the full reference.
 
 ## Operations
 
@@ -150,4 +150,4 @@ docker compose -f docker-compose.postgres.yml up -d
 
 - Always generate a strong `BETTER_AUTH_SECRET` (`openssl rand -base64 32`) and a real `POSTGRES_PASSWORD`.
 - Don't commit `.env` (`echo ".env" >> .gitignore`; `chmod 600 .env`).
-- Don't commit secrets (client secrets, API keys) into any mounted `auth-config.json`.
+- Don't commit secrets (client secrets, API keys) into `.env` or the compose file.

--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/kubernetes.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/deploy/kubernetes.mdx
@@ -250,7 +250,7 @@ Studio uses Better Auth. For Kubernetes, configure it with environment variables
 See [Authentication](/en/studio/self-hosting/authentication) for the full reference.
 
 <Callout type="note">
-  The `auth-config.json` file mentioned in the authentication reference is a Docker Compose convenience — the Kubernetes path does not need it. If you want it anyway (for SAML, or to keep one config artifact), mount it at `/app/apps/api/auth-config.json` from a ConfigMap using the chart's `volumes` and `volumeMounts` values, which apply to both the API and worker Deployments. Keep provider secrets in the Secret, not in that file.
+  There's no `auth-config.json` file anywhere — auth is configured entirely through the `AUTH_*` environment variables above. Keep provider secrets in the Secret, not in a ConfigMap.
 </Callout>
 
 ## Sandbox configuration

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/authentication.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/authentication.mdx
@@ -17,7 +17,7 @@ O deco Studio usa Better Auth e suporta:
 
 ## Configurar autenticação (self-hosting)
 
-Implantações self-hosted carregam um arquivo `auth-config.json` na inicialização (consulte seus guias de deploy para detalhes de montagem).
+Implantações self-hosted configuram a autenticação inteiramente por variáveis de ambiente `AUTH_*` — não há arquivo de configuração para montar. Veja as variáveis abaixo.
 
 <Callout type="warning">
   Mantenha os secrets dos provedores fora do Git. Em produção, use gerenciamento de Secrets (Kubernetes Secrets, External Secrets Operator, etc.).
@@ -91,8 +91,7 @@ organização para que apenas usuários do seu domínio consigam logar.
 ### Login social vs. SSO
 
 Essas envs configuram **SSO via OIDC** (plugin `@better-auth/sso`). São
-diferentes dos botões de **login social** configurados via `auth-config.json`
-(`socialProviders.google`, `socialProviders.github`) ou via
+diferentes dos botões de **login social** configurados via
 `AUTH_GOOGLE_CLIENT_ID` / `AUTH_GITHUB_CLIENT_ID`. Login social deixa os
 usuários autenticarem com suas contas pessoais; o SSO de deployment inteiro
 roteia todo mundo que casar com `AUTH_SSO_DOMAIN` para o IdP corporativo.

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/docker-compose.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/docker-compose.mdx
@@ -99,7 +99,7 @@ AUTH_GITHUB_CLIENT_ID=...
 AUTH_GITHUB_CLIENT_SECRET=...
 ```
 
-Para configurações mais ricas (SAML/SSO, provedores de email, magic links), monte um `auth-config.json` dentro do container em `/app/apps/api/auth-config.json` adicionando um volume ao serviço `studio`, usando [`apps/api/auth-config.example.json`](https://github.com/decocms/studio/blob/main/apps/api/auth-config.example.json) como ponto de partida. Veja [Autenticação](/pt-br/studio/self-hosting/authentication) para a referência completa.
+Para configurações mais ricas (SSO de deployment inteiro, provedores de email, magic links), defina as variáveis `AUTH_*` correspondentes no bloco `environment` do compose — não há arquivo de configuração para montar. Veja [Autenticação](/pt-br/studio/self-hosting/authentication) para a referência completa.
 
 ## Operações
 
@@ -150,4 +150,4 @@ docker compose -f docker-compose.postgres.yml up -d
 
 - Sempre gere um `BETTER_AUTH_SECRET` forte (`openssl rand -base64 32`) e um `POSTGRES_PASSWORD` de verdade.
 - Não faça commit do `.env` (`echo ".env" >> .gitignore`; `chmod 600 .env`).
-- Não faça commit de secrets (client secrets, API keys) em nenhum `auth-config.json` montado.
+- Não faça commit de secrets (client secrets, API keys) no `.env` ou no arquivo do compose.

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/kubernetes.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/deploy/kubernetes.mdx
@@ -250,7 +250,7 @@ O Studio usa o Better Auth. No Kubernetes, configure por variáveis de ambiente 
 Veja [Autenticação](/pt-br/studio/self-hosting/authentication) para a referência completa.
 
 <Callout type="note">
-  O arquivo `auth-config.json` citado na referência de autenticação é uma conveniência do Docker Compose — o caminho de Kubernetes não precisa dele. Se você quiser usá-lo mesmo assim (para SAML, ou para manter um único artefato de configuração), monte-o em `/app/apps/api/auth-config.json` a partir de um ConfigMap usando os values `volumes` e `volumeMounts` do chart, que valem para os Deployments de API e worker. Mantenha os secrets dos provedores no Secret, não nesse arquivo.
+  Não existe arquivo `auth-config.json` — a autenticação é configurada inteiramente pelas variáveis de ambiente `AUTH_*` acima. Mantenha os secrets dos provedores no Secret, não em um ConfigMap.
 </Callout>
 
 ## Configuração de sandbox


### PR DESCRIPTION
**Source:** a real doc/code drift. #5579 (merged) deleted `apps/api/auth-config.example.json` and moved auth entirely to `AUTH_*` environment variables — `apps/api/src/core/config.ts`'s `getConfig()` now only ever loads auth via `loadAuthConfig()` (env vars) and explicitly warns+ignores an `auth` key in `config.json`. Nothing in `apps/api/src` reads an `auth-config.json` file anymore. The self-hosting docs never got updated.

**Why a maintainer wants this:** the self-hosting authentication/docker-compose/kubernetes docs (en + pt-br) still tell operators to mount an `auth-config.json` for SAML/SSO/email-provider config and link to the deleted example file (confirmed 404 on GitHub: `apps/api/auth-config.example.json`). Following these instructions today mounts a file the app never reads — a self-hoster configuring SSO would silently get nothing.

**What changed:** removed the `auth-config.json` mount instructions and the dead GitHub link from `self-hosting/authentication.mdx`, `self-hosting/deploy/docker-compose.mdx`, and `self-hosting/deploy/kubernetes.mdx` (both `en` and `pt-br`), replacing them with the accurate `AUTH_*` env-var guidance that's already correct elsewhere in these same files (e.g. the kubernetes.mdx env-var table right above the fixed Callout).

**How to verify:** `curl -I https://raw.githubusercontent.com/decocms/studio/main/apps/api/auth-config.example.json` returns 404; `grep -rn auth-config apps/api/src` returns nothing — confirming the mechanism is fully dead and the fix is accurate.

**Checks run locally:** `bun run fmt` (no changes needed — plain .mdx prose edit, no code/types touched, so `tsc`/test/oxlint don't apply here). Diff is docs-only, 6 files, +10/-12.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes stale self-hosting references to `auth-config.json` and updates docs to configure authentication via `AUTH_*` environment variables. The API no longer reads `auth-config.json` and the example file was deleted, so previous instructions caused silent SSO misconfiguration and 404 links.

- Migration
  - Stop mounting `auth-config.json` in Docker Compose or Kubernetes; remove related volumes and ConfigMaps.
  - Configure auth via `AUTH_*` env vars (e.g., `AUTH_GOOGLE_*`, `AUTH_GITHUB_*`, SSO vars, `BETTER_AUTH_SECRET`) in Compose `environment` or Kubernetes `env`/Secret.
  - Keep provider secrets in a Secret; do not commit secrets in `.env` or the compose file.

<sup>Written for commit fe4a9b13240b08017cce9722e8755b228469d141. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

