### PR TITLE
feat(assets): native per-site Assets tab behind native_assets_tab flag

### DIFF
--- a/apps/api/src/file-storage/file-config-s3.ts
+++ b/apps/api/src/file-storage/file-config-s3.ts
@@ -7,7 +7,11 @@
  * across requests.
  */
 
-import { ListObjectsV2Command, S3Client } from "@aws-sdk/client-s3";
+import {
+  DeleteObjectCommand,
+  ListObjectsV2Command,
+  S3Client,
+} from "@aws-sdk/client-s3";
 import type {
   FileConfigCredentials,
   OrgFileConfigStorage,
@@ -218,6 +222,24 @@ export async function resolveFileConfig(
     }
   }
   return ctx;
+}
+
+/**
+ * Delete a single object from a configured bucket. The `key` is the raw S3
+ * key (not URL-encoded) as returned by {@link listObjects}. Deleting a
+ * non-existent key is a no-op on S3 (returns 204), so this is idempotent.
+ */
+export async function deleteObject(params: {
+  ctx: FileConfigContext;
+  key: string;
+}): Promise<void> {
+  const client = buildS3Client(params.ctx);
+  await client.send(
+    new DeleteObjectCommand({
+      Bucket: params.ctx.info.bucket,
+      Key: params.key,
+    }),
+  );
 }
 
 export interface ListedObject {

--- a/apps/api/src/tools/file-configs/delete-object.ts
+++ b/apps/api/src/tools/file-configs/delete-object.ts
@@ -1,0 +1,40 @@
+import z from "zod";
+import { defineTool } from "../../core/define-tool";
+import { requireAuth, requireOrganization } from "../../core/studio-context";
+import {
+  deleteObject,
+  resolveFileConfig,
+} from "../../file-storage/file-config-s3";
+
+export const FILE_OBJECT_DELETE = defineTool({
+  name: "FILE_OBJECT_DELETE",
+  description:
+    "Delete a single object from a configured S3 bucket by its key. Used by the Assets browser to remove uploaded files. Idempotent: deleting a missing key succeeds.",
+  annotations: {
+    idempotentHint: true,
+    destructiveHint: true,
+  },
+  inputSchema: z.object({
+    configId: z.string().min(1),
+    key: z.string().min(1),
+  }),
+  outputSchema: z.object({
+    success: z.literal(true),
+  }),
+  handler: async (input, ctx) => {
+    requireAuth(ctx);
+    const org = requireOrganization(ctx);
+    await ctx.access.check();
+
+    // resolveFileConfig enforces managed-config ownership (the single choke point).
+    const fileCfg = await resolveFileConfig(
+      ctx.storage.orgFileConfigs,
+      ctx.storage.orgSites,
+      input.configId,
+      org.id,
+    );
+
+    await deleteObject({ ctx: fileCfg, key: input.key });
+    return { success: true as const };
+  },
+});

--- a/apps/api/src/tools/file-configs/index.ts
+++ b/apps/api/src/tools/file-configs/index.ts
@@ -3,3 +3,4 @@ export { FILE_CONFIG_LIST } from "./list";
 export { FILE_CONFIG_UPDATE } from "./update";
 export { FILE_CONFIG_DELETE } from "./delete";
 export { FILE_OBJECTS_LIST } from "./list-objects";
+export { FILE_OBJECT_DELETE } from "./delete-object";

--- a/apps/api/src/tools/index.ts
+++ b/apps/api/src/tools/index.ts
@@ -199,6 +199,7 @@ export const CORE_TOOLS = [
   FileConfigTools.FILE_CONFIG_UPDATE,
   FileConfigTools.FILE_CONFIG_DELETE,
   FileConfigTools.FILE_OBJECTS_LIST,
+  FileConfigTools.FILE_OBJECT_DELETE,
 
   // Org filesystem (shared public skill sets)
   ORG_FS_PUBLIC_SETS_SYNC,

--- a/apps/web/src/components/file-picker/asset-utils.test.ts
+++ b/apps/web/src/components/file-picker/asset-utils.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import { basename, extensionTag, formatSize, isImageKey } from "./asset-utils";
+
+describe("isImageKey", () => {
+  it("matches common image extensions case-insensitively", () => {
+    for (const key of [
+      "a.png",
+      "b.JPG",
+      "c.jpeg",
+      "d.gif",
+      "e.webp",
+      "f.svg",
+      "g.avif",
+      "h.bmp",
+      "nested/path/i.PNG",
+    ]) {
+      expect(isImageKey(key)).toBe(true);
+    }
+  });
+
+  it("rejects non-image and extensionless keys", () => {
+    for (const key of ["a.pdf", "b.mp4", "c.txt", "noext", "trailingdot."]) {
+      expect(isImageKey(key)).toBe(false);
+    }
+  });
+});
+
+describe("extensionTag", () => {
+  it("returns the lowercased extension", () => {
+    expect(extensionTag("photo.PNG")).toBe("png");
+    expect(extensionTag("dir/archive.tar.gz")).toBe("gz");
+  });
+
+  it('falls back to "file" without a usable extension', () => {
+    expect(extensionTag("README")).toBe("file");
+    expect(extensionTag("trailingdot.")).toBe("file");
+  });
+});
+
+describe("basename", () => {
+  it("returns the last path segment", () => {
+    expect(basename("2026/01/uuid-name.png")).toBe("uuid-name.png");
+    expect(basename("flat.png")).toBe("flat.png");
+  });
+});
+
+describe("formatSize", () => {
+  it("formats bytes, KB, and MB", () => {
+    expect(formatSize(512)).toBe("512 B");
+    expect(formatSize(2048)).toBe("2.0 KB");
+    expect(formatSize(5 * 1024 * 1024)).toBe("5.0 MB");
+  });
+});

--- a/apps/web/src/components/file-picker/asset-utils.ts
+++ b/apps/web/src/components/file-picker/asset-utils.ts
@@ -1,0 +1,25 @@
+/**
+ * Small pure helpers shared by the file-picker dialog and the Assets browser
+ * for rendering object keys (extension tags, basenames, human sizes).
+ */
+
+export function isImageKey(key: string): boolean {
+  return /\.(png|jpe?g|gif|webp|svg|avif|bmp)$/i.test(key);
+}
+
+export function extensionTag(key: string): string {
+  const dot = key.lastIndexOf(".");
+  if (dot < 0 || dot === key.length - 1) return "file";
+  return key.slice(dot + 1).toLowerCase();
+}
+
+export function basename(key: string): string {
+  const parts = key.split("/");
+  return parts[parts.length - 1] ?? key;
+}
+
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/apps/web/src/components/file-picker/file-picker-dialog.tsx
+++ b/apps/web/src/components/file-picker/file-picker-dialog.tsx
@@ -43,6 +43,7 @@ import {
   useFilePickerObjects,
   useFilePickerUpload,
 } from "@/hooks/use-file-picker";
+import { basename, extensionTag, formatSize, isImageKey } from "./asset-utils";
 
 export type FilePickerMode = "image" | "any";
 
@@ -432,16 +433,6 @@ function NoSearchResults({ query }: { query: string }) {
   );
 }
 
-function isImageKey(key: string): boolean {
-  return /\.(png|jpe?g|gif|webp|svg|avif|bmp)$/i.test(key);
-}
-
-function extensionTag(key: string): string {
-  const dot = key.lastIndexOf(".");
-  if (dot < 0 || dot === key.length - 1) return "file";
-  return key.slice(dot + 1).toLowerCase();
-}
-
 function ImageGrid({
   items,
   onSelect,
@@ -616,15 +607,4 @@ function AssetCardMenu({
       </DropdownMenuContent>
     </DropdownMenu>
   );
-}
-
-function basename(key: string): string {
-  const parts = key.split("/");
-  return parts[parts.length - 1] ?? key;
-}
-
-function formatSize(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }

--- a/apps/web/src/hooks/use-file-picker.ts
+++ b/apps/web/src/hooks/use-file-picker.ts
@@ -9,7 +9,11 @@
  */
 
 import { useProjectContext } from "@/sdk";
-import { useInfiniteQuery, useMutation } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { useStudioTools } from "@/lib/studio-tools";
 import { KEYS } from "../lib/query-keys";
 
@@ -118,6 +122,28 @@ export function useFilePickerUpload() {
       }
 
       return (await response.json()) as UploadResult;
+    },
+  });
+}
+
+/**
+ * Delete an object from a configured bucket via the FILE_OBJECT_DELETE tool,
+ * then invalidate every listing variant (search / imageOnly) for that config
+ * so the grid drops the removed file. Used by the Assets browser only — the
+ * selection-oriented picker dialog stays read-only.
+ */
+export function useFilePickerDelete() {
+  const { org } = useProjectContext();
+  const studio = useStudioTools();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input: { configId: string; key: string }) =>
+      studio.call("FILE_OBJECT_DELETE", input),
+    onSuccess: (_result, input) => {
+      queryClient.invalidateQueries({
+        queryKey: KEYS.filePickerObjectsByConfig(org.id, input.configId),
+      });
     },
   });
 }

