### PR TITLE
fix(task-board): stop a task run from archiving its own in-review card

### DIFF
--- a/apps/api/src/tools/task-board/update.test.ts
+++ b/apps/api/src/tools/task-board/update.test.ts
@@ -147,11 +147,15 @@ describe("closesOwnReview", () => {
     expect(closesOwnReview("done", "in_review", true)).toBe(true);
   });
 
+  it("catches a run archiving a task under review — archiving skips review just like completing", () => {
+    expect(closesOwnReview("archived", "in_review", true)).toBe(true);
+  });
+
   it("allows a run to complete a task that needed no code change", () => {
     expect(closesOwnReview("done", "in_progress", true)).toBe(false);
   });
 
-  it("allows a run to move a task under review anywhere but Done", () => {
+  it("allows a run to move a task under review anywhere but Done/Archived", () => {
     expect(closesOwnReview("in_progress", "in_review", true)).toBe(false);
     expect(closesOwnReview(undefined, "in_review", true)).toBe(false);
   });

--- a/apps/api/src/tools/task-board/update.ts
+++ b/apps/api/src/tools/task-board/update.ts
@@ -106,6 +106,14 @@ export function delegatesToSuperAgent(
     : previous.status === "todo";
 }
 
+/** Forward-only terminal lanes (see the activity comment above): once a card
+ *  lands here it's out of the review loop, same as "done" — `archived` skips
+ *  review just as effectively as completing it does. */
+const REVIEW_CLOSING_STATUSES = new Set<TaskBoardItemStatus>([
+  "done",
+  "archived",
+]);
+
 /** `task-run-context` withholds REVIEW_DECISION and PROMOTE_TO_PRODUCTION for this
  *  invariant; this tool sets `status` freely, so it needs the same guard. */
 export function closesOwnReview(
@@ -113,7 +121,8 @@ export function closesOwnReview(
   previousStatus: TaskBoardItemStatus | undefined,
   isTaskRun: boolean,
 ): boolean {
-  const completesTask = inputStatus === "done";
+  const completesTask =
+    inputStatus !== undefined && REVIEW_CLOSING_STATUSES.has(inputStatus);
   const awaitingReview = previousStatus === "in_review";
   return isTaskRun && completesTask && awaitingReview;
 }
@@ -210,9 +219,10 @@ export const TASK_BOARD_ITEM_UPDATE = defineTool({
     const isTaskRun = taskRunContextStore.getStore() !== undefined;
     if (closesOwnReview(input.status, previous?.status, isTaskRun)) {
       throw new Error(
-        "This task is In Review — a run can't move it to Done. Leave it in " +
-          "in_review for the reviewer; only a person, or TASK_BOARD_REVIEW_DECISION " +
-          "on a reviewer's own run, completes a task under review.",
+        "This task is In Review — a run can't move it to Done or Archived. " +
+          "Leave it in in_review for the reviewer; only a person, or " +
+          "TASK_BOARD_REVIEW_DECISION on a reviewer's own run, closes out a " +
+          "task under review.",
       );
     }
 


### PR DESCRIPTION
Follows #6231's `closesOwnReview()` guard, which stops an agent run from setting `status: done` on its own In Review card (the same invariant `task-run-context.ts` enforces by withholding `TASK_BOARD_REVIEW_DECISION`/`TASK_BOARD_PROMOTE_TO_PRODUCTION` from a task run's MCP toolset — a run must not approve or merge its own work).

`TASK_BOARD_ITEM_UPDATE` is exposed to a task run (`TASK_RUN_TOOL_NAMES`) and sets `status` freely, but `closesOwnReview()` only checked `inputStatus === "done"`. `archived` is just as much a review bypass: it's a forward-only terminal lane (see the comment above `LOGGED_FIELDS` — activity/status never un-does Done or Archived), reached in practice only via the automatic merged-PR sweep (`archive-merged.ts`) or a human — never through the board UI's drag lanes (`archived` is in `HIDDEN_STATUSES`). A task run calling `TASK_BOARD_ITEM_UPDATE({ status: "archived" })` on its own in-review card slipped straight past review with no reviewer decision ever recorded.

**Fix**: widen the gate from the single literal `"done"` to a small `REVIEW_CLOSING_STATUSES` set (`done`, `archived`), so either terminal status is blocked coming from `in_review` while `isTaskRun` is true. Added `update.test.ts` coverage for the new `archived` case (pure unit test on the exported `closesOwnReview`, same technique as the existing `done` test).

Reviewer check: `bun test apps/api/src/tools/task-board/update.test.ts`.

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops a task run from archiving its own In Review card. Previously, runs were blocked from setting status to done but could set archived and bypass review; now both done and archived are blocked when the previous status is in_review.

**Review notes**
- Introduces REVIEW_CLOSING_STATUSES with done and archived; `closesOwnReview` checks this set.
- Updates the `TASK_BOARD_ITEM_UPDATE` error to mention Done or Archived; non-terminal moves from In Review remain allowed.
- Adds a unit test for the archived case in apps/api/src/tools/task-board/update.test.ts (run: bun test apps/api/src/tools/task-board/update.test.ts).

<sup>Written for commit fcbd843d303cf3ee2681ed9218fc723acb4ebc46. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

