### PR TITLE
perf(storage): stop decrypting secrets on every connection update

### DIFF
--- a/apps/api/src/storage/connection.ts
+++ b/apps/api/src/storage/connection.ts
@@ -380,10 +380,16 @@ export class ConnectionStorage implements ConnectionStoragePort {
     // every update, using presence (not `??`) so an explicit null clears the field
     // it was derived from instead of silently keeping the old slug.
     const slugData: Record<string, unknown> = { ...data };
-    const existing = await this.findById(id);
+    // Skip findById() here — it decrypts secrets we don't need just for a slug merge.
+    const existing = await this.db
+      .selectFrom("connections")
+      .select(["app_name", "connection_url", "title"])
+      .where("id", "=", id)
+      .executeTakeFirst();
     if (existing) {
-      const merged = <K extends keyof ConnectionEntity>(key: K) =>
-        data[key] === undefined ? existing[key] : data[key];
+      const merged = <K extends "app_name" | "connection_url" | "title">(
+        key: K,
+      ) => (data[key] === undefined ? existing[key] : data[key]);
       slugData.slug = getConnectionSlug({
         app_name: merged("app_name"),
         connection_url: merged("connection_url"),


### PR DESCRIPTION
Follows #6220's connection create/update round-trip cuts — found while auditing `ConnectionStorage` for remaining round trips in this same area.

`update()` computed the denormalized `slug` column by merging incoming `data` with the existing row's `app_name`/`connection_url`/`title`, fetched via `findById(id)`. `findById` deserializes the full row, which decrypts `connection_token`, `configuration_state`, and every STDIO env var through the vault — all of that decrypted work was thrown away immediately since only three plaintext columns were read.

This makes every connection update pay for a vault decrypt (token + config state + N env vars) it never uses — real cost on the hot connection-settings-save path, and one that scales with how many secrets a given connection has configured.

Fix: select only `app_name`, `connection_url`, `title` directly instead of going through `findById`/`deserializeConnection`. Same merge logic, same slug output — just without decrypting unrelated encrypted columns.

Behavior preserved: `getConnectionSlug` only reads `app_name`/`connection_url`/`title`/`id`, and the raw DB columns for those three fields are already plaintext (see `deserializeConnection`, which assigns them directly with no `vault.decrypt` call). The `merged()` closure and `getConnectionSlug` call are unchanged.

To confirm: `cd apps/api && bunx tsc --noEmit` (clean) and `bunx oxlint apps/api/src/storage/connection.ts` (0 warnings/errors). `connection.integration.test.ts` covers this path but needs real Postgres, unavailable in this environment — full CI runs it.

Locally verified: `bun run fmt`, targeted `tsc --noEmit` in `apps/api`, and per-file `oxlint`. Full CI (including the Postgres-backed integration suite) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoids decrypting secrets on connection update by computing the slug from plaintext columns. Previously `update()` called `findById()` and deserialized the full row; now it selects only `app_name`, `connection_url`, and `title`, preserving behavior and speeding up settings saves.

**Reviewer notes**
- Touches `apps/api/src/storage/connection.ts` in `ConnectionStorage.update()` only; `getConnectionSlug` and slug merge logic are unchanged.
- Skips vault decrypts of `connection_token`, `configuration_state`, and all STDIO env vars on each update; benefit scales with number of secrets.
- Maintains existing merge semantics: presence (not nullish coalescing); explicit null still clears its source field for slug derivation.
- No API or schema changes; no migration actions.

<sup>Written for commit 3708c0187637c4a03544568dc94836d7fda7a2b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

