### PR TITLE
perf(mcp-clients): skip header-build DB lookup on outbound client cache hit

### DIFF
--- a/apps/api/src/core/studio-context.ts
+++ b/apps/api/src/core/studio-context.ts
@@ -429,9 +429,9 @@ export interface StudioContext extends HarnessContext {
     conn: Parameters<typeof createMCPProxy>[0],
   ) => ReturnType<typeof createMCPProxy>;
 
-  // Client pool for STDIO connection reuse (LRU cache)
+  // Client pool for STDIO connection reuse (LRU cache); createTransport runs only on a cache miss
   getOrCreateClient: <T extends Transport>(
-    transport: T,
+    createTransport: () => T | Promise<T>,
     key: string,
   ) => Promise<Client>;
 

--- a/apps/api/src/mcp-clients/outbound/client-pool.test.ts
+++ b/apps/api/src/mcp-clients/outbound/client-pool.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
+import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
+import { createClientPool } from "./client-pool";
+
+/** A fake transport that answers the MCP `initialize` handshake so `Client.connect()` resolves. */
+function createFakeTransport(): Transport {
+  let onMessage: ((msg: JSONRPCMessage) => void) | undefined;
+  return {
+    async start() {},
+    async send(msg: JSONRPCMessage) {
+      if ("method" in msg && msg.method === "initialize" && "id" in msg) {
+        onMessage?.({
+          jsonrpc: "2.0",
+          id: msg.id,
+          result: {
+            protocolVersion: "2025-06-18",
+            capabilities: {},
+            serverInfo: { name: "fake", version: "1.0" },
+          },
+        });
+      }
+    },
+    async close() {},
+    set onmessage(fn: ((msg: JSONRPCMessage) => void) | undefined) {
+      onMessage = fn;
+    },
+    get onmessage() {
+      return onMessage;
+    },
+    onerror: undefined,
+    onclose: undefined,
+  };
+}
+
+describe("createClientPool", () => {
+  it("does not invoke createTransport again on a cache hit", async () => {
+    const pool = createClientPool();
+    let calls = 0;
+    const createTransport = () => {
+      calls++;
+      return createFakeTransport();
+    };
+
+    const first = await pool(createTransport, "conn_1");
+    const second = await pool(createTransport, "conn_1");
+
+    expect(first).toBe(second);
+    expect(calls).toBe(1);
+
+    await pool[Symbol.asyncDispose]();
+  });
+
+  it("invokes createTransport separately per key", async () => {
+    const pool = createClientPool();
+    let calls = 0;
+    const createTransport = () => {
+      calls++;
+      return createFakeTransport();
+    };
+
+    await pool(createTransport, "conn_1");
+    await pool(createTransport, "conn_2");
+
+    expect(calls).toBe(2);
+
+    await pool[Symbol.asyncDispose]();
+  });
+});

