### PR TITLE
ci: add Depot CI workflows alongside GitHub Actions

### DIFF
--- a/.depot/actions/apt-mirror-fallback/action.yml
+++ b/.depot/actions/apt-mirror-fallback/action.yml
@@ -1,0 +1,100 @@
+name: Run an apt command with Ubuntu mirror fallback
+description: >-
+  Run a command that installs Ubuntu packages, retrying it against a different
+  Ubuntu mirror each time it stalls.
+
+  GitHub's hosted runners point apt at a mirrorlist (`/etc/apt/apt-mirrors.txt`)
+  whose first entry is `azure.archive.ubuntu.com`. When that mirror degrades it
+  does not fail — it crawls (37 kB/s measured on 2026-08-19, so a 21 MB font
+  download could not finish inside 5 minutes), and apt's own mirrorlist fallback
+  only triggers on a hard error, never on a slow transfer. This action gives
+  each mirror a hard wall-clock budget instead: blow the budget, rewrite the
+  mirrorlist to the next mirror, try again.
+
+inputs:
+  run:
+    description: >-
+      Shell command to run. Include `apt-get update` — the mirror changes
+      underneath it between attempts, so its package lists must be refetched.
+    required: true
+  timeout-seconds:
+    description: Wall-clock budget for one mirror's attempt.
+    default: "120"
+  mirrors:
+    description: >-
+      Ubuntu archive mirrors to try, in order, one per line. Every entry must
+      carry the -security pocket as well as the release pocket, because the
+      runner's sources point both at this one mirrorlist.
+    default: |
+      http://azure.archive.ubuntu.com/ubuntu/
+      http://mirrors.edge.kernel.org/ubuntu/
+      http://archive.ubuntu.com/ubuntu/
+
+runs:
+  using: composite
+  steps:
+    - name: Run with Ubuntu mirror fallback
+      shell: bash
+      env:
+        APT_FALLBACK_RUN: ${{ inputs.run }}
+        APT_FALLBACK_TIMEOUT: ${{ inputs.timeout-seconds }}
+        APT_FALLBACK_MIRRORS: ${{ inputs.mirrors }}
+      run: |
+        set -uo pipefail
+
+        # Bound apt's own network waits so a dead connection fails inside the
+        # per-mirror budget instead of consuming all of it.
+        sudo tee /etc/apt/apt.conf.d/99-ci-mirror-fallback >/dev/null <<'APTCONF'
+        Acquire::Retries "2";
+        Acquire::http::Timeout "20";
+        Acquire::https::Timeout "20";
+        APTCONF
+
+        # A timed-out attempt leaves apt-get/dpkg alive holding the dpkg lock,
+        # which would fail the next mirror for the wrong reason. Kill and repair.
+        reset_apt() {
+          sudo pkill -9 -x apt-get 2>/dev/null || true
+          sudo pkill -9 -x dpkg 2>/dev/null || true
+          sudo dpkg --configure -a >/dev/null 2>&1 || true
+        }
+
+        # The mirrorlist is a GitHub-hosted-image thing: on any other runner the
+        # sources do not point at it, so switching mirrors is a no-op and only
+        # the timeout-and-retry half of this action does any work. Say so rather
+        # than claim a fallback we did not get.
+        MIRRORLIST=/etc/apt/apt-mirrors.txt
+        if [ ! -f "$MIRRORLIST" ]; then
+          echo "::warning::${MIRRORLIST} not found — this runner does not use a mirrorlist, so attempts will retry the same mirror"
+        fi
+
+        mirrors=()
+        while IFS= read -r line; do
+          line="${line%$'\r'}"
+          [ -n "${line//[[:space:]]/}" ] || continue
+          mirrors+=("$line")
+        done <<< "$APT_FALLBACK_MIRRORS"
+        if [ "${#mirrors[@]}" -eq 0 ]; then
+          echo "::error::apt-mirror-fallback: no mirrors configured"
+          exit 1
+        fi
+
+        for mirror in "${mirrors[@]}"; do
+          echo "::group::apt via ${mirror}"
+          # One mirror per attempt, deliberately: leaving the others in the file
+          # would let apt silently fall back inside an attempt, which is exactly
+          # the behaviour that fails to trigger on a merely-slow mirror.
+          if [ -f "$MIRRORLIST" ]; then
+            printf '%s\n' "$mirror" | sudo tee "$MIRRORLIST" >/dev/null
+          fi
+          if timeout "$APT_FALLBACK_TIMEOUT" bash -c "$APT_FALLBACK_RUN"; then
+            echo "::endgroup::"
+            echo "apt succeeded via ${mirror}"
+            exit 0
+          fi
+          reset_apt
+          echo "::endgroup::"
+          echo "::warning::Ubuntu mirror ${mirror} failed or exceeded ${APT_FALLBACK_TIMEOUT}s — falling back to the next mirror"
+        done
+
+        echo "::error::every Ubuntu mirror failed: ${mirrors[*]}"
+        exit 1

--- a/.depot/actions/setup-bun/action.yml
+++ b/.depot/actions/setup-bun/action.yml
@@ -1,0 +1,25 @@
+name: Setup Bun and install dependencies
+description: >-
+  Install Bun (pinned version) and run `bun install`. Shared by every workflow
+  that installs workspace dependencies so the pinned Bun version lives in
+  exactly one place. Deliberately NOT cached: measured on real runs, restoring
+  the ~570MB actions/cache entry (~18s) is slower than a cold `bun install`
+  from npm (~18s cold, and GH runners pull npm at ~70MB/s), while pressuring
+  the repo's 10GB cache quota that buildkit layers share.
+
+inputs:
+  bun-version:
+    description: Bun version to install — single source of truth for CI.
+    default: "1.3.14"
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Bun
+      uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: ${{ inputs.bun-version }}
+
+    - name: Install dependencies
+      shell: bash
+      run: bun install

--- a/.depot/actions/start-minio/action.yml
+++ b/.depot/actions/start-minio/action.yml
@@ -1,0 +1,52 @@
+name: Start MinIO
+description: >-
+  Start a MinIO (S3-compatible) server as a detached container and wait until it
+  accepts connections. MinIO only runs the server with an explicit command,
+  which GitHub `services:` can't provide — so it has to be a step, not a service.
+  Shared by e2e.yml and storage-integration.yml so the pinned image version
+  lives in exactly one place.
+
+inputs:
+  image:
+    description: MinIO container image — single source of truth for the pinned version.
+    # Docker Hub, not quay.io: same official image/tags, but quay.io
+    # intermittently times out in CI, and GitHub-hosted runners are exempt
+    # from Docker Hub rate limits for public images.
+    default: minio/minio:RELEASE.2025-09-07T16-13-09Z
+  port:
+    description: Host port to publish and probe for readiness.
+    default: "9000"
+  root-user:
+    description: MINIO_ROOT_USER.
+    default: minioadmin
+  root-password:
+    description: MINIO_ROOT_PASSWORD.
+    default: minioadmin
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        # Pull explicitly with retry/backoff: the implicit pull inside
+        # `docker run` has no retry, so one transient registry failure kills
+        # the whole job. Same pattern as the NATS pull in e2e.yml and the
+        # compose retry in resilience.yml.
+        for attempt in 1 2 3 4 5; do
+          docker pull ${{ inputs.image }} && break
+          echo "docker pull ${{ inputs.image }} failed (attempt $attempt); retrying in $((attempt * 5))s"
+          sleep $((attempt * 5))
+        done
+        docker run -d --name minio -p ${{ inputs.port }}:9000 \
+          -e MINIO_ROOT_USER=${{ inputs.root-user }} \
+          -e MINIO_ROOT_PASSWORD=${{ inputs.root-password }} \
+          ${{ inputs.image }} server /data
+        # Poll MinIO's readiness endpoint, not a bare TCP probe: `nc -z` passes
+        # as soon as the port is listening, but the object layer isn't serving
+        # yet and resets S3 requests (ECONNRESET). /minio/health/ready returns
+        # 200 only once it can actually serve.
+        ready="http://localhost:${{ inputs.port }}/minio/health/ready"
+        for i in $(seq 1 30); do
+          curl -fsS "$ready" >/dev/null 2>&1 && break || sleep 1
+        done
+        curl -fsS "$ready" >/dev/null

--- a/.depot/workflows/auto-label-claude-prs.yml
+++ b/.depot/workflows/auto-label-claude-prs.yml
@@ -1,0 +1,31 @@
+# Depot CI Migration
+# Source: .github/workflows/auto-label-claude-prs.yml
+#
+# Changes made:
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Auto-label Claude PRs
+# PRs authored by coding agents carry the "🤖 Generated with" signature line
+# (mandated by CLAUDE.md). Label them so downstream automation (comment-cop)
+# and reviewers can key off AI provenance.
+on:
+  pull_request:
+    types: [opened]
+jobs:
+  auto-label:
+    if: "contains(github.event.pull_request.body, '\U0001F916 Generated with')"
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Add claude label
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['claude']
+            });

--- a/.depot/workflows/codeql.yml
+++ b/.depot/workflows/codeql.yml
@@ -1,0 +1,56 @@
+# Depot CI Migration
+# Source: .github/workflows/codeql.yml
+#
+# Changes made:
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: CodeQL
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  # CodeQL query packs ship new rules continuously, so re-scan the default
+  # branch weekly even when nothing lands — a scheduled run is what surfaces
+  # newly-written queries against already-merged code.
+  schedule:
+    - cron: "27 5 * * 1" # Mondays 05:27 UTC
+# A force-push to a PR obsoletes the in-flight scan — cancel it. Pushes to main
+# all run (no cancel) so every merged commit keeps its own set of alerts, and
+# scheduled runs are never cancelled by each other.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+permissions:
+  contents: read
+# All third-party actions are pinned to a full commit SHA, not a tag.
+jobs:
+  # Scoped to JS/TS on purpose. The javascript-typescript extractor covers
+  # .js/.jsx/.ts/.tsx in one pass and needs no build, so this is the whole
+  # apps/ + packages/ TypeScript surface (~3.3k files) and nothing else.
+  # The repo's other languages are deliberately out of scope for now:
+  #   - go     (packages/sandbox/daemon-go) — compiled, needs a build step
+  #   - python (packages/sandbox/image/skills) — 8 script files
+  #   - rust   (apps/native) — src-tauri won't compile on Linux, so it would
+  #             need a macOS runner plus a full cargo build (see native.yml)
+  analyze:
+    name: Analyze (javascript-typescript)
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    timeout-minutes: 120
+    permissions:
+      contents: read
+      security-events: write # upload the SARIF results to code scanning
+      packages: read # CodeQL query packs are pulled from GHCR
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@faaa5d804fc648d0fdb28822a8e36cf7d0a6132c # v4
+        with:
+          languages: javascript-typescript
+          build-mode: none
+          config-file: ./.github/codeql/codeql-config.yml
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@faaa5d804fc648d0fdb28822a8e36cf7d0a6132c # v4
+        with:
+          category: /language:javascript-typescript

