### PR TITLE
fix(preview): the sticky comment had no host

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -472,6 +472,23 @@ jobs:
           BUILD=.github/workflows/preview-build.yaml
           CHART=deploy/helm/studio-previews
 
+          # A job cannot read its own outputs through `needs` — the expression
+          # resolves to empty and the workflow still succeeds. That shipped a
+          # sticky comment reading "Preview: https://" with no host.
+          python3 - <<'SELFREF'
+          import re, sys, yaml
+          wf = yaml.safe_load(open(".github/workflows/preview-build.yaml"))
+          bad = [f"{name}.outputs references needs.{ref}"
+                 for name, job in wf["jobs"].items()
+                 for ref in re.findall(r"needs\.(\w+)\.", str(job.get("outputs", {})))
+                 if ref == name]
+          if bad:
+              print("::error::a job reads its own outputs through needs, which is "
+                    "always empty: " + "; ".join(bad))
+              sys.exit(1)
+          print("no job reads its own outputs through needs")
+          SELFREF
+
           # The node pool accepts both architectures, so the images have to
           # carry both. A spot reclaim once replaced an amd64 node with a
           # Graviton one and every pod died with `exec format error` — nothing

--- a/.github/workflows/preview-build.yaml
+++ b/.github/workflows/preview-build.yaml
@@ -45,7 +45,7 @@ jobs:
       pull-requests: write
     outputs:
       tag: ${{ steps.meta.outputs.tag }}
-      host: ${{ needs.package.outputs.host }}
+      host: ${{ steps.meta.outputs.host }}
     steps:
       # This workflow triggers on `pull_request` ONLY, so the checkout is
       # refs/pull/N/merge — GitHub constructs it by merging the PR into main,


### PR DESCRIPTION
The preview comment on decocms/studio#6233 shipped as:

```
### 🔍 Preview: https://

Built from `pr-6233-4ece050`.
```

No host.

## Cause

When decocms/studio#6211 split the build into `package` / `docker` / `publish`, the comment steps moved into `publish` and their host reference changed from `steps.meta.outputs.host` to `needs.package.outputs.host`. That replacement also hit the **declaration** inside `package`:

```yaml
  package:
    outputs:
      tag: ${{ steps.meta.outputs.tag }}
      host: ${{ needs.package.outputs.host }}   # reads its own output
```

A job cannot read its own outputs through `needs`. The expression resolves to empty, the step succeeds, and the workflow stays green.

The tag survived because its line was not part of that replacement — which is why the comment showed a correct image tag beside an empty URL, and why nothing looked broken until someone read it.

## Assertion

`helm-test.yml` now rejects any job whose `outputs` reference `needs.<itself>`. Verified against the pre-fix workflow: it flags `package.outputs -> needs.package`, and passes here.

This is the second failure of this shape today — an expression that evaluates to nothing, produces no error, and leaves a green run. The first was `preview.namespaceLabels` never being passed, which rendered a namespace with no gateway label.

## Impact

Cosmetic but load bearing: the sticky comment is how a reviewer gets the URL. Everything else about decocms/studio#6233 is fine; the environment is reachable at the address the ApplicationSet computed independently.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the preview sticky comment showing an empty host. Before: the comment rendered "Preview: https://". Now: it includes the correct host. Adds a CI guard so this class of mistake fails fast.

- Changes
  - In .github/workflows/preview-build.yaml, `package.outputs.host` now reads from `${{ steps.meta.outputs.host }}` instead of `needs.package`.
  - In .github/workflows/helm-test.yml, add a check that fails if any job’s `outputs` reference `needs.<same job>`.

- Rollout
  - If any workflow defines outputs via `needs.<same job>`, update them to read from the producing step; otherwise CI will fail.

<sup>Written for commit ed78e3615564f8c196dc222bf3758b6700989ad1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