--- a/apps/web/src/i18n/en/assets.ts
+++ b/apps/web/src/i18n/en/assets.ts
@@ -1,0 +1,15 @@
+export const assets = {
+  "assets.browser.title": "Assets",
+  "assets.browser.bucketLabel": "Bucket: {name}",
+  "assets.browser.noBucketTitle": "No assets bucket for this site",
+  "assets.browser.noBucketDescription":
+    "Configure and associate an S3-compatible bucket with this site to browse and upload assets here.",
+  "assets.browser.deleteAction": "Delete",
+  "assets.browser.deleteConfirmTitle": "Delete file?",
+  "assets.browser.deleteConfirmDescription":
+    'Permanently delete "{name}" from the bucket? This cannot be undone.',
+  "assets.browser.deleteCancel": "Cancel",
+  "assets.browser.deleteConfirm": "Delete",
+  "assets.browser.deleted": "File deleted",
+  "assets.browser.deleteFailed": "Failed to delete file",
+} as const;

--- a/apps/web/src/i18n/en/common.ts
+++ b/apps/web/src/i18n/en/common.ts
@@ -287,6 +287,7 @@ export const common = {
   "common.mainPanelTabs.preview": "Preview",
   "common.mainPanelTabs.code": "Code",
   "common.mainPanelTabs.content": "Content",
+  "common.mainPanelTabs.assets": "Assets",
   "common.mainPanelTabs.reviewChanges": "Review changes",
   "common.mainPanelTabs.automations": "Automations",
   "common.mainPanelTabs.settings": "Settings",

--- a/apps/web/src/i18n/en/index.ts
+++ b/apps/web/src/i18n/en/index.ts
@@ -35,6 +35,7 @@ import { admin } from "./admin.ts";
 import { sandbox } from "./sandbox.ts";
 import { settings } from "./settings.ts";
 import { announcements } from "./announcements.ts";
+import { assets } from "./assets.ts";
 
 // English is the source of truth: every domain file is spread here and
 // TranslationKey is derived from the result. pt-BR mirrors this structure
@@ -77,6 +78,7 @@ export const en = {
   ...sandbox,
   ...settings,
   ...announcements,
+  ...assets,
 } as const;
 
 export type TranslationKey = keyof typeof en;

--- a/apps/web/src/i18n/pt-br/assets.ts
+++ b/apps/web/src/i18n/pt-br/assets.ts
@@ -1,0 +1,17 @@
+import type { assets as enAssets } from "../en/assets.ts";
+
+export const assets = {
+  "assets.browser.title": "Assets",
+  "assets.browser.bucketLabel": "Bucket: {name}",
+  "assets.browser.noBucketTitle": "Nenhum bucket de assets para este site",
+  "assets.browser.noBucketDescription":
+    "Configure e associe um bucket compatível com S3 a este site para navegar e enviar assets aqui.",
+  "assets.browser.deleteAction": "Excluir",
+  "assets.browser.deleteConfirmTitle": "Excluir arquivo?",
+  "assets.browser.deleteConfirmDescription":
+    'Excluir permanentemente "{name}" do bucket? Isso não pode ser desfeito.',
+  "assets.browser.deleteCancel": "Cancelar",
+  "assets.browser.deleteConfirm": "Excluir",
+  "assets.browser.deleted": "Arquivo excluído",
+  "assets.browser.deleteFailed": "Falha ao excluir o arquivo",
+} satisfies Record<keyof typeof enAssets, string>;

--- a/apps/web/src/i18n/pt-br/common.ts
+++ b/apps/web/src/i18n/pt-br/common.ts
@@ -297,6 +297,7 @@ export const common = {
   "common.mainPanelTabs.preview": "Visualização",
   "common.mainPanelTabs.code": "Código",
   "common.mainPanelTabs.content": "Conteúdo",
+  "common.mainPanelTabs.assets": "Assets",
   "common.mainPanelTabs.reviewChanges": "Revisar alterações",
   "common.mainPanelTabs.automations": "Automações",
   "common.mainPanelTabs.settings": "Configurações",

--- a/apps/web/src/i18n/pt-br/index.ts
+++ b/apps/web/src/i18n/pt-br/index.ts
@@ -35,6 +35,7 @@ import { admin } from "./admin.ts";
 import { sandbox } from "./sandbox.ts";
 import { settings } from "./settings.ts";
 import { announcements } from "./announcements.ts";
+import { assets } from "./assets.ts";
 import type { TranslationKey } from "../en/index.ts";
 
 export const ptBR = {
@@ -75,4 +76,5 @@ export const ptBR = {
   ...sandbox,
   ...settings,
   ...announcements,
+  ...assets,
 } satisfies Record<TranslationKey, string>;

--- a/apps/web/src/layouts/main-panel-tabs/assets-tab.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/assets-tab.tsx
@@ -1,0 +1,465 @@
+/**
+ * Assets tab — a native, per-site browser over the S3 bucket associated with
+ * this site's `metadata.siteSlug` (matched via `matchSiteSlugConfig`). Replaces
+ * the deco.cx admin-MCP `fetch_assets` iframe view: it lists, uploads, and
+ * deletes objects directly against the configured bucket using the same
+ * FILE_* tools the CMS file picker uses. The tab only appears when a bucket is
+ * associated to the site (see use-main-panel-tabs), so a missing config here is
+ * a rare race — handled with an empty state rather than an error.
+ */
+
+import { useRef, useState } from "react";
+import {
+  Check,
+  Copy01,
+  DotsVertical,
+  File02,
+  Image01,
+  LinkExternal01,
+  Loading01,
+  Package,
+  Trash01,
+  Upload01,
+} from "@untitledui/icons";
+import { toast } from "sonner";
+import { Button, buttonVariants } from "@decocms/ui/components/button.tsx";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@decocms/ui/components/alert-dialog.tsx";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@decocms/ui/components/dropdown-menu.tsx";
+import { SearchInput } from "@decocms/ui/components/search-input.tsx";
+import { cn } from "@decocms/ui/lib/utils.ts";
+import { useVirtualMCP } from "@/sdk";
+import { useT } from "@/i18n/use-t.ts";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import { type FileConfigInfo, useFileConfigs } from "@/hooks/use-file-configs";
+import {
+  type PickerObject,
+  useFilePickerDelete,
+  useFilePickerObjects,
+  useFilePickerUpload,
+} from "@/hooks/use-file-picker";
+import { matchSiteSlugConfig } from "@/components/file-picker/match-site-slug-config";
+import {
+  basename,
+  extensionTag,
+  formatSize,
+  isImageKey,
+} from "@/components/file-picker/asset-utils";
+
+export function AssetsTab({ virtualMcpId }: { virtualMcpId: string }) {
+  const entity = useVirtualMCP(virtualMcpId);
+  const configs = useFileConfigs();
+  const siteSlug =
+    (entity?.metadata as { siteSlug?: string | null } | undefined)?.siteSlug ??
+    null;
+  const config = matchSiteSlugConfig(configs, siteSlug);
+
+  if (!config) {
+    return <NoBucketState />;
+  }
+
+  return <AssetsBrowser config={config} />;
+}
+
+function NoBucketState() {
+  const t = useT();
+  return (
+    <div className="flex h-full min-h-0 flex-col items-center justify-center gap-3 p-10 text-center">
+      <div className="flex size-12 items-center justify-center rounded-full bg-muted">
+        <Package size={20} className="text-muted-foreground" />
+      </div>
+      <div>
+        <p className="text-sm font-medium">
+          {t("assets.browser.noBucketTitle")}
+        </p>
+        <p className="mt-1 max-w-sm text-xs text-muted-foreground">
+          {t("assets.browser.noBucketDescription")}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function AssetsBrowser({ config }: { config: FileConfigInfo }) {
+  const t = useT();
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, 300);
+  const objectsQuery = useFilePickerObjects({
+    configId: config.id,
+    search: debouncedSearch,
+  });
+  const upload = useFilePickerUpload();
+  const [isDragging, setIsDragging] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<PickerObject | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  async function handleFiles(files: FileList | File[] | null) {
+    if (!files) return;
+    const list = Array.from(files);
+    if (list.length === 0) return;
+
+    // Upload each file independently so one failure doesn't discard the rest.
+    const failures: string[] = [];
+    for (const f of list) {
+      try {
+        await upload.mutateAsync({ configId: config.id, file: f });
+      } catch (err) {
+        failures.push(
+          `${f.name} (${err instanceof Error ? err.message : "upload failed"})`,
+        );
+      }
+    }
+    await objectsQuery.refetch();
+    if (failures.length > 0) {
+      toast.error(
+        failures.length === list.length
+          ? t("filePicker.filePickerDialog.uploadFailedAll", {
+              errors: failures.join("; "),
+            })
+          : t("filePicker.filePickerDialog.uploadFailedSome", {
+              errors: failures.join("; "),
+            }),
+      );
+    }
+  }
+
+  function onDragOver(e: React.DragEvent) {
+    e.preventDefault();
+    setIsDragging(true);
+  }
+  function onDragLeave() {
+    setIsDragging(false);
+  }
+  function onDrop(e: React.DragEvent) {
+    e.preventDefault();
+    // Don't let the drop bubble to the chat composer's window-level listener.
+    e.stopPropagation();
+    setIsDragging(false);
+    handleFiles(e.dataTransfer.files);
+  }
+
+  const pages = objectsQuery.data?.pages ?? [];
+  const items = pages.flatMap((p) => p.items);
+  const activeSearch = debouncedSearch.trim();
+  const isSearching =
+    search !== debouncedSearch ||
+    (objectsQuery.isFetching && !objectsQuery.isFetchingNextPage);
+
+  return (
+    <div className="flex h-full min-h-0 flex-col gap-3 p-4">
+      <div className="flex shrink-0 items-center justify-between gap-3">
+        <div className="min-w-0">
+          <h2 className="text-sm font-semibold">{t("assets.browser.title")}</h2>
+          <p className="truncate text-xs text-muted-foreground">
+            {t("assets.browser.bucketLabel", { name: config.name })}
+          </p>
+        </div>
+        <Button
+          type="button"
+          size="sm"
+          disabled={upload.isPending}
+          onClick={() => fileInputRef.current?.click()}
+        >
+          {upload.isPending ? (
+            <Loading01 size={14} className="animate-spin" />
+          ) : (
+            <Upload01 size={14} />
+          )}
+          {upload.isPending
+            ? t("filePicker.filePickerDialog.uploading")
+            : t("filePicker.filePickerDialog.dropFilesOrClick")}
+        </Button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          className="hidden"
+          onChange={(e) => {
+            // Copy refs out before reset: e.target.files is live and clears.
+            const files = Array.from(e.target.files ?? []);
+            e.target.value = "";
+            handleFiles(files);
+          }}
+        />
+      </div>
+
+      <SearchInput
+        value={search}
+        onChange={setSearch}
+        isSearching={isSearching}
+        placeholder={t("filePicker.filePickerDialog.searchFilesPlaceholder")}
+        className="shrink-0"
+      />
+
+      <button
+        type="button"
+        onClick={() => fileInputRef.current?.click()}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
+        className={cn(
+          "flex shrink-0 flex-col items-center justify-center gap-1 rounded-xl border border-dashed border-border/60 p-4 text-center transition-colors",
+          isDragging && "border-primary bg-primary/5",
+          upload.isPending && "pointer-events-none opacity-60",
+        )}
+      >
+        <Upload01 size={16} className="text-muted-foreground" />
+        <p className="text-xs text-muted-foreground">
+          {t("filePicker.filePickerDialog.dropFilesOrClick")}{" "}
+          {t("filePicker.filePickerDialog.uploadSizeLimit")}
+        </p>
+      </button>
+
+      <div className="min-h-0 flex-1 overflow-y-auto pr-1">
+        {items.length === 0 ? (
+          activeSearch ? (
+            <EmptyNote
+              title={t("filePicker.filePickerDialog.noMatches", {
+                query: activeSearch,
+              })}
+              description={t(
+                "filePicker.filePickerDialog.tryDifferentSearchOrLoadMore",
+              )}
+            />
+          ) : (
+            <EmptyNote
+              title={t("filePicker.filePickerDialog.noFilesYet")}
+              description={t(
+                "filePicker.filePickerDialog.dropFileToGetStarted",
+              )}
+            />
+          )
+        ) : (
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
+            {items.map((item) => (
+              <AssetCard
+                key={item.key}
+                item={item}
+                onDelete={() => setPendingDelete(item)}
+              />
+            ))}
+          </div>
+        )}
+
+        {objectsQuery.hasNextPage && (
+          <div className="flex justify-center py-4">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              disabled={objectsQuery.isFetchingNextPage}
+              onClick={() => objectsQuery.fetchNextPage()}
+            >
+              {objectsQuery.isFetchingNextPage ? (
+                <>
+                  <Loading01 size={14} className="animate-spin" />
+                  {t("filePicker.filePickerDialog.loading")}
+                </>
+              ) : (
+                t("filePicker.filePickerDialog.loadMore")
+              )}
+            </Button>
+          </div>
+        )}
+      </div>
+
+      <DeleteAssetDialog
+        configId={config.id}
+        item={pendingDelete}
+        onClose={() => setPendingDelete(null)}
+      />
+    </div>
+  );
+}
+
+function EmptyNote({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex h-full min-h-40 flex-col items-center justify-center gap-2 py-8 text-center">
+      <div className="flex size-10 items-center justify-center rounded-full bg-muted">
+        <Image01 size={18} className="text-muted-foreground" />
+      </div>
+      <p className="text-sm font-medium">{title}</p>
+      <p className="text-xs text-muted-foreground">{description}</p>
+    </div>
+  );
+}
+
+function AssetCard({
+  item,
+  onDelete,
+}: {
+  item: PickerObject;
+  onDelete: () => void;
+}) {
+  const ext = extensionTag(item.key);
+  const isImage = isImageKey(item.key);
+  return (
+    <div className="group relative flex flex-col overflow-hidden rounded-lg border border-border/60 bg-muted">
+      <a
+        href={item.publicUrl}
+        target="_blank"
+        rel="noreferrer"
+        title={item.key}
+        className="flex aspect-square items-center justify-center transition hover:ring-2 hover:ring-primary"
+      >
+        {isImage ? (
+          <img
+            src={item.publicUrl}
+            alt={item.key}
+            loading="lazy"
+            className="h-full w-full object-cover"
+            onError={(e) => {
+              (e.target as HTMLImageElement).style.display = "none";
+            }}
+          />
+        ) : (
+          <File02 size={28} className="text-muted-foreground" />
+        )}
+      </a>
+      <div className="flex items-center gap-1 border-t border-border/60 bg-background px-2 py-1.5">
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-xs font-medium" title={item.key}>
+            {basename(item.key)}
+          </p>
+          <p className="text-[10px] uppercase text-muted-foreground">
+            {ext} · {formatSize(item.size)}
+          </p>
+        </div>
+        <AssetCardMenu item={item} onDelete={onDelete} />
+      </div>
+    </div>
+  );
+}
+
+function AssetCardMenu({
+  item,
+  onDelete,
+}: {
+  item: PickerObject;
+  onDelete: () => void;
+}) {
+  const t = useT();
+  const [copied, setCopied] = useState(false);
+
+  async function copyUrl() {
+    try {
+      await navigator.clipboard.writeText(item.publicUrl);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      toast.error(t("filePicker.filePickerDialog.failedToCopyUrl"));
+    }
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-7 shrink-0 rounded-md"
+          aria-label={t("filePicker.filePickerDialog.assetActions")}
+        >
+          <DotsVertical size={14} />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={copyUrl}>
+          {copied ? <Check size={14} /> : <Copy01 size={14} />}
+          {copied
+            ? t("filePicker.filePickerDialog.copied")
+            : t("filePicker.filePickerDialog.copyUrl")}
+        </DropdownMenuItem>
+        <DropdownMenuItem asChild>
+          <a href={item.publicUrl} target="_blank" rel="noreferrer">
+            <LinkExternal01 size={14} />
+            {t("filePicker.filePickerDialog.openInNewTab")}
+          </a>
+        </DropdownMenuItem>
+        <DropdownMenuItem variant="destructive" onClick={onDelete}>
+          <Trash01 size={14} />
+          {t("assets.browser.deleteAction")}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+function DeleteAssetDialog({
+  configId,
+  item,
+  onClose,
+}: {
+  configId: string;
+  item: PickerObject | null;
+  onClose: () => void;
+}) {
+  const t = useT();
+  const del = useFilePickerDelete();
+
+  async function confirmDelete() {
+    if (!item) return;
+    try {
+      await del.mutateAsync({ configId, key: item.key });
+      toast.success(t("assets.browser.deleted"));
+      onClose();
+    } catch {
+      toast.error(t("assets.browser.deleteFailed"));
+    }
+  }
+
+  return (
+    <AlertDialog open={!!item} onOpenChange={(open) => !open && onClose()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            {t("assets.browser.deleteConfirmTitle")}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {t("assets.browser.deleteConfirmDescription", {
+              name: item ? basename(item.key) : "",
+            })}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={del.isPending}>
+            {t("assets.browser.deleteCancel")}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            className={cn(buttonVariants({ variant: "destructive" }))}
+            disabled={del.isPending}
+            onClick={(e) => {
+              e.preventDefault();
+              confirmDelete();
+            }}
+          >
+            {del.isPending ? (
+              <Loading01 size={14} className="animate-spin" />
+            ) : null}
+            {t("assets.browser.deleteConfirm")}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/web/src/layouts/main-panel-tabs/index.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/index.tsx
@@ -17,6 +17,7 @@ import { GitTab } from "@/components/thread/github/git-tab";
 import { PreviewTab } from "./preview-tab";
 import { CodeTab } from "./code-tab";
 import { ContentTab } from "./content-tab";
+import { AssetsTab } from "./assets-tab";
 import { AutomationTab } from "./automation-tab";
 import { AutomationsListTab } from "./automations-list-tab";
 import { FileTab } from "./file-tab";
@@ -103,6 +104,9 @@ function TabBody({
   }
   if (activeTab === "content") {
     return <ContentTab virtualMcpId={virtualMcpId} />;
+  }
+  if (activeTab === "assets") {
+    return <AssetsTab virtualMcpId={virtualMcpId} />;
   }
   if (activeTab === "files") {
     return <LibraryTab />;

--- a/apps/web/src/layouts/main-panel-tabs/resolve-tab-icon.ts
+++ b/apps/web/src/layouts/main-panel-tabs/resolve-tab-icon.ts
@@ -8,6 +8,7 @@ import {
   Home02,
   LayoutAlt04,
   Lightning01,
+  Package,
 } from "@untitledui/icons";
 import { getIconComponent, parseIconString } from "../../components/agent-icon";
 
@@ -27,6 +28,7 @@ export type SystemTabId =
   | "preview"
   | "code"
   | "content"
+  | "assets"
   | "git"
   | "files";
 
@@ -37,6 +39,7 @@ export const SYSTEM_TAB_ICONS: Record<SystemTabId, IconComponent> = {
   preview: Globe01,
   code: Code02,
   content: File02,
+  assets: Package,
   git: GitBranch01,
   files: Folder,
 };

--- a/apps/web/src/layouts/main-panel-tabs/tab-id.ts
+++ b/apps/web/src/layouts/main-panel-tabs/tab-id.ts
@@ -177,6 +177,7 @@ export const FIXED_SYSTEM_TABS = [
   "preview",
   "code",
   "content",
+  "assets",
   "git",
 ] as const;
 

--- a/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -66,7 +66,13 @@ import {
   shouldDeepLinkSourceTab,
 } from "./source-system-tabs";
 import { useCapability } from "@/hooks/use-capability";
-import { useNavV2, useReportsOnly } from "@/hooks/use-organization-settings";
+import { useFileConfigsQuery } from "@/hooks/use-file-configs";
+import { matchSiteSlugConfig } from "@/components/file-picker/match-site-slug-config";
+import {
+  useNavV2,
+  useOrgFlag,
+  useReportsOnly,
+} from "@/hooks/use-organization-settings";
 import { useT } from "@/i18n/use-t.ts";
 
 export type AgentTabDef = {
@@ -286,6 +292,21 @@ export function useMainPanelTabs(ctx: {
   });
   const showContentTab = hasEditableDecoContent(decofile, meta);
 
+  /**
+   * Assets is a per-site tab behind the `native_assets_tab` org flag: it shows
+   * only when the flag is on AND an S3 bucket is associated to this site's slug
+   * (managed `deco-assets-<slug>` or a BYOB bucket). Uses the non-suspense
+   * configs query so the bar never blocks on the bucket list.
+   */
+  const nativeAssetsTabEnabled = useOrgFlag("native_assets_tab");
+  const siteSlug =
+    (entity?.metadata as { siteSlug?: string | null } | undefined)?.siteSlug ??
+    null;
+  const fileConfigsQuery = useFileConfigsQuery();
+  const showAssetsTab =
+    nativeAssetsTabEnabled &&
+    !!matchSiteSlugConfig(fileConfigsQuery.data?.configs ?? [], siteSlug);
+
   const { activeTab: rawActiveTab, mainOpen: rawMainOpen } =
     resolveActiveTabAndOpen({
       mainParam: search.main,
@@ -374,6 +395,12 @@ export function useMainPanelTabs(ctx: {
     systemTabs.push({
       id: "content",
       title: t("common.mainPanelTabs.content"),
+    });
+  }
+  if (showAssetsTab) {
+    systemTabs.push({
+      id: "assets",
+      title: t("common.mainPanelTabs.assets"),
     });
   }
   if (gitTabVisible) {

--- a/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -334,7 +334,9 @@ export function useMainPanelTabs(ctx: {
       ? resolveDefaultTabId(layoutForDefault)
       : rawActiveTab === "content" && !showContentTab
         ? resolveDefaultTabId(layoutForDefault)
-        : rawActiveTab;
+        : rawActiveTab === "assets" && !showAssetsTab
+          ? resolveDefaultTabId(layoutForDefault)
+          : rawActiveTab;
   const mainOpen =
     rawActiveTab === "git" && !gitTabVisible && !prQuery.isPending
       ? false

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -530,6 +530,10 @@ export const KEYS = {
       search ?? "",
       imageOnly ?? false,
     ] as const,
+  /** Prefix of every filePickerObjects variant for one config — used to
+   *  invalidate all search/imageOnly listings after an upload or delete. */
+  filePickerObjectsByConfig: (orgId: string, configId: string) =>
+    ["file-picker-objects", orgId, configId] as const,
 
   // AI provider credits balance (scoped by org + keyId)
   aiProviderCredits: (orgId: string, keyId: string) =>

--- a/packages/shared/src/organization/schema.ts
+++ b/packages/shared/src/organization/schema.ts
@@ -173,6 +173,12 @@ export const OrgFlagsSchema = z.object({
     .describe(
       "When a report import creates a task board item without an assignee, delegate it to the Super Agent automatically instead of leaving it unassigned.",
     ),
+  native_assets_tab: z
+    .boolean()
+    .optional()
+    .describe(
+      "Show the native Assets tab (a browser over the site's associated S3 bucket) instead of relying on the external admin-MCP fetch_assets view. Off by default while in development.",
+    ),
 });
 
 export type OrgFlags = z.infer<typeof OrgFlagsSchema>;

--- a/packages/shared/src/tools/registry-metadata.ts
+++ b/packages/shared/src/tools/registry-metadata.ts
@@ -174,6 +174,7 @@ const ALL_TOOL_NAMES = [
   "FILE_CONFIG_UPDATE",
   "FILE_CONFIG_DELETE",
   "FILE_OBJECTS_LIST",
+  "FILE_OBJECT_DELETE",
 
   // Org filesystem (shared public skill sets)
   "ORG_FS_PUBLIC_SETS_SYNC",
@@ -883,6 +884,11 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
     description: "List existing objects in a configured bucket",
     category: "File Configs",
   },
+  {
+    name: "FILE_OBJECT_DELETE",
+    description: "Delete an object from a configured bucket",
+    category: "File Configs",
+  },
 
   // Object Storage tools
   {
@@ -1442,6 +1448,7 @@ const PERMISSION_CAPABILITIES: PermissionCapability[] = [
       "FILE_CONFIG_UPDATE",
       "FILE_CONFIG_DELETE",
       "FILE_OBJECTS_LIST",
+      "FILE_OBJECT_DELETE",
       "ORG_REPO_SYNC_CREATE",
       "ORG_REPO_SYNC_LIST",
       "ORG_REPO_SYNC_UPDATE",

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -127,6 +127,7 @@ export interface StudioToolIO {
             auto_merge?: boolean | undefined;
             cheap_reviewer_model?: boolean | undefined;
             auto_assign_report_tasks_to_super_agent?: boolean | undefined;
+            native_assets_tab?: boolean | undefined;
           }
         | null
         | undefined;
@@ -195,6 +196,7 @@ export interface StudioToolIO {
             auto_merge?: boolean | undefined;
             cheap_reviewer_model?: boolean | undefined;
             auto_assign_report_tasks_to_super_agent?: boolean | undefined;
+            native_assets_tab?: boolean | undefined;
           }
         | undefined;
       main_agent_id?: string | null | undefined;
@@ -263,6 +265,7 @@ export interface StudioToolIO {
             auto_merge?: boolean | undefined;
             cheap_reviewer_model?: boolean | undefined;
             auto_assign_report_tasks_to_super_agent?: boolean | undefined;
+            native_assets_tab?: boolean | undefined;
           }
         | null
         | undefined;
@@ -4761,6 +4764,10 @@ export interface StudioToolIO {
       }[];
       nextCursor: string | null;
     };
+  };
+  FILE_OBJECT_DELETE: {
+    input: { configId: string; key: string };
+    output: { success: true };
   };
   ORG_FS_PUBLIC_SETS_SYNC: {
     input: { [x: string]: never };


### PR DESCRIPTION
## Summary

Adds a **native Assets tab** — a browser over the S3 bucket associated with a site's `metadata.siteSlug` — to replace the external deco.cx admin-MCP `fetch_assets` iframe view. It lists, uploads, and deletes objects directly using the same `FILE_*` tools the CMS file picker already relies on.

The tab is **per-site** (shows only when a bucket is associated to the site via `matchSiteSlugConfig`) and **behind a default-off org flag** (`native_assets_tab`) so it can be enabled per-org for testing before the admin-MCP view is retired. When the flag is off, nothing changes; when on, a site with a bucket gets the native tab alongside the existing one until `fetch_assets` is removed from the MCP.

## Changes

**API**
- `FILE_OBJECT_DELETE` tool + `deleteObject` S3 helper — ownership enforced through the single `resolveFileConfig` choke point (managed-config ownership gate). Registered in the tool registry and `registry-metadata.ts` under `file-configs:manage` (destructive, so not in the member read-only group).

**Web**
- `AssetsTab`: grid with image thumbnails / file icons, drag-drop + button upload, debounced search, pagination, and per-item copy URL / open / **delete** (with an `AlertDialog` confirm). Empty state when no bucket is associated.
- `useFilePickerDelete` hook (invalidates all listing variants for the config via a new `KEYS.filePickerObjectsByConfig`).
- Extracted shared `asset-utils` (`isImageKey`/`extensionTag`/`basename`/`formatSize`) reused by the picker dialog and the new browser.
- Per-site system tab wired in `use-main-panel-tabs` (gated on flag + bucket match), dispatch in `main-panel-tabs/index.tsx`, `Package` icon, `assets` added to `FIXED_SYSTEM_TABS`. Mobile + desktop bars pick it up automatically.

**Shared / config**
- `native_assets_tab` added to `OrgFlagsSchema` (default off). Tool contracts regenerated.
- i18n en + pt-br (`common.mainPanelTabs.assets` + `assets` domain).

## Enabling for testing

Per-org flag (shallow-merged, doesn't touch other flags):

```
ORGANIZATION_SETTINGS_UPDATE { flags: { native_assets_tab: true } }
```

Then open a site that has a bucket (e.g. als-storefront).

## Testing notes
- `tsc --noEmit` passes (shared / web / api); `oxlint` clean on touched files; `bun run fmt` applied.
- Unit tests: extracted `asset-utils` helpers; existing registry-sync and `file-config-s3` unit tests pass.
- **Follow-ups**: e2e for delete needs a real S3 backend (only pure helpers unit-tested here); optionally hide the delete action for users without `file-configs:manage` (currently a 403 toast); the admin-MCP `fetch_assets` pinned view is removed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native, per-site Assets tab that lists, uploads, and deletes files in a site’s S3 bucket. When the `native_assets_tab` org flag is on and a bucket is associated, the new tab appears alongside the existing admin‑MCP view; when off, nothing changes. Fix: a `?main=assets` deep link could render the tab without the flag or bucket; the render path is now gated and falls back to the default tab.

- API: Adds `deleteObject` (S3 `DeleteObjectCommand`) and the `FILE_OBJECT_DELETE` tool. Access is enforced via `resolveFileConfig` and registered under the destructive `file-configs:manage` set. Deletes are idempotent.
- Web/UI: New `AssetsTab` (grid with thumbnails/icons, drag‑drop or button upload, debounced search, pagination, copy URL/open/delete with confirm). Adds `useFilePickerDelete` and invalidates `KEYS.filePickerObjectsByConfig` on success. Extracts shared `asset-utils`. Tab visibility and render path are gated on `native_assets_tab` and `matchSiteSlugConfig` (bar never blocks on the bucket list). en/pt‑BR i18n. Known limitation: delete is visible to all; unauthorized users see a 403 toast.
- Review focus: tool registration and permission gate; render fallback when assets tab isn’t visible; query invalidation after delete; large `assets-tab.tsx` behaviors.

- Rollout: Enable per org via `ORGANIZATION_SETTINGS_UPDATE { flags: { native_assets_tab: true } }`. No migrations. Follow‑up: retire the admin‑MCP `fetch_assets` view after bake‑in.

<sup>Written for commit 1022bf088a86165063ce6ca685ac932637be756a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6251?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

