### PR TITLE
ci(e2e): bound the playwright apt step so a stalled mirror can't eat the job

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -174,11 +174,15 @@ jobs:
       - name: Install Playwright chromium
         if: steps.cache-playwright.outputs.cache-hit != 'true'
         working-directory: packages/e2e
+        # apt's mirror stalls silently — run 32264701513 sat 11 minutes with no
+        # output before the job was cancelled. Fail fast and re-runnable instead.
+        timeout-minutes: 5
         run: npx playwright install chromium --with-deps
 
       - name: Install Playwright chromium system deps
         if: steps.cache-playwright.outputs.cache-hit == 'true'
         working-directory: packages/e2e
+        timeout-minutes: 5
         run: npx playwright install-deps chromium
 
       - name: Create data directory

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,11 +221,15 @@ jobs:
       - name: Install Playwright chromium
         if: steps.cache-playwright.outputs.cache-hit != 'true'
         working-directory: apps/web
+        # apt's mirror stalls silently — run 32264701513 sat 11 minutes with no
+        # output before the job was cancelled. Fail fast and re-runnable instead.
+        timeout-minutes: 5
         run: npx playwright install chromium --with-deps
 
       - name: Install Playwright chromium system deps
         if: steps.cache-playwright.outputs.cache-hit == 'true'
         working-directory: apps/web
+        timeout-minutes: 5
         run: npx playwright install-deps chromium
 
       - name: Run component tests


### PR DESCRIPTION
## What happened

[Run 32264701513](https://github.com/decocms/studio/actions/runs/32264701513) shard 2, attempt 1, step by step:

| step | shard 1 | shard 2 |
|---|---|---|
| `npx playwright install-deps chromium` | 25s | **759s** |
| `Run e2e tests` | 87s | never started |

The log shows apt printing its mirrorlist at `14:35:57` and then nothing at all until the job was cancelled at `14:46:56` — 11 silent minutes on an Azure apt mirror. The runner then reaped `npm exec playwright install-deps chromium` as an orphan. The tests themselves take 87 seconds.

With no bound on the step, a stalled mirror is free to consume the job's whole 35-minute budget, and the only signal is a check that sits there looking busy.

## Change

`timeout-minutes: 5` on both Playwright install steps, in `e2e.yml` (`e2e-shard`) and `test.yml` (`web-component-tests`) — all four have the same apt exposure. GitHub kills the step's whole process tree, so a stall becomes a fast, obvious red that re-runs in ~4 minutes.

Headroom is generous: 25s observed for `install-deps` on a cache hit, and the cache-miss path (`install --with-deps`, which also downloads the browser) is well under 5 minutes.

## Not in scope

- **Retrying the step.** `timeout` on the shell command only signals `npx`; apt survives as an orphan holding the dpkg lock, so attempt 2 fails on lock contention. Worth revisiting if mirror stalls turn out to be frequent rather than rare — right now this is n=1.
- **Shard rebalancing.** Measured over the last ~60 PR runs, `e2e-shard (2)` exec p50 is 4.5m / p90 9.4m against shard 1's 3.9m / 6.0m. Real, but a separate problem from this one.
- **Self-hosted runners** (#5828). Queue time on this repo right now measures p50 2s / p90 5s across `test.yml`, and effectively zero for `e2e.yml`. Whatever this run cost, it was not queue.

## Testing

YAML parses and the four timeouts land on the intended steps. Otherwise this is CI config — the e2e run on this PR exercises the cache-hit path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the Playwright install steps in CI to 5 minutes so a stalled apt mirror can’t consume the whole job. Previously these steps were unbounded and could hang silently; now they time out in 5 minutes and GitHub kills the process tree, failing fast and making reruns quick.

- Adds `timeout-minutes: 5` to four steps across `.github/workflows/e2e.yml` and `.github/workflows/test.yml` for both `install chromium --with-deps` and `install-deps chromium`.
- Headroom is safe: cache hit ~25s; cache miss is typically under 5m. If a slow cache miss exceeds 5m, re-run the job.
- No retry logic added; this change only bounds the step duration.

<sup>Written for commit 55c583b735eeddf3f2b47999bd7d3c60eb2198e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

