### PR TITLE
fix(sections-editor): narrow to a loader whose extensions[] item is labelled by __resolveType

### DIFF
--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -579,6 +579,47 @@ describe("resolveActiveFieldKey", () => {
     ).toBeNull();
   });
 
+  test("narrows to a loader whose extensions[] item is labelled by __resolveType", () => {
+    // ALS /flashsale: the extensions[] item's "DetailsPage" label comes from __resolveType (no name/label/title/alt), so ownership must see it.
+    const properties = {
+      page: {
+        title: "Page",
+        type: "block-ref",
+        anyOfRefs: [
+          {
+            resolveType: "commerce/loaders/product/extensions/detailsPage.ts",
+            title: "Details Page",
+          },
+        ],
+      },
+      defaultSkuFilter: { title: "Default SKU Filter", type: "string" },
+      showColorVariantOutOfStock: {
+        title: "Show Color Variant Out of Stock",
+        type: "boolean",
+      },
+    } satisfies Record<string, SchemaProperty>;
+    const objValue = {
+      page: {
+        __resolveType: "commerce/loaders/product/extensions/detailsPage.ts",
+        data: { __resolveType: "vtex/loaders/legacy/productDetailsPage.ts" },
+        extensions: [
+          {
+            __resolveType: "vtex/loaders/product/extensions/detailsPage.ts",
+            simulate: true,
+            similars: true,
+          },
+        ],
+      },
+      defaultSkuFilter: "only-on-sale",
+      showColorVariantOutOfStock: false,
+    };
+    expect(
+      resolveActiveFieldKey(Object.keys(properties), properties, objValue, [
+        { label: "DetailsPage", itemIndex: 0 },
+      ]),
+    ).toBe("page");
+  });
+
   test("does not spuriously match primitive arrays or href/id fallbacks", () => {
     const properties = {
       loader: {

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -1,6 +1,7 @@
 import { getArrayItemDisplayLabels } from "./array-item-display";
 import { isPageMultivariateSectionArrayField } from "./page-variants";
 import type { SchemaProperty } from "./resolve-schema";
+import { labelFromResolveType } from "./section-types";
 import { unwrapBlockReference } from "./unwrap-section";
 
 /**
@@ -363,6 +364,11 @@ function itemOwnershipLabel(item: unknown): string | undefined {
     const value = obj[key];
     if (typeof value === "string" && value.trim()) return value;
   }
+  // Loader/section-ref items (e.g. `extensions: ExtensionOf[]`) label by `__resolveType` (see `baseArrayItemLabel`) — match that so ownership can find them.
+  const resolveType = obj.__resolveType;
+  if (typeof resolveType === "string" && resolveType) {
+    return labelFromResolveType(resolveType);
+  }
   return undefined;
 }
 
@@ -378,7 +384,7 @@ function itemOwnershipLabel(item: unknown): string | undefined {
  * narrowing to the item.
  *
  * Deliberately conservative — matches only object items via
- * {@link OWNERSHIP_LABEL_KEYS} (no item schema is available here). Items labeled
+ * {@link OWNERSHIP_LABEL_KEYS} or their `__resolveType` label (no item schema here). Items labeled
  * via a custom `titleBy`, via `text`/`href`/`id`, or primitive-array items are
  * NOT detected; those degrade to the pre-fix behavior (all siblings shown)
  * rather than risk narrowing to the wrong loader. Bounded by depth and a shared


### PR DESCRIPTION
## Summary

Drilling into a loader's `extensions: ExtensionOf[]` array item in the Content editor opened the item but kept **every sibling section prop rendering below it** (Default SKU Filter, Show Color Variant Out of Stock, …), instead of showing a focused drill-in view. Reproduced on ALS `/flashsale`.

### Root cause

The section has a `page` block-ref loader (`commerce/loaders/product/extensions/detailsPage.ts`) that holds the `extensions` array internally. Each item is a loader ref:

```json
{ "__resolveType": "vtex/loaders/product/extensions/detailsPage.ts", "simulate": true, "similars": true }
```

The item carries no `name`/`label`/`title`/`alt` — its displayed label **"DetailsPage"** comes from `labelFromResolveType(__resolveType)`. When drilling in, the trail is a bare `[{label:"DetailsPage", itemIndex:0}]`.

At the **section scope**, `resolveActiveFieldKey` tries to narrow to `page` by asking whether that loader's value owns the crumb, via `valueOwnsItemCrumb` → `itemOwnershipLabel`. But `itemOwnershipLabel` only recognized the naming keys (`name`/`label`/`title`/`alt`) — never `__resolveType`. So the item was invisible to ownership, the section never narrowed to `page`, `visibleKeys = keys`, and all sibling props leaked below the drilled item.

(`ArrayField` always opened the correct item because it addresses items by the crumb's `itemIndex` — hence the "opens but doesn't narrow" asymmetry.)

### Fix

`itemOwnershipLabel` now falls back to `labelFromResolveType(__resolveType)` when no naming key is present — the same source `baseArrayItemLabel` already uses to *display* these items. Ownership now matches the label the user actually clicks. If labels diverge it degrades to the pre-fix "show all siblings" behavior, never narrows to the wrong field.

## Testing

- New regression test in `schema-form-breadcrumb.test.ts` using the exact `/flashsale` shape — fails (`null`) before, passes (`"page"`) after.
- `83/83` breadcrumb tests, `661/661` sections-editor tests.
- `bun run fmt`, `tsc --noEmit` (web), and `bun run lint` (0 errors) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes drill-in for a loader’s `extensions[]` item in the Sections editor. Previously opening the item kept sibling section fields visible; now it narrows to the owning `page` loader when the item’s label comes from `__resolveType` (e.g., "DetailsPage").

- Core change: in `schema-form-breadcrumb.ts`, `itemOwnershipLabel` falls back to `labelFromResolveType(__resolveType)` when no `name`/`label`/`title`/`alt` exist, aligning ownership with what `baseArrayItemLabel` displays.
- Scope and safety: applies only to object items with `__resolveType`; if labels diverge or items use other fallbacks, it degrades to pre-fix behavior (no narrowing) to avoid false matches. Primitive arrays and `href`/`id` fallbacks are unchanged.
- Tests: adds a regression test in `schema-form-breadcrumb.test.ts` reproducing ALS `/flashsale`; all existing breadcrumb and sections-editor tests pass.

<sup>Written for commit f7e7156b9084ff5bfacae1ea3ce83f651321bd90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