--- a/apps/api/src/mcp-clients/outbound/client-pool.ts
+++ b/apps/api/src/mcp-clients/outbound/client-pool.ts
@@ -20,7 +20,7 @@ import { sharedJsonSchemaValidator } from "@decocms/mcp-utils";
  * @returns Function to get or create a client connection from the pool
  */
 export function createClientPool(): (<T extends Transport>(
-  transport: T,
+  createTransport: () => T | Promise<T>,
   key: string,
 ) => Promise<Client>) & {
   [Symbol.asyncDispose]: () => Promise<void>;
@@ -32,12 +32,18 @@ export function createClientPool(): (<T extends Transport>(
    * Get or create a client connection from the pool
    * Implements single-flight pattern: concurrent requests for the same key share the same connection promise
    *
-   * @param transport - The transport to use for the connection
+   * `createTransport` is called lazily — only on a cache miss. On a cache hit
+   * (the common case for a virtual MCP calling multiple tools on the same
+   * downstream connection within one request) it never runs, so callers that
+   * build headers via a DB lookup + JWT issuance (see `buildRequestHeaders`)
+   * don't pay that cost for a client they're about to reuse anyway.
+   *
+   * @param createTransport - Builds the transport for the connection; only invoked on a cache miss
    * @param key - Unique key for the cache (typically connectionId)
    * @returns The connected client
    */
   function getOrCreateClientImpl<T extends Transport>(
-    transport: T,
+    createTransport: () => T | Promise<T>,
     key: string,
   ): Promise<Client> {
     // Check cache for existing promise (single-flight pattern)
@@ -48,35 +54,36 @@ export function createClientPool(): (<T extends Transport>(
 
     // Create the connection promise immediately and store it
     // This ensures concurrent requests for the same key get the same promise
-    const client = new Client(
-      {
-        name: `outbound-client-${key}`,
-        version: "1.0.0",
-      },
-      {
-        capabilities: {
-          tasks: {
-            list: {},
-            cancel: {},
-            requests: { tool: { call: {} } },
-          },
+    const clientPromise = (async () => {
+      const transport = await createTransport();
+      const client = new Client(
+        {
+          name: `outbound-client-${key}`,
+          version: "1.0.0",
         },
-        jsonSchemaValidator: sharedJsonSchemaValidator,
-      },
-    );
+        {
+          capabilities: {
+            tasks: {
+              list: {},
+              cancel: {},
+              requests: { tool: { call: {} } },
+            },
+          },
+          jsonSchemaValidator: sharedJsonSchemaValidator,
+        },
+      );
 
-    // Set up cleanup handler BEFORE connecting - remove from cache when connection closes
-    client.onclose = () => {
-      clientMap.delete(key);
-    };
-
-    const clientPromise = client
-      .connect(transport)
-      .then(() => client)
-      .catch((e) => {
+      // Set up cleanup handler BEFORE connecting - remove from cache when connection closes
+      client.onclose = () => {
         clientMap.delete(key);
-        throw e;
-      });
+      };
+
+      await client.connect(transport);
+      return client;
+    })().catch((e) => {
+      clientMap.delete(key);
+      throw e;
+    });
 
     clientMap.set(key, clientPromise);
 
@@ -96,7 +103,7 @@ export function createClientPool(): (<T extends Transport>(
       clientMap.clear();
     },
   }) as (<T extends Transport>(
-    transport: T,
+    createTransport: () => T | Promise<T>,
     key: string,
   ) => Promise<Client>) & {
     [Symbol.asyncDispose]: () => Promise<void>;

--- a/apps/api/src/mcp-clients/outbound/index.ts
+++ b/apps/api/src/mcp-clients/outbound/index.ts
@@ -89,7 +89,7 @@ export async function createOutboundClient(
 
       // STDIO uses a singleton pool — child processes must persist across requests.
       // NOT the per-request pool on ctx (that one is for HTTP/SSE with fresh auth headers).
-      return stdioPool(transport, connectionId);
+      return stdioPool(() => transport, connectionId);
     }
 
     case "HTTP":
@@ -97,64 +97,72 @@ export async function createOutboundClient(
       if (!connection.connection_url) {
         throw new Error(`${connection.connection_type} connection missing URL`);
       }
+      const connectionUrl = connection.connection_url;
 
-      const headers = await buildRequestHeaders(connection, ctx, superUser);
+      // Deferred: only builds headers (DB lookup + JWT issuance) on a cache miss.
+      return ctx.getOrCreateClient(async () => {
+        const headers = await buildRequestHeaders(connection, ctx, superUser);
 
-      const httpParams = connection.connection_headers;
-      if (httpParams && "headers" in httpParams) {
-        Object.assign(headers, httpParams.headers);
-      }
+        const httpParams = connection.connection_headers;
+        if (httpParams && "headers" in httpParams) {
+          Object.assign(headers, httpParams.headers);
+        }
 
-      let transport: Transport = new StreamableHTTPClientTransport(
-        new URL(connection.connection_url),
-        { requestInit: { headers } },
-      );
+        let transport: Transport = new StreamableHTTPClientTransport(
+          new URL(connectionUrl),
+          { requestInit: { headers } },
+        );
 
-      // Compose with auth and monitoring transports
-      transport = composeTransport(
-        transport,
-        (t) => new AuthTransport(t, { ctx, connection, superUser }),
-        (t) =>
-          new MonitoringTransport(t, {
-            ctx,
-            connectionId,
-            virtualMcpId,
-          }),
-      );
+        // Compose with auth and monitoring transports
+        transport = composeTransport(
+          transport,
+          (t) => new AuthTransport(t, { ctx, connection, superUser }),
+          (t) =>
+            new MonitoringTransport(t, {
+              ctx,
+              connectionId,
+              virtualMcpId,
+            }),
+        );
 
-      return ctx.getOrCreateClient(transport, connectionId);
+        return transport;
+      }, connectionId);
     }
 
     case "SSE": {
       if (!connection.connection_url) {
         throw new Error("SSE connection missing URL");
       }
+      const connectionUrl = connection.connection_url;
 
-      const headers = await buildRequestHeaders(connection, ctx, superUser);
+      // Deferred: only builds headers (DB lookup + JWT issuance) on a cache miss.
+      return ctx.getOrCreateClient(async () => {
+        const headers = await buildRequestHeaders(connection, ctx, superUser);
 
-      const httpParams = connection.connection_headers;
-      if (httpParams && "headers" in httpParams) {
-        Object.assign(headers, httpParams.headers);
-      }
+        const httpParams = connection.connection_headers;
+        if (httpParams && "headers" in httpParams) {
+          Object.assign(headers, httpParams.headers);
+        }
 
-      let transport: Transport = new SSEClientTransport(
-        new URL(connection.connection_url),
-        { requestInit: { headers } },
-      );
+        let transport: Transport = new SSEClientTransport(
+          new URL(connectionUrl),
+          { requestInit: { headers } },
+        );
 
-      // Compose with auth and monitoring transports
-      transport = composeTransport(
-        transport,
-        (t) => new AuthTransport(t, { ctx, connection, superUser }),
-        (t) =>
-          new MonitoringTransport(t, {
-            ctx,
-            connectionId,
-            virtualMcpId,
-          }),
-      );
+        // Compose with auth and monitoring transports
+        transport = composeTransport(
+          transport,
+          (t) => new AuthTransport(t, { ctx, connection, superUser }),
+          (t) =>
+            new MonitoringTransport(t, {
+              ctx,
+              connectionId,
+              virtualMcpId,
+            }),
+        );
 
-      return ctx.getOrCreateClient(transport, connectionId);
+        return transport;
+      }, connectionId);
     }
 
     default:


### PR DESCRIPTION
Follows the DB-latency-amplification investigation (issue #2995: sequential DB roundtrips inside a single MCP tool call amplify any DB slowdown). This closes one concrete redundant roundtrip on the outbound-connection hot path.

**The gap:** `createOutboundClient` (HTTP/Websocket/SSE) always called `buildRequestHeaders()` — a `downstream_tokens` DB lookup plus a Studio JWT mint — *before* handing the built transport to `ctx.getOrCreateClient()`. But `getOrCreateClient` is a single-flight cache keyed by `connectionId`, explicitly documented for reuse "within the same request cycle (e.g., virtual MCP calling multiple tools on the same downstream connection)". On a cache hit it returns the existing client and silently discards the freshly-built transport — so every tool call after the first against the same downstream connection paid the DB lookup and JWT issuance for nothing.

**The fix:** `createClientPool`/`getOrCreateClient` now take a transport *factory* instead of an eager transport; the factory (and `buildRequestHeaders` inside it) only runs on a cache miss. Behavior-preserving: on a cache miss the exact same transport is built and connected as before; on a cache hit no DB call or JWT mint happens at all instead of happening and being thrown away.

**Verify:** `cd apps/api && bun test src/mcp-clients/outbound/client-pool.test.ts` — new test asserts the transport factory is invoked exactly once across repeated calls with the same key, and once per distinct key.

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (green), the targeted test above (2 pass), and `bunx oxlint` on all 4 touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips redundant DB lookup and JWT mint when reusing an outbound MCP client from the cache. Previously `buildRequestHeaders` ran before `getOrCreateClient`, even on cache hits; now a transport factory defers header building to cache misses only.

- Updates `createClientPool`/`getOrCreateClient` to take `createTransport: () => Transport | Promise<Transport>`. Behavior on miss is unchanged; on hit, no DB call or JWT mint occurs.
- Adjusts HTTP/Websocket/SSE paths to pass factories; `STDIO` uses a no-op factory for the existing transport.
- Adds a unit test to assert the factory runs once per key and not on cache hits.

**Migration**
- If you call `createClientPool` or `ctx.getOrCreateClient` directly, pass a factory function instead of an eager transport:
  - Before: `getOrCreateClient(transport, key)`
  - After: `getOrCreateClient(() => transport, key)` or an async factory that builds headers and the transport.

<sup>Written for commit c023896b54889a2918e951cfaa1a0199c3900c67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

