### PR TITLE
feat(sidebar): show agent avatar in first-class nav coding agents

### DIFF
--- a/apps/web/src/components/sidebar/nav-destinations.tsx
+++ b/apps/web/src/components/sidebar/nav-destinations.tsx
@@ -16,13 +16,7 @@
 
 import type { ReactNode } from "react";
 import { useNavigate, useSearch } from "@tanstack/react-router";
-import {
-  BarChartSquare02,
-  Columns03,
-  Folder,
-  Globe01,
-  Home02,
-} from "@untitledui/icons";
+import { BarChartSquare02, Columns03, Folder, Home02 } from "@untitledui/icons";
 import {
   SidebarMenu,
   SidebarMenuButton,
@@ -35,6 +29,7 @@ import {
   useProjectContext,
   useVirtualMCPs,
 } from "@/sdk";
+import { AgentAvatar } from "@/components/agent-icon";
 import { agentHasClonableSource } from "@/lib/agent-capabilities";
 import { getActiveGithubRepo } from "@/lib/github-repo";
 import { useThreads } from "@/components/chat/store/hooks";
@@ -199,7 +194,14 @@ function useCodingAgents({
       return {
         key: agent.id,
         label: repo?.name || agent.title,
-        icon: <Globe01 size={16} />,
+        icon: (
+          <AgentAvatar
+            icon={agent.icon}
+            name={agent.title}
+            size="2xs"
+            className="shrink-0"
+          />
+        ),
         isActive: search.virtualmcpid === agent.id,
         onSelect: () => {
           track("nav_destination_clicked", { destination: "coding_agent" });


### PR DESCRIPTION
## Summary
In the first-class navigation, coding-agent rows showed a generic globe icon. They now render the agent's own **avatar** via `AgentAvatar` — the same component used in the agents section — so each row shows the agent's real icon (e.g. the faststore-fila "F" logo), with the deterministic color + icon fallback when an agent has no custom icon.

## Changes
- `apps/web/src/components/sidebar/nav-destinations.tsx`:
  - Removed the static `Globe01` icon on coding-agent rows.
  - Import `AgentAvatar` from `@/components/agent-icon`.
  - Render `<AgentAvatar icon={agent.icon} name={agent.title} size="2xs" />` per coding-agent destination.

## Testing
- `bun run fmt` passes.
- Visual: coding-agent rows in the sidebar first-class nav now match the avatar shown on the agent detail header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the agent’s avatar in the first-class sidebar navigation for coding agents, replacing the generic globe icon. This improves visual identification and matches the avatar used in the agents section; agents without a custom icon use the deterministic color + fallback icon.

- Update `apps/web/src/components/sidebar/nav-destinations.tsx`: replace `Globe01` with `<AgentAvatar icon={agent.icon} name={agent.title} size="2xs" className="shrink-0" />`; import from `@/components/agent-icon`; remove the `Globe01` import from `@untitledui/icons`.
- No changes to selection, routing, or analytics.
- Verify avatars render for coding agents in the sidebar and match the agent header avatar.

<sup>Written for commit 5b4920363dadb86917089546f1b1600c0578febc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

