### PR TITLE
fix(sandbox): drop a duplicate-key block in the Go daemon's decofile merge

### DIFF
--- a/packages/sandbox/daemon-go/internal/decofile/merge.go
+++ b/packages/sandbox/daemon-go/internal/decofile/merge.go
@@ -75,6 +75,7 @@ func generateFromBlocks(blocksDir string) (string, bool) {
 	var b strings.Builder
 	b.WriteByte('{')
 	first := true
+	seenKeys := make(map[string]bool, len(names))
 	for _, name := range names {
 		stem := name[:len(name)-len(".json")]
 		raw, err := os.ReadFile(filepath.Join(blocksDir, name))
@@ -92,7 +93,15 @@ func generateFromBlocks(blocksDir string) (string, bool) {
 		if !json.Valid(content) {
 			continue
 		}
-		keyJSON, err := json.Marshal(decodeOnce(stem))
+		key := decodeOnce(stem)
+		// Two distinct filenames can decode to the same key (mirrors the TS
+		// mergeBlocks fix): splicing both would silently drop one via the
+		// consumer's last-key-wins JSON parse. Keep the first (sorted) file.
+		if seenKeys[key] {
+			continue
+		}
+		seenKeys[key] = true
+		keyJSON, err := json.Marshal(key)
 		if err != nil {
 			continue
 		}

--- a/packages/sandbox/daemon-go/internal/decofile/merge_test.go
+++ b/packages/sandbox/daemon-go/internal/decofile/merge_test.go
@@ -77,6 +77,26 @@ func TestGenerateFromBlocks(t *testing.T) {
 		}
 	})
 
+	t.Run("drops a block whose decoded key collides with another file's", func(t *testing.T) {
+		dir := t.TempDir()
+		// "100%" (invalid escape, kept literal) and "100%25" (decodes to "100%")
+		// both map to the key "100%" — splicing both would produce a duplicate
+		// JSON key that the consumer's parser resolves last-key-wins.
+		writeBlock(t, dir, "100%.json", `{"n":1}`)
+		writeBlock(t, dir, "100%25.json", `{"n":2}`)
+		merged, ok := generateFromBlocks(dir)
+		if !ok {
+			t.Fatal("expected ok=true")
+		}
+		if merged != `{"100%":{"n":1}}` {
+			t.Fatalf("merged = %q, want only the first (sorted) file's block kept", merged)
+		}
+		var v any
+		if err := json.Unmarshal([]byte(merged), &v); err != nil {
+			t.Fatalf("merged blob is not valid JSON: %v", err)
+		}
+	})
+
 	t.Run("single-decodes a single-encoded stem (space in the key)", func(t *testing.T) {
 		dir := t.TempDir()
 		writeBlock(t, dir, "Compre%20Junto.json", `{"x":1}`)


### PR DESCRIPTION
Follows #6226, which fixed this same bug on the TS side (`packages/shared/src/decofile/merge.ts`) but left the Go daemon's mirror implementation (`packages/sandbox/daemon-go/internal/decofile/merge.go`, `generateFromBlocks`) unpatched.

**Why it matters:** two distinct `.deco/blocks/*.json` filenames can decode to the same block key — e.g. `100%.json` (an invalid `%` escape, kept literal by `decodeOnce`) and `100%25.json` (which decodes to `100%`). `generateFromBlocks` spliced both key-value pairs into the merged JSON text without checking for a collision, producing a duplicate object key. The consumer's JSON parser resolves duplicate keys last-key-wins, so one block's content silently disappears from the CMS's merged view — the exact failure #6226 fixed on the TS side, still live in the Go daemon that serves the same `.deco/blocks.gen.json` fallback during sandbox boot.

**Fix:** track `seenKeys` while iterating the sorted filenames and skip (drop) any file whose decoded key was already emitted, keeping the first (alphabetically sorted) file — same policy as the TS `mergeBlocks`.

**Regression test:** `TestGenerateFromBlocks/drops_a_block_whose_decoded_key_collides_with_another_file's` in `merge_test.go`, writing `100%.json` and `100%25.json` and asserting only the first file's block survives and the merged blob stays valid JSON.

**To verify:** `cd packages/sandbox/daemon-go && go test ./internal/decofile/...`

**Locally ran:** `go test ./internal/decofile/...` (all pass, including the new case and the existing concurrent-coalescer race test), `gofmt -l` (clean), `go vet ./internal/decofile/...` (clean). Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops duplicate-key blocks during the Go daemon’s decofile merge to prevent silent data loss. Previously, two filenames that decoded to the same key produced duplicate JSON object keys and the consumer kept the last value; now the merge keeps only the first (alphabetical) file for that key, matching the TS implementation.

- Tracks `seenKeys` in `generateFromBlocks` in `packages/sandbox/daemon-go/internal/decofile/merge.go` and skips subsequent collisions; policy is first-wins by sorted filename.
- Adds a regression test in `merge_test.go` covering `100%.json` vs `100%25.json` and asserting valid JSON with only the first block kept.
- To verify: `cd packages/sandbox/daemon-go && go test ./internal/decofile/...`

<sup>Written for commit f5e2dc941ba8c32a4c86b34fa011ed434179a25f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6241?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