--- a/.depot/workflows/deploy-docs.yaml
+++ b/.depot/workflows/deploy-docs.yaml
@@ -1,0 +1,31 @@
+# Depot CI Migration
+# Source: .github/workflows/deploy-docs.yaml
+#
+# Changes made:
+# - Rewrote .github/ path references to .depot/
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Deploy Docs
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/docs/**"
+jobs:
+  deploy:
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Bun and install dependencies
+        uses: ./.depot/actions/setup-bun
+      - name: Build
+        run: bun run build
+        working-directory: apps/docs
+      - name: Deploy to Cloudflare Pages
+        run: bunx wrangler pages deploy dist/client --project-name=decocms-docs
+        working-directory: apps/docs
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}

--- a/.depot/workflows/deploy-storybook.yml
+++ b/.depot/workflows/deploy-storybook.yml
@@ -1,0 +1,31 @@
+# Depot CI Migration
+# Source: .github/workflows/deploy-storybook.yml
+#
+# Changes made:
+# - Rewrote .github/ path references to .depot/
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Deploy Storybook
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/ui/**"
+  workflow_dispatch:
+jobs:
+  deploy:
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Bun and install dependencies
+        uses: ./.depot/actions/setup-bun
+      - name: Build Storybook
+        run: bun run build-storybook
+        working-directory: packages/ui
+      - name: Deploy to Cloudflare Workers (static assets)
+        run: bunx wrangler deploy
+        working-directory: packages/ui
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}

--- a/.depot/workflows/e2e.yml
+++ b/.depot/workflows/e2e.yml
@@ -1,0 +1,212 @@
+# Depot CI Migration
+# Source: .github/workflows/e2e.yml
+#
+# Changes made:
+# - Rewrote .github/ path references to .depot/
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: E2E Tests
+on:
+  push:
+    branches:
+      - main
+    # Skip pushes to main that only touch the version bump, CI/workflow config,
+    # or docs — none need the suite re-run (PRs already validated them, and the
+    # [release] bump is owned by release-studio).
+    paths-ignore:
+      - "apps/api/package.json"
+      - ".github/**"
+      - "apps/docs/**"
+      - "**/*.md"
+  pull_request:
+    branches:
+      - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+jobs:
+  # See test.yml for why this gate exists: skip the (required) check on
+  # workflow/docs/markdown-only PRs without leaving the required check
+  # stuck pending. Pushes to main always run.
+  changes:
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Detect relevant changes
+        id: filter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            # Push to main runs everything — except the [release]: version-bump
+            # commit, which only touches the version string. release-studio picks
+            # that commit up on its own push trigger and cuts the release.
+            case "$HEAD_MSG" in
+              '[release]:'*) echo "relevant=false" >> "$GITHUB_OUTPUT" ;;
+              *) echo "relevant=true" >> "$GITHUB_OUTPUT" ;;
+            esac
+            exit 0
+          fi
+          set +e
+          if ! FILES=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename'); then
+            echo "Could not list PR files — running to be safe."
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Changed files:"; echo "$FILES"
+          relevant=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              .github/*|apps/docs/*|deploy/*|*.md) ;;
+              *) relevant=true; break ;;
+            esac
+          done <<< "$FILES"
+          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+  e2e-shard:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    # Backstop above playwright's own 30min globalTimeout so its report wins.
+    timeout-minutes: 35
+    strategy:
+      # One slow/broken shard shouldn't hide the other's result.
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    defaults:
+      run:
+        working-directory: apps/api
+    services:
+      postgres:
+        image: public.ecr.aws/docker/library/postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres" --health-interval 10s --health-timeout 5s --health-retries 5
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+      NATS_URL: nats://localhost:4222
+      # Better Auth's per-endpoint signup limiter kicks in after a handful of
+      # /sign-up/email POSTs in a short window. Our e2e specs do multiple
+      # signups per run; without this they get 429s and only pass on retry,
+      # which masks real regressions as "flaky".
+      DISABLE_RATE_LIMIT: "true"
+      # MinIO, started below — makes the app resolve OBJECT_STORAGE to the real
+      # S3Service path (not the DevObjectStorage filesystem fallback) so the
+      # object-storage e2e exercises production code end-to-end.
+      S3_ENDPOINT: http://localhost:9000
+      S3_BUCKET: studio-e2e
+      S3_ACCESS_KEY_ID: minioadmin
+      S3_SECRET_ACCESS_KEY: minioadmin
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Bun and install dependencies
+        uses: ./.depot/actions/setup-bun
+      - name: Start NATS with JetStream
+        run: |
+          # Pull explicitly with retry/backoff: the registry mirror occasionally
+          # answers `toomanyrequests: Rate exceeded`, and an inline pull inside
+          # `docker run` has no retry, so a transient 429 fails the whole job.
+          for attempt in 1 2 3 4 5; do
+            docker pull public.ecr.aws/docker/library/nats:2.14.2 && break
+            echo "docker pull public.ecr.aws/docker/library/nats:2.14.2 failed (attempt $attempt); retrying in $((attempt * 5))s"
+            sleep $((attempt * 5))
+          done
+          docker run -d --name nats -p 4222:4222 public.ecr.aws/docker/library/nats:2.14.2 -js
+          for _ in $(seq 1 10); do
+            if nc -z localhost 4222; then
+              break
+            fi
+            sleep 1
+          done
+          nc -z localhost 4222
+      - name: Start MinIO
+        uses: ./.depot/actions/start-minio
+      # Create the bucket the app expects (S3Service never auto-creates it);
+      # reuse the already-installed @aws-sdk/client-s3 so there's no `mc`
+      # version to keep in sync.
+      - name: Create S3 bucket
+        run: |
+          bun -e '
+            import { S3Client, CreateBucketCommand } from "@aws-sdk/client-s3";
+            const c = new S3Client({
+              endpoint: process.env.S3_ENDPOINT,
+              region: "auto",
+              credentials: {
+                accessKeyId: process.env.S3_ACCESS_KEY_ID,
+                secretAccessKey: process.env.S3_SECRET_ACCESS_KEY,
+              },
+              forcePathStyle: true,
+            });
+            await c.send(new CreateBucketCommand({ Bucket: process.env.S3_BUCKET }));
+            console.log("created bucket", process.env.S3_BUCKET);
+          '
+      - name: Cache Playwright browsers
+        id: cache-playwright
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('packages/e2e/package.json') }}
+          # On a key rotation (any packages/e2e dep bump) the fallback restores
+          # the previous browsers and `playwright install` downloads only the
+          # missing version instead of a full cold install.
+          restore-keys: |
+            playwright-${{ runner.os }}-
+      - name: Install Playwright chromium
+        if: steps.cache-playwright.outputs.cache-hit != 'true'
+        working-directory: packages/e2e
+        run: npx playwright install chromium --with-deps
+      - name: Install Playwright chromium system deps
+        if: steps.cache-playwright.outputs.cache-hit == 'true'
+        working-directory: packages/e2e
+        run: npx playwright install-deps chromium
+      - name: Create data directory
+        run: mkdir -p data
+      - name: Run database migrations
+        run: bun run migrate
+      # The e2e web build (~70s) is pure function of these inputs — cache the
+      # dist so each shard serves it instead of rebuilding. Exact-match only
+      # (no restore-keys): a stale dist must never be served, so any input
+      # change falls back to a full build. Key includes apps/api/package.json
+      # because __STUDIO_VERSION__ is baked from its version field.
+      - name: Cache web production build
+        id: cache-web-dist
+        uses: actions/cache@v4
+        with:
+          path: apps/web/dist
+          key: web-dist-e2e-${{ runner.os }}-${{ hashFiles('apps/web/src/**', 'apps/web/index.html', 'apps/web/vite.config.ts', 'apps/web/package.json', 'apps/web/tsconfig.json', 'packages/ui/src/**', 'packages/shared/src/**', 'packages/bindings/src/**', 'apps/api/package.json', 'bun.lock') }}
+      - name: Run e2e tests
+        # The suite lives in packages/e2e; its Playwright config spawns the API
+        # from apps/api and the web app from apps/web via separate webServer
+        # entries. DB/NATS/S3 env are job-level, so both inherit them. Each
+        # shard runs its half of the specs against its own full stack.
+        working-directory: packages/e2e
+        env:
+          E2E_SKIP_WEB_BUILD: ${{ steps.cache-web-dist.outputs.cache-hit == 'true' && '1' || '' }}
+        run: bun run test:e2e --shard=${{ matrix.shard }}/2
+  # Aggregator carrying the required-check name: branch protection requires a
+  # check called "e2e", and matrix jobs report as "e2e-shard (1)"/"(2)" — a
+  # renamed required check would block merges forever. This job is the one
+  # the protection rule sees; skipped shards (docs-only PRs) count as pass,
+  # same as the changes-gate semantics everywhere else.
+  e2e:
+    needs: [changes, e2e-shard]
+    if: always()
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Verify shard results
+        run: |
+          case "${{ needs.e2e-shard.result }}" in
+            success|skipped) echo "shards: ${{ needs.e2e-shard.result }}"; exit 0 ;;
+            *) echo "shards: ${{ needs.e2e-shard.result }}"; exit 1 ;;
+          esac

--- a/.depot/workflows/e2e.yml
+++ b/.depot/workflows/e2e.yml
@@ -21,6 +21,9 @@ on:
   pull_request:
     branches:
       - main
+  # Both triggers above skip `.github/**`-only changes, so a CI-infrastructure
+  # fix cannot validate itself. Dispatch runs the suite on demand from any branch.
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -151,25 +154,48 @@ jobs:
             await c.send(new CreateBucketCommand({ Bucket: process.env.S3_BUCKET }));
             console.log("created bucket", process.env.S3_BUCKET);
           '
+      # Key on the RESOLVED Playwright version, not a hash of the manifest: the
+      # manifest carries a caret range, so its hash does not change when the
+      # lockfile resolves a new version — and the cache would then serve
+      # browsers built for a different Playwright than the tests run against.
+      - name: Resolve Playwright version
+        id: playwright-version
+        working-directory: packages/e2e
+        run: |
+          version=$(node -p "require('@playwright/test/package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Cache Playwright browsers
         id: cache-playwright
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('packages/e2e/package.json') }}
-          # On a key rotation (any packages/e2e dep bump) the fallback restores
-          # the previous browsers and `playwright install` downloads only the
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+          # On a key rotation (a Playwright bump) the fallback restores the
+          # previous browsers and `playwright install` downloads only the
           # missing version instead of a full cold install.
           restore-keys: |
             playwright-${{ runner.os }}-
+      # Browser binary only (Playwright's own CDN, no apt involved) — kept
+      # separate from the system deps below so an Ubuntu mirror outage can
+      # never block the download that actually has to succeed. Invoked via
+      # ./node_modules/.bin/playwright, never `npx playwright`: npx ignores the
+      # lockfile and resolves from the registry, so a cache miss would install
+      # browsers for the LATEST release while the tests run against the pinned
+      # one — a mismatch a warm cache hides.
       - name: Install Playwright chromium
         if: steps.cache-playwright.outputs.cache-hit != 'true'
         working-directory: packages/e2e
-        run: npx playwright install chromium --with-deps
+        timeout-minutes: 5
+        run: ./node_modules/.bin/playwright install chromium
+      # Everything chromium links against is already in the runner image — the
+      # only thing this step downloads is ~21 MB of font packages. So a total
+      # mirror outage costs us glyph coverage, not a red build; if a library
+      # ever really is missing, chromium fails to launch and the suite says so.
       - name: Install Playwright chromium system deps
-        if: steps.cache-playwright.outputs.cache-hit == 'true'
-        working-directory: packages/e2e
-        run: npx playwright install-deps chromium
+        uses: ./.depot/actions/apt-mirror-fallback
+        continue-on-error: true
+        with:
+          run: cd packages/e2e && ./node_modules/.bin/playwright install-deps chromium
       - name: Create data directory
         run: mkdir -p data
       - name: Run database migrations

--- a/.depot/workflows/helm-test.yml
+++ b/.depot/workflows/helm-test.yml
@@ -196,6 +196,29 @@ jobs:
 
           grep -q "studio-pr-42-preview-migrate" /tmp/preview.yaml \
             || fail "preview render is missing the migration Job"
+          # A hook Job that hangs blocks the sync operation, and a blocked
+          # operation cannot be superseded — so the ApplicationSet cannot delete
+          # the Application, and the preview outlives its TTL. backoffLimit does
+          # not help: a Job with no pod, or a pod stuck pulling, never counts a
+          # failed attempt.
+          python3 - <<'DEADLINE'
+          import sys, yaml
+          bad = []
+          for d in yaml.safe_load_all(open("/tmp/preview.yaml")):
+              if not d or d["kind"] != "Job":
+                  continue
+              ann = d["metadata"].get("annotations") or {}
+              if "argocd.argoproj.io/hook" not in ann:
+                  continue
+              if not d["spec"].get("activeDeadlineSeconds"):
+                  bad.append(d["metadata"]["name"])
+          if bad:
+              print("::error::hook Jobs need activeDeadlineSeconds or a hang blocks "
+                    "teardown and the TTL: " + ", ".join(bad))
+              sys.exit(1)
+          print("every hook Job has a deadline")
+          DEADLINE
+
           grep -q "studio-pr-42-postgres" /tmp/preview.yaml \
             || fail "preview render has no Postgres — the DB must live and die with the namespace"
 

--- a/.depot/workflows/helm-test.yml
+++ b/.depot/workflows/helm-test.yml
@@ -1,0 +1,612 @@
+# Depot CI Migration
+# Source: .github/workflows/helm-test.yml
+#
+# Changes made:
+# - Rewrote .github/ path references to .depot/
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Helm chart checks
+# PR-scoped lint + render + vendor-drift checks for the Helm charts. The
+# release workflows (release-sandbox-charts.yaml, publish-chart.yml) are
+# publish-only — without this gate, a helpers typo or a hand-edit to
+# vendored CRDs ships straight to consumers. Runs on every PR that touches
+# deploy/helm/** so reviewers see render failures inline.
+on:
+  pull_request:
+    paths:
+      - 'deploy/helm/**'
+      - '.depot/workflows/helm-test.yml'
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+jobs:
+  sandbox-operator:
+    name: sandbox-operator chart
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+      - name: Lint
+        # The chart's namespace validation (templates/validations.yaml)
+        # requires `agent-sandbox-system`. Pass it here so render-time
+        # checks during lint don't see the wrong namespace.
+        run: helm lint deploy/helm/sandbox-operator --namespace agent-sandbox-system
+      - name: Render
+        run: |
+          helm template sandbox-operator deploy/helm/sandbox-operator \
+            --namespace agent-sandbox-system \
+            > /dev/null
+      # Catches hand-edits to crds/ or templates/agent-sandbox-manifest.yaml
+      # that bypass vendor.sh. The .gitattributes linguist-generated marker
+      # collapses those files in PR review, so without this gate a manual
+      # tweak would slip through unnoticed.
+      - name: Vendor drift check
+        run: |
+          set -euo pipefail
+          bash deploy/helm/sandbox-operator/vendor.sh
+          if ! git diff --exit-code -- \
+              deploy/helm/sandbox-operator/crds \
+              deploy/helm/sandbox-operator/templates/agent-sandbox-manifest.yaml; then
+            echo "::error::Vendored files differ from vendor.sh output. Re-run deploy/helm/sandbox-operator/vendor.sh and commit the result."
+            exit 1
+          fi
+  sandbox-env:
+    name: sandbox-env chart
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+      - name: Lint
+        # envName is required, so lint must pass it. Use a representative
+        # value rather than `Release.Name` because helm lint doesn't drive
+        # render with a release name.
+        run: |
+          helm lint deploy/helm/sandbox-env \
+            --namespace agent-sandbox-system \
+            --set envName=ci
+      - name: Render (default values)
+        run: |
+          helm template sandbox-env deploy/helm/sandbox-env \
+            --namespace agent-sandbox-system \
+            --set envName=ci \
+            > /dev/null
+      - name: Render (preview gateway enabled)
+        run: |
+          helm template sandbox-env deploy/helm/sandbox-env \
+            --namespace agent-sandbox-system \
+            --set envName=ci \
+            --set previewGateway.enabled=true \
+            --set previewGateway.domain=preview.example.com \
+            --set previewGateway.clusterIssuer=letsencrypt-prod \
+            --api-versions gateway.networking.k8s.io/v1 \
+            --api-versions cert-manager.io/v1 \
+            > /dev/null
+      - name: Render (warm pool enabled)
+        run: |
+          helm template sandbox-env deploy/helm/sandbox-env \
+            --namespace agent-sandbox-system \
+            --set envName=ci \
+            --set warmPool.enabled=true \
+            --set warmPool.size=2 \
+            > /dev/null
+      - name: Render (envName missing must fail)
+        run: |
+          set +e
+          helm template sandbox-env deploy/helm/sandbox-env \
+            --namespace agent-sandbox-system \
+            > /tmp/render.out 2>&1
+          rc=$?
+          set -e
+          if [ "${rc}" -eq 0 ]; then
+            echo "::error::sandbox-env rendered without envName — required-value check is missing."
+            cat /tmp/render.out
+            exit 1
+          fi
+          if ! grep -q "envName is required" /tmp/render.out; then
+            echo "::error::sandbox-env failed for the wrong reason — expected envName-required error."
+            cat /tmp/render.out
+            exit 1
+          fi
+  studio:
+    name: studio chart
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+      - name: Lint
+        run: |
+          helm lint deploy/helm/studio \
+            --set database.url=postgresql://ci:ci@postgres.example.com:5432/studio
+      # Subchart .tgz files are vendored under deploy/helm/studio/charts/
+      # (see .gitignore comment) — no `helm dependency build` needed.
+      - name: Render
+        run: |
+          helm template deco-studio deploy/helm/studio \
+            --set database.url=postgresql://ci:ci@postgres.example.com:5432/studio \
+            > /dev/null
+      # -n deco-studio matches the watchNamespaces pin in the example values;
+      # the chart's namespace validation fails the render otherwise.
+      - name: Render (in-cluster ClickHouse example)
+        run: |
+          helm template deco-studio deploy/helm/studio \
+            -n deco-studio \
+            --set database.url=postgresql://ci:ci@postgres.example.com:5432/studio \
+            -f deploy/helm/studio/examples/values-clickhouse.yaml \
+            > /dev/null
+      # values-preview.yaml is consumed by the studio-previews ApplicationSet,
+      # which supplies the deployment-specific half. Render it here the same way
+      # that chart does, and assert the properties previews depend on — not just
+      # that it renders.
+      - name: Render (per-PR preview)
+        run: |
+          set -euo pipefail
+          helm template studio-pr-42 deploy/helm/studio \
+            -f deploy/helm/studio/values-preview.yaml \
+            --set preview.prNumber=42 \
+            --set preview.host=pr-42.pr.studio.decocms.com \
+            --set image.repository=ghcr.io/decocms/studio/studio-preview \
+            --set image.tag=pr-42-abc1234 \
+            --set nginx.image.tag=pr-42-abc1234 \
+            --set externalSecret.secretPath=preview/studio/application \
+            --set externalSecret.secretStoreName=aws-secrets-manager \
+            --set externalSecret.secretStoreKind=ClusterSecretStore \
+            --set 'preview.namespaceLabels.decocms\.com/preview=true' \
+            --api-versions gateway.networking.k8s.io/v1 \
+            > /tmp/preview.yaml
+
+          fail() { echo "::error::$1"; exit 1; }
+
+          # Without a Namespace in the render, Argo's CreateNamespace=true creates
+          # one it never adopts: everything inside is deleted correctly and the
+          # namespace itself is left behind, one per PR, forever.
+          grep -q '^kind: Namespace' /tmp/preview.yaml \
+            || fail "preview render has no Namespace — it would outlive the PR"
+          python3 - <<'NS'
+          import sys, yaml
+          ns = [d for d in yaml.safe_load_all(open("/tmp/preview.yaml"))
+                if d and d["kind"] == "Namespace"]
+          if len(ns) != 1:
+              print(f"::error::expected exactly one Namespace, found {len(ns)}"); sys.exit(1)
+          m = ns[0]["metadata"]
+          w = int((m.get("annotations") or {}).get("argocd.argoproj.io/sync-wave", 0))
+          if w >= -30:
+              print(f"::error::Namespace is at wave {w}, but everything lives inside it "
+                    "— it must come before the ExternalSecret at -30"); sys.exit(1)
+          if not any(k.endswith("/preview") for k in (m.get("labels") or {})):
+              print("::error::Namespace carries no preview label — the Gateway admits "
+                    "routes by namespace label, so the HTTPRoute would attach to nothing")
+              sys.exit(1)
+          print(f"namespace rendered at wave {w} with the gateway selector label")
+          NS
+
+          grep -q 'kind: HTTPRoute' /tmp/preview.yaml \
+            || fail "preview render has no HTTPRoute — the preview would be unreachable"
+          grep -q 'pr-42.pr.studio.decocms.com' /tmp/preview.yaml \
+            || fail "preview HTTPRoute is missing its hostname"
+
+          grep -q "studio-pr-42-preview-migrate" /tmp/preview.yaml \
+            || fail "preview render is missing the migration Job"
+          grep -q "studio-pr-42-postgres" /tmp/preview.yaml \
+            || fail "preview render has no Postgres — the DB must live and die with the namespace"
+
+          grep -q "studio-pr-42-minio" /tmp/preview.yaml \
+            || fail "preview render has no MinIO — object storage must live and die with the namespace"
+          # All six together, or the application downloads and runs its own
+          # MinIO binary at boot: a fresh ~100MB pull on every pod start, on a
+          # spot pool that consolidates after a minute.
+          for k in S3_ENDPOINT S3_BUCKET S3_REGION S3_FORCE_PATH_STYLE \
+                   S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY; do
+            grep -q "  ${k}:" /tmp/preview.yaml \
+              || fail "preview render is missing ${k} — a partial S3 config makes the app self-provision MinIO"
+          done
+          grep -q 'S3_ENDPOINT: "http://studio-pr-42-minio:9000"' /tmp/preview.yaml \
+            || fail "S3_ENDPOINT does not point at this preview's own MinIO"
+
+          # Ordering is the whole correctness argument: Postgres must be healthy
+          # before the migration Job runs, and that Job must finish before the
+          # app Deployments start. Argo expresses that with waves, and a wrong
+          # one shows up as a CrashLoopBackOff on first sync, not a render error.
+          python3 - <<'WAVES'
+          import sys, yaml
+          waves = {}
+          for d in yaml.safe_load_all(open("/tmp/preview.yaml")):
+              if not d:
+                  continue
+              name = d["metadata"]["name"]
+              ann = (d["metadata"].get("annotations") or {})
+              w = int(ann.get("argocd.argoproj.io/sync-wave", 0))
+              waves[(d["kind"], name)] = w
+          pg = waves[("Deployment", "studio-pr-42-postgres")]
+          mig = waves[("Job", "studio-pr-42-preview-migrate")]
+          app = waves[("Deployment", "studio-pr-42")]
+          ok = pg < mig < app
+          print(f"postgres={pg} migrate={mig} app={app} ordered={ok}")
+          if not ok:
+              print("::error::preview sync-waves are out of order "
+                    f"(want postgres < migrate < app, got {pg} < {mig} < {app})")
+          sys.exit(0 if ok else 1)
+          WAVES
+
+          # Previews run un-merged code on a dedicated spot-only node pool. Both
+          # halves must reach EVERY pod: the toleration alone lets a preview onto
+          # the pool without keeping it there, and the selector alone strands it
+          # Pending. A subchart (NATS) inherits neither, so it is the one that
+          # silently lands on shared nodes when this regresses.
+          python3 - <<'POOL'
+          import sys, yaml
+          bad = []
+          for d in yaml.safe_load_all(open("/tmp/preview.yaml")):
+              if not d or d.get("kind") not in ("Deployment", "StatefulSet", "Job"):
+                  continue
+              spec = d["spec"]["template"]["spec"]
+              sel = (spec.get("nodeSelector") or {}).get("decocms.com/nodepool")
+              tol = any(t.get("key") == "decocms.com/studio-preview"
+                        for t in (spec.get("tolerations") or []))
+              if sel != "studio-preview" or not tol:
+                  bad.append(f'{d["kind"]}/{d["metadata"]["name"]} '
+                             f'(selector={sel!r}, toleration={tol})')
+          if bad:
+              print("::error::pods not pinned to the preview node pool: " + "; ".join(bad))
+              sys.exit(1)
+          print("every preview pod is pinned to the preview node pool")
+          POOL
+
+          # Ordering between waves is not enough: a resource also has to come
+          # AFTER everything it consumes. The migrate Job takes both the
+          # ConfigMap and the Secret via envFrom, and the ConfigMap had no wave
+          # at all — so it landed at 0, after the Job at -10, and the Job sat in
+          # CreateContainerConfigError while the whole sync stalled waiting on
+          # the hook. Nothing on the object said anything was wrong, and
+          # `helm template` cannot see it because it never sequences.
+          python3 - <<'DEPS'
+          import sys, yaml
+          waves, needs = {}, []
+          for d in yaml.safe_load_all(open("/tmp/preview.yaml")):
+              if not d:
+                  continue
+              kind, name = d["kind"], d["metadata"]["name"]
+              w = int((d["metadata"].get("annotations") or {})
+                      .get("argocd.argoproj.io/sync-wave", 0))
+              waves[(kind, name)] = w
+              if kind not in ("Job", "Deployment", "StatefulSet"):
+                  continue
+              spec = d["spec"]["template"]["spec"]
+              # Everything a pod names and the kubelet must resolve before it
+              # can start. envFrom was the first one to bite (the ConfigMap at
+              # 0.14.1); serviceAccountName was the second, and produced a
+              # stranger failure — the Job never even got a pod, so there were
+              # no logs and no events on anything except the Job itself.
+              if spec.get("serviceAccountName"):
+                  needs.append((kind, name, w, "ServiceAccount", spec["serviceAccountName"]))
+              for c in (spec.get("initContainers") or []) + spec["containers"]:
+                  for ref in (c.get("envFrom") or []):
+                      for key, k8s in (("configMapRef", "ConfigMap"), ("secretRef", "Secret")):
+                          if key in ref:
+                              needs.append((kind, name, w, k8s, ref[key]["name"]))
+              for v in (spec.get("volumes") or []):
+                  for key, k8s in (("configMap", "ConfigMap"), ("secret", "Secret")):
+                      if key in v:
+                          n = v[key].get("name") or v[key].get("secretName")
+                          if n:
+                              needs.append((kind, name, w, k8s, n))
+          bad = []
+          for kind, name, w, dep_kind, dep in needs:
+              # An ExternalSecret produces a Secret of the same name; credit its
+              # wave to the Secret it targets.
+              key = (dep_kind, dep)
+              if key not in waves and dep_kind == "Secret":
+                  key = ("ExternalSecret", dep)
+              if key not in waves:
+                  continue  # not rendered by this chart
+              if waves[key] > w:
+                  bad.append(f"{kind}/{name} (wave {w}) needs "
+                             f"{dep_kind}/{dep} (wave {waves[key]})")
+          if bad:
+              print("::error::a resource is sequenced before something it needs: "
+                    + "; ".join(bad))
+              sys.exit(1)
+          print(f"every referenced object is created no later than what needs it "
+                f"({len(needs)} references checked)")
+          DEPS
+
+          # The preview Postgres is an emptyDir, so any reschedule hands the pod
+          # an empty volume. The Job is a sync hook and will not re-run, so
+          # without an init container the app comes up against zero tables with
+          # every signal reporting healthy. Exactly one pod may migrate — Kysely
+          # locks, DBOS does not.
+          python3 - <<'BOOT'
+          import sys, yaml
+          migrators, waiters = [], []
+          for d in yaml.safe_load_all(open("/tmp/preview.yaml")):
+              if not d or d["kind"] != "Deployment":
+                  continue
+              for c in (d["spec"]["template"]["spec"].get("initContainers") or []):
+                  if c["name"] == "migrate-on-boot":
+                      migrators.append(d["metadata"]["name"])
+                  if c["name"] == "wait-for-schema":
+                      waiters.append(d["metadata"]["name"])
+          if len(migrators) != 1:
+              print(f"::error::exactly one Deployment may migrate on boot, found "
+                    f"{len(migrators)}: {migrators} — DBOS has no lock and parallel "
+                    "launches collide on dbos.dbos_migrations")
+              sys.exit(1)
+          if not waiters:
+              print("::error::the worker has no wait-for-schema init container — it "
+                    "would start against a database the API pod has not migrated yet")
+              sys.exit(1)
+          print(f"schema is re-applied on boot by {migrators[0]}, awaited by {waiters}")
+          BOOT
+
+          # Every studio container (api-0, api-1, worker) must skip migrations:
+          # the PreSync Job is the single writer. Three, not two.
+          # `|| true` — grep exits 1 on zero matches, which under `set -e` would
+          # abort before the explanatory message below.
+          count=$(grep -c -- '--skip-migrations' /tmp/preview.yaml || true)
+          [ "$count" -eq 3 ] \
+            || fail "expected 3 containers with --skip-migrations, found ${count}"
+
+          # The preview tag is mutable — same tag, different bits, whenever the
+          # base moves — so a cached image must never win.
+          python3 - <<'PULL'
+          import sys, yaml
+          bad = []
+          for d in yaml.safe_load_all(open("/tmp/preview.yaml")):
+              if not d or d.get("kind") not in ("Deployment", "Job", "StatefulSet"):
+                  continue
+              spec = d["spec"]["template"]["spec"]
+              for c in (spec.get("initContainers") or []) + spec["containers"]:
+                  # Only the studio images carry a mutable tag; postgres, minio
+                  # and nats are pinned upstream releases.
+                  if "-preview:" not in c["image"]:
+                      continue
+                  if c.get("imagePullPolicy") != "Always":
+                      bad.append(f'{d["kind"]}/{d["metadata"]["name"]}/{c["name"]}'
+                                 f' = {c.get("imagePullPolicy")}')
+          if bad:
+              print("::error::preview images must use imagePullPolicy: Always — the "
+                    "tag is mutable, so a cached layer serves stale code: " + "; ".join(bad))
+              sys.exit(1)
+          print("every preview image is pulled fresh")
+          PULL
+
+          grep -q 'DATABASE_POOL_MAX: "5"' /tmp/preview.yaml \
+            || fail "DATABASE_POOL_MAX is not 5"
+
+          # This repository is public and the chart is published. Nothing that
+          # names one deployment may live in the shared values file.
+          # Domains are matched only where they are a HOSTNAME — i.e. not
+          # followed by `/`. Kubernetes label and taint keys are domain-prefixed
+          # by convention (decocms.com/nodepool), and those are structure, not
+          # identity: they carry no account, bucket or endpoint.
+          #
+          # `if grep` and not `grep && fail`: under `set -e` a bare grep that
+          # matches nothing exits 1 and aborts the step — which is the passing
+          # case here.
+          for leak in 'cloudflarestorage\.com([^/]|$)' 'decocms\.com([^/]|$)' \
+                      'deco\.cx([^/]|$)' 'amazonaws\.com([^/]|$)' \
+                      'deco-studio-storage' 'aws-secrets-manager'; do
+            if grep -qE "$leak" deploy/helm/studio/values-preview.yaml; then
+              echo "--- offending lines ---"
+              grep -nE "$leak" deploy/helm/studio/values-preview.yaml
+              fail "values-preview.yaml names a specific deployment (/${leak}/) — that belongs in the studio-previews values, which are not published"
+            fi
+          done
+          echo "values-preview.yaml carries no deployment-specific identifiers"
+
+          # DATABASE_URL must address this preview's OWN Postgres. If it ever
+          # points somewhere else, a preview is writing to a database it does
+          # not own.
+          grep -q 'DATABASE_URL: "postgresql://postgres:postgres@studio-pr-42-postgres:5432/postgres"' /tmp/preview.yaml \
+            || fail "preview DATABASE_URL does not point at this preview's own in-namespace Postgres"
+
+          # A namespaced SecretStore needs per-namespace IRSA, which per-PR
+          # namespaces do not have.
+          grep -q 'kind: ClusterSecretStore' /tmp/preview.yaml \
+            || fail "preview ExternalSecret does not reference a ClusterSecretStore"
+          if grep -qE '^kind: SecretStore$' /tmp/preview.yaml; then
+            fail "preview render creates a namespaced SecretStore"
+          fi
+
+          # PVC finalizers are the most common cause of a namespace that never
+          # finishes deleting.
+          if grep -qE '^kind: PersistentVolumeClaim' /tmp/preview.yaml; then
+            fail "preview render contains a PersistentVolumeClaim"
+          fi
+
+          # Shell scripts embedded in the hook Jobs — a bad heredoc indent here
+          # only surfaces at sync time otherwise.
+          python3 -c 'import yaml' 2>/dev/null || pip install --quiet pyyaml
+          python3 - <<'PY'
+          import subprocess, sys, yaml
+          bad = 0
+          for d in yaml.safe_load_all(open("/tmp/preview.yaml")):
+              if not d or d.get("kind") != "Job":
+                  continue
+              spec = d["spec"]["template"]["spec"]
+              for c in (spec.get("initContainers") or []) + spec["containers"]:
+                  if not c.get("args"):
+                      continue
+                  p = subprocess.run(["sh", "-n"], input=c["args"][0],
+                                     capture_output=True, text=True)
+                  if p.returncode != 0:
+                      print(f"::error::{d['metadata']['name']}/{c['name']}: {p.stderr.strip()}")
+                      bad += 1
+          sys.exit(1 if bad else 0)
+          PY
+      # The whole reason the ApplicationSet lives in this repository: the tag the
+      # build publishes and the tag the generator asks for are now checkable
+      # against each other. When they were in two repositories, they silently
+      # disagreed — the workflow tagged the ephemeral refs/pull/N/merge commit
+      # while the generator asked for .head_sha, and every preview would have
+      # sat in ImagePullBackOff with both repos' CI green.
+      - name: Preview build and ApplicationSet agree on tag and host
+        run: |
+          set -euo pipefail
+          fail() { echo "::error::$1"; exit 1; }
+
+          BUILD=.depot/workflows/preview-build.yaml
+          CHART=deploy/helm/studio-previews
+
+          # A job cannot read its own outputs through `needs` — the expression
+          # resolves to empty and the workflow still succeeds. That shipped a
+          # sticky comment reading "Preview: https://" with no host.
+          python3 - <<'SELFREF'
+          import re, sys, yaml
+          wf = yaml.safe_load(open(".depot/workflows/preview-build.yaml"))
+          bad = [f"{name}.outputs references needs.{ref}"
+                 for name, job in wf["jobs"].items()
+                 for ref in re.findall(r"needs\.(\w+)\.", str(job.get("outputs", {})))
+                 if ref == name]
+          if bad:
+              print("::error::a job reads its own outputs through needs, which is "
+                    "always empty: " + "; ".join(bad))
+              sys.exit(1)
+          print("no job reads its own outputs through needs")
+          SELFREF
+
+          # The node pool accepts both architectures, so the images have to
+          # carry both. A spot reclaim once replaced an amd64 node with a
+          # Graviton one and every pod died with `exec format error` — nothing
+          # in a render can see this, so assert it against the build workflow.
+          grep -q 'ubuntu-24.04-arm' "$BUILD" \
+            || fail "preview images must be built for arm64: the studio-preview node pool schedules on amd64 and arm64"
+          grep -q 'imagetools create' "$BUILD" \
+            || fail "per-arch digests must be merged into a manifest list, or the tag resolves to one architecture"
+
+          grep -q 'github.event.pull_request.head.sha' "$BUILD" \
+            || fail "preview-build.yaml must tag from the PR head sha; the ApplicationSet can only name .head_sha"
+          if grep -q 'rev-parse --short=7 HEAD' "$BUILD"; then
+            fail "preview-build.yaml tags from the merge ref — the ApplicationSet has no parameter for that commit"
+          fi
+          grep -q 'head_sha' "$CHART/templates/_helpers.tpl" \
+            || fail "the ApplicationSet image tag must derive from .head_sha"
+
+          # Same host on both sides, or the bot comment links somewhere that does
+          # not exist while the environment serves somewhere else. Compare the
+          # host the workflow advertises against the one the chart renders, both
+          # for the same PR number — not just that each is non-empty.
+          BUILD_DOMAIN=$(awk -F': ' '/^  PREVIEW_DOMAIN:/{print $2}' "$BUILD")
+          test -n "$BUILD_DOMAIN" || fail "PREVIEW_DOMAIN is unset in preview-build.yaml"
+          # `host=pr-<n>.${PREVIEW_DOMAIN}` in the workflow's meta step.
+          BUILD_HOST="pr-42.${BUILD_DOMAIN}"
+
+          # Every value the chart requires, in ONE place. It ships no
+          # deployment-specific defaults by design, so each new guard adds
+          # another mandatory value — keeping the list here means the render
+          # steps stay correct when that happens, instead of failing with a
+          # message about a value the test never meant to exercise.
+          PREVIEWS_VALUES=(
+            --set applicationSet.repo.owner=o
+            --set applicationSet.repo.name=r
+            --set applicationSet.repo.tokenSecret.name=t
+            --set applicationSet.repo.tokenSecret.externalSecret.secretPath=p
+            --set applicationSet.repo.tokenSecret.externalSecret.secretStoreName=s
+            --set studioChart.repoURL=oci://x
+            --set studioChart.version=0.0.0
+            --set studioChart.valuesRepo.url=https://x
+            --set images.api=a
+            --set images.nginx=n
+            --set studioValues.externalSecret.secretPath=s
+            --set studioValues.externalSecret.secretStoreName=s
+          )
+
+          helm template p "$CHART" \
+            --set domain="$BUILD_DOMAIN" \
+            "${PREVIEWS_VALUES[@]}" \
+            --api-versions gateway.networking.k8s.io/v1 > /tmp/appset.yaml
+
+          # The rendered host still carries the generator's own template, so
+          # substitute a PR number the way the controller would.
+          RENDER_HOST=$(grep -oE "host: '[^']+'" /tmp/appset.yaml | head -1 \
+            | sed -E "s/host: '(.*)'/\1/; s/\{\{ \.number \}\}/42/")
+          [ "$RENDER_HOST" = "$BUILD_HOST" ] \
+            || fail "host mismatch: preview-build advertises ${BUILD_HOST}, the ApplicationSet serves ${RENDER_HOST}"
+          echo "both halves agree on ${BUILD_HOST}"
+      # The previews chart must refuse to render without the values that name a
+      # deployment — it is published publicly and must carry no defaults.
+      - name: Render (studio-previews requires explicit configuration)
+        run: |
+          set -euo pipefail
+          if helm template p deploy/helm/studio-previews >/tmp/bare.yaml 2>&1; then
+            echo "::error::studio-previews rendered with no values — it must require them"
+            exit 1
+          fi
+          grep -q 'domain is required' /tmp/bare.yaml \
+            || { echo "::error::wrong failure message"; cat /tmp/bare.yaml; exit 1; }
+          echo "studio-previews correctly refuses to render unconfigured"
+      - name: Render (preview validations must fail)
+        run: |
+          set -uo pipefail
+          expect_fail() {
+            desc="$1"; want="$2"; shift 2
+            # `if cmd; then` and not `out=$(cmd); [ $? -eq 0 ]` — the runner's
+            # default shell is `bash -e`, under which a failing assignment aborts
+            # the step. Every render here is SUPPOSED to fail.
+            # secretPath/secretStoreName are supplied by the studio-previews
+            # ApplicationSet, not by values-preview.yaml — they name an account,
+            # and this file is published. Without them here, validateExternalSecret
+            # fires before validatePreview and every case below fails for the
+            # wrong reason.
+            if out=$(helm template studio-pr-42 deploy/helm/studio \
+                       -f deploy/helm/studio/values-preview.yaml \
+                       --set preview.prNumber=42 \
+                       --set externalSecret.secretPath=preview/studio/application \
+                       --set externalSecret.secretStoreName=some-cluster-store \
+                       --api-versions gateway.networking.k8s.io/v1 "$@" 2>&1); then
+              echo "::error::${desc}: rendered successfully — the guard is missing"
+              exit 1
+            fi
+            if ! echo "$out" | grep -q "$want"; then
+              echo "::error::${desc}: failed for the wrong reason. Wanted '${want}', got:"
+              echo "$out"
+              exit 1
+            fi
+            echo "ok: ${desc}"
+          }
+
+          expect_fail "missing preview.host" "preview.host is required"
+          expect_fail "ingress conflict" "mutually exclusive" \
+            --set preview.host=h.example.com \
+            --set ingress.enabled=true \
+            --set 'ingress.hosts[0].host=h.example.com' \
+            --set 'ingress.hosts[0].paths[0].path=/' \
+            --set 'ingress.hosts[0].paths[0].pathType=Prefix'
+          expect_fail "missing gateway name" "preview.gateway.name is required" \
+            --set preview.host=h.example.com --set preview.gateway.name=
+          # Turning off the built-in Postgres without supplying a database
+          # elsewhere would render pods pointing at nothing. Caught by the
+          # chart's general database validation, not a preview-specific one.
+          expect_fail "no database at all" "set database.url when database.engine=postgresql" \
+            --set preview.host=h.example.com \
+            --set preview.postgres.enabled=false \
+            --set externalSecret.enabled=false
+
+          # Binding sandbox access to the namespace's `default` ServiceAccount
+          # would hand it to every pod in the preview — Postgres and MinIO
+          # included — and the render would look perfectly healthy.
+          # values-preview.yaml turns serviceAccount.create on, so this case has
+          # to turn it back off — the point is the guard, not the default.
+          expect_fail "sandbox without a named ServiceAccount" "requires serviceAccount.create=true" \
+            --set preview.host=h.example.com \
+            --set preview.sandbox.enabled=true \
+            --set preview.sandbox.roleName=some-role \
+            --set serviceAccount.create=false
+          expect_fail "sandbox without a role" "preview.sandbox.roleName is required" \
+            --set preview.host=h.example.com \
+            --set preview.sandbox.enabled=true \
+            --set serviceAccount.create=true
+
+          # image.command is a list, which --set cannot express cleanly.
+          printf 'image:\n  command: ["bun","run","deco"]\n' > /tmp/no-skip.yaml
+          expect_fail "missing --skip-migrations" "requires --skip-migrations" \
+            --set preview.host=h.example.com -f /tmp/no-skip.yaml

--- a/.depot/workflows/multi-pod.yml
+++ b/.depot/workflows/multi-pod.yml
@@ -1,0 +1,73 @@
+# Depot CI Migration
+# Source: .github/workflows/multi-pod.yml
+#
+# Changes made:
+# - Rewrote .github/ path references to .depot/
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Multi-Pod Tests
+on:
+  push:
+    branches:
+      - main
+    # Skip pushes to main that only touch the version bump, CI/workflow config,
+    # or docs — none need this heavy suite re-run.
+    paths-ignore:
+      - "apps/api/package.json"
+      - ".github/**"
+      - "apps/docs/**"
+      - "**/*.md"
+  pull_request:
+    # Multi-pod tests are slow (~7-10 min cold image build + serialized
+    # boot + scenarios). Only run on PRs that change code the framework
+    # actually exercises — the Studio API, dispatch/automations, storage
+    # schema, or the test infra itself. UI/docs/plugin PRs skip.
+    paths:
+      - "apps/api/src/api/**"
+      - "apps/api/src/auth/**"
+      - "apps/api/src/core/**"
+      - "apps/api/src/storage/**"
+      - "apps/api/src/dispatch-queue/**"
+      - "apps/api/src/event-bus/**"
+      - "apps/api/src/automations/**"
+      - "apps/api/src/database/**"
+      - "apps/api/src/index.ts"
+      - "apps/api/migrations/**"
+      - "packages/runtime/**"
+      - "packages/bindings/**"
+      - "tests/multi-pod/**"
+      - "tests/resilience/Dockerfile.studio"
+      - ".depot/workflows/multi-pod.yml"
+  workflow_dispatch:
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+jobs:
+  multi-pod:
+    # Skip the [release]: version-bump commit — it only changes the version
+    # string and would otherwise re-run this heavy suite on every release.
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, '[release]:')
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Bun and install dependencies
+        uses: ./.depot/actions/setup-bun
+      # No --wait here: the one-shot `migrate` service exits 0 once schemas
+      # are created and `--wait` mis-classifies that as a failure. The test
+      # suite's beforeAll hook (lib/hooks.ts → cluster.waitReady) polls
+      # /health/live on each Studio test service instead.
+      - name: Start cluster
+        run: docker compose -f tests/multi-pod/docker-compose.yml up -d --build
+      - name: Run multi-pod scenarios
+        run: bun test tests/multi-pod/scenarios/ --serial --timeout 900000
+      - name: Dump Studio logs
+        if: failure()
+        run: docker compose -f tests/multi-pod/docker-compose.yml logs mesh-1 mesh-2 mesh-3
+      - name: Dump infra logs
+        if: failure()
+        run: docker compose -f tests/multi-pod/docker-compose.yml logs postgres nats migrate
+      - name: Tear down cluster
+        if: always()
+        run: docker compose -f tests/multi-pod/docker-compose.yml down -v

