### PR TITLE
fix(mcp-clients): don't return a coerced retry that still fails validation

### DIFF
--- a/apps/api/src/mcp-clients/lazy-client.test.ts
+++ b/apps/api/src/mcp-clients/lazy-client.test.ts
@@ -11,6 +11,7 @@
 import { describe, expect, it, beforeEach, mock } from "bun:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import { createBridgeTransportPair } from "@decocms/mcp-utils";
 import { CircuitOpenError, resetAll } from "./circuit-breaker";
@@ -371,5 +372,34 @@ describe("lazy-client argument repair", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content[0]!.text).toBe("post not found");
+  });
+
+  it("does not return a repaired retry that still fails validation as if it succeeded", async () => {
+    // First rejection thrown, retry rejection returned as an isError result.
+    let callCount = 0;
+    const flakyClient = {
+      callTool: async () => {
+        callCount++;
+        if (callCount === 1) {
+          throw new McpError(ErrorCode.InvalidParams, "save: Required");
+        }
+        return {
+          isError: true,
+          content: [
+            { type: "text", text: "Input validation error: save: Required" },
+          ],
+        };
+      },
+    } as unknown as Client;
+    clientFromConnectionMock.mockResolvedValue(flakyClient);
+
+    const lazy = createLazyClient(fakeConnection, fakeCtx, false, toolsCache);
+
+    await expect(
+      lazy.callTool({
+        name: "edit",
+        arguments: { patch: '{"sections":[1]}' },
+      }),
+    ).rejects.toThrow(/Wrong type/);
   });
 });

--- a/apps/api/src/mcp-clients/lazy-client.ts
+++ b/apps/api/src/mcp-clients/lazy-client.ts
@@ -345,8 +345,9 @@ export function createLazyClient(
         throw err;
       }
       const schema = await inputSchema();
+      // A retry that still reports invalid params must not be returned as a success.
       const retried = await retryCoerced(schema);
-      if (retried) return retried;
+      if (retried && !invalidParamsResultText(retried)) return retried;
       throw enrichInvalidParams(err, toolName, schema, args);
     }
 


### PR DESCRIPTION
Follows #6210, which added argument-repair (coerce + retry) to `placeholder.callTool` in `lazy-client.ts`.

That PR added the repair logic on two paths: a thrown `McpError` (older-style servers) and an `isError: true` result (servers on MCP SDK >= 1.29, which catch validation errors internally). The result-based path correctly re-checks the retry with `invalidParamsResultText(retried)` before accepting it — but the thrown-error path just did `if (retried) return retried;` with no such check. If the coerced retry itself came back as an `isError: true` validation-failure result (rather than throwing again), it was returned to the caller as if the call had succeeded, silently swallowing a call that actually still failed, without appending the correction hint.

**Failure scenario:** a downstream server whose first rejection is a thrown `McpError(InvalidParams)`, but whose retry (after argument coercion) reports the same validation failure as an `isError` result instead of throwing — the proxy returned that failing result as a normal success, hiding both the failure and the hint from the caller/agent.

**Fix:** the thrown-error branch now checks `invalidParamsResultText(retried)` the same way the result-based branch does, so a still-invalid retry falls through to the hinted throw instead of being returned.

Regression test added in `lazy-client.test.ts` (`does not return a repaired retry that still fails validation as if it succeeded`) — verified it fails against the pre-fix code and passes against the fix.

To confirm: `bun test apps/api/src/mcp-clients/lazy-client.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bun test apps/api/src/mcp-clients/lazy-client.test.ts`, `bunx oxlint` on both changed files — all clean. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents `lazy-client` from returning a coerced retry as a success when it still fails validation after an initial thrown `InvalidParams` error. Previously, the thrown-error path returned the retry unconditionally; now it rejects retries that still report invalid params and throws with the correction hint.

- Applies the same `invalidParamsResultText(retried)` check to the thrown-error branch as the result-based branch.
- Adds a regression test in `apps/api/src/mcp-clients/lazy-client.test.ts` (“does not return a repaired retry that still fails validation as if it succeeded”).
- Impact: callers now get an enriched `InvalidParams` error (with hint) instead of a misleading success when the retry remains invalid. No migration required.

<sup>Written for commit 4ff6bfa8b8e42a44badaa21d5c1dd853cce212a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6242?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

