### PR TITLE
fix(thread): stop COLLECTION_THREADS_UPDATE from clearing the runtime stamp

### DIFF
--- a/apps/api/src/tools/thread/update.integration.test.ts
+++ b/apps/api/src/tools/thread/update.integration.test.ts
@@ -123,4 +123,42 @@ describe("COLLECTION_THREADS_UPDATE", () => {
       ),
     ).rejects.toThrow(/Virtual MCP not found/i);
   });
+
+  it("preserves the immutable runtime stamp across an unrelated metadata write", async () => {
+    const vmcp = await env.ctx.storage.virtualMcps.create(
+      env.orgId,
+      env.userId,
+      {
+        title: "sandbox-stamped",
+        connections: [],
+        status: "active",
+        pinned: false,
+        metadata: {
+          previewServerUrl: "https://preview.example.com",
+          fastPreview: true,
+        },
+      },
+    );
+    const created = await COLLECTION_THREADS_CREATE.handler(
+      {
+        data: {
+          virtual_mcp_id: vmcp.id,
+          title: "t",
+          branch: "main",
+          runtime: "sandbox",
+        },
+      },
+      env.ctx,
+    );
+    expect(created.item.metadata?.runtime).toBe("sandbox");
+
+    const updated = await COLLECTION_THREADS_UPDATE.handler(
+      {
+        id: created.item.id,
+        data: { metadata: { expanded_tools: [] } },
+      },
+      env.ctx,
+    );
+    expect(updated.item.metadata?.runtime).toBe("sandbox");
+  });
 });

--- a/apps/api/src/tools/thread/update.ts
+++ b/apps/api/src/tools/thread/update.ts
@@ -21,6 +21,7 @@ import {
   ThreadEntitySchema,
   ThreadUpdateDataSchema,
 } from "@decocms/shared/thread/schema";
+import { parseThreadRuntime } from "@decocms/shared/thread/session-runtime";
 
 /**
  * Input schema for updating threads
@@ -103,7 +104,13 @@ export const COLLECTION_THREADS_UPDATE = defineTool({
     }
 
     if (data.metadata !== undefined) {
-      updateData.metadata = data.metadata;
+      // `runtime` is stamped once at creation and immutable (session-runtime.ts); preserve it across this full-replacement write.
+      const existingRuntime = parseThreadRuntime(
+        (existing.metadata as { runtime?: unknown } | null)?.runtime,
+      );
+      updateData.metadata = existingRuntime
+        ? { ...data.metadata, runtime: existingRuntime }
+        : data.metadata;
     }
 
     if (data.branch !== undefined) {


### PR DESCRIPTION
Bug found while auditing the new per-thread session-runtime lock (`#6196`, `packages/shared/src/thread/session-runtime.ts`).

`thread.metadata.runtime` is documented as "stamped once at creation and immutable for the thread's life" (see `session-runtime.ts` and `entities.ts`) — it's the flag that keeps a sandbox-backed coding session out of the sandbox-less Fast Preview claim. But `COLLECTION_THREADS_UPDATE`'s `metadata` field is a documented *full replacement*, and nothing preserved `runtime` across it. Any caller that writes `data.metadata` without knowing about `runtime` silently drops it — the existing `useTaskExpandedTools` hook (`apps/web/src/hooks/use-task-expanded-tools.ts`) does a read-merge-write so it happens to be safe today, but the tool itself gives no such guarantee, and any future/API caller that sets `metadata` (or a stale client) flips a `"sandbox"`-stamped coding session's thread back to the project's default CMS runtime — the client would then resolve `resolveSessionRuntime` differently mid-session.

Fix: `update.ts` now carries the existing (parsed, validated) `runtime` stamp through into `updateData.metadata` regardless of what the caller sent, matching the documented immutability.

Failure scenario before the fix: create a thread with `runtime: "sandbox"` on a Fast Preview vMCP, then call `COLLECTION_THREADS_UPDATE` with any other `metadata` (e.g. `{ expanded_tools: [] }`) — the thread's `metadata.runtime` is gone, so a later `resolveSessionRuntime` call for that thread falls back to the project default (`"cms"`) instead of staying `"sandbox"`.

Regression test added to `update.integration.test.ts` ("preserves the immutable runtime stamp across an unrelated metadata write"), run against real Postgres.

Reviewer command: `cd apps/api && bun test src/tools/thread/update.integration.test.ts`

Locally verified: `bun run fmt`, `bunx tsc --noEmit` (apps/api), the targeted integration test above (5 pass), and `bunx oxlint` on both changed files (0 errors/warnings). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the thread’s immutable runtime stamp when `COLLECTION_THREADS_UPDATE` writes `metadata`, preventing sandbox-backed sessions from flipping to the project default runtime mid-session. Previously, `metadata` was a full replacement that could drop `metadata.runtime`; now the update preserves the existing, validated runtime value on every write.

- Review and testing
  - Focus on `apps/api/src/tools/thread/update.ts` logic that carries the existing `metadata.runtime` forward.
  - Integration test added: `apps/api/src/tools/thread/update.integration.test.ts` (“preserves the immutable runtime stamp…”).
  - Run: cd apps/api && bun test src/tools/thread/update.integration.test.ts

- Rollout
  - No migrations. Callers updating `metadata` do not need to include `runtime`; the server preserves it.

<sup>Written for commit ab596f3552d7852eabe4261234c7aafc19af6772. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