--- a/.depot/workflows/preview-build.yaml
+++ b/.depot/workflows/preview-build.yaml
@@ -1,0 +1,265 @@
+# Depot CI Migration
+# Source: .github/workflows/preview-build.yaml
+#
+# Changes made:
+# - Rewrote .github/ path references to .depot/
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Preview build
+# Builds the two images for a per-PR preview environment and posts (or edits)
+# the sticky PR comment carrying the URL.
+#
+# Deliberately a separate workflow rather than a workflow_call refactor of
+# release-studio.yaml: that file is release-consistency logic (npm version
+# probing, GHCR existence checks, provenance, the deco-apps-cd dispatch gate,
+# the docs webhook), and parameterising it would thread ~8 booleans through
+# every `if:` in the PRODUCTION release path. The genuinely shared surface is
+# one command (`bun run build:studio`) and two Dockerfiles, already reusable
+# as-is — so previews cannot destabilise shipping.
+#
+# What deploys the images is Argo CD, in decocms/deco-apps-cd: an ApplicationSet
+# with a GitHub PR generator, also gated on the `preview` label. Nothing here
+# holds a cluster credential.
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+concurrency:
+  group: preview-build-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+env:
+  REGISTRY: ghcr.io
+  # Separate GHCR packages from the release ones, so the preview GC can be
+  # aggressive with zero chance of deleting a release tag.
+  IMAGE_NAME: ${{ github.repository }}/studio-preview
+  NGINX_IMAGE_NAME: ${{ github.repository }}/studio-nginx-preview
+  PREVIEW_DOMAIN: pr.studio.decocms.com
+jobs:
+  package:
+    name: Build preview images
+    # Opt-in. `labeled` is in the trigger list so adding the label to an
+    # already-open PR starts a build; the ApplicationSet enforces the same
+    # label independently, so neither half alone can create an orphan.
+    if: contains(github.event.pull_request.labels.*.name, 'preview')
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: write
+    outputs:
+      tag: ${{ steps.meta.outputs.tag }}
+      host: ${{ steps.meta.outputs.host }}
+    steps:
+      # This workflow triggers on `pull_request` ONLY, so the checkout is
+      # refs/pull/N/merge — GitHub constructs it by merging the PR into main,
+      # meaning the image always contains main ∪ PR migrations. That invariant
+      # is load-bearing (Kysely's strict missing-migration check hard-fails a
+      # boot against a database that knows a migration the image lacks) but it
+      # holds by construction, so there is nothing to assert. If a
+      # workflow_dispatch trigger is ever added, it breaks and must be
+      # re-established — a shallow checkout cannot prove ancestry, so that
+      # would need `fetch-depth: 0`.
+      #
+      # Note the split between CONTENT and NAME: the image content comes from
+      # the merge ref, but the tag names the PR head sha, because that is the
+      # only commit both this workflow and the Argo pullRequest generator can
+      # refer to.
+      - uses: actions/checkout@v4
+      - id: meta
+        run: |
+          # The 7-char prefix of the PR HEAD sha, NOT `git rev-parse HEAD`.
+          # The checkout below lands on refs/pull/N/merge, whose HEAD is an
+          # ephemeral merge commit that the Argo pullRequest generator has no
+          # parameter for — it can only name `.head_sha`. Tagging from the merge
+          # commit produces an image the ApplicationSet can never ask for, and
+          # every preview sits in ImagePullBackOff. Asserted in helm-test.yml.
+          echo "tag=pr-${{ github.event.pull_request.number }}-$(echo '${{ github.event.pull_request.head.sha }}' | cut -c1-7)" >> "$GITHUB_OUTPUT"
+          echo "host=pr-${{ github.event.pull_request.number }}.${PREVIEW_DOMAIN}" >> "$GITHUB_OUTPUT"
+      # The hidden marker is what makes this comment sticky: find it first, then
+      # edit in place. Without the lookup every push would append a new comment.
+      - name: Find existing preview comment
+        id: find-comment
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: <!-- studio-preview -->
+      # Posted before the build so a reviewer sees "building" at t+15s rather
+      # than nothing for seven minutes. Edited in place when the images land.
+      - name: Comment (building)
+        uses: peter-evans/create-or-update-comment@v4
+        continue-on-error: true
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          edit-mode: replace
+          body: "<!-- studio-preview -->\n\U0001F528 **Building preview** for `${{ steps.meta.outputs.tag }}`…\n"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+      - name: Setup Bun and install dependencies
+        uses: ./.depot/actions/setup-bun
+      # No sourcemaps (nothing un-minifies preview stacks), no npm publish, no
+      # provenance, no tarball smoke test. Same `build:studio` and same
+      # `bun add /tmp/decocms.tgz` install as a release, so preview packaging
+      # cannot drift from production packaging.
+      - name: Build combined Studio distribution
+        run: bun run build:studio
+        env:
+          BUILD_SOURCEMAPS: "0"
+      - name: Strip sourcemaps and pack
+        run: |
+          find apps/web/dist apps/api/dist -name '*.map' -delete 2>/dev/null || true
+          cd apps/api && npm pack
+      - name: Stage the tarball for both build contexts
+        run: |
+          mkdir -p docker-context
+          mv apps/api/decocms-*.tgz docker-context/decocms.tgz
+          # apps/web/Dockerfile builds from the repo root because it also COPYs
+          # deploy/helm/studio/files/api-nginx.conf.
+          cp docker-context/decocms.tgz decocms.tgz
+      - name: Upload build context
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-context
+          path: docker-context/decocms.tgz
+          retention-days: 1
+  # One job per architecture on its OWN runner. The preview node pool schedules
+  # on amd64 and arm64 so Karpenter can take whatever spot capacity exists, and
+  # a reclaim proved it: an r8in.large was replaced by an r7gd.large (Graviton)
+  # and every amd64-only pod died with `exec format error`.
+  #
+  # Native runners, not QEMU. The release workflow measures ~1.0 min for a
+  # native arm64 image against ~0.7 min for amd64; emulating arm64 instead would
+  # add minutes to a build whose whole point is being quick enough that a
+  # reviewer waits for it. GitHub's arm64 runners are free on public repos.
+  docker:
+    name: Build ${{ matrix.arch }} images
+    needs: package
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: depot-ubuntu-latest # was: ubuntu-latest. Matrix-supplied runner; mapped to Depot equivalent.
+          - arch: arm64
+            platform: linux/arm64
+            runner: depot-ubuntu-24.04-arm # was: ubuntu-24.04-arm. Matrix-supplied runner; mapped to Depot equivalent.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download build context
+        uses: actions/download-artifact@v4
+        with:
+          name: preview-context
+          path: docker-context
+      - name: Stage the tarball for both build contexts
+        run: cp docker-context/decocms.tgz decocms.tgz
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+      - name: Build and push API by digest
+        id: api
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker-context
+          file: ./apps/api/Dockerfile
+          platforms: ${{ matrix.platform }}
+          provenance: false
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: |
+            type=gha,scope=studio-preview-${{ matrix.arch }}
+            type=gha,scope=studio-api-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=studio-preview-${{ matrix.arch }}
+      - name: Build and push nginx by digest
+        id: web
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./apps/web/Dockerfile
+          platforms: ${{ matrix.platform }}
+          provenance: false
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.NGINX_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: |
+            type=gha,scope=studio-preview-web-${{ matrix.arch }}
+            type=gha,scope=studio-web-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=studio-preview-web-${{ matrix.arch }}
+      - name: Export digests
+        run: |
+          set -euo pipefail
+          mkdir -p "${{ runner.temp }}/digests/api" "${{ runner.temp }}/digests/web"
+          touch "${{ runner.temp }}/digests/api/${API_DIGEST#sha256:}"
+          touch "${{ runner.temp }}/digests/web/${WEB_DIGEST#sha256:}"
+        env:
+          API_DIGEST: ${{ steps.api.outputs.digest }}
+          WEB_DIGEST: ${{ steps.web.outputs.digest }}
+      - name: Upload digests
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-digests-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          retention-days: 1
+  # Stitch the per-arch digests into one tagged manifest list, then hand the
+  # reviewer the link. Only after this does `:pr-<n>-<sha>` exist as a tag —
+  # which is what the ApplicationSet asks for.
+  publish:
+    name: Merge manifests and comment
+    needs: [package, docker]
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: write
+    steps:
+      - uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: preview-digests-*
+          path: digests
+          merge-multiple: true
+      - name: Merge and push manifest lists
+        env:
+          TAG: ${{ needs.package.outputs.tag }}
+        run: |
+          set -euo pipefail
+          merge() {
+            local image="$1" dir="$2" refs=()
+            for d in "$dir"/*; do
+              [ -e "$d" ] || continue
+              refs+=("${image}@sha256:$(basename "$d")")
+            done
+            (( ${#refs[@]} > 0 )) || { echo "::error::no digests for ${image}"; exit 1; }
+            docker buildx imagetools create -t "${image}:${TAG}" "${refs[@]}"
+            docker buildx imagetools inspect "${image}:${TAG}" | grep -E "Platform|Name:" | head -6
+          }
+          merge "${REGISTRY}/${IMAGE_NAME}" digests/api
+          merge "${REGISTRY}/${NGINX_IMAGE_NAME}" digests/web
+      # Re-find: on the first run the "building" step created the comment, so
+      # the id from before the build is empty.
+      - name: Re-find preview comment
+        id: find-comment-ready
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: <!-- studio-preview -->
+      - name: Comment (ready)
+        uses: peter-evans/create-or-update-comment@v4
+        continue-on-error: true
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-id: ${{ steps.find-comment-ready.outputs.comment-id }}
+          edit-mode: replace
+          body: "<!-- studio-preview -->\n### \U0001F50D Preview: https://${{ needs.package.outputs.host }}\n\nBuilt from `${{ needs.package.outputs.tag }}`. Argo CD picks the image up\nwithin ~60s; the first sync also creates and migrates the database, so\nallow another minute or two on a brand-new preview.\n\n**Sign in:** the database is empty and yours — sign up with any email\nand password. It is thrown away when this PR closes.\n\n<details><summary>What does <b>not</b> work in a preview</summary>\n\n- **Agent tool execution against a hosted sandbox** — previews run\n  `STUDIO_SANDBOX_PROVIDER=user-desktop` with no daemon attached, so\n  dispatch returns `409 link_offline`. Sandbox previews and the\n  sandbox lifecycle UI are equally out.\n- **AI features** until you add your own provider key in org settings.\n  Previews ship no key, so preview LLM spend is zero by construction.\n- **Google / GitHub sign-in** — OAuth callbacks cannot be registered\n  for a per-PR hostname. The buttons are hidden.\n- **Monitoring dashboard** (no ClickHouse), **billing** (no Stripe),\n  **outbound email** (no mail provider).\n- **Multi-pod behaviour** — a preview is one pod. Do not conclude\n  \"it worked in preview\" about a distributed-systems change; that is\n  what `tests/multi-pod/` is for.\n\n</details>\n\nRemove the `preview` label to tear this down now. Previews expire\n**48h after their last deploy** — push, or re-add the label, to\nreset the clock.\n"

--- a/.depot/workflows/preview-gc.yaml
+++ b/.depot/workflows/preview-gc.yaml
@@ -1,0 +1,114 @@
+# Depot CI Migration
+# Source: .github/workflows/preview-gc.yaml
+#
+# Changes made:
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Preview GC
+# GHCR has no TTL, so preview image tags accumulate forever without this.
+# Deletes every `pr-<n>-<sha>` tag whose pull request is closed, then applies a
+# retention floor to whatever survives.
+#
+# Scoped to the *-preview packages only. Release tags live in different
+# packages (studio/studio, studio/studio-nginx) and are never reachable from
+# here, which is the whole reason previews got their own packages.
+on:
+  schedule:
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+permissions:
+  contents: read
+  packages: write
+  pull-requests: read
+jobs:
+  gc:
+    name: Prune preview image tags
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [studio/studio-preview, studio/studio-nginx-preview]
+    steps:
+      - name: Delete tags for closed PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ORG: ${{ github.repository_owner }}
+          PACKAGE: ${{ matrix.package }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # %2F — the package name contains a slash and must be path-escaped.
+          ENCODED=$(printf '%s' "$PACKAGE" | sed 's#/#%2F#g')
+
+          if ! gh api "orgs/${ORG}/packages/container/${ENCODED}/versions?per_page=100" \
+                 --paginate > /tmp/versions.json 2>/tmp/api-err; then
+            # A package that has never been pushed 404s. That is the expected
+            # state before the first preview, not a failure.
+            if grep -q "Not Found" /tmp/api-err; then
+              echo "Package ${PACKAGE} does not exist yet — nothing to prune."
+              exit 0
+            fi
+            # The org-level packages API is frequently out of reach for
+            # GITHUB_TOKEN. Warn loudly and exit clean: a janitor that pages
+            # nightly gets muted, and a silent skip would read as "pruned".
+            if grep -q "read:packages scope\|Forbidden\|403" /tmp/api-err; then
+              echo "::warning::Cannot list ${PACKAGE}: GITHUB_TOKEN lacks org package read."
+              echo "::warning::Preview image tags are NOT being pruned. Grant a PAT with"
+              echo "::warning::read:packages + delete:packages as secrets.PREVIEW_GC_TOKEN"
+              echo "::warning::and set GH_TOKEN to it, or prune manually."
+              exit 0
+            fi
+            cat /tmp/api-err >&2
+            exit 1
+          fi
+
+          jq -r '.[] | . as $v | ($v.metadata.container.tags // [])[] | "\($v.id) \(.)"' \
+            /tmp/versions.json > /tmp/tags.txt
+
+          # Resolve each PR's state ONCE, not once per tag: a PR routinely has
+          # a dozen tags and the API is rate-limited.
+          awk '{ n = $2; sub(/^pr-/, "", n); sub(/-.*$/, "", n);
+                 if (n ~ /^[0-9]+$/) print n }' /tmp/tags.txt | sort -u > /tmp/prs.txt
+
+          : > /tmp/closed.txt
+          while read -r pr_number; do
+            [ -n "$pr_number" ] || continue
+            state=$(gh pr view "$pr_number" --repo "$REPO" --json state --jq .state 2>/dev/null || echo UNKNOWN)
+            echo "PR #${pr_number}: ${state}"
+            # UNKNOWN (deleted or inaccessible PR) is deliberately kept — this
+            # job must never be the thing that removes an image someone is
+            # still looking at.
+            if [ "$state" = "CLOSED" ] || [ "$state" = "MERGED" ]; then
+              echo "$pr_number" >> /tmp/closed.txt
+            fi
+          done < /tmp/prs.txt
+
+          deleted=0
+          while read -r version_id tag; do
+            [ -n "$tag" ] || continue
+            case "$tag" in pr-*) ;; *) continue ;; esac
+            pr_number="${tag#pr-}"
+            pr_number="${pr_number%%-*}"
+            case "$pr_number" in ''|*[!0-9]*) echo "skip malformed tag: $tag"; continue ;; esac
+
+            if grep -qx "$pr_number" /tmp/closed.txt; then
+              echo "deleting ${PACKAGE}:${tag} (PR #${pr_number})"
+              gh api --method DELETE \
+                "orgs/${ORG}/packages/container/${ENCODED}/versions/${version_id}" || true
+              deleted=$((deleted + 1))
+            fi
+          done < /tmp/tags.txt
+
+          echo "deleted ${deleted} tag(s) from ${PACKAGE}"
+      # Backstop for untagged layers orphaned by tag deletion and for tags whose
+      # PR lookup kept failing. The floor is generous on purpose: this job is
+      # about bounding growth, not reclaiming every byte.
+      - name: Retention floor
+        uses: actions/delete-package-versions@v5
+        continue-on-error: true
+        with:
+          owner: ${{ github.repository_owner }}
+          package-name: ${{ matrix.package }}
+          package-type: container
+          min-versions-to-keep: 50
+          delete-only-untagged-versions: true

--- a/.depot/workflows/preview-ttl.yaml
+++ b/.depot/workflows/preview-ttl.yaml
@@ -1,0 +1,44 @@
+# Depot CI Migration
+# Source: .github/workflows/preview-ttl.yaml
+#
+# Changes made:
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Preview TTL
+# Expires previews 48h after their last deploy, by removing the `preview`
+# label. The Argo ApplicationSet in decocms/deco-apps-cd generates Applications
+# from labelled open PRs, so dropping the label makes the preview disappear on
+# the next poll — namespace, Postgres pod and all.
+#
+# Removing the LABEL rather than deleting the Application directly is the whole
+# trick: a directly-deleted Application is regenerated within ~60s, because the
+# generator's source of truth is the GitHub API, not the cluster.
+#
+# Long-lived PRs accumulating forgotten previews is the failure mode this
+# exists for. Pushing to the PR, or re-adding the label, resets the clock.
+on:
+  schedule:
+    # Every 2h. A coarser cadence would make "48h" mean "up to 54h" and the
+    # job costs seconds.
+    - cron: "23 */2 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "List what would expire without removing any labels"
+        type: boolean
+        default: false
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  expire:
+    name: Expire stale previews
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Expire previews older than the TTL
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TTL_HOURS: "48"
+          DRY_RUN: ${{ inputs.dry_run && 'true' || 'false' }}
+        run: "set -euo pipefail\n\ngh pr list --repo \"$REPO\" --label preview --state open \\\n  --json number --jq '.[].number' > /tmp/prs.txt\n\nif [ ! -s /tmp/prs.txt ]; then\n  echo \"No open PRs carry the preview label.\"\n  exit 0\nfi\n\nnow=$(date -u +%s)\nttl_seconds=$(( TTL_HOURS * 3600 ))\nexpired=0\nkept=0\n\nwhile read -r pr; do\n  [ -n \"$pr\" ] || continue\n\n  # Age is measured from the sticky preview comment, which\n  # preview-build.yaml rewrites on every successful deploy. That is\n  # the only signal that means \"when was this preview last actually\n  # built\": the PR's updatedAt moves on any comment, and the head\n  # commit date would instantly expire a months-old PR that someone\n  # labelled thirty seconds ago to review it.\n  deployed_at=$(gh api \"repos/${REPO}/issues/${pr}/comments\" --paginate \\\n    --jq '[.[] | select(.body | contains(\"<!-- studio-preview -->\")) | .updated_at] | last // empty')\n\n  if [ -z \"$deployed_at\" ]; then\n    # No comment means we cannot date the preview. Never reap on\n    # ambiguity — the same rule the image GC follows for PRs it\n    # cannot resolve.\n    echo \"PR #${pr}: no preview comment, cannot determine age — keeping\"\n    kept=$((kept + 1))\n    continue\n  fi\n\n  deployed_ts=$(date -u -d \"$deployed_at\" +%s)\n  age_h=$(( (now - deployed_ts) / 3600 ))\n\n  if [ \"$(( now - deployed_ts ))\" -lt \"$ttl_seconds\" ]; then\n    echo \"PR #${pr}: deployed ${age_h}h ago — keeping\"\n    kept=$((kept + 1))\n    continue\n  fi\n\n  echo \"PR #${pr}: deployed ${age_h}h ago — EXPIRED (ttl ${TTL_HOURS}h)\"\n  expired=$((expired + 1))\n  if [ \"$DRY_RUN\" = \"true\" ]; then\n    continue\n  fi\n\n  gh pr edit \"$pr\" --repo \"$REPO\" --remove-label preview\n\n  # Rewrite the sticky comment in place. Leaving the old one up would\n  # advertise a URL that now 404s, which is exactly the confusion\n  # this feature is supposed to avoid.\n  comment_id=$(gh api \"repos/${REPO}/issues/${pr}/comments\" --paginate \\\n    --jq '[.[] | select(.body | contains(\"<!-- studio-preview -->\")) | .id] | last // empty')\n  if [ -n \"$comment_id\" ]; then\n    # Heredoc rather than an inline string: the body contains\n    # backticks, which inside a command substitution would be read as\n    # one.\n    cat > /tmp/expired.md <<EOF\n<!-- studio-preview -->\n\U0001F319 **Preview expired** — it had not been redeployed in ${TTL_HOURS}h, so it\nwas torn down to stop idle previews piling up on long-lived PRs.\n\nAdd the \\`preview\\` label again to rebuild it.\nEOF\n    gh api --method PATCH \"repos/${REPO}/issues/comments/${comment_id}\" \\\n      -F body=@/tmp/expired.md > /dev/null\n  fi\ndone < /tmp/prs.txt\n\necho \"---\"\necho \"expired=${expired} kept=${kept} dry_run=${DRY_RUN}\"\nif [ \"$expired\" -gt 0 ] && [ \"$DRY_RUN\" != \"true\" ]; then\n  echo \"::notice::Expired ${expired} preview(s) after ${TTL_HOURS}h.\"\nfi\n"

--- a/.depot/workflows/publish-bindings.yml
+++ b/.depot/workflows/publish-bindings.yml
@@ -1,0 +1,55 @@
+# Depot CI Migration
+# Source: .github/workflows/publish-bindings.yml
+#
+# Changes made:
+# - Rewrote .github/ path references to .depot/
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Publish @decocms/bindings
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/bindings/**"
+  workflow_dispatch:
+permissions:
+  contents: write
+  id-token: write
+jobs:
+  publish:
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js for npm registry
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+      - name: Setup Bun and install dependencies
+        uses: ./.depot/actions/setup-bun
+      - name: Check if version changed
+        id: version-check
+        run: "# Get the current version from package.json\nCURRENT_VERSION=$(bun -e \"console.log(require('./package.json').version)\")\n\n# Check if this specific version already exists in npm\n# This works for both stable and prerelease versions (unlike checking 'latest' tag)\nif npm view @decocms/bindings@$CURRENT_VERSION version >/dev/null 2>&1; then\n  echo \"version-changed=false\" >> $GITHUB_OUTPUT\n  echo \"⏭️ Version $CURRENT_VERSION already published, skipping publish\"\nelse\n  echo \"version-changed=true\" >> $GITHUB_OUTPUT\n  echo \"✅ Version $CURRENT_VERSION not found in npm, will publish\"\nfi\n\necho \"current-version=$CURRENT_VERSION\" >> $GITHUB_OUTPUT\n\n# Check if this is a prerelease version (contains a hyphen)\nif [[ \"$CURRENT_VERSION\" == *-* ]]; then\n  echo \"npm-tag=next\" >> $GITHUB_OUTPUT\n  echo \"\U0001F4E6 Prerelease version detected, will publish with tag 'next'\"\nelse\n  echo \"npm-tag=latest\" >> $GITHUB_OUTPUT\n  echo \"\U0001F4E6 Stable version detected, will publish with tag 'latest'\"\nfi\n"
+        working-directory: packages/bindings
+      - name: Publish to npm
+        if: steps.version-check.outputs.version-changed == 'true'
+        run: npm publish --access public --tag ${{ steps.version-check.outputs.npm-tag }} --provenance
+        working-directory: packages/bindings
+      - name: Create Release
+        if: steps.version-check.outputs.version-changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "bindings-v${{ steps.version-check.outputs.current-version }}" \
+            --title "@decocms/bindings v${{ steps.version-check.outputs.current-version }}" \
+            --notes "## Changes
+
+          Automated release of @decocms/bindings package.
+
+          ### Installation
+          \`\`\`bash
+          npm install @decocms/bindings
+          \`\`\`"

--- a/.depot/workflows/publish-chart.yml
+++ b/.depot/workflows/publish-chart.yml
@@ -1,0 +1,68 @@
+# Depot CI Migration
+# Source: .github/workflows/publish-chart.yml
+#
+# Changes made:
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Publish Helm Chart
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'deploy/helm/studio/Chart.yaml'
+jobs:
+  publish:
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      version: ${{ steps.chart.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+      - name: Get chart version
+        id: chart
+        run: echo "version=$(grep '^version:' deploy/helm/studio/Chart.yaml | awk '{print $2}')" >> "$GITHUB_OUTPUT"
+      - name: Login to GHCR
+        run: helm registry login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+      - name: Package chart
+        run: helm package deploy/helm/studio/ --dependency-update
+      - name: Push chart to GHCR
+        run: helm push chart-deco-studio-${{ steps.chart.outputs.version }}.tgz oci://ghcr.io/decocms
+      - name: Summary
+        run: echo "Published ghcr.io/decocms/chart-deco-studio:${{ steps.chart.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+  # ---------------------------------------------------------------------------
+  # GitOps: tell deco-apps-cd to bump the chart version. Mirrors the image path
+  # in release-studio.yaml — we do NOT write into that repo from here, we fire a
+  # `studio-chart-bump` repository_dispatch and its own bump-studio-chart.yml
+  # self-commits (rewriting Chart.yaml + regenerating Chart.lock + the vendored
+  # tgz). Without this, chart bumps were manual and stranded the lock/tgz,
+  # stalling Argo's `helm dependency build`.
+  # ---------------------------------------------------------------------------
+  bump-deco-apps-cd:
+    name: Trigger deco-apps-cd chart bump
+    needs: publish
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    # Reuses DEPLOY_REPO_TOKEN (decobot PAT, admin on decocms/deco-apps-cd) —
+    # same token/mechanism as the image bump. The bump is a convenience and must
+    # never fail this workflow: no token → the step no-ops and the job passes.
+    env:
+      DISPATCH_TOKEN: ${{ secrets.DEPLOY_REPO_TOKEN }}
+    steps:
+      - name: Skip notice (dispatch token not configured)
+        if: env.DISPATCH_TOKEN == ''
+        run: echo "::notice::DEPLOY_REPO_TOKEN not set — skipping the deco-apps-cd chart bump."
+      - name: Dispatch studio-chart-bump to deco-apps-cd
+        if: env.DISPATCH_TOKEN != ''
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DEPLOY_REPO_TOKEN }}
+          repository: decocms/deco-apps-cd
+          event-type: studio-chart-bump
+          client-payload: '{"version": "${{ needs.publish.outputs.version }}"}'
+      - name: Summary
+        if: env.DISPATCH_TOKEN != ''
+        run: echo "Dispatched \`studio-chart-bump\` (version ${{ needs.publish.outputs.version }}) to decocms/deco-apps-cd" >> "$GITHUB_STEP_SUMMARY"

--- a/.depot/workflows/publish-create-deco-npm.yaml
+++ b/.depot/workflows/publish-create-deco-npm.yaml
@@ -1,0 +1,90 @@
+# Depot CI Migration
+# Source: .github/workflows/publish-create-deco-npm.yaml
+#
+# Changes made:
+# - Rewrote .github/ path references to .depot/
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Publish create-deco to NPM
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/create-deco/**"
+  workflow_dispatch:
+  workflow_run:
+    workflows: ["Publish CLI to NPM"]
+    types:
+      - completed
+permissions:
+  contents: write
+  id-token: write
+jobs:
+  publish:
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    # Only run if CLI workflow completed successfully or if triggered by create-deco changes
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+      - name: Setup Bun and install dependencies
+        uses: ./.depot/actions/setup-bun
+      - name: Check if version changed
+        id: version-check
+        run: |
+          # Get the current version from package.json
+          CURRENT_VERSION=$(bun -e "console.log(require('./package.json').version)")
+
+          # Try to get the published version from npm (will fail if package doesn't exist)
+          PUBLISHED_VERSION=$(npm view create-deco version 2>/dev/null || echo "0.0.0")
+
+          echo "Current version: $CURRENT_VERSION"
+          echo "Published version: $PUBLISHED_VERSION"
+          echo "current-version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+
+          if [ "$CURRENT_VERSION" != "$PUBLISHED_VERSION" ]; then
+            echo "version-changed=true" >> $GITHUB_OUTPUT
+            echo "✅ Version changed ($PUBLISHED_VERSION → $CURRENT_VERSION), will publish"
+          else
+            echo "version-changed=false" >> $GITHUB_OUTPUT
+            echo "⏭️ Version unchanged ($CURRENT_VERSION), skipping publish"
+          fi
+        working-directory: packages/create-deco
+      - name: Publish to NPM
+        if: steps.version-check.outputs.version-changed == 'true'
+        run: npm publish --provenance
+        working-directory: packages/create-deco
+      - name: Create Release
+        if: steps.version-check.outputs.version-changed == 'true'
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: create-deco-v${{ steps.version-check.outputs.current-version }}
+          release_name: create-deco v${{ steps.version-check.outputs.current-version }}
+          body: |
+            ## Changes
+
+            Automated release of create-deco package.
+
+            ### Installation
+            ```bash
+            npm create deco <project-name>
+            # or with Bun
+            bun create deco <project-name>
+            ```
+
+            ### Usage
+            Create a new deco project with integrated authentication and workspace selection.
+          draft: false
+          prerelease: false

--- a/.depot/workflows/publish-decostudio-npm.yaml
+++ b/.depot/workflows/publish-decostudio-npm.yaml
@@ -1,0 +1,50 @@
+# Depot CI Migration
+# Source: .github/workflows/publish-decostudio-npm.yaml
+#
+# Changes made:
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Publish decostudio
+on:
+  push:
+    branches: [main]
+    paths:
+      - "decostudio-alias/**"
+  workflow_dispatch:
+permissions:
+  contents: write
+  id-token: write
+jobs:
+  publish:
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup Node.js for npm registry
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+      # No install/build: the package is a 2-line bin that imports decocms
+      # in-process; its `decocms: "*"` dep resolves at the consumer's install
+      # time, so it only republishes when the alias itself changes.
+      - name: Check if version changed
+        id: version-check
+        run: |
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+
+          # Check if this specific version already exists in npm
+          if npm view decostudio@$CURRENT_VERSION version >/dev/null 2>&1; then
+            echo "version-changed=false" >> $GITHUB_OUTPUT
+            echo "⏭️ Version $CURRENT_VERSION already published, skipping publish"
+          else
+            echo "version-changed=true" >> $GITHUB_OUTPUT
+            echo "✅ Version $CURRENT_VERSION not found in npm, will publish"
+          fi
+
+          echo "current-version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+        working-directory: decostudio-alias
+      - name: Publish to npm
+        if: steps.version-check.outputs.version-changed == 'true'
+        run: npm publish --access public --provenance
+        working-directory: decostudio-alias

--- a/.depot/workflows/publish-mcp-utils-npm.yaml
+++ b/.depot/workflows/publish-mcp-utils-npm.yaml
@@ -1,0 +1,61 @@
+# Depot CI Migration
+# Source: .github/workflows/publish-mcp-utils-npm.yaml
+#
+# Changes made:
+# - Rewrote .github/ path references to .depot/
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Publish @decocms/mcp-utils
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/mcp-utils/**"
+  workflow_dispatch:
+permissions:
+  contents: write
+  id-token: write
+jobs:
+  publish:
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js for npm registry
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+      - name: Setup Bun and install dependencies
+        uses: ./.depot/actions/setup-bun
+      - name: Check if version changed
+        id: version-check
+        run: "# Get the current version from package.json\nCURRENT_VERSION=$(bun -e \"console.log(require('./package.json').version)\")\n\n# Check if this specific version already exists in npm\nif npm view @decocms/mcp-utils@$CURRENT_VERSION version >/dev/null 2>&1; then\n  echo \"version-changed=false\" >> $GITHUB_OUTPUT\n  echo \"⏭️ Version $CURRENT_VERSION already published, skipping publish\"\nelse\n  echo \"version-changed=true\" >> $GITHUB_OUTPUT\n  echo \"✅ Version $CURRENT_VERSION not found in npm, will publish\"\nfi\n\necho \"current-version=$CURRENT_VERSION\" >> $GITHUB_OUTPUT\n\n# Check if this is a prerelease version (contains a hyphen)\nif [[ \"$CURRENT_VERSION\" == *-* ]]; then\n  echo \"npm-tag=next\" >> $GITHUB_OUTPUT\n  echo \"\U0001F4E6 Prerelease version detected, will publish with tag 'next'\"\nelse\n  echo \"npm-tag=latest\" >> $GITHUB_OUTPUT\n  echo \"\U0001F4E6 Stable version detected, will publish with tag 'latest'\"\nfi\n"
+        working-directory: packages/mcp-utils
+      - name: Publish to npm
+        if: steps.version-check.outputs.version-changed == 'true'
+        run: npm publish --access public --tag ${{ steps.version-check.outputs.npm-tag }} --provenance
+        working-directory: packages/mcp-utils
+      - name: Create Release
+        if: steps.version-check.outputs.version-changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "mcp-utils-v${{ steps.version-check.outputs.current-version }}" \
+            --title "@decocms/mcp-utils v${{ steps.version-check.outputs.current-version }}" \
+            --notes "## Changes
+
+          Automated release of @decocms/mcp-utils package.
+
+          ### Installation
+          \`\`\`bash
+          npm install @decocms/mcp-utils
+          \`\`\`
+
+          ### Features
+          - MCP proxy and gateway primitives (GatewayClient, composeTransport)
+          - Bridge transport for in-process MCP client/server communication
+          - Server-from-client adapter (createServerFromClient)
+          - QuickJS sandbox for safe code execution with MCP tools"

--- a/.depot/workflows/publish-runtime-npm.yaml
+++ b/.depot/workflows/publish-runtime-npm.yaml
@@ -1,0 +1,58 @@
+# Depot CI Migration
+# Source: .github/workflows/publish-runtime-npm.yaml
+#
+# Changes made:
+# - Rewrote .github/ path references to .depot/
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Publish @decocms/runtime
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/runtime/**"
+  workflow_dispatch:
+permissions:
+  contents: write
+  id-token: write
+jobs:
+  publish:
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js for npm registry
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+      - name: Setup Bun and install dependencies
+        uses: ./.depot/actions/setup-bun
+      - name: Generate JSON schema
+        run: bun run scripts/generate-json-schema.ts
+        working-directory: packages/runtime
+      - name: Check if version changed
+        id: version-check
+        run: "# Get the current version from package.json\nCURRENT_VERSION=$(node -e \"console.log(require('./package.json').version)\")\n\n# Check if this specific version already exists in npm\n# This works for both stable and prerelease versions (unlike checking 'latest' tag)\nif npm view @decocms/runtime@$CURRENT_VERSION version >/dev/null 2>&1; then\n  echo \"version-changed=false\" >> $GITHUB_OUTPUT\n  echo \"⏭️ Version $CURRENT_VERSION already published, skipping publish\"\nelse\n  echo \"version-changed=true\" >> $GITHUB_OUTPUT\n  echo \"✅ Version $CURRENT_VERSION not found in npm, will publish\"\nfi\n\necho \"current-version=$CURRENT_VERSION\" >> $GITHUB_OUTPUT\n\n# Check if this is a prerelease version (contains a hyphen)\nif [[ \"$CURRENT_VERSION\" == *-* ]]; then\n  echo \"npm-tag=next\" >> $GITHUB_OUTPUT\n  echo \"\U0001F4E6 Prerelease version detected, will publish with tag 'next'\"\nelse\n  echo \"npm-tag=latest\" >> $GITHUB_OUTPUT\n  echo \"\U0001F4E6 Stable version detected, will publish with tag 'latest'\"\nfi\n"
+        working-directory: packages/runtime
+      - name: Publish to npm
+        if: steps.version-check.outputs.version-changed == 'true'
+        run: npm publish --access public --tag ${{ steps.version-check.outputs.npm-tag }} --provenance
+        working-directory: packages/runtime
+      - name: Create Release
+        if: steps.version-check.outputs.version-changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "runtime-v${{ steps.version-check.outputs.current-version }}" \
+            --title "@decocms/runtime v${{ steps.version-check.outputs.current-version }}" \
+            --notes "## Changes
+
+          Automated release of @decocms/runtime package.
+
+          ### Installation
+          \`\`\`bash
+          npm install @decocms/runtime
+          \`\`\`"

--- a/.depot/workflows/publish-typegen-npm.yaml
+++ b/.depot/workflows/publish-typegen-npm.yaml
@@ -1,0 +1,63 @@
+# Depot CI Migration
+# Source: .github/workflows/publish-typegen-npm.yaml
+#
+# Changes made:
+# - Rewrote .github/ path references to .depot/
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Publish @decocms/typegen
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/typegen/**"
+  workflow_dispatch:
+permissions:
+  contents: write
+  id-token: write
+jobs:
+  publish:
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js for npm registry
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+      - name: Setup Bun and install dependencies
+        uses: ./.depot/actions/setup-bun
+      - name: Build
+        run: bun run build
+        working-directory: packages/typegen
+      - name: Check if version changed
+        id: version-check
+        run: "CURRENT_VERSION=$(node -e \"console.log(require('./package.json').version)\")\n\nif npm view @decocms/typegen@$CURRENT_VERSION version >/dev/null 2>&1; then\n  echo \"version-changed=false\" >> $GITHUB_OUTPUT\n  echo \"⏭️ Version $CURRENT_VERSION already published, skipping publish\"\nelse\n  echo \"version-changed=true\" >> $GITHUB_OUTPUT\n  echo \"✅ Version $CURRENT_VERSION not found in npm, will publish\"\nfi\n\necho \"current-version=$CURRENT_VERSION\" >> $GITHUB_OUTPUT\n\nif [[ \"$CURRENT_VERSION\" == *-* ]]; then\n  echo \"npm-tag=next\" >> $GITHUB_OUTPUT\n  echo \"\U0001F4E6 Prerelease version detected, will publish with tag 'next'\"\nelse\n  echo \"npm-tag=latest\" >> $GITHUB_OUTPUT\n  echo \"\U0001F4E6 Stable version detected, will publish with tag 'latest'\"\nfi\n"
+        working-directory: packages/typegen
+      - name: Publish to npm
+        if: steps.version-check.outputs.version-changed == 'true'
+        run: npm publish --access public --tag ${{ steps.version-check.outputs.npm-tag }} --provenance
+        working-directory: packages/typegen
+      - name: Create Release
+        if: steps.version-check.outputs.version-changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "typegen-v${{ steps.version-check.outputs.current-version }}" \
+            --title "@decocms/typegen v${{ steps.version-check.outputs.current-version }}" \
+            --notes "## Changes
+
+          Automated release of @decocms/typegen package.
+
+          ### Installation
+          \`\`\`bash
+          npm install @decocms/typegen
+          \`\`\`
+
+          ### Usage
+          \`\`\`bash
+          bunx @decocms/typegen --mcp <virtual-mcp-id> --key <api-key> --output client.ts
+          \`\`\`"

--- a/.depot/workflows/publish-ui-npm.yaml
+++ b/.depot/workflows/publish-ui-npm.yaml
@@ -1,0 +1,58 @@
+# Depot CI Migration
+# Source: .github/workflows/publish-ui-npm.yaml
+#
+# Changes made:
+# - Rewrote .github/ path references to .depot/
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Publish @decocms/ui
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/ui/**"
+  workflow_dispatch:
+permissions:
+  contents: write
+  id-token: write
+jobs:
+  publish:
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js for npm registry
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+      - name: Setup Bun and install dependencies
+        uses: ./.depot/actions/setup-bun
+      - name: Check if version changed
+        id: version-check
+        run: "# Get the current version from package.json\nCURRENT_VERSION=$(bun -e \"console.log(require('./package.json').version)\")\n\n# Check if this specific version already exists in npm\n# This works for both stable and prerelease versions (unlike checking 'latest' tag)\nif npm view @decocms/ui@$CURRENT_VERSION version >/dev/null 2>&1; then\n  echo \"version-changed=false\" >> $GITHUB_OUTPUT\n  echo \"⏭️ Version $CURRENT_VERSION already published, skipping publish\"\nelse\n  echo \"version-changed=true\" >> $GITHUB_OUTPUT\n  echo \"✅ Version $CURRENT_VERSION not found in npm, will publish\"\nfi\n\necho \"current-version=$CURRENT_VERSION\" >> $GITHUB_OUTPUT\n\n# Check if this is a prerelease version (contains a hyphen)\nif [[ \"$CURRENT_VERSION\" == *-* ]]; then\n  echo \"npm-tag=next\" >> $GITHUB_OUTPUT\n  echo \"\U0001F4E6 Prerelease version detected, will publish with tag 'next'\"\nelse\n  echo \"npm-tag=latest\" >> $GITHUB_OUTPUT\n  echo \"\U0001F4E6 Stable version detected, will publish with tag 'latest'\"\nfi\n"
+        working-directory: packages/ui
+      - name: Publish to npm
+        if: steps.version-check.outputs.version-changed == 'true'
+        run: npm publish --access public --tag ${{ steps.version-check.outputs.npm-tag }} --provenance
+        working-directory: packages/ui
+      - name: Create Release
+        if: steps.version-check.outputs.version-changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "ui-v${{ steps.version-check.outputs.current-version }}" \
+            --title "@decocms/ui v${{ steps.version-check.outputs.current-version }}" \
+            --notes "## Changes
+
+          Automated release of the @decocms/ui design system.
+
+          ### Installation
+          \`\`\`bash
+          bun add @decocms/ui react react-dom
+          \`\`\`
+
+          ### Docs
+          https://designsystem.decocms.com/"

--- a/.depot/workflows/release-orgfs-sidecar.yaml
+++ b/.depot/workflows/release-orgfs-sidecar.yaml
@@ -1,0 +1,105 @@
+# Depot CI Migration
+# Source: .github/workflows/release-orgfs-sidecar.yaml
+#
+# Changes made:
+# - Rewrote .github/ path references to .depot/
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Release orgfs-sidecar image
+# Tag is read back from deploy/helm/sandbox-env/values.yaml (`orgFs.image.tag`)
+# so the chart and the published image can't drift (netinit pattern).
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/sandbox/orgfs/**"
+      - "packages/shared/**"
+      - "deploy/helm/sandbox-env/orgfs-sidecar/**"
+      - "deploy/helm/sandbox-env/values.yaml"
+      - ".depot/workflows/release-orgfs-sidecar.yaml"
+  workflow_dispatch:
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/orgfs-sidecar
+jobs:
+  build-push:
+    name: Build & Push orgfs-sidecar image
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Read image tag from chart values
+        id: version
+        run: |
+          set -euo pipefail
+          VERSION=$(yq -r '.orgFs.image.tag' deploy/helm/sandbox-env/values.yaml)
+          if [ -z "${VERSION}" ] || [ "${VERSION}" = "null" ]; then
+            echo "::error::orgFs.image.tag missing from deploy/helm/sandbox-env/values.yaml"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=sha,format=short
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push Docker image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          # Repo-root context: the image bundles TS from packages/ + apps/api.
+          context: .
+          file: ./deploy/helm/sandbox-env/orgfs-sidecar/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+      # Catch a Dockerfile regression that would otherwise only surface as a
+      # CrashLoopBackOff sidecar in prod.
+      - name: Smoke-test built image
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          docker pull --platform linux/amd64 "${IMAGE}"
+          docker run --rm --platform linux/amd64 "${IMAGE}" sh -c '
+            rclone version &&
+            grep -q user_allow_other /etc/fuse.conf &&
+            test -s /srv/sidecar.js
+          '
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+      - name: Sign image with cosign
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          for tag in $(echo "${TAGS}" | tr ',' '\n'); do
+            cosign sign --yes "${tag}@${DIGEST}"
+          done
+      - name: Generate SLSA build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/.depot/workflows/release-s3-sync.yaml
+++ b/.depot/workflows/release-s3-sync.yaml
@@ -1,0 +1,55 @@
+# Depot CI Migration
+# Source: .github/workflows/release-s3-sync.yaml
+#
+# Changes made:
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Release S3 Sync Sidecar
+on:
+  push:
+    branches: [main]
+    paths:
+      - "deploy/s3-sync/**"
+  workflow_dispatch:
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/s3-sync
+jobs:
+  build-push:
+    name: Build & Push s3-sync image
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=3.0.0
+            type=raw,value=latest
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./deploy/s3-sync
+          file: ./deploy/s3-sync/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64

--- a/.depot/workflows/release-sandbox-charts.yaml
+++ b/.depot/workflows/release-sandbox-charts.yaml
@@ -1,0 +1,164 @@
+# Depot CI Migration
+# Source: .github/workflows/release-sandbox-charts.yaml
+#
+# Changes made:
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Release sandbox Helm charts
+on:
+  push:
+    branches: [main]
+    paths:
+      - "deploy/helm/sandbox-operator/**"
+      - "deploy/helm/sandbox-env/**"
+      - "deploy/helm/studio-previews/**"
+  workflow_dispatch:
+env:
+  REGISTRY: ghcr.io
+  # OCI charts in ghcr.io live at <registry>/<owner>/<name>:<tag>. Helm
+  # treats the parent path as the "repo" (here ghcr.io/decocms/studio/charts)
+  # and the chart name+version as ref. Argo CD's helm source supports this
+  # natively via repoURL=<registry>/<owner>/<name> + chart=<chart-name>.
+  OCI_REPO: oci://ghcr.io/${{ github.repository }}/charts
+jobs:
+  release:
+    name: Package & push ${{ matrix.chart }}
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    # Run every auxiliary chart in parallel — independent OCI tags, no shared
+    # mutable state. These are published here, and NOT by publish-chart.yml,
+    # because that workflow dispatches a chart bump into deco-apps-cd on every
+    # publish: a change to preview policy must not roll the production Studio.
+    strategy:
+      fail-fast: false
+      matrix:
+        chart: [sandbox-operator, sandbox-env, studio-previews]
+    # `[release]:` commits come from the auto-bump bot and don't actually
+    # change chart contents — skip them so we don't republish the same
+    # version.
+    if: ${{ !startsWith(github.event.head_commit.message, '[release]:') }}
+    permissions:
+      contents: read
+      packages: write
+      # OIDC token for keyless cosign signing (Sigstore Fulcio).
+      id-token: write
+      # Required to attach SLSA provenance attestations.
+      attestations: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.4
+      - name: Read chart version
+        id: version
+        env:
+          CHART_PATH: deploy/helm/${{ matrix.chart }}
+        run: |
+          set -euo pipefail
+          VERSION="$(awk '/^version:/{print $2; exit}' "${CHART_PATH}/Chart.yaml")"
+          NAME="$(awk '/^name:/{print $2; exit}' "${CHART_PATH}/Chart.yaml")"
+          {
+            echo "version=${VERSION}"
+            echo "name=${NAME}"
+            echo "path=${CHART_PATH}"
+          } >> "${GITHUB_OUTPUT}"
+          echo "::notice::Chart ${NAME} version ${VERSION}"
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # Skip republishing if the version tag already exists. Without this
+      # guard, every push to main that touches the chart silently mutates
+      # the chart under a tag consumers may already be pinning.
+      - name: Check if chart version already exists
+        id: tag-check
+        run: |
+          set -euo pipefail
+          # `helm show chart` against an OCI ref hits the registry; success
+          # means the tag is published.
+          if helm show chart "${OCI_REPO}/${{ steps.version.outputs.name }}" \
+              --version "${{ steps.version.outputs.version }}" \
+              >/dev/null 2>&1; then
+            echo "exists=true" >> "${GITHUB_OUTPUT}"
+            echo "::notice::Chart ${{ steps.version.outputs.name }}-${{ steps.version.outputs.version }} already published — skipping. Bump ${{ steps.version.outputs.path }}/Chart.yaml version to publish."
+          else
+            echo "exists=false" >> "${GITHUB_OUTPUT}"
+          fi
+      - name: Package chart
+        if: steps.tag-check.outputs.exists != 'true'
+        id: package
+        run: |
+          set -euo pipefail
+          helm package "${{ steps.version.outputs.path }}" --destination dist
+          PACKAGE="dist/${{ steps.version.outputs.name }}-${{ steps.version.outputs.version }}.tgz"
+          echo "package=${PACKAGE}" >> "${GITHUB_OUTPUT}"
+      - name: Push chart to OCI registry
+        if: steps.tag-check.outputs.exists != 'true'
+        id: push
+        run: |
+          set -euo pipefail
+          PUSH_OUT=$(helm push "${{ steps.package.outputs.package }}" "${OCI_REPO}" 2>&1)
+          echo "${PUSH_OUT}"
+          DIGEST=$(echo "${PUSH_OUT}" | awk '/Digest:/{print $2}')
+          if [ -z "${DIGEST}" ]; then
+            echo "::error::Could not extract digest from helm push output"
+            exit 1
+          fi
+          echo "digest=${DIGEST}" >> "${GITHUB_OUTPUT}"
+      # Keyless cosign signing for parity with the image release workflow.
+      # Verifies provenance via Sigstore's public transparency log without
+      # long-lived keys. Verify downstream with:
+      #   cosign verify ghcr.io/decocms/studio/charts/<chart>:<tag> \
+      #     --certificate-identity-regexp 'https://github.com/decocms/studio/.*' \
+      #     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+      - name: Install cosign
+        if: steps.tag-check.outputs.exists != 'true'
+        uses: sigstore/cosign-installer@v3
+      - name: Sign chart with cosign
+        if: steps.tag-check.outputs.exists != 'true'
+        env:
+          DIGEST: ${{ steps.push.outputs.digest }}
+          NAME: ${{ steps.version.outputs.name }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          REF="${{ env.REGISTRY }}/${{ github.repository }}/charts/${NAME}@${DIGEST}"
+          cosign sign --yes "${REF}"
+      - name: Generate SLSA build provenance
+        if: steps.tag-check.outputs.exists != 'true'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ github.repository }}/charts/${{ steps.version.outputs.name }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true
+      - name: Release summary
+        if: steps.tag-check.outputs.exists != 'true'
+        run: |
+          {
+            echo "## Helm chart published"
+            echo ""
+            echo "**${{ steps.version.outputs.name }} ${{ steps.version.outputs.version }}**"
+            echo ""
+            echo "### Install"
+            echo '```bash'
+            if [ "${{ matrix.chart }}" = "sandbox-operator" ]; then
+              echo "helm install sandbox-operator ${OCI_REPO}/${{ steps.version.outputs.name }} \\"
+              echo "  --version ${{ steps.version.outputs.version }} \\"
+              echo "  --namespace agent-sandbox-system --create-namespace"
+            else
+              echo "helm install sandbox-env-<envName> ${OCI_REPO}/${{ steps.version.outputs.name }} \\"
+              echo "  --version ${{ steps.version.outputs.version }} \\"
+              echo "  --namespace agent-sandbox-system \\"
+              echo "  --set envName=<envName> \\"
+              echo "  --set mesh.namespace=<studio-namespace> \\"
+              echo "  --set mesh.serviceAccountName=<studio-release-name>"
+            fi
+            echo '```'
+            if [ "${{ matrix.chart }}" = "sandbox-env" ]; then
+              echo ""
+              echo "> Compatibility: \`mesh.*\` is the legacy values namespace for Studio release references."
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.depot/workflows/release-sandbox-netinit.yaml
+++ b/.depot/workflows/release-sandbox-netinit.yaml
@@ -1,0 +1,101 @@
+# Depot CI Migration
+# Source: .github/workflows/release-sandbox-netinit.yaml
+#
+# Changes made:
+# - Rewrote .github/ path references to .depot/
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Release sandbox-netinit image
+# Tag is read back from deploy/helm/sandbox-env/values.yaml (`netinit.tag`)
+# so the chart and the published image can't drift.
+on:
+  push:
+    branches: [main]
+    paths:
+      - "deploy/helm/sandbox-env/image/**"
+      - "deploy/helm/sandbox-env/values.yaml"
+      - ".depot/workflows/release-sandbox-netinit.yaml"
+  workflow_dispatch:
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/sandbox-netinit
+jobs:
+  build-push:
+    name: Build & Push sandbox-netinit image
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Read image tag from chart values
+        id: version
+        run: |
+          set -euo pipefail
+          VERSION=$(yq -r '.netinit.tag' deploy/helm/sandbox-env/values.yaml)
+          if [ -z "${VERSION}" ] || [ "${VERSION}" = "null" ]; then
+            echo "::error::netinit.tag missing from deploy/helm/sandbox-env/values.yaml"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=sha,format=short
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push Docker image
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: ./deploy/helm/sandbox-env/image
+          file: ./deploy/helm/sandbox-env/image/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+      # Catch a Dockerfile regression that would otherwise only surface as
+      # an init-container CrashLoopBackOff in prod.
+      - name: Smoke-test built image
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          docker pull --platform linux/amd64 "${IMAGE}"
+          docker run --rm --platform linux/amd64 "${IMAGE}" sh -c '
+            iptables --version &&
+            ip6tables --version
+          '
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v3
+      - name: Sign image with cosign
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          for tag in $(echo "${TAGS}" | tr ',' '\n'); do
+            cosign sign --yes "${tag}@${DIGEST}"
+          done
+      - name: Generate SLSA build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true

--- a/.depot/workflows/release-studio-sandbox.yaml
+++ b/.depot/workflows/release-studio-sandbox.yaml
@@ -1,0 +1,161 @@
+# Depot CI Migration
+# Source: .github/workflows/release-studio-sandbox.yaml
+#
+# Changes made:
+# - Rewrote .github/ path references to .depot/
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Release Studio Sandbox Image
+on:
+  push:
+    branches: [main]
+    paths:
+      - "packages/sandbox/**"
+      # The harness runner is packed INTO the image (see image/Dockerfile), so a
+      # fix there ships nothing without a rebuild. The version gate below still
+      # applies: bump packages/sandbox/package.json or the tag is reused.
+      - "packages/harness-runner/**"
+  workflow_dispatch:
+env:
+  REGISTRY: ghcr.io
+  # One image, one daemon (Go). The `studio-sandbox` name is frozen at its last
+  # TS-daemon tag (1.35.2) — kept pullable for rollback, never pushed again.
+  IMAGE_NAME: ${{ github.repository }}/studio-sandbox-go
+jobs:
+  build-push:
+    name: Build & Push studio-sandbox-go image
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      # "true" when the tag was already in GHCR (build skipped) — the bump job
+      # uses this to skip docs/test-only pushes that reuse the existing tag.
+      image-exists: ${{ steps.tag-check.outputs.exists }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Read sandbox version
+        id: version
+        run: |
+          VERSION="$(python3 -c "import json; print(json.load(open('packages/sandbox/package.json'))['version'])")"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # Fast-fail: skip the entire build if this version is already published.
+      # Keeps docs-only or test-only changes to packages/sandbox from
+      # re-pushing the same image under a tag consumers may already be pinning.
+      - name: Check if version tag already exists
+        id: tag-check
+        run: |
+          STATUS=$(curl -sS -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+            "https://${{ env.REGISTRY }}/v2/${{ env.IMAGE_NAME }}/manifests/${{ steps.version.outputs.version }}")
+          if [ "${STATUS}" = "200" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Image ${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }} already exists — skipping push. Bump packages/sandbox/package.json to publish."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Setup Bun and install dependencies
+        if: steps.tag-check.outputs.exists != 'true'
+        uses: ./.depot/actions/setup-bun
+      # The Dockerfile copies dist/typegen.tgz into the image.
+      - name: Build typegen package
+        if: steps.tag-check.outputs.exists != 'true'
+        run: bun run --cwd=packages/sandbox build
+      # `:latest` is only emitted on manual workflow_dispatch runs so
+      # pinned consumers know it was a deliberate human action.
+      - name: Extract metadata (tags, labels)
+        id: meta
+        if: steps.tag-check.outputs.exists != 'true'
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=sha,format=short
+      - name: Set up Docker Buildx
+        if: steps.tag-check.outputs.exists != 'true'
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push Docker image
+        id: build
+        if: steps.tag-check.outputs.exists != 'true'
+        uses: docker/build-push-action@v5
+        with:
+          context: ./packages/sandbox
+          file: ./packages/sandbox/image/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # Multi-arch to match every sibling image (Studio API, orgfs-sidecar,
+          # sandbox-netinit, s3-sync). Without arm64 the sandbox can't run
+          # natively on Apple Silicon / arm64 nodes. buildx emulates arm64 via
+          # the runner's preinstalled binfmt, same as orgfs-sidecar.
+          platforms: linux/amd64,linux/arm64
+      - name: Install cosign
+        if: steps.tag-check.outputs.exists != 'true'
+        uses: sigstore/cosign-installer@v3
+      - name: Sign image with cosign
+        if: steps.tag-check.outputs.exists != 'true'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          for tag in $(echo "${TAGS}" | tr ',' '\n'); do
+            cosign sign --yes "${tag}@${DIGEST}"
+          done
+      - name: Generate SLSA build provenance
+        if: steps.tag-check.outputs.exists != 'true'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+  # ---------------------------------------------------------------------------
+  # GitOps: tell deco-apps-cd to bump the sandbox image tag. We fire the generic
+  # `image-bump` repository_dispatch (receiver: deco-apps-cd's bump-image.yml,
+  # which surgically rewrites the `tag:` under the matching `repository:` line
+  # and self-commits with its own GITHUB_TOKEN). No cross-repo write credential
+  # lives here — only a token to trigger the dispatch. Bumps both stg and prod
+  # sandbox values; both are ArgoCD auto-sync, but a SandboxTemplate tag bump
+  # only changes what NEW sandbox claims get — it doesn't disturb running pods.
+  # ---------------------------------------------------------------------------
+  bump-deco-apps-cd:
+    name: Trigger deco-apps-cd bump
+    needs: [build-push]
+    # Only when a NEW image was actually pushed (skip docs/test-only changes to
+    # packages/sandbox that reuse the existing tag).
+    if: needs.build-push.result == 'success' && needs.build-push.outputs.image-exists != 'true'
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    # Reuses DEPLOY_REPO_TOKEN — the decobot machine-user PAT (admin on
+    # decocms/deco-apps-cd), same token release-studio uses. The bump is a
+    # convenience and must never red the release: absent token → no-op, job passes.
+    env:
+      DISPATCH_TOKEN: ${{ secrets.DEPLOY_REPO_TOKEN }}
+    steps:
+      - name: Skip notice (dispatch token not configured)
+        if: env.DISPATCH_TOKEN == ''
+        run: echo "::notice::DEPLOY_REPO_TOKEN not set — skipping the deco-apps-cd bump."
+      - name: Dispatch image-bump to deco-apps-cd
+        if: env.DISPATCH_TOKEN != ''
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DEPLOY_REPO_TOKEN }}
+          repository: decocms/deco-apps-cd
+          event-type: image-bump
+          client-payload: '{"version": "${{ needs.build-push.outputs.version }}", "repository": "decocms/studio/studio-sandbox-go", "files": ["apps/studio-sandbox-stg/values.yaml", "apps/studio-sandbox-prod/values.yaml"]}'
+      - name: Summary
+        if: env.DISPATCH_TOKEN != ''
+        run: echo "Dispatched \`image-bump\` (studio-sandbox-go ${{ needs.build-push.outputs.version }}) to decocms/deco-apps-cd" >> "$GITHUB_STEP_SUMMARY"

--- a/.depot/workflows/release-studio.yaml
+++ b/.depot/workflows/release-studio.yaml
@@ -1,0 +1,724 @@
+# Depot CI Migration
+# Source: .github/workflows/release-studio.yaml
+#
+# Changes made:
+# - Rewrote .github/ path references to .depot/
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Release Studio
+on:
+  # Releases are driven by the version bump. release-tagging commits
+  # "[release]: bump to X" touching ONLY apps/api/package.json, and that push
+  # (App token → re-triggers workflows) is what fires this. Triggering on
+  # package.json alone means we run exactly ONCE per release — the feature
+  # commit that preceded the bump no longer also spawns a (redundant) run.
+  push:
+    branches: [main]
+    paths:
+      - "apps/api/package.json"
+  workflow_dispatch:
+    inputs:
+      deploy_to_production:
+        description: "Deploy to production (trigger ArgoCD sync)"
+        required: false
+        default: "false"
+        type: string
+      ref:
+        description: "Commit SHA to release (pins checkout to the exact version bump; empty = triggering ref)"
+        required: false
+        default: ""
+        type: string
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/studio
+  NGINX_IMAGE_NAME: ${{ github.repository }}/studio-nginx
+jobs:
+  prepare:
+    name: Prepare release metadata
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    # Releases are cut by the [release]: version-bump commit that release-tagging
+    # pushes to main (the bot push uses the App token, which re-triggers
+    # workflows). We run on EVERY push here — a non-bump push just reads an
+    # already-published version and short-circuits at the version-changed check.
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      version-changed: ${{ steps.version.outputs.version-changed }}
+      npm-tag: ${{ steps.version.outputs.npm-tag }}
+      image-exists: ${{ steps.image.outputs.image-exists }}
+      nginx-image-exists: ${{ steps.nginx-image.outputs.image-exists }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Read version + check npm
+        id: version
+        working-directory: apps/api
+        run: |
+          CURRENT_VERSION="$(node -p "require('./package.json').version")"
+          echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+          if npm view "decocms@$CURRENT_VERSION" version >/dev/null 2>&1; then
+            echo "version-changed=false" >> "$GITHUB_OUTPUT"
+            echo "Version $CURRENT_VERSION already published"
+          else
+            echo "version-changed=true" >> "$GITHUB_OUTPUT"
+            echo "Version $CURRENT_VERSION not found in npm, will publish"
+          fi
+          if [[ "$CURRENT_VERSION" == *-* ]]; then
+            echo "npm-tag=next" >> "$GITHUB_OUTPUT"
+          else
+            echo "npm-tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Check if Docker image exists
+        id: image
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if docker manifest inspect "$IMAGE_REF" >/dev/null 2>&1; then
+            echo "image-exists=true" >> "$GITHUB_OUTPUT"
+            echo "Image $VERSION already in GHCR"
+          else
+            echo "image-exists=false" >> "$GITHUB_OUTPUT"
+            echo "Image $VERSION not in GHCR, will build"
+          fi
+      - name: Check if nginx Docker image exists
+        id: nginx-image
+        env:
+          IMAGE_REF: ${{ env.REGISTRY }}/${{ env.NGINX_IMAGE_NAME }}:${{ steps.version.outputs.version }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if docker manifest inspect "$IMAGE_REF" >/dev/null 2>&1; then
+            echo "image-exists=true" >> "$GITHUB_OUTPUT"
+            echo "Nginx image $VERSION already in GHCR"
+          else
+            echo "image-exists=false" >> "$GITHUB_OUTPUT"
+            echo "Nginx image $VERSION not in GHCR, will build"
+          fi
+  # Build the npm tarball EXACTLY ONCE, then hand it to both publish-npm and
+  # build-docker as a workflow artifact. `npm pack` does not run prepublishOnly,
+  # so we build both apps explicitly first, stage apps/web/dist into the API
+  # package at apps/api/dist/client, then pack. Sharing one tarball is what
+  # guarantees the API image, nginx image, and published npm package are
+  # byte-identical.
+  build-dist:
+    name: Build package artifact
+    needs: prepare
+    if: |
+      needs.prepare.outputs.version-changed == 'true' ||
+      needs.prepare.outputs.image-exists == 'false' ||
+      needs.prepare.outputs.nginx-image-exists == 'false'
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    permissions:
+      contents: read
+    env:
+      # Hoisted to the job because `secrets` is not readable from a step `if:`.
+      HAS_POSTHOG_SOURCEMAPS: ${{ secrets.POSTHOG_CLI_API_KEY != '' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+      - name: Setup Bun and install dependencies
+        uses: ./.depot/actions/setup-bun
+      # Sourcemaps are emitted ONLY when the PostHog secret exists, uploaded so
+      # error tracking can un-minify stack traces, then deleted before packing.
+      # Without them production frames name no file anyone can open.
+      - name: Build combined Studio distribution
+        run: bun run build:studio
+        env:
+          BUILD_SOURCEMAPS: ${{ env.HAS_POSTHOG_SOURCEMAPS == 'true' && '1' || '0' }}
+      # Telemetry must never break a release, so this cannot fail the job
+      # (`--no-fail` plus `continue-on-error`). The cleanup below runs
+      # regardless, so a partial upload still cannot leak sources.
+      - name: Upload sourcemaps to PostHog
+        if: env.HAS_POSTHOG_SOURCEMAPS == 'true'
+        continue-on-error: true
+        env:
+          POSTHOG_CLI_API_KEY: ${{ secrets.POSTHOG_CLI_API_KEY }}
+          POSTHOG_CLI_PROJECT_ID: ${{ secrets.POSTHOG_PROJECT_ID }}
+        run: |
+          npx --yes --package=@posthog/cli@0.11.0 posthog-cli --no-fail \
+            sourcemap process \
+            --directory apps/api/dist/client \
+            --release-name studio-web \
+            --release-version "${{ github.sha }}"
+      # Unconditional: a `.map` reaching this point would be published in the
+      # npm tarball AND the Docker image, since build-studio copies dist wholesale.
+      - name: Strip sourcemaps before packing
+        if: always()
+        run: |
+          find apps/web/dist apps/api/dist -name '*.map' -delete 2>/dev/null || true
+          remaining=$(find apps/web/dist apps/api/dist -name '*.map' 2>/dev/null | wc -l | tr -d ' ')
+          test "$remaining" = "0" || { echo "::error::$remaining sourcemap(s) survived cleanup"; exit 1; }
+      - name: Verify combined distribution layout
+        run: |
+          test -f apps/web/dist/index.html
+          test -f apps/api/dist/client/index.html
+          test -f apps/api/dist/server/server.js
+          test -f apps/api/dist/server/migrate.js
+          test -f apps/api/dist/server/migrate-dbos.js
+          test -f apps/api/dist/server/cli.js
+      - name: Pack the npm tarball
+        working-directory: apps/api
+        run: npm pack
+      # Install the just-packed tarball into a scratch directory exactly the
+      # way a consumer would (`bun add decocms@<version>`), then invoke the
+      # `deco` bin. `bun build --target bun` emits top-level ESM `import`
+      # for externals, so loading cli.js eagerly resolves every external —
+      # a missing one (e.g. an nft-traced OTel package that never got copied
+      # into dist/server/node_modules/) crashes here with "Cannot find
+      # module …", the exact decocms#2.393.0 production symptom. Catching
+      # it here means publish-npm + build-docker never see the bad artifact.
+      #
+      # Static-side defense lives in apps/api/scripts/bundle-server-script.ts
+      # (verifyBundlesShipExternals). This step is the publish-time backstop
+      # that also catches npm-publish-side filtering of files/node_modules.
+      #
+      # The bin invocation is hidden inside the smoke-tarball.ts script (and
+      # not inlined here) because knip's "unlisted binaries" check scans
+      # workflow `run:` blocks for bare binary names — see the comment at
+      # the top of that script.
+      - name: Smoke-test the packed tarball
+        working-directory: apps/api
+        run: |
+          set -euxo pipefail
+          TARBALL="$(find "$PWD" -maxdepth 1 -type f -name 'decocms-*.tgz' -print -quit)"
+          test -n "$TARBALL"
+          bun run scripts/smoke-tarball.ts "$TARBALL"
+      - name: Upload package artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: studio-package
+          path: apps/api/decocms-*.tgz
+          if-no-files-found: error
+          retention-days: 1
+  publish-npm:
+    name: Publish to NPM
+    needs: [prepare, build-dist]
+    if: needs.prepare.outputs.version-changed == 'true'
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+      - name: Download package artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: studio-package
+      - name: Publish to NPM
+        run: npm publish decocms-*.tgz --access public --tag ${{ needs.prepare.outputs.npm-tag }} --provenance
+  # Multi-arch build split across NATIVE runners — amd64 on ubuntu-latest,
+  # arm64 on ubuntu-24.04-arm — instead of emulating arm64 under QEMU on amd64.
+  # The expensive `bun add /tmp/decocms.tgz` layer ran ~5x slower under QEMU
+  # (~64s vs ~13s) and is a guaranteed cache miss every release (the tarball
+  # content changes each version), so we paid the full emulation tax every time.
+  # Each leg builds + pushes its single-arch image BY DIGEST (no tags), and the
+  # merge-docker job below assembles the tagged manifest list from both digests.
+  #
+  # Consumes the tarball built by build-dist (NOT the npm registry): the
+  # Dockerfile does `bun add /tmp/decocms.tgz`, so there is no registry read to
+  # race against publish-npm. Runs in PARALLEL with publish-npm — both gate only
+  # on build-dist and install the same tarball, so the image stays byte-identical
+  # to the published package.
+  build-docker:
+    name: Build Docker (${{ matrix.arch }})
+    needs: [prepare, build-dist]
+    if: |
+      always() &&
+      needs.prepare.outputs.image-exists == 'false' &&
+      needs.build-dist.result == 'success'
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: depot-ubuntu-latest # was: ubuntu-latest. Matrix-supplied runner; mapped to Depot equivalent.
+          - arch: arm64
+            platform: linux/arm64
+            runner: depot-ubuntu-24.04-arm # was: ubuntu-24.04-arm. Matrix-supplied runner; mapped to Depot equivalent.
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+      - name: Download package artifact into build context
+        uses: actions/download-artifact@v4
+        with:
+          name: studio-package
+          path: docker-context
+      - name: Normalize tarball filename
+        run: mv docker-context/decocms-*.tgz docker-context/decocms.tgz
+      - name: Image labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      # push-by-digest=true publishes a single-arch image addressable only by
+      # digest (no tag); merge-docker stitches the per-arch digests into the
+      # tagged manifest list. provenance:false keeps each pushed digest a plain
+      # single-platform image — provenance attestations turn it into a nested
+      # index that `buildx imagetools create` can't merge cleanly.
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: ./docker-context
+          file: ./apps/api/Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=studio-api-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=studio-api-${{ matrix.arch }}
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.arch }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+  build-nginx-docker:
+    name: Build Nginx Docker (${{ matrix.arch }})
+    needs: [prepare, build-dist]
+    if: |
+      always() &&
+      needs.prepare.outputs.nginx-image-exists == 'false' &&
+      needs.build-dist.result == 'success'
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            platform: linux/amd64
+            runner: depot-ubuntu-latest # was: ubuntu-latest. Matrix-supplied runner; mapped to Depot equivalent.
+          - arch: arm64
+            platform: linux/arm64
+            runner: depot-ubuntu-24.04-arm # was: ubuntu-24.04-arm. Matrix-supplied runner; mapped to Depot equivalent.
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+      - name: Download package artifact into build context
+        uses: actions/download-artifact@v4
+        with:
+          name: studio-package
+          path: docker-context
+      - name: Normalize tarball filename
+        run: mv docker-context/decocms-*.tgz docker-context/decocms.tgz
+      - name: Copy tarball to repository root
+        run: cp docker-context/decocms.tgz decocms.tgz
+      - name: Image labels
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NGINX_IMAGE_NAME }}
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./apps/web/Dockerfile
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.NGINX_IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=studio-web-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=studio-web-${{ matrix.arch }}
+      - name: Export digest
+        run: |
+          mkdir -p "${{ runner.temp }}/nginx-digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/nginx-digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: nginx-digests-${{ matrix.arch }}
+          path: ${{ runner.temp }}/nginx-digests/*
+          if-no-files-found: error
+          retention-days: 1
+  # Assemble the per-arch digests pushed by build-docker into one tagged
+  # multi-arch manifest list and push it to GHCR. This is the job that makes
+  # `ghcr.io/.../studio:<version>` resolve to both amd64 + arm64.
+  merge-docker:
+    name: Merge & push Docker manifest
+    needs: [prepare, build-docker]
+    if: |
+      always() &&
+      needs.prepare.outputs.image-exists == 'false' &&
+      needs.build-docker.result == 'success'
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+      - name: Extract metadata (tags)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.prepare.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.prepare.outputs.version }}
+            type=raw,value=latest
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          TARGET_IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        run: |
+          mapfile -t tags < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          tag_args=()
+          for tag in "${tags[@]}"; do
+            tag_args+=("-t" "$tag")
+          done
+
+          digest_refs=()
+          for digest in *; do
+            [[ -f "$digest" ]] || continue
+            digest_refs+=("${TARGET_IMAGE}@sha256:${digest}")
+          done
+
+          ((${#tag_args[@]} > 0))
+          ((${#digest_refs[@]} > 0))
+          docker buildx imagetools create "${tag_args[@]}" "${digest_refs[@]}"
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.version }}"
+  merge-nginx-docker:
+    name: Merge & push Nginx Docker manifest
+    needs: [prepare, build-nginx-docker]
+    if: |
+      always() &&
+      needs.prepare.outputs.nginx-image-exists == 'false' &&
+      needs.build-nginx-docker.result == 'success'
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/nginx-digests
+          pattern: nginx-digests-*
+          merge-multiple: true
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/setup-buildx-action@v3
+      - name: Extract metadata (tags)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.NGINX_IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ needs.prepare.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ needs.prepare.outputs.version }}
+            type=raw,value=latest
+      - name: Create manifest list and push
+        working-directory: ${{ runner.temp }}/nginx-digests
+        env:
+          TARGET_IMAGE: ${{ env.REGISTRY }}/${{ env.NGINX_IMAGE_NAME }}
+        run: |
+          mapfile -t tags < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          tag_args=()
+          for tag in "${tags[@]}"; do
+            tag_args+=("-t" "$tag")
+          done
+
+          digest_refs=()
+          for digest in *; do
+            [[ -f "$digest" ]] || continue
+            digest_refs+=("${TARGET_IMAGE}@sha256:${digest}")
+          done
+
+          ((${#tag_args[@]} > 0))
+          ((${#digest_refs[@]} > 0))
+          docker buildx imagetools create "${tag_args[@]}" "${digest_refs[@]}"
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect "${{ env.REGISTRY }}/${{ env.NGINX_IMAGE_NAME }}:${{ needs.prepare.outputs.version }}"
+  release:
+    name: GitHub Release + Deployment
+    needs: [prepare, build-dist, publish-npm, merge-docker, merge-nginx-docker]
+    if: |
+      always() &&
+      (
+        needs.prepare.outputs.version-changed == 'true' ||
+        needs.prepare.outputs.image-exists == 'false' ||
+        needs.prepare.outputs.nginx-image-exists == 'false'
+      ) &&
+      (needs.build-dist.result == 'success' || needs.build-dist.result == 'skipped') &&
+      (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped') &&
+      (needs.merge-docker.result == 'success' || needs.merge-docker.result == 'skipped') &&
+      (needs.merge-nginx-docker.result == 'success' || needs.merge-nginx-docker.result == 'skipped')
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ needs.prepare.outputs.version }}
+          target_commitish: ${{ inputs.ref || github.sha }}
+          name: "Studio v${{ needs.prepare.outputs.version }}"
+          body: |
+            ## Studio v${{ needs.prepare.outputs.version }}
+
+            The open-source control plane for MCP traffic.
+
+            ### Install via npm
+            ```bash
+            bunx decocms@${{ needs.prepare.outputs.version }}
+            ```
+
+            ### Install via Docker
+            ```bash
+            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.version }}
+            docker pull ${{ env.REGISTRY }}/${{ env.NGINX_IMAGE_NAME }}:${{ needs.prepare.outputs.version }}
+
+            docker run -d \
+              -p 3000:3000 \
+              -v studio-data:/app/data \
+              --name studio \
+              ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.version }}
+            ```
+
+            ### Documentation
+            https://github.com/decocms/studio
+          draft: false
+          prerelease: ${{ contains(needs.prepare.outputs.version, 'alpha') || contains(needs.prepare.outputs.version, 'beta') || contains(needs.prepare.outputs.version, 'rc') }}
+      - name: Generate release summary
+        run: |
+          {
+            echo "## Release Summary"
+            echo ""
+            echo "**Studio v${{ needs.prepare.outputs.version }} Released**"
+            echo ""
+            echo "### npm"
+            echo "\`\`\`bash"
+            echo "bunx decocms@${{ needs.prepare.outputs.version }}"
+            echo "\`\`\`"
+            echo ""
+            echo "### Docker"
+            echo "\`\`\`bash"
+            echo "docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.prepare.outputs.version }}"
+            echo "docker pull ${{ env.REGISTRY }}/${{ env.NGINX_IMAGE_NAME }}:${{ needs.prepare.outputs.version }}"
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+  # ---------------------------------------------------------------------------
+  # GitOps: tell deco-apps-cd to bump the Studio images. We do NOT write into that
+  # repo from here — we fire a `studio-image-bump` repository_dispatch, and its
+  # own workflow (.depot/workflows/bump-studio-image.yml) self-commits with its
+  # native GITHUB_TOKEN. Decoupled, race-safe (it rebases), and no cross-repo
+  # write credential lives here — only a token to trigger the dispatch.
+  # The receiver bumps deco-studio-stg (auto-sync → rolls out) + deco-studio
+  # (manual-sync → desired only; the prod promotion gate is preserved).
+  # ---------------------------------------------------------------------------
+  bump-deco-apps-cd:
+    name: Trigger deco-apps-cd bump
+    needs: [prepare, build-dist, publish-npm, merge-docker, merge-nginx-docker]
+    # Only bump when this release is fully consistent across the artifact set:
+    #   * a VALID image for this version exists (either already published, so
+    #     its merge job is skipped, or freshly built + merged), AND
+    #   * the npm side didn't fail. publish-npm is gated separately because the
+    #     docker build is parallel to it — without this clause, an npm failure
+    #     could still ship an image to prod whose `bunx decocms@X`
+    #     wouldn't resolve, leaving the artifacts inconsistent.
+    # A skipped publish-npm (version already on npm) or skipped merge job
+    # (image already in GHCR) is fine — those mean "nothing to do", not failure.
+    if: |
+      always() &&
+      (needs.build-dist.result == 'success' || needs.build-dist.result == 'skipped') &&
+      (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped') &&
+      (
+        (
+          needs.prepare.outputs.image-exists == 'true' ||
+          needs.merge-docker.result == 'success'
+        ) &&
+        (
+          needs.prepare.outputs.nginx-image-exists == 'true' ||
+          needs.merge-nginx-docker.result == 'success'
+        )
+      )
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    # Reuses DEPLOY_REPO_TOKEN — the decobot machine-user PAT already used to
+    # dispatch the Studio image bump (non-personal; decobot is admin on
+    # decocms/deco-apps-cd). Same bot, same mechanism as the legacy repo, no
+    # new/ personal token. The bump is a convenience and must never red the
+    # release: if the token isn't present the step no-ops and the job passes.
+    env:
+      DISPATCH_TOKEN: ${{ secrets.DEPLOY_REPO_TOKEN }}
+    steps:
+      - name: Skip notice (dispatch token not configured)
+        if: env.DISPATCH_TOKEN == ''
+        run: echo "::notice::DEPLOY_REPO_TOKEN not set — skipping the deco-apps-cd bump."
+      - uses: actions/checkout@v4
+        if: env.DISPATCH_TOKEN != ''
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Read deploy scope from release commit
+        id: scope
+        if: env.DISPATCH_TOKEN != ''
+        # release-tagging stamps a `Deploy-Scope:` trailer on the [release]
+        # commit (web / server / both). deco-apps-cd's bump-studio-image rolls
+        # only the matching tier. Absent/old commits default to both.
+        run: |
+          S=$(git log -1 --format=%B | sed -n 's/^Deploy-Scope:[[:space:]]*//p' | head -1)
+          echo "scope=${S:-both}" >> "$GITHUB_OUTPUT"
+      - name: Dispatch studio-image-bump to deco-apps-cd
+        if: env.DISPATCH_TOKEN != ''
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.DEPLOY_REPO_TOKEN }}
+          repository: decocms/deco-apps-cd
+          event-type: studio-image-bump
+          client-payload: '{"version": "${{ needs.prepare.outputs.version }}", "scope": "${{ steps.scope.outputs.scope }}"}'
+      - name: Summary
+        if: env.DISPATCH_TOKEN != ''
+        run: echo "Dispatched \`studio-image-bump\` (version ${{ needs.prepare.outputs.version }}, scope ${{ steps.scope.outputs.scope }}) to decocms/deco-apps-cd" >> "$GITHUB_STEP_SUMMARY"
+  # ---------------------------------------------------------------------------
+  # Notify the docs agent that a new Studio version shipped. The agent decides
+  # whether the docs need updating from the CHANGE RANGE between the previous
+  # release and this one — NOT the release-bump commit alone, whose diff is only
+  # the version bump in package.json. We resolve the previous release tag and
+  # send a `compare_url` (previous_tag...tag) so the agent diffs the real
+  # feature changes.
+  # This is a convenience hook and must NEVER red the release: it no-ops when
+  # the webhook isn't configured, and a failed call is logged, not fatal.
+  #   * URL   -> repo variable  DOCS_AGENT_WEBHOOK_URL   (not sensitive)
+  #   * token -> repo secret    DOCS_AGENT_WEBHOOK_TOKEN (sent as Bearer)
+  # Runs only after `release` actually cut a release, so re-runs where the
+  # version already existed don't re-ping the agent.
+  # ---------------------------------------------------------------------------
+  notify-docs-agent:
+    name: Notify docs agent
+    needs: [prepare, release]
+    if: always() && needs.release.result == 'success'
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    env:
+      WEBHOOK_URL: ${{ vars.DOCS_AGENT_WEBHOOK_URL }}
+      WEBHOOK_TOKEN: ${{ secrets.DOCS_AGENT_WEBHOOK_TOKEN }}
+    steps:
+      - name: Skip notice (webhook not configured)
+        if: env.WEBHOOK_URL == '' || env.WEBHOOK_TOKEN == ''
+        run: echo "::notice::DOCS_AGENT_WEBHOOK_URL / DOCS_AGENT_WEBHOOK_TOKEN not set — skipping the docs-agent notification."
+      - uses: actions/checkout@v4
+        if: env.WEBHOOK_URL != '' && env.WEBHOOK_TOKEN != ''
+        with:
+          # Full history + tags so we can resolve the previous release tag.
+          fetch-depth: 0
+          ref: ${{ inputs.ref }}
+      - name: Resolve previous release tag
+        id: range
+        if: env.WEBHOOK_URL != '' && env.WEBHOOK_TOKEN != ''
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          git fetch --tags --force --quiet || true
+          TAG="v${VERSION}"
+          # Nearest release tag reachable from this tag's first parent. Empty on
+          # the very first release (agent then falls back to the sha alone).
+          PREV="$(git describe --tags --abbrev=0 --match 'v*' "${TAG}^" 2>/dev/null || true)"
+          echo "prev_tag=${PREV}" >> "$GITHUB_OUTPUT"
+          if [ -n "$PREV" ]; then
+            echo "compare_url=${{ github.server_url }}/${{ github.repository }}/compare/${PREV}...${TAG}" >> "$GITHUB_OUTPUT"
+          else
+            echo "compare_url=" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Call docs-agent webhook
+        if: env.WEBHOOK_URL != '' && env.WEBHOOK_TOKEN != ''
+        run: |
+          set -euo pipefail
+          payload=$(cat <<EOF
+          {
+            "event": "studio.released",
+            "version": "${{ needs.prepare.outputs.version }}",
+            "tag": "v${{ needs.prepare.outputs.version }}",
+            "previous_tag": "${{ steps.range.outputs.prev_tag }}",
+            "repository": "${{ github.repository }}",
+            "sha": "${{ inputs.ref || github.sha }}",
+            "compare_url": "${{ steps.range.outputs.compare_url }}",
+            "run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          }
+          EOF
+          )
+          code=$(curl -sS -o /tmp/resp.txt -w '%{http_code}' \
+            --retry 3 --retry-connrefused --max-time 30 \
+            -X POST "$WEBHOOK_URL" \
+            -H "Authorization: Bearer $WEBHOOK_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$payload") || true
+          echo "Webhook responded HTTP $code"
+          echo "::group::Response body"; cat /tmp/resp.txt || true; echo; echo "::endgroup::"
+          if [ "${code:0:1}" != "2" ]; then
+            echo "::warning::docs-agent webhook returned HTTP $code (non-blocking)"
+          else
+            echo "Notified docs agent for v${{ needs.prepare.outputs.version }} (range ${{ steps.range.outputs.prev_tag }}...v${{ needs.prepare.outputs.version }})" >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.depot/workflows/release-tagging.yaml
+++ b/.depot/workflows/release-tagging.yaml
@@ -1,0 +1,320 @@
+# Depot CI Migration
+# Source: .github/workflows/release-tagging.yaml
+#
+# Changes made:
+# - Rewrote .github/ path references to .depot/
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Release Tagging
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "apps/api/**"
+      - "apps/web/**"
+      - "apps/native/**"
+      - "package.json"
+      - "scripts/build-studio.ts"
+      - "scripts/release-changes.ts"
+      - "packages/**"
+      - ".depot/workflows/release-tagging.yaml"
+      # Baked into the nginx image at build time (apps/web/Dockerfile), so a change
+      # here must cut a release to rebuild that image — it is not a ConfigMap.
+      - "deploy/helm/studio/files/**"
+# Serialize release-tagging across merges. This job pushes a `[release]:`
+# version-bump commit straight to main; two runs from near-simultaneous
+# merges would otherwise race and one push would be rejected non-fast-forward.
+# cancel-in-progress: false — every merge's bump must run, so queue them
+# rather than cancel. (The push step also rebases-and-retries as a backstop
+# for main advancing via an unrelated merge.)
+concurrency:
+  group: release-tagging-main
+  cancel-in-progress: false
+permissions:
+  contents: write
+  pull-requests: read
+jobs:
+  determine-tag:
+    # Skip release-bump commits so the bot's own push (made with the GitHub App
+    # token, which — unlike GITHUB_TOKEN — re-triggers workflows) does not loop.
+    if: >-
+      github.event_name == 'push' && !startsWith(github.event.head_commit.message, '[release]:')
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_BOT_APP_ID }}
+          private-key: ${{ secrets.RELEASE_BOT_APP_PRIVATE_KEY }}
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.14"
+      - name: Find the merged pull request
+        id: find_pr
+        env:
+          EVENT_SHA: ${{ github.sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          PR_DATA=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+            --jq "map(select(.merged_at != null and .merge_commit_sha == \"${EVENT_SHA}\")) | .[0] // {}")
+
+          PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number // empty')
+          PR_TITLE=$(echo "$PR_DATA" | jq -r '.title // empty')
+
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No merged PR associated with ${{ github.sha }}; skipping release bump."
+            echo "pr_number=" >> "$GITHUB_OUTPUT"
+            echo "pr_title=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Found merged PR #$PR_NUMBER: $PR_TITLE"
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "pr_title=$PR_TITLE" >> "$GITHUB_OUTPUT"
+      - name: Determine bump type from PR title
+        id: bump_type
+        if: steps.find_pr.outputs.pr_number != ''
+        env:
+          PR_TITLE: ${{ steps.find_pr.outputs.pr_title }}
+        run: |
+          set -euo pipefail
+
+          BUMP_TYPE=$(node <<'NODE'
+          const title = process.env.PR_TITLE ?? "";
+          const match = title.match(/^([a-z]+)(\([^)]+\))?(!)?:/);
+
+          if (!match) {
+            console.log("patch");
+          } else if (match[3]) {
+            console.log("major");
+          } else if (match[1] === "feat") {
+            console.log("minor");
+          } else {
+            console.log("patch");
+          }
+          NODE
+          )
+
+          echo "Bump type from PR title: $BUMP_TYPE"
+          echo "bump_type=$BUMP_TYPE" >> "$GITHUB_OUTPUT"
+      - name: Find changed workspace package manifests
+        id: changed_workspaces
+        if: steps.find_pr.outputs.pr_number != ''
+        env:
+          MERGE_SHA: ${{ github.sha }}
+          PR_NUMBER: ${{ steps.find_pr.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          if ! git merge-base --is-ancestor "$MERGE_SHA" origin/main; then
+            echo "::error::Merge commit $MERGE_SHA is not on origin/main"
+            exit 1
+          fi
+
+          DIFF_BASE=$(git rev-parse "${MERGE_SHA}^1")
+          CHANGED_FILES_PATH="$RUNNER_TEMP/release-tagging-${PR_NUMBER}.paths"
+          git diff --no-renames --name-only -z \
+            "$DIFF_BASE" "$MERGE_SHA" -- > "$CHANGED_FILES_PATH"
+
+          RELEASE_CHANGES=$(bun run scripts/release-changes.ts "$CHANGED_FILES_PATH")
+          FILE_COUNT=$(jq -r '.fileCount' <<< "$RELEASE_CHANGES")
+          PACKAGE_MANIFESTS=$(jq -c '.packageManifests' <<< "$RELEASE_CHANGES")
+          SCOPE=$(jq -r '.deployScope' <<< "$RELEASE_CHANGES")
+
+          echo "Changed files: $FILE_COUNT"
+          echo "Workspace manifests to bump: $PACKAGE_MANIFESTS"
+          echo "package_manifests=$PACKAGE_MANIFESTS" >> "$GITHUB_OUTPUT"
+
+          # Deploy scope drives which CD tier rolls (see deco-apps-cd
+          # bump-studio-image): apps/web-only changes roll only the web pods;
+          # apps/api-only changes roll api+worker; mixed or no app changes roll
+          # both (safe default).
+          echo "Deploy scope: $SCOPE"
+          echo "deploy_scope=$SCOPE" >> "$GITHUB_OUTPUT"
+      - name: Update package.json versions
+        id: update_versions
+        if: >-
+          steps.find_pr.outputs.pr_number != '' && steps.changed_workspaces.outputs.package_manifests != '' && steps.changed_workspaces.outputs.package_manifests != '[]'
+        env:
+          BUMP_TYPE: ${{ steps.bump_type.outputs.bump_type }}
+          PACKAGE_MANIFESTS: ${{ steps.changed_workspaces.outputs.package_manifests }}
+          PR_NUMBER: ${{ steps.find_pr.outputs.pr_number }}
+          PR_TITLE: ${{ steps.find_pr.outputs.pr_title }}
+          DEPLOY_SCOPE: ${{ steps.changed_workspaces.outputs.deploy_scope }}
+        run: |
+          set -euo pipefail
+
+          node <<'NODE'
+          const fs = require("fs");
+
+          const bumpType = process.env.BUMP_TYPE;
+          const manifests = JSON.parse(process.env.PACKAGE_MANIFESTS ?? "[]");
+
+          const nextVersion = (version) => {
+            const match = version.match(/^(\d+)\.(\d+)\.(\d+)(?:-([A-Za-z]+)\.(\d+))?$/);
+            if (!match) {
+              throw new Error(`Could not parse version: ${version}`);
+            }
+
+            const major = Number(match[1]);
+            const minor = Number(match[2]);
+            const patch = Number(match[3]);
+
+            switch (bumpType) {
+              case "major":
+                return `${major + 1}.0.0`;
+              case "minor":
+                return `${major}.${minor + 1}.0`;
+              case "patch":
+                return `${major}.${minor}.${patch + 1}`;
+              default:
+                throw new Error(`Unsupported bump type: ${bumpType}`);
+            }
+          };
+
+          const updated = manifests.map((manifest) => {
+            const pkg = JSON.parse(fs.readFileSync(manifest, "utf8"));
+            const currentVersion = pkg.version;
+            const newVersion = nextVersion(currentVersion);
+            pkg.version = newVersion;
+            fs.writeFileSync(manifest, `${JSON.stringify(pkg, null, 2)}\n`);
+            return {
+              manifest,
+              name: pkg.name ?? manifest,
+              currentVersion,
+              newVersion,
+            };
+          });
+
+          // Charts that pin an image tag in lockstep with a workspace package
+          // version. The package.json bump above publishes a new image
+          // (release-studio-sandbox.yaml tags it from package.json); without
+          // this the chart's image.tag / appVersion silently drift behind it
+          // (they had drifted 5 minors — #4870). Sync both to the new version
+          // and patch-bump the chart's own version so release-sandbox-charts
+          // republishes it. All committed in this same [release]: commit, whose
+          // App-token push re-triggers the chart publish workflow.
+          const CHART_IMAGE_LOCKSTEP = {
+            "packages/sandbox/package.json": "deploy/helm/sandbox-env",
+          };
+          const extra = [];
+          for (const { manifest, newVersion } of updated) {
+            const chartDir = CHART_IMAGE_LOCKSTEP[manifest];
+            if (!chartDir) continue;
+
+            const valuesPath = `${chartDir}/values.yaml`;
+            const values = fs.readFileSync(valuesPath, "utf8");
+            const nextValues = values.replace(
+              /(repository: ghcr\.io\/decocms\/studio\/studio-sandbox[\s\S]*?\n\s*tag: )"[^"]*"/,
+              `$1"${newVersion}"`,
+            );
+            if (nextValues === values) {
+              throw new Error(`could not find studio-sandbox image tag in ${valuesPath}`);
+            }
+            fs.writeFileSync(valuesPath, nextValues);
+
+            const chartPath = `${chartDir}/Chart.yaml`;
+            const chart = fs.readFileSync(chartPath, "utf8");
+            let chartVersion;
+            const nextChart = chart
+              .replace(/(\nappVersion: )"[^"]*"/, `$1"${newVersion}"`)
+              .replace(/\nversion: (\d+)\.(\d+)\.(\d+)/, (_m, a, b, c) => {
+                chartVersion = `${a}.${b}.${Number(c) + 1}`;
+                return `\nversion: ${chartVersion}`;
+              });
+            if (!chartVersion) {
+              throw new Error(`could not bump chart version in ${chartPath}`);
+            }
+            fs.writeFileSync(chartPath, nextChart);
+
+            extra.push({
+              name: `${chartDir} (chart ${chartVersion})`,
+              manifest: `${valuesPath} ${chartPath}`,
+              currentVersion: "image.tag/appVersion",
+              newVersion,
+            });
+          }
+
+          const summary = [...updated, ...extra]
+            .map(({ name, manifest, currentVersion, newVersion }) =>
+              `- ${name} (${manifest}): ${currentVersion} -> ${newVersion}`,
+            )
+            .join("\n");
+
+          const commitMessage = [
+            `[release]: bump changed workspace versions`,
+            "",
+            `PR: #${process.env.PR_NUMBER} ${process.env.PR_TITLE}`,
+            `Bump type: ${bumpType}`,
+            "",
+            summary,
+            "",
+            // Read by release-studio's deco-apps-cd dispatch to roll only the
+            // affected CD tier (web / server / both).
+            `Deploy-Scope: ${process.env.DEPLOY_SCOPE || "both"}`,
+          ].join("\n");
+
+          fs.writeFileSync(".release-commit-message", `${commitMessage}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `updated=true\n`);
+          fs.appendFileSync(
+            process.env.GITHUB_OUTPUT,
+            `changed_paths=${[...updated, ...extra].map(({ manifest }) => manifest).join(" ")}\n`,
+          );
+
+          console.log(summary);
+          NODE
+      - name: Commit and push version bump
+        if: steps.update_versions.outputs.updated == 'true'
+        run: |
+          set -euo pipefail
+
+          # Same identity as release-native.yaml's cask bump: both pushes
+          # already authenticate as the release bot App, so main's history
+          # shows ONE bot, not github-actions[bot] + decocms-release[bot].
+          git config user.name "decocms-release[bot]"
+          git config user.email "decocms-release[bot]@users.noreply.github.com"
+          git add ${{ steps.update_versions.outputs.changed_paths }}
+
+          if git diff --cached --quiet; then
+            echo "No version changes to commit."
+            exit 0
+          fi
+
+          git commit -F .release-commit-message
+          # main can advance between our checkout and this push (a sibling
+          # merge). Rebase our bump onto the latest main and retry instead of
+          # failing non-fast-forward — the bump only touches version manifests,
+          # so it rebases cleanly over unrelated merges. (A concurrent bump of
+          # the *same* manifest is serialized away by the `concurrency` guard
+          # above; if one still conflicts, we fail loudly rather than guess.)
+          for attempt in 1 2 3 4 5; do
+            if git push origin HEAD:main; then
+              echo "pushed version bump (attempt ${attempt})"
+              break
+            fi
+            if [ "${attempt}" = "5" ]; then
+              echo "::error::version-bump push rejected after ${attempt} attempts"
+              exit 1
+            fi
+            echo "push rejected; rebasing onto origin/main and retrying"
+            git fetch origin main
+            git rebase origin/main
+          done
+          # No [skip ci], no API dispatch: this push (made with the App token,
+          # which re-triggers workflows) is itself what kicks off release-studio
+          # and the package publish workflows for the package.json files that
+          # changed. The heavy test/multi-pod/resilience suites skip [release]:
+          # commits via guards.

--- a/.depot/workflows/resilience.yml
+++ b/.depot/workflows/resilience.yml
@@ -1,0 +1,61 @@
+# Depot CI Migration
+# Source: .github/workflows/resilience.yml
+#
+# Changes made:
+# - Rewrote .github/ path references to .depot/
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Resilience Tests
+on:
+  push:
+    branches:
+      - main
+    # Skip pushes to main that only touch the version bump, CI/workflow config,
+    # or docs — none need this heavy suite re-run.
+    paths-ignore:
+      - "apps/api/package.json"
+      - ".github/**"
+      - "apps/docs/**"
+      - "**/*.md"
+  workflow_dispatch:
+jobs:
+  resilience:
+    # Skip the [release]: version-bump commit — it only changes the version
+    # string and would otherwise re-run this heavy suite on every release.
+    if: github.event_name != 'push' || !startsWith(github.event.head_commit.message, '[release]:')
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Bun and install dependencies
+        uses: ./.depot/actions/setup-bun
+      - name: Start infrastructure
+        # `up --build --wait` pulls base images (postgres, nats, toxiproxy) from
+        # Docker Hub, which intermittently times out ("registry-1.docker.io:
+        # context deadline exceeded") and fails the whole job before any test
+        # runs. Retry the startup a few times, tearing down between attempts so
+        # each retry starts clean.
+        run: |
+          for attempt in 1 2 3; do
+            if docker compose -f tests/resilience/docker-compose.yml up -d --build --wait; then
+              echo "Infrastructure started (attempt $attempt)"
+              exit 0
+            fi
+            echo "::warning::Infrastructure startup failed (attempt $attempt); tearing down and retrying in 15s..."
+            docker compose -f tests/resilience/docker-compose.yml down -v || true
+            sleep 15
+          done
+          echo "::error::Infrastructure failed to start after 3 attempts"
+          exit 1
+      - name: Run resilience tests
+        run: bun test tests/resilience/scenarios/ --serial --timeout 900000
+      - name: Dump container logs
+        if: failure()
+        run: docker compose -f tests/resilience/docker-compose.yml logs studio
+      - name: Dump link-daemon logs
+        if: failure()
+        run: docker compose -f tests/resilience/docker-compose.yml --profile link logs link-daemon
+      - name: Tear down infrastructure
+        if: always()
+        run: docker compose -f tests/resilience/docker-compose.yml down -v

--- a/.depot/workflows/sandbox-daemon.yml
+++ b/.depot/workflows/sandbox-daemon.yml
@@ -1,0 +1,156 @@
+# Depot CI Migration
+# Source: .github/workflows/sandbox-daemon.yml
+#
+# Changes made:
+# - Rewrote .github/ path references to .depot/
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Sandbox
+# packages/sandbox/daemon-e2e/ spawns the built daemon binary and exercises real
+# HTTP/SSE endpoints — it's an integration test that runs under `bun test`
+# purely because of the language its assertions are written in.
+# Split into its own workflow so the unit-test job stays infrastructure-free
+# (no daemon build, no per-test process spawning) per TESTING.md.
+on:
+  push:
+    branches:
+      - main
+    # Skip pushes to main that only touch the version bump, CI/workflow config,
+    # or docs — none need the suite re-run (PRs already validated them, and the
+    # [release] bump is owned by release-studio).
+    paths-ignore:
+      - "apps/api/package.json"
+      - ".github/**"
+      - "apps/docs/**"
+      - "**/*.md"
+  pull_request:
+    branches:
+      - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+jobs:
+  # See test.yml for why this gate exists: skip the (required) check without
+  # leaving it stuck pending. Here the gate is scoped tighter than test.yml's:
+  # the daemon e2e suite only exercises the sandbox daemon bundle, so it runs
+  # only when the packages feeding that build change. Pushes to main always run.
+  changes:
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Detect relevant changes
+        id: filter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            # Push to main runs everything — except the [release]: version-bump
+            # commit, which only touches the version string. release-studio picks
+            # that commit up on its own push trigger and cuts the release.
+            case "$HEAD_MSG" in
+              '[release]:'*) echo "relevant=false" >> "$GITHUB_OUTPUT" ;;
+              *) echo "relevant=true" >> "$GITHUB_OUTPUT" ;;
+            esac
+            exit 0
+          fi
+          set +e
+          if ! FILES=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename'); then
+            echo "Could not list PR files — running to be safe."
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Changed files:"; echo "$FILES"
+          relevant=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              packages/sandbox/*|packages/typegen/*|packages/shared/*) relevant=true; break ;;
+            esac
+          done <<< "$FILES"
+          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+  daemon-e2e:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Bun and install dependencies
+        uses: ./.depot/actions/setup-bun
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: packages/sandbox/daemon-go/go.mod
+          cache-dependency-path: packages/sandbox/daemon-go/go.sum
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+      - name: Go vet and unit tests
+        working-directory: packages/sandbox/daemon-go
+        run: |
+          go vet ./...
+          go test -race ./...
+      - name: Build the daemon
+        run: cd packages/sandbox/daemon-go && go build -o bin/daemon .
+      - name: Run daemon e2e tests
+        # All daemon e2e specs end in `.e2e.test.ts` (core + git + proxy +
+        # dispatch); the helpers file is `.e2e.helpers.ts` and is not matched.
+        # DAEMON_E2E_CMD is what makes the suite implementation-agnostic; the
+        # default it falls back to is this same binary.
+        env:
+          DAEMON_E2E_CMD: ${{ github.workspace }}/packages/sandbox/daemon-go/bin/daemon
+        run: bun test packages/sandbox/daemon-e2e/daemon*.e2e.test.ts
+  docker-smoke:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Bun and install dependencies
+        uses: ./.depot/actions/setup-bun
+      - name: Build typegen package
+        run: bun run --cwd=packages/sandbox build
+      - name: Build the sandbox image
+        run: |
+          docker build \
+            -t studio-sandbox-go:ci \
+            -f packages/sandbox/image/Dockerfile \
+            packages/sandbox
+      # The image must boot the daemon with no env telling it which — the
+      # `impl=` boot line is the assertion, so an image that shipped the wrong
+      # binary fails here rather than in a canary panel.
+      - name: Smoke test
+        run: |
+          smoke() {
+            image="$1"; impl="$2"; port="$3"; name="sandbox-smoke-$impl"
+            docker run -d --name "$name" -p "$port:9000" \
+              -e DAEMON_TOKEN="$(printf 't%.0s' {1..32})" \
+              -e DAEMON_BOOT_ID="ci-smoke-$impl" \
+              -e APP_ROOT=/app \
+              -e PROXY_PORT=9000 \
+              -e DAEMON_NO_AUTOSTART=1 \
+              "$image"
+            for _ in $(seq 1 30); do
+              if curl -fsS "http://localhost:$port/health" \
+                   | grep -q "\"bootId\":\"ci-smoke-$impl\""; then
+                if docker logs "$name" 2>&1 | grep -q "impl=$impl"; then
+                  echo "$impl ok"
+                  return 0
+                fi
+                echo "$image answered /health but did not log impl=$impl"
+                docker logs "$name"
+                return 1
+              fi
+              sleep 1
+            done
+            echo "smoke test failed ($impl) — /health did not report ci-smoke-$impl"
+            docker logs "$name"
+            return 1
+          }
+          smoke studio-sandbox-go:ci go 19998
+      - name: Tear down
+        if: always()
+        run: docker rm -f sandbox-smoke-go || true

--- a/.depot/workflows/sandbox-daemon.yml
+++ b/.depot/workflows/sandbox-daemon.yml
@@ -26,6 +26,9 @@ on:
   pull_request:
     branches:
       - main
+  # Both triggers above skip `.github/**`-only changes, so a CI-infrastructure
+  # fix cannot validate itself. Dispatch runs the suite on demand from any branch.
+  workflow_dispatch:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -86,7 +89,9 @@ jobs:
           go-version-file: packages/sandbox/daemon-go/go.mod
           cache-dependency-path: packages/sandbox/daemon-go/go.sum
       - name: Install ripgrep
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
+        uses: ./.depot/actions/apt-mirror-fallback
+        with:
+          run: sudo apt-get update && sudo apt-get install -y ripgrep
       - name: Go vet and unit tests
         working-directory: packages/sandbox/daemon-go
         run: |

--- a/.depot/workflows/sast.yml
+++ b/.depot/workflows/sast.yml
@@ -1,0 +1,40 @@
+# Depot CI Migration
+# Source: .github/workflows/sast.yml
+#
+# Changes made:
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: SAST
+on:
+  pull_request:
+  push:
+    branches: [main]
+concurrency:
+  group: sast-${{ github.ref }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+# All third-party actions are pinned to a full commit SHA, not a tag.
+jobs:
+  gitleaks:
+    name: Gitleaks (secret history)
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      # On pull_request the action calls GET /repos/{o}/{r}/pulls/{n}/commits
+      # to scan only the PR range. Without this it 403s with
+      # "Resource not accessible by integration".
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0 # full history so rotated-but-committed secrets are caught
+      # gitleaks-action requires a license key for ORGANIZATION-owned repos.
+      # Free for personal accounts and public repos, where the var is unused.
+      # Get a key at https://gitleaks.io and add it as a repo/org secret
+      # named GITLEAKS_LICENSE (Settings > Secrets and variables > Actions).
+      - uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/.depot/workflows/storage-integration.yml
+++ b/.depot/workflows/storage-integration.yml
@@ -1,0 +1,133 @@
+# Depot CI Migration
+# Source: .github/workflows/storage-integration.yml
+#
+# Changes made:
+# - Rewrote .github/ path references to .depot/
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Storage Integration
+# Storage-layer tests that previously used PGlite (WASM-emulated Postgres)
+# now run against a real `postgres:16` service so the SQL surface, query
+# planner, RETURNING/ON CONFLICT semantics, advisory locks, LISTEN/NOTIFY,
+# and extension behavior all match production. PGlite produced false
+# confidence — passing locally, sometimes failing in prod.
+#
+# Lives outside the unit-test workflow because real Postgres is
+# infrastructure per TESTING.md. No HTTP, no auth, no Playwright — just
+# the storage adapters being exercised against a real DB.
+on:
+  push:
+    branches:
+      - main
+    # Skip pushes to main that only touch the version bump, CI/workflow config,
+    # or docs — none need the suite re-run (PRs already validated them, and the
+    # [release] bump is owned by release-studio).
+    paths-ignore:
+      - "apps/api/package.json"
+      - ".github/**"
+      - "apps/docs/**"
+      - "**/*.md"
+  pull_request:
+    branches:
+      - main
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+jobs:
+  # See test.yml for why this gate exists: skip the (required) check without
+  # leaving it stuck pending. Scoped tighter than test.yml's gate: every
+  # *.integration.test.ts lives under apps/api and imports only apps/api +
+  # packages code, so web/plugins/scripts-only PRs skip the suite entirely.
+  # Pushes to main always run.
+  changes:
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - name: Detect relevant changes
+        id: filter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            # Push to main runs everything — except the [release]: version-bump
+            # commit, which only touches the version string. release-studio picks
+            # that commit up on its own push trigger and cuts the release.
+            case "$HEAD_MSG" in
+              '[release]:'*) echo "relevant=false" >> "$GITHUB_OUTPUT" ;;
+              *) echo "relevant=true" >> "$GITHUB_OUTPUT" ;;
+            esac
+            exit 0
+          fi
+          set +e
+          if ! FILES=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename'); then
+            echo "Could not list PR files — running to be safe."
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Changed files:"; echo "$FILES"
+          relevant=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              *.md) ;;
+              apps/api/*|packages/*) relevant=true; break ;;
+            esac
+          done <<< "$FILES"
+          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+  storage-integration:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    services:
+      postgres:
+        image: public.ecr.aws/docker/library/postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres" --health-interval 5s --health-timeout 5s --health-retries 10
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+      # MinIO, started below — backs the s3-service integration test.
+      S3_ENDPOINT: http://localhost:9000
+      S3_ACCESS_KEY_ID: minioadmin
+      S3_SECRET_ACCESS_KEY: minioadmin
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Bun and install dependencies
+        uses: ./.depot/actions/setup-bun
+      - name: Run migrations
+        run: bun run --cwd=apps/api migrate
+      # Backs the s3-service integration test. The test creates its own bucket
+      # in beforeAll, so this only needs the server up. Shared composite action
+      # so the pinned image version stays in sync with e2e.yml.
+      - name: Start MinIO
+        uses: ./.depot/actions/start-minio
+      # Convention: every `*.integration.test.ts` file is picked up here.
+      # Adding a new integration test = create a `something.integration.test.ts`
+      # and it auto-routes to this workflow. See TESTING.md.
+      #
+      # One bun process per file: cleanest isolation between heavy-DB
+      # files. The previous signal-tolerance branch (exit > 128 +
+      # (pass) marker → accept) is gone because the Bun teardown crash
+      # it caught was DuckDB's N-API finalizer — neutralized in code by
+      # the `monitoringEngines` stub in the context-factory test. CI
+      # confirmed no other test trips a teardown crash. If a real one
+      # ever shows up, it should fail loudly so we diagnose it instead
+      # of silently swallowing it.
+      - name: Run storage integration tests
+        run: |
+          set -e
+          while IFS= read -r f; do
+            echo "::group::$f"
+            bun test "$f"
+            echo "::endgroup::"
+          done < <(find apps/api packages -name '*.integration.test.ts' -not -path '*/node_modules/*' | sort)

--- a/.depot/workflows/test.yml
+++ b/.depot/workflows/test.yml
@@ -21,6 +21,9 @@ on:
   pull_request:
     branches:
       - main
+  # Both triggers above skip `.github/**`-only changes, so a CI-infrastructure
+  # fix cannot validate itself. Dispatch runs the suite on demand from any branch.
+  workflow_dispatch:
 # A force-push to a PR obsoletes the in-flight run — cancel it instead of
 # letting 6 jobs run to completion. Pushes to main all run (no cancel) so
 # every merged commit keeps its own result.
@@ -180,30 +183,55 @@ jobs:
     needs: changes
     if: needs.changes.outputs.web == 'true'
     runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
-    timeout-minutes: 15
+    # Headroom for the worst case of the mirror fallback below: 5 min for the
+    # browser download plus 3 mirrors x 2 min for the system deps.
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Setup Bun and install dependencies
         uses: ./.depot/actions/setup-bun
+      # Key on the RESOLVED Playwright version, not a hash of the manifest: the
+      # manifest carries a caret range, so its hash does not change when the
+      # lockfile resolves a new version — and the cache would then serve
+      # browsers built for a different Playwright than the tests run against.
+      - name: Resolve Playwright version
+        id: playwright-version
+        working-directory: apps/web
+        run: |
+          version=$(node -p "require('@playwright/test/package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Cache Playwright browsers
         id: cache-playwright
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-ct-${{ runner.os }}-${{ hashFiles('apps/web/package.json') }}
-          # On a key rotation (playwright version bump) the fallback restores
-          # the previous browsers and `playwright install` downloads only the
+          key: playwright-ct-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+          # On a key rotation (a Playwright bump) the fallback restores the
+          # previous browsers and `playwright install` downloads only the
           # missing version instead of everything.
           restore-keys: |
             playwright-ct-${{ runner.os }}-
+      # Browser binary only (Playwright's own CDN, no apt involved) — kept
+      # separate from the system deps below so an Ubuntu mirror outage can
+      # never block the download that actually has to succeed. Invoked via
+      # ./node_modules/.bin/playwright, never `npx playwright`: npx ignores the
+      # lockfile and resolves from the registry, so a cache miss would install
+      # browsers for the LATEST release while the tests run against the pinned
+      # one — a mismatch a warm cache hides.
       - name: Install Playwright chromium
         if: steps.cache-playwright.outputs.cache-hit != 'true'
         working-directory: apps/web
-        run: npx playwright install chromium --with-deps
+        timeout-minutes: 5
+        run: ./node_modules/.bin/playwright install chromium
+      # Everything chromium links against is already in the runner image — the
+      # only thing this step downloads is ~21 MB of font packages. So a total
+      # mirror outage costs us glyph coverage, not a red build; if a library
+      # ever really is missing, chromium fails to launch and the suite says so.
       - name: Install Playwright chromium system deps
-        if: steps.cache-playwright.outputs.cache-hit == 'true'
-        working-directory: apps/web
-        run: npx playwright install-deps chromium
+        uses: ./.depot/actions/apt-mirror-fallback
+        continue-on-error: true
+        with:
+          run: cd apps/web && ./node_modules/.bin/playwright install-deps chromium
       - name: Run component tests
         run: bun run --cwd=apps/web test:ct

--- a/.depot/workflows/test.yml
+++ b/.depot/workflows/test.yml
@@ -1,0 +1,209 @@
+# Depot CI Migration
+# Source: .github/workflows/test.yml
+#
+# Changes made:
+# - Rewrote .github/ path references to .depot/
+# - Changed GitHub runs-on labels to their Depot equivalents
+
+name: Checks & Unit Tests
+on:
+  push:
+    branches:
+      - main
+    # Skip pushes to main that only touch the version bump, CI/workflow config,
+    # or docs — none need the suite re-run (PRs already validated them, and the
+    # [release] bump is owned by release-studio).
+    paths-ignore:
+      - "apps/api/package.json"
+      - ".github/**"
+      - "apps/docs/**"
+      - "**/*.md"
+  pull_request:
+    branches:
+      - main
+# A force-push to a PR obsoletes the in-flight run — cancel it instead of
+# letting 6 jobs run to completion. Pushes to main all run (no cancel) so
+# every merged commit keeps its own result.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+jobs:
+  # Gate: skip the (required) check jobs when a PR only touches workflow YAML,
+  # docs, or markdown. Required checks can't be skipped via workflow-level
+  # `paths` filters — a never-scheduled required check blocks the merge forever.
+  # A job skipped via `if`, by contrast, reports as passed. So we keep the
+  # trigger broad and skip at the job level. Pushes to main always run.
+  changes:
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    outputs:
+      relevant: ${{ steps.filter.outputs.relevant }}
+      web: ${{ steps.filter.outputs.web }}
+    steps:
+      - name: Detect relevant changes
+        id: filter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            # Push to main runs everything — except the [release]: version-bump
+            # commit, which only touches the version string. release-studio picks
+            # that commit up on its own push trigger and cuts the release.
+            case "$HEAD_MSG" in
+              '[release]:'*)
+                echo "relevant=false" >> "$GITHUB_OUTPUT"
+                echo "web=false" >> "$GITHUB_OUTPUT"
+                ;;
+              *)
+                echo "relevant=true" >> "$GITHUB_OUTPUT"
+                echo "web=true" >> "$GITHUB_OUTPUT"
+                ;;
+            esac
+            exit 0
+          fi
+          set +e
+          if ! FILES=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename'); then
+            echo "Could not list PR files — running to be safe."
+            echo "relevant=true" >> "$GITHUB_OUTPUT"
+            echo "web=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "Changed files:"; echo "$FILES"
+          # relevant: run unless every changed file is workflow/docs/markdown.
+          # web: gate for web-component-tests (browser tests only when web
+          # code can be affected).
+          relevant=false
+          web=false
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              .github/*|apps/docs/*|deploy/*|*.md) ;;
+              *) relevant=true ;;
+            esac
+            case "$f" in
+              apps/web/*|packages/ui/*) web=true ;;
+            esac
+          done <<< "$FILES"
+          echo "relevant=$relevant" >> "$GITHUB_OUTPUT"
+          echo "web=$web" >> "$GITHUB_OUTPUT"
+  format:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Bun and install dependencies
+        uses: ./.depot/actions/setup-bun
+      - name: Run format check
+        run: bun run fmt:check
+  lint:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Bun and install dependencies
+        uses: ./.depot/actions/setup-bun
+      - name: Run lint
+        run: bun run lint
+      # knip only reads source (knip.jsonc references no dist/ paths), so it
+      # lives here instead of serializing after the builds in the build job.
+      - name: Run knip
+        run: bun run knip
+  typecheck:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Setup Bun and install dependencies
+        uses: ./.depot/actions/setup-bun
+      - name: Run typecheck
+        run: bun run check:ci
+  test:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    # The suite normally finishes in ~1 min. A single hung file under the
+    # parallel runner stalls the whole job silently (per-file output is
+    # buffered, so the culprit prints nothing) — without this bound that's
+    # GitHub's 6h default; it already cost one 50-minute zombie job.
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Bun and install dependencies
+        uses: ./.depot/actions/setup-bun
+      - name: Run tests
+        # The root command discovers the same filename-based unit tier and runs
+        # each file in an isolated Bun process. Integration, daemon E2E, and
+        # Playwright suites remain owned by their dedicated workflows.
+        run: bun run test
+  build:
+    needs: changes
+    if: needs.changes.outputs.relevant == 'true'
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Bun and install dependencies
+        uses: ./.depot/actions/setup-bun
+      - name: Build server bundle
+        run: bun run --cwd=apps/api build:server
+      - name: Verify bundle outputs
+        run: |
+          test -f apps/api/dist/server/server.js
+          test -f apps/api/dist/server/migrate.js
+          test -f apps/api/dist/server/cli.js
+      # `build:web` rather than `build` so VITE_TAURI_APP=0 is stated, not
+      # inherited from the variable happening to be unset — the desktop-free
+      # assertion below is only meaningful against a known browser build.
+      - name: Build web app
+        run: bun run --cwd=apps/web build:web
+      - name: Verify web output
+        run: test -f apps/web/dist/index.html
+      - name: Assert no Tauri desktop code in the browser bundle
+        run: bun run check:web-bundle
+  # Playwright component tests for the sections-editor field widgets
+  # (apps/web/ct). Self-contained — real chromium, no server/DB — so it lives
+  # here rather than e2e.yml, gated to web changes only.
+  web-component-tests:
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
+    runs-on: depot-ubuntu-latest # was: ubuntu-latest. Mapped standard GitHub runner to Depot equivalent.
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Bun and install dependencies
+        uses: ./.depot/actions/setup-bun
+      - name: Cache Playwright browsers
+        id: cache-playwright
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-ct-${{ runner.os }}-${{ hashFiles('apps/web/package.json') }}
+          # On a key rotation (playwright version bump) the fallback restores
+          # the previous browsers and `playwright install` downloads only the
+          # missing version instead of everything.
+          restore-keys: |
+            playwright-ct-${{ runner.os }}-
+      - name: Install Playwright chromium
+        if: steps.cache-playwright.outputs.cache-hit != 'true'
+        working-directory: apps/web
+        run: npx playwright install chromium --with-deps
+      - name: Install Playwright chromium system deps
+        if: steps.cache-playwright.outputs.cache-hit == 'true'
+        working-directory: apps/web
+        run: npx playwright install-deps chromium
+      - name: Run component tests
+        run: bun run --cwd=apps/web test:ct

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -162,26 +162,41 @@ jobs:
             console.log("created bucket", process.env.S3_BUCKET);
           '
 
+      # Key on the RESOLVED Playwright version, not a hash of the manifest: the
+      # manifest carries a caret range, so its hash does not change when the
+      # lockfile resolves a new version — and the cache would then serve
+      # browsers built for a different Playwright than the tests run against.
+      - name: Resolve Playwright version
+        id: playwright-version
+        working-directory: packages/e2e
+        run: |
+          version=$(node -p "require('@playwright/test/package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Cache Playwright browsers
         id: cache-playwright
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('packages/e2e/package.json') }}
-          # On a key rotation (any packages/e2e dep bump) the fallback restores
-          # the previous browsers and `playwright install` downloads only the
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+          # On a key rotation (a Playwright bump) the fallback restores the
+          # previous browsers and `playwright install` downloads only the
           # missing version instead of a full cold install.
           restore-keys: |
             playwright-${{ runner.os }}-
 
       # Browser binary only (Playwright's own CDN, no apt involved) — kept
       # separate from the system deps below so an Ubuntu mirror outage can
-      # never block the download that actually has to succeed.
+      # never block the download that actually has to succeed. Invoked via
+      # ./node_modules/.bin/playwright, never `npx playwright`: npx ignores the
+      # lockfile and resolves from the registry, so a cache miss would install
+      # browsers for the LATEST release while the tests run against the pinned
+      # one — a mismatch a warm cache hides.
       - name: Install Playwright chromium
         if: steps.cache-playwright.outputs.cache-hit != 'true'
         working-directory: packages/e2e
         timeout-minutes: 5
-        run: npx playwright install chromium
+        run: ./node_modules/.bin/playwright install chromium
 
       # Everything chromium links against is already in the runner image — the
       # only thing this step downloads is ~21 MB of font packages. So a total
@@ -191,7 +206,7 @@ jobs:
         uses: ./.github/actions/apt-mirror-fallback
         continue-on-error: true
         with:
-          run: cd packages/e2e && npx playwright install-deps chromium
+          run: cd packages/e2e && ./node_modules/.bin/playwright install-deps chromium
 
       - name: Create data directory
         run: mkdir -p data

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,26 +211,41 @@ jobs:
       - name: Setup Bun and install dependencies
         uses: ./.github/actions/setup-bun
 
+      # Key on the RESOLVED Playwright version, not a hash of the manifest: the
+      # manifest carries a caret range, so its hash does not change when the
+      # lockfile resolves a new version — and the cache would then serve
+      # browsers built for a different Playwright than the tests run against.
+      - name: Resolve Playwright version
+        id: playwright-version
+        working-directory: apps/web
+        run: |
+          version=$(node -p "require('@playwright/test/package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Cache Playwright browsers
         id: cache-playwright
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-ct-${{ runner.os }}-${{ hashFiles('apps/web/package.json') }}
-          # On a key rotation (playwright version bump) the fallback restores
-          # the previous browsers and `playwright install` downloads only the
+          key: playwright-ct-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+          # On a key rotation (a Playwright bump) the fallback restores the
+          # previous browsers and `playwright install` downloads only the
           # missing version instead of everything.
           restore-keys: |
             playwright-ct-${{ runner.os }}-
 
       # Browser binary only (Playwright's own CDN, no apt involved) — kept
       # separate from the system deps below so an Ubuntu mirror outage can
-      # never block the download that actually has to succeed.
+      # never block the download that actually has to succeed. Invoked via
+      # ./node_modules/.bin/playwright, never `npx playwright`: npx ignores the
+      # lockfile and resolves from the registry, so a cache miss would install
+      # browsers for the LATEST release while the tests run against the pinned
+      # one — a mismatch a warm cache hides.
       - name: Install Playwright chromium
         if: steps.cache-playwright.outputs.cache-hit != 'true'
         working-directory: apps/web
         timeout-minutes: 5
-        run: npx playwright install chromium
+        run: ./node_modules/.bin/playwright install chromium
 
       # Everything chromium links against is already in the runner image — the
       # only thing this step downloads is ~21 MB of font packages. So a total
@@ -240,7 +255,7 @@ jobs:
         uses: ./.github/actions/apt-mirror-fallback
         continue-on-error: true
         with:
-          run: cd apps/web && npx playwright install-deps chromium
+          run: cd apps/web && ./node_modules/.bin/playwright install-deps chromium
 
       - name: Run component tests
         run: bun run --cwd=apps/web test:ct


### PR DESCRIPTION
Adds `.depot/` generated by `depot ci migrate workflows`, which copies `.github/workflows/` into `.depot/workflows/` with Depot-compatibility fixes applied. The `.github/` originals are untouched and keep running on GitHub Actions, so this PR changes nothing about current CI.

## What the migrator did

95 changes across 32 workflows: 60 `runs-on` remaps to `depot-ubuntu-latest`, 25 local-action path rewrites to vendored `.depot/actions/` copies, 7 rewrites of self-referencing path filters, and 3 whitespace-only changes inside folded `if:` expressions.

Verified by parsing both YAML trees and diffing the resolved structures rather than reading the text diff. That mattered: the tool rewrites files via YAML round-trip and in 6 files flattened multi-line `run:` blocks into single escaped strings. The parsed values are identical, so there is no behavior change, but those files are noticeably harder to read. `on:` survived intact and comments were preserved. Both vendored composite actions are byte-identical to their `.github/actions/` originals.

Validation on the committed tree: 30 files, 56 jobs, 312 steps, 0 parse errors, 0 dangling `needs:`, every `./`-relative action resolves.

## Two manual corrections on top of the generated output

**Dropped `native.yml` and `release-native.yaml`.** The migrator remapped their five `macos-latest` jobs to `depot-ubuntu-latest`, flagging it only in a trailing comment. Those jobs build, codesign, and notarize the macOS app, so they cannot pass on Linux. Both workflows stay on GitHub Actions only. Nothing else referenced them except comments.

**Remapped matrix-supplied runners** in `release-studio.yaml` and `preview-build.yaml`. The migrator only rewrites literal `runs-on:` values, so the `ubuntu-latest` and `ubuntu-24.04-arm` entries feeding `runs-on: ${{ matrix.runner }}` in the native multi-arch Docker builds were left as GitHub labels. Remapped to `depot-ubuntu-latest` / `depot-ubuntu-24.04-arm`.

## Not done yet

- **Secrets are not imported.** The 17 secrets and 2 variables these workflows reference are not in Depot CI, so anything needing one fails until they are added. 6 of the 17 are Apple signing material used only by the two dropped workflows.
- **`.depot/` is a second source of truth.** Nothing keeps it in sync with `.github/`. `helm-test.yml` shows the shape of this: its drift check now parses `.depot/workflows/preview-build.yaml`, so on Depot CI it validates the Depot copy while GitHub Actions validates the GitHub copy.
- **`paths-ignore` still lists `.github/**`, not `.depot/**`** in `test.yml`, `e2e.yml`, `resilience.yml`, `multi-pod.yml`, `storage-integration.yml`, `sandbox-daemon.yml`, so editing a Depot workflow triggers the full suite on Depot CI.

Per Depot's docs these workflows only activate once merged to main, so no timing comparison is possible from this PR alone.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Depot CI workflows that mirror `.github/workflows/` so CI can run on Depot without changing GitHub Actions, and fixes Playwright installs to use the pinned local binary with a cache keyed to the resolved `@playwright/test` version. Old: CI ran only on GitHub Actions and used `npx playwright install` with a manifest-hash cache; New: Depot-compatible copies under `.depot/` plus `./node_modules/.bin/playwright install` and cache by resolved version. Side effects: `.depot/` is a second source of truth; Depot jobs run only after merge to `main`.

- Mirrored 32 workflows into `.depot/workflows/`: remapped `runs-on` to `depot-ubuntu-*`, rewrote local action paths to `.depot/actions/`, adjusted self-referencing path filters; kept macOS workflows (`native.yml`, `release-native.yaml`) on GitHub Actions; remapped matrix-provided runners in `release-studio.yaml` and `preview-build.yaml`; vendored shared actions (`setup-bun`, `start-minio`, `apt-mirror-fallback`). YAML was reserialized only.
- Stabilized Playwright in `.github/workflows/e2e.yml` and `.github/workflows/test.yml`; regenerated `.depot/` from the fixed sources to match. Cache now keys to the resolved Playwright version; installs call `./node_modules/.bin/playwright`.

- Required to enable green Depot runs: import 17 secrets and 2 variables into Depot; decide how to keep `.depot/` in sync with `.github/`; optionally add `.depot/**` to `paths-ignore` where we already ignore `.github/**`.

<sup>Written for commit 04c5bd79e0ff17377a305ac5dace128033d45f17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6244?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

