### PR TITLE
fix(preview): give the migration Job a deadline

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -210,6 +210,29 @@ jobs:
 
           grep -q "studio-pr-42-preview-migrate" /tmp/preview.yaml \
             || fail "preview render is missing the migration Job"
+          # A hook Job that hangs blocks the sync operation, and a blocked
+          # operation cannot be superseded — so the ApplicationSet cannot delete
+          # the Application, and the preview outlives its TTL. backoffLimit does
+          # not help: a Job with no pod, or a pod stuck pulling, never counts a
+          # failed attempt.
+          python3 - <<'DEADLINE'
+          import sys, yaml
+          bad = []
+          for d in yaml.safe_load_all(open("/tmp/preview.yaml")):
+              if not d or d["kind"] != "Job":
+                  continue
+              ann = d["metadata"].get("annotations") or {}
+              if "argocd.argoproj.io/hook" not in ann:
+                  continue
+              if not d["spec"].get("activeDeadlineSeconds"):
+                  bad.append(d["metadata"]["name"])
+          if bad:
+              print("::error::hook Jobs need activeDeadlineSeconds or a hang blocks "
+                    "teardown and the TTL: " + ", ".join(bad))
+              sys.exit(1)
+          print("every hook Job has a deadline")
+          DEADLINE
+
           grep -q "studio-pr-42-postgres" /tmp/preview.yaml \
             || fail "preview render has no Postgres — the DB must live and die with the namespace"
 

--- a/deploy/helm/studio/Chart.yaml
+++ b/deploy/helm/studio/Chart.yaml
@@ -2,6 +2,13 @@ apiVersion: v2
 name: chart-deco-studio
 description: Helm chart for deco Studio — supports inline secrets, external secretName, and AWS Secrets Manager via ExternalSecret
 type: application
+# 0.14.8: the migration Job gets activeDeadlineSeconds. backoffLimit only counts
+# failed pods, so the two ways this Job actually broke — no pod at all, and a pod
+# stuck on a missing ConfigMap — left it Running indefinitely. Because it is a
+# sync hook, that blocked the whole operation, and a blocked operation cannot be
+# superseded: the ApplicationSet could not delete the Application, so the preview
+# ignored its label being removed and outlived the 48h TTL.
+#
 # 0.14.7: wait-for-schema now gates the worker on BOTH public.kysely_migration
 # and dbos.dbos_migrations. 0.14.6's migrate-on-boot init container runs
 # migrate.js then migrate-dbos.js as two sequential steps; gating on the
@@ -65,7 +72,7 @@ type: application
 # when disabled, so existing releases are unaffected.
 # 0.12.4: chart-managed API/worker dispatch roles now use
 # STUDIO_DISPATCH_ROLE; legacy overrides are rejected.
-version: 0.14.7
+version: 0.14.8
 appVersion: "latest"
 
 dependencies:

--- a/deploy/helm/studio/templates/preview-migrate-job.yaml
+++ b/deploy/helm/studio/templates/preview-migrate-job.yaml
@@ -28,6 +28,22 @@ metadata:
     argocd.argoproj.io/sync-wave: "-10"
 spec:
   backoffLimit: 3
+  # A deadline, because backoffLimit does not cover the ways this Job hangs
+  # rather than fails. Twice now it sat Running 0/1 indefinitely — once with the
+  # pod stuck in CreateContainerConfigError on a missing ConfigMap, once with no
+  # pod at all because the ServiceAccount did not exist yet. Neither counts as a
+  # failed attempt, so backoffLimit never trips.
+  #
+  # That matters beyond this Job. It is a sync hook, so Argo blocks the whole
+  # operation waiting for it — and a blocked operation cannot be superseded,
+  # which means the ApplicationSet cannot delete the Application either. A
+  # preview in that state ignores its label being removed and outlives the 48h
+  # TTL, which is the one thing the TTL exists to prevent.
+  #
+  # Failing frees the operation: Argo reports a failed sync, retry applies, and
+  # removing the label works again. 15 minutes is well past a cold migration
+  # (measured ~3 min, nearly all of it waiting for the image to publish).
+  activeDeadlineSeconds: {{ .Values.preview.migrateDeadlineSeconds }}
   template:
     metadata:
       labels:

--- a/deploy/helm/studio/values.yaml
+++ b/deploy/helm/studio/values.yaml
@@ -188,6 +188,13 @@ preview:
     # An existing Role in that namespace, owned by the sandbox-env chart.
     roleName: ""
 
+  # Hard deadline for the migration Job. backoffLimit only counts failed pods;
+  # a Job that hangs without producing one — missing ConfigMap, missing
+  # ServiceAccount — never trips it and blocks the sync operation forever, which
+  # in turn blocks teardown and the TTL. Generous: a cold migration measures
+  # around 3 minutes, nearly all of it waiting for the image.
+  migrateDeadlineSeconds: 900
+
   # Resources for the short-lived migration Job.
   jobResources:
     requests:


### PR DESCRIPTION
The last structural hole in the preview lifecycle, hit twice and cleared by hand both times.

## What happens

`backoffLimit` only counts **failed pods**. Neither way this Job actually broke produced one:

| failure | what the Job did |
|---|---|
| ConfigMap did not exist yet (0.14.1) | pod stuck in `CreateContainerConfigError` | 
| ServiceAccount did not exist yet (0.14.5) | no pod created at all |

Both left it `Running 0/1` indefinitely, and `backoffLimit` never tripped.

## Why it matters beyond this Job

It is a **sync hook**, so Argo blocks the whole operation waiting for it. A blocked operation cannot be superseded — which means the ApplicationSet cannot delete the Application either.

A preview in that state **ignores its label being removed**, and outlives the 48h TTL. That is the one thing the TTL exists to prevent. Both times we saw it, the only way out was terminating the operation manually.

Failing frees the operation: Argo reports a failed sync, `retry` applies, and removing the label works again.

## The number

`900s`. A cold migration measured around 3 minutes, and nearly all of that was waiting for the image to publish rather than migrating — the Job is created ~30s after the label while the build still has ~3 minutes to run. 15 minutes is well clear of that.

## Assertion

`helm-test.yml` now fails if any Job carrying an `argocd.argoproj.io/hook` annotation lacks `activeDeadlineSeconds` — the property that matters is "a hook cannot hang forever", not "this particular Job has a number".

## Note

Rebased onto 0.14.7, which fixed a real bug in my `wait-for-schema`: gating the worker on `public.kysely_migration` alone let it call `DBOS.launch()` while `migrate-dbos.js` was still running, racing inserts into `dbos.dbos_migrations` — the exact collision splitting the two migrate scripts was meant to prevent. That fix is untouched here.

## Verification

- Render: `backoffLimit=3`, `activeDeadlineSeconds=900`, worker init container unchanged.
- Default render outside preview: **0 lines of difference** against `main`.
- `helm lint` clean.

Chart `0.14.7` → `0.14.8`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 900s deadline to the preview migration Job so Argo sync cannot hang indefinitely. Previously, missing ConfigMap or ServiceAccount left the hook Job Running 0/1 without counting toward backoffLimit; now the Job times out, fails the sync, and allows retries and teardown, restoring the preview TTL.

- Chart bumped to 0.14.8; the Job now sets spec.activeDeadlineSeconds from `preview.migrateDeadlineSeconds` (default 900s) with `backoffLimit: 3` unchanged.
- CI now fails if any Job annotated with `argocd.argoproj.io/hook` lacks `activeDeadlineSeconds` (enforced in `.github/workflows/helm-test.yml`).
- Scope: only affects preview; default non-preview render is unchanged. No runtime change to worker init container.
- Action required: add `activeDeadlineSeconds` to any other Argo hook Jobs in this repo to satisfy CI. Adjust the timeout via `preview.migrateDeadlineSeconds` if needed.

<sup>Written for commit 7ba8b57768cf8ea018647a02edd9441a565799f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6237?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

