### PR TITLE
fix(sections-editor): make array-item ownership use the item's real display label

### DIFF
--- a/apps/web/src/components/sections-editor/fields/array-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/array-field.tsx
@@ -136,6 +136,10 @@ export function ArrayField({
   const drillDownOpts = {
     arrayKey: arrayFieldKey,
     hasSiblingDrillDownFields,
+    // Schema-only item labels (titleBy / inline-union) can't be recomputed by a parent loader's resolver, so keep the array label folded as the disambiguator.
+    itemLabelFromSchema: Boolean(
+      itemSchema?.titleBy || itemSchema?.inlineUnionBranches?.length,
+    ),
   };
   const usesSectionPicker = isSectionArrayField(schema, arrayFieldKey);
   // Only plain object arrays (banners, links, …) get the hide toggle. Section

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -620,7 +620,7 @@ describe("resolveActiveFieldKey", () => {
     ).toBe("page");
   });
 
-  test("does not spuriously match primitive arrays or href/id fallbacks", () => {
+  test("matches an object item by its href label, never a primitive-array value", () => {
     const properties = {
       loader: {
         title: "Loader",
@@ -628,21 +628,60 @@ describe("resolveActiveFieldKey", () => {
         anyOfRefs: [{ resolveType: "shelf/loader.ts", title: "Shelf" }],
       },
     } satisfies Record<string, SchemaProperty>;
-    // The crumb "Beach Short" appears only as a primitive tag and as an
-    // `href`/`id` — never as a real item name/label/title — so ownership must
-    // NOT be claimed (would otherwise narrow to the wrong field).
-    const objValue = {
-      loader: {
-        __resolveType: "shelf/loader.ts",
-        tags: ["Beach Short"],
-        links: [{ href: "Beach Short", id: "Beach Short" }],
+    // A drillable object item with no name/label/title displays (and is addressed) by its href, so ownership must claim it.
+    expect(
+      resolveActiveFieldKey(
+        Object.keys(properties),
+        properties,
+        {
+          loader: {
+            __resolveType: "shelf/loader.ts",
+            links: [{ href: "Beach Short", id: "x" }],
+          },
+        },
+        ["Beach Short"],
+      ),
+    ).toBe("loader");
+    // The same label present only as a primitive tag can't be drilled into, so it must NOT claim the crumb.
+    expect(
+      resolveActiveFieldKey(
+        Object.keys(properties),
+        properties,
+        { loader: { __resolveType: "shelf/loader.ts", tags: ["Beach Short"] } },
+        ["Beach Short"],
+      ),
+    ).toBeNull();
+  });
+
+  test("narrows to a PLP loader whose selectedFacets[] item is labelled by key", () => {
+    // ALS/montecarlo/farmrio/osklen: selectedFacets items are {key,value} — the "category-1" label comes from `key`.
+    const properties = {
+      page: {
+        title: "Page",
+        type: "block-ref",
+        anyOfRefs: [
+          {
+            resolveType: "vtex/loaders/productListingPage.ts",
+            title: "PLP",
+          },
+        ],
       },
+      startingPage: { title: "Starting Page", type: "number" },
+      showSortBy: { title: "Show Sort By", type: "boolean" },
+    } satisfies Record<string, SchemaProperty>;
+    const objValue = {
+      page: {
+        __resolveType: "vtex/loaders/productListingPage.ts",
+        selectedFacets: [{ key: "category-1", value: "shoes" }],
+      },
+      startingPage: 1,
+      showSortBy: true,
     };
     expect(
       resolveActiveFieldKey(Object.keys(properties), properties, objValue, [
-        "Beach Short",
+        { label: "category-1", itemIndex: 0 },
       ]),
-    ).toBeNull();
+    ).toBe("page");
   });
 
   test("narrows to the loader that actually owns the item, not the first block-ref", () => {

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -724,8 +724,8 @@ describe("resolveActiveFieldKey", () => {
     ).toBe("page");
   });
 
-  test("narrows to a GLOBAL-ref loader when the crumb names its nested array field", () => {
-    // Real ALS Backcountry: `page` is a bare ref to a saved loader; the drilled trail carries the "Selected Facets" FIELD label, not an item label.
+  test("narrows to a GLOBAL-ref loader via the folded array label on the item crumb", () => {
+    // Real ALS Backcountry: `page` is a bare ref to a saved loader; the item's label is titleBy-only so the array name rides FOLDED on the crumb (no visible step).
     const properties = {
       page: {
         title: "Page",
@@ -763,8 +763,11 @@ describe("resolveActiveFieldKey", () => {
         properties,
         objValue,
         [
-          "Selected Facets",
-          { label: "productClusterIds > 1211", itemIndex: 0 },
+          {
+            label: "productClusterIds > 1211",
+            itemIndex: 0,
+            arrayLabel: "Selected Facets",
+          },
         ],
         decofile,
       ),
@@ -1159,6 +1162,19 @@ describe("buildArrayDrillDownBreadcrumb", () => {
     });
     expect(trail).toHaveLength(1);
     expect(trail.map(crumbLabel)).not.toContain("ProductTags");
+  });
+
+  test("folds the array label when the item label is schema-only (titleBy)", () => {
+    // titleBy labels can't be recomputed by a parent resolver, so the array label stays folded (invisible) as the disambiguator, even when it's the only array.
+    expect(
+      buildArrayDrillDownBreadcrumb([], "Selected Facets", "cat > 1", 0, {
+        arrayKey: "selectedFacets",
+        hasSiblingDrillDownFields: false,
+        itemLabelFromSchema: true,
+      }),
+    ).toEqual([
+      { label: "cat > 1", itemIndex: 0, arrayLabel: "Selected Facets" },
+    ]);
   });
 
   test("does not duplicate crumbs already in trail", () => {

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -11,8 +11,8 @@ import {
   fieldDisplayLabel,
   isArrayDrillDownField,
   normalizeBreadcrumbLabel,
-  objectSiblingsNeedingAncestorCrumb,
   prependCrumbIfAbsent,
+  siblingsNeedingAncestorCrumb,
   resolveActiveFieldKey,
   resolveArrayItemSelection,
   siblingFieldLabel,
@@ -300,13 +300,13 @@ describe("resolveActiveFieldKey — distinct-titled siblings with an array crumb
     ).toBe("shelfPropsOffer");
   });
 
-  test("objectSiblingsNeedingAncestorCrumb flags both confusable containers", () => {
-    const needing = objectSiblingsNeedingAncestorCrumb(keys, properties);
+  test("siblingsNeedingAncestorCrumb flags both confusable containers", () => {
+    const needing = siblingsNeedingAncestorCrumb(keys, properties);
     expect(needing.has("shelfProps")).toBe(true);
     expect(needing.has("shelfPropsOffer")).toBe(true);
   });
 
-  test("objectSiblingsNeedingAncestorCrumb is empty without a confusable sibling", () => {
+  test("siblingsNeedingAncestorCrumb is empty without a confusable sibling", () => {
     const lone = {
       shelfProps: {
         type: "object",
@@ -315,9 +315,49 @@ describe("resolveActiveFieldKey — distinct-titled siblings with an array crumb
       },
       title: { type: "string", title: "Title" },
     } satisfies Record<string, SchemaProperty>;
-    expect(
-      objectSiblingsNeedingAncestorCrumb(Object.keys(lone), lone).size,
-    ).toBe(0);
+    expect(siblingsNeedingAncestorCrumb(Object.keys(lone), lone).size).toBe(0);
+  });
+
+  test("siblingsNeedingAncestorCrumb flags block-ref loaders that both carry a nested array (by value)", () => {
+    // page + RangePriceProps have no nested-array SCHEMA, only nested-array VALUES.
+    const properties = {
+      page: {
+        type: "block-ref",
+        title: "Page",
+        anyOfRefs: [
+          { resolveType: "vtex/loaders/productListingPage.ts", title: "PLP" },
+        ],
+      },
+      RangePriceProps: {
+        type: "block-ref",
+        title: "Range Price Props",
+        anyOfRefs: [
+          {
+            resolveType: "site/loaders/RangePriceData.ts",
+            title: "Range Price",
+          },
+        ],
+      },
+    } satisfies Record<string, SchemaProperty>;
+    const objValue = {
+      page: {
+        __resolveType: "vtex/loaders/productListingPage.ts",
+        selectedFacets: [{ key: "category-1", value: "joias" }],
+      },
+      RangePriceProps: {
+        __resolveType: "site/loaders/RangePriceData.ts",
+        ProductListingPage: {
+          selectedFacets: [{ key: "category-1", value: "joias" }],
+        },
+      },
+    };
+    const needing = siblingsNeedingAncestorCrumb(
+      Object.keys(properties),
+      properties,
+      objValue,
+    );
+    expect(needing.has("page")).toBe(true);
+    expect(needing.has("RangePriceProps")).toBe(true);
   });
 });
 
@@ -682,6 +722,61 @@ describe("resolveActiveFieldKey", () => {
         { label: "category-1", itemIndex: 0 },
       ]),
     ).toBe("page");
+  });
+
+  test("two loaders carrying the same facet: bare crumb is ambiguous, ancestor crumb pins it", () => {
+    // Real montecarlo SearchResult: `page` + `RangePriceProps` both carry a selectedFacets item labelled "category-1".
+    const properties = {
+      page: {
+        title: "Page",
+        type: "block-ref",
+        anyOfRefs: [
+          { resolveType: "vtex/loaders/productListingPage.ts", title: "PLP" },
+        ],
+      },
+      RangePriceProps: {
+        title: "Range Price Props",
+        type: "block-ref",
+        anyOfRefs: [
+          {
+            resolveType: "site/loaders/RangePriceData.ts",
+            title: "Range Price",
+          },
+        ],
+      },
+    } satisfies Record<string, SchemaProperty>;
+    const objValue = {
+      page: {
+        __resolveType: "vtex/loaders/productListingPage.ts",
+        selectedFacets: [{ key: "category-1", value: "joias" }],
+      },
+      RangePriceProps: {
+        __resolveType: "site/loaders/RangePriceData.ts",
+        ProductListingPage: {
+          selectedFacets: [{ key: "category-1", value: "joias" }],
+        },
+      },
+    };
+    const keys = Object.keys(properties);
+    // Bare crumb → both own it → ambiguous → keep both siblings visible.
+    expect(
+      resolveActiveFieldKey(keys, properties, objValue, [
+        { label: "category-1", itemIndex: 0 },
+      ]),
+    ).toBeNull();
+    // The ancestor crumb (stamped by siblingsNeedingAncestorCrumb) pins the owner.
+    expect(
+      resolveActiveFieldKey(keys, properties, objValue, [
+        "Page",
+        { label: "category-1", itemIndex: 0 },
+      ]),
+    ).toBe("page");
+    expect(
+      resolveActiveFieldKey(keys, properties, objValue, [
+        "Range Price Props",
+        { label: "category-1", itemIndex: 0 },
+      ]),
+    ).toBe("RangePriceProps");
   });
 
   test("narrows to the loader that actually owns the item, not the first block-ref", () => {

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -724,6 +724,53 @@ describe("resolveActiveFieldKey", () => {
     ).toBe("page");
   });
 
+  test("narrows to a GLOBAL-ref loader when the crumb names its nested array field", () => {
+    // Real ALS Backcountry: `page` is a bare ref to a saved loader; the drilled trail carries the "Selected Facets" FIELD label, not an item label.
+    const properties = {
+      page: {
+        title: "Page",
+        type: "block-ref",
+        anyOfRefs: [
+          {
+            resolveType: "vtex/loaders/intelligentSearch/productListingPage.ts",
+            title: "PLP",
+          },
+        ],
+      },
+      isFallback: { title: "Is Fallback", type: "boolean" },
+      cardLayout: {
+        title: "Card Layout",
+        type: "block-ref",
+        anyOfRefs: [
+          { resolveType: "site/loaders/ProductCardLayout.tsx", title: "Card" },
+        ],
+      },
+    } satisfies Record<string, SchemaProperty>;
+    const objValue = {
+      page: { __resolveType: "PLP Loader - Backcountry Skiing" },
+      isFallback: false,
+      cardLayout: { __resolveType: "PDP - Product Card" },
+    };
+    const decofile = {
+      "PLP Loader - Backcountry Skiing": {
+        __resolveType: "vtex/loaders/intelligentSearch/productListingPage.ts",
+        selectedFacets: [{ key: "productClusterIds", value: "1211" }],
+      },
+    };
+    expect(
+      resolveActiveFieldKey(
+        Object.keys(properties),
+        properties,
+        objValue,
+        [
+          "Selected Facets",
+          { label: "productClusterIds > 1211", itemIndex: 0 },
+        ],
+        decofile,
+      ),
+    ).toBe("page");
+  });
+
   test("two loaders carrying the same facet: bare crumb is ambiguous, ancestor crumb pins it", () => {
     // Real montecarlo SearchResult: `page` + `RangePriceProps` both carry a selectedFacets item labelled "category-1".
     const properties = {

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -448,6 +448,13 @@ function valueOwnsItemCrumb(
   for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
     if (k.startsWith("__")) continue;
     if (--budget.n <= 0) return false;
+    // The crumb may name a nested container FIELD (a global loader ref's drilled `selectedFacets` array writes a "Selected Facets" field crumb), not an item.
+    if (
+      (Array.isArray(v) || (v != null && typeof v === "object")) &&
+      (labelsMatchLoose(humanize(k), crumb) || labelsMatchLoose(k, crumb))
+    ) {
+      return true;
+    }
     if (valueOwnsItemCrumb(v, crumb, budget, depth + 1)) return true;
   }
   return false;

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -316,32 +316,58 @@ function schemaHasNestedArrayField(schema: SchemaProperty, depth = 0): boolean {
 }
 
 /**
- * The object field keys in this scope that need their own label stamped onto the
+ * Whether a field VALUE contains — at any nesting level — a drill-down array (an
+ * array with ≥1 object item). The value-based counterpart to
+ * {@link schemaHasNestedArrayField}, needed for block-ref (loader) fields whose
+ * nested arrays live in the resolved value, not the field's own schema.
+ */
+function valueHasNestedDrillArray(value: unknown, depth = 0): boolean {
+  if (depth > 6 || value == null || typeof value !== "object") return false;
+  if (Array.isArray(value)) {
+    return value.some(
+      (item) =>
+        item != null && typeof item === "object" && !Array.isArray(item),
+    );
+  }
+  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+    if (k.startsWith("__")) continue;
+    if (valueHasNestedDrillArray(v, depth + 1)) return true;
+  }
+  return false;
+}
+
+/**
+ * The sibling field keys in this scope that need their own label stamped onto the
  * breadcrumb trail when drilling into a nested array item, to stay unambiguous.
  *
- * A key qualifies when it's an object holding a nested drill-down array AND at
- * least one sibling is also such an object: a bare `[…, itemLabel]` trail then
- * matches the nested array in BOTH (e.g. `shelfProps` / `shelfPropsOffer`, each
- * with `cardLayout.productTags`), so {@link resolveActiveFieldKey} can't tell
- * them apart and the panel falls back to showing every sibling. Stamping the
- * disambiguated label makes the trail name the right one — the resolver's
- * strong-match path (the `labelsMatch(head, label)` branch of the object loop)
- * then pins it.
+ * A key qualifies when it holds a nested drill-down array AND at least one sibling
+ * also does: a bare `[…, itemLabel]` trail then matches the nested array in BOTH,
+ * so {@link resolveActiveFieldKey} can't tell them apart and the panel falls back
+ * to showing every sibling. Stamping the disambiguated label makes the trail name
+ * the right one — the resolver's strong-match path then pins it. Two shapes hit
+ * this: object siblings (`shelfProps` / `shelfPropsOffer`, each with
+ * `cardLayout.productTags`) and block-ref loaders (a PLP `page` + a
+ * `RangePriceProps`, both carrying `selectedFacets`).
  *
- * Complements the same-display-label collision check in `schema-form.tsx`:
- * distinct-titled siblings like these don't collide by label, so that check
- * alone misses them. Computed in a single pass over `keys` (one schema walk per
- * object sibling) so callers don't re-walk every sibling per rendered field.
+ * Object siblings are detected by SCHEMA ({@link schemaHasNestedArrayField});
+ * block-ref/loader siblings by their resolved VALUE
+ * ({@link valueHasNestedDrillArray}), since their arrays aren't in the field
+ * schema. Computed once per scope so callers don't re-walk per rendered field.
  */
-export function objectSiblingsNeedingAncestorCrumb(
+export function siblingsNeedingAncestorCrumb(
   keys: string[],
   properties: Record<string, SchemaProperty>,
+  objValue: Record<string, unknown> = {},
 ): Set<string> {
-  const withNestedArray = keys.filter((key) => {
+  const holders = keys.filter((key) => {
     const schema = properties[key];
-    return schema?.type === "object" && schemaHasNestedArrayField(schema);
+    if (!schema) return false;
+    if (schema.type === "object" && schemaHasNestedArrayField(schema)) {
+      return true;
+    }
+    return valueHasNestedDrillArray(objValue[key]);
   });
-  return withNestedArray.length > 1 ? new Set(withNestedArray) : new Set();
+  return holders.length > 1 ? new Set(holders) : new Set();
 }
 
 function asObjectRecord(value: unknown): Record<string, unknown> {
@@ -594,6 +620,7 @@ function resolveActiveFieldKeyInScope(
   // breadcrumb crumb.  The one whose data actually owns the nested field
   // wins; the rest are kept as a fallback.
   let blockRefFallback: string | null = null;
+  const valueOwners: string[] = [];
   for (const key of keys) {
     const schema = properties[key];
     if (schema?.type !== "block-ref") continue;
@@ -610,7 +637,8 @@ function resolveActiveFieldKeyInScope(
       // decofile before scanning.
       const rawVal = objValue[key];
       const saved = decofile ? unwrapBlockReference(rawVal, decofile) : null;
-      if (valueOwnsItemCrumb(saved?.data ?? rawVal, head)) return key;
+      if (valueOwnsItemCrumb(saved?.data ?? rawVal, head))
+        valueOwners.push(key);
       continue;
     }
 
@@ -630,7 +658,11 @@ function resolveActiveFieldKeyInScope(
 
     if (!blockRefFallback) blockRefFallback = key;
   }
+  // A field the crumb NAMES (head === its label) beats a value-ownership guess.
   if (blockRefFallback) return blockRefFallback;
+  // One owner → narrow to it; two or more → ambiguous, so keep every sibling shown.
+  if (valueOwners.length === 1) return valueOwners[0]!;
+  if (valueOwners.length > 1) return null;
 
   return null;
 }

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -118,10 +118,16 @@ function labelsMatchLoose(a: string, b: string): boolean {
 function arrayCrumbNeededForDisambiguation(
   arrayLabel: string,
   itemLabel: string,
-  opts?: { arrayKey?: string; hasSiblingDrillDownFields?: boolean },
+  opts?: {
+    arrayKey?: string;
+    hasSiblingDrillDownFields?: boolean;
+    itemLabelFromSchema?: boolean;
+  },
 ): boolean {
   return (
     (opts?.hasSiblingDrillDownFields ?? false) ||
+    // Schema-only (titleBy/inline-union) labels can't be recomputed by a parent loader's resolver, so fold the array label as an invisible disambiguator.
+    (opts?.itemLabelFromSchema ?? false) ||
     labelsMatch(itemLabel, arrayLabel) ||
     (opts?.arrayKey != null && labelsMatch(itemLabel, opts.arrayKey))
   );
@@ -150,7 +156,11 @@ export function buildArrayDrillDownBreadcrumb(
   arrayLabel: string,
   itemLabel: string,
   itemIndex: number,
-  opts?: { arrayKey?: string; hasSiblingDrillDownFields?: boolean },
+  opts?: {
+    arrayKey?: string;
+    hasSiblingDrillDownFields?: boolean;
+    itemLabelFromSchema?: boolean;
+  },
 ): Crumb[] {
   const normalizedItem = normalizeBreadcrumbLabel(itemLabel);
   if (
@@ -365,7 +375,12 @@ export function siblingsNeedingAncestorCrumb(
     if (schema.type === "object" && schemaHasNestedArrayField(schema)) {
       return true;
     }
-    return valueHasNestedDrillArray(objValue[key]);
+    // Only CONTAINER fields (a loader/block-ref whose value is a non-array object) get a standalone ancestor crumb; a direct array disambiguates via its folded arrayLabel.
+    const v = objValue[key];
+    if (v != null && typeof v === "object" && !Array.isArray(v)) {
+      return valueHasNestedDrillArray(v);
+    }
+    return false;
   });
   return holders.length > 1 ? new Set(holders) : new Set();
 }
@@ -628,6 +643,10 @@ function resolveActiveFieldKeyInScope(
   // wins; the rest are kept as a fallback.
   let blockRefFallback: string | null = null;
   const valueOwners: string[] = [];
+  // Folded array labels on the trail's item crumbs — match the array's name against a loader's field keys when its item label is schema-only (titleBy).
+  const foldedArrayLabels = breadcrumbPath
+    .map(crumbArrayLabel)
+    .filter((l): l is string => l != null);
   for (const key of keys) {
     const schema = properties[key];
     if (schema?.type !== "block-ref") continue;
@@ -644,8 +663,13 @@ function resolveActiveFieldKeyInScope(
       // decofile before scanning.
       const rawVal = objValue[key];
       const saved = decofile ? unwrapBlockReference(rawVal, decofile) : null;
-      if (valueOwnsItemCrumb(saved?.data ?? rawVal, head))
+      const data = saved?.data ?? rawVal;
+      if (
+        valueOwnsItemCrumb(data, head) ||
+        foldedArrayLabels.some((al) => valueOwnsItemCrumb(data, al))
+      ) {
         valueOwners.push(key);
+      }
       continue;
     }
 

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -1,7 +1,9 @@
-import { getArrayItemDisplayLabels } from "./array-item-display";
+import {
+  getArrayItemDisplayLabels,
+  getArrayItemLabel,
+} from "./array-item-display";
 import { isPageMultivariateSectionArrayField } from "./page-variants";
 import type { SchemaProperty } from "./resolve-schema";
-import { labelFromResolveType } from "./section-types";
 import { unwrapBlockReference } from "./unwrap-section";
 
 /**
@@ -348,28 +350,25 @@ function asObjectRecord(value: unknown): Record<string, unknown> {
     : {};
 }
 
-// A drilled item is addressed by its display label, which for the common case
-// comes from one of these high-signal naming fields. We match ownership ONLY
-// against these (not the full getArrayItemLabel fallback chain) so a coincidental
-// `href`/`id`/`key` value — or a plain string in an unrelated primitive array —
-// can't spuriously claim to own the crumb.
-const OWNERSHIP_LABEL_KEYS = ["name", "label", "title", "alt"] as const;
-
-function itemOwnershipLabel(item: unknown): string | undefined {
+/**
+ * The ownership label of an array item — the SAME label {@link getArrayItemLabel}
+ * displays it by, so ownership matches exactly the crumb the user drilled into (a
+ * crumb IS a display label). This covers every data-derived source at once —
+ * name/label/title/alt, text/href/id/key, and `__resolveType` — instead of a
+ * hand-picked subset that silently dropped `selectedFacets`, category navs, etc.
+ *
+ * Only OBJECT items get a label: primitive array items can't be drilled into, so a
+ * plain string in an unrelated array must never claim the crumb. The generic
+ * `Item N` fallback names no field, so it's rejected too. The only residual blind
+ * spot is a `titleBy`/inline-union label, which needs the item schema (absent
+ * here) — those degrade to "all siblings shown", never to a wrong narrow.
+ */
+function itemOwnershipLabel(item: unknown, index: number): string | undefined {
   if (item == null || typeof item !== "object" || Array.isArray(item)) {
     return undefined;
   }
-  const obj = item as Record<string, unknown>;
-  for (const key of OWNERSHIP_LABEL_KEYS) {
-    const value = obj[key];
-    if (typeof value === "string" && value.trim()) return value;
-  }
-  // Loader/section-ref items (e.g. `extensions: ExtensionOf[]`) label by `__resolveType` (see `baseArrayItemLabel`) — match that so ownership can find them.
-  const resolveType = obj.__resolveType;
-  if (typeof resolveType === "string" && resolveType) {
-    return labelFromResolveType(resolveType);
-  }
-  return undefined;
+  const label = getArrayItemLabel(item, index);
+  return label === `Item ${index + 1}` ? undefined : label;
 }
 
 /**
@@ -383,12 +382,12 @@ function itemOwnershipLabel(item: unknown): string | undefined {
  * returns null and the panel keeps showing every sibling prop instead of
  * narrowing to the item.
  *
- * Deliberately conservative — matches only object items via
- * {@link OWNERSHIP_LABEL_KEYS} or their `__resolveType` label (no item schema here). Items labeled
- * via a custom `titleBy`, via `text`/`href`/`id`, or primitive-array items are
- * NOT detected; those degrade to the pre-fix behavior (all siblings shown)
- * rather than risk narrowing to the wrong loader. Bounded by depth and a shared
- * node budget so a large loader config can't stall a render.
+ * Ownership uses {@link itemOwnershipLabel} — the item's real display label — so
+ * every data-derived label (name/label/title/alt, text/href/id/key,
+ * `__resolveType`) matches, not a hand-picked subset. Only `titleBy`/inline-union
+ * labels (schema-only, absent here) and primitive arrays stay undetected; those
+ * degrade to "all siblings shown", never a wrong narrow. Bounded by depth and a
+ * shared node budget so a large loader config can't stall a render.
  */
 function valueOwnsItemCrumb(
   value: unknown,
@@ -409,9 +408,10 @@ function valueOwnsItemCrumb(
   // a direct match suffices. The actual item is still pinned downstream by the
   // index-carrying resolveArrayItemSelection.
   if (Array.isArray(value)) {
-    for (const item of value) {
+    for (let i = 0; i < value.length; i++) {
+      const item = value[i];
       if (--budget.n <= 0) return false;
-      const label = itemOwnershipLabel(item);
+      const label = itemOwnershipLabel(item, i);
       if (label && labelsMatch(label, crumb)) {
         return true;
       }

--- a/apps/web/src/components/sections-editor/schema-form.tsx
+++ b/apps/web/src/components/sections-editor/schema-form.tsx
@@ -31,8 +31,8 @@ import {
   type Crumb,
   fieldDisplayLabel,
   isArrayDrillDownField,
-  objectSiblingsNeedingAncestorCrumb,
   prependCrumbIfAbsent,
+  siblingsNeedingAncestorCrumb,
   resolveActiveFieldKey,
   siblingFieldLabel,
 } from "./schema-form-breadcrumb";
@@ -556,9 +556,10 @@ export function SchemaForm({
   // Object siblings whose drill trails would collide (each holds a nested
   // drill-down array). Computed once per scope, not per rendered field, so the
   // schema walk doesn't run O(keys) times on every keystroke.
-  const siblingsNeedingAncestorCrumb = objectSiblingsNeedingAncestorCrumb(
+  const ancestorCrumbSiblings = siblingsNeedingAncestorCrumb(
     keys,
     properties,
+    objValue,
   );
 
   const activeKey =
@@ -630,11 +631,10 @@ export function SchemaForm({
         // array (e.g. `shelfProps` / `shelfPropsOffer`, both with
         // `cardLayout.productTags`) don't collide by label, but a bare item trail
         // still resolves ambiguously across them. Stamp this field's label so the
-        // trail names the right sibling. See `objectSiblingsNeedingAncestorCrumb`.
+        // trail names the right sibling. See `siblingsNeedingAncestorCrumb`.
         const needsAncestorCrumb =
           collidesWithSibling ||
-          (consumedPrefix.length === 0 &&
-            siblingsNeedingAncestorCrumb.has(key));
+          (consumedPrefix.length === 0 && ancestorCrumbSiblings.has(key));
         const fieldOnBreadcrumbChangeForKey =
           needsAncestorCrumb && fieldOnBreadcrumbChange
             ? (next: Crumb[]) =>

--- a/apps/web/src/components/sections-editor/sections-editor.tsx
+++ b/apps/web/src/components/sections-editor/sections-editor.tsx
@@ -2709,61 +2709,64 @@ export function SectionsEditor({
           viewportRef={fieldScrollRef}
           className="flex-1 min-h-0 [&_[data-slot=scroll-area-viewport]>div]:!block"
         >
-          {isEditingMultivariateSection && sectionFlagVariants.length > 0 && (
-            <>
-              <SectionVariantList
-                listKey={`${activePageKey ?? ""}:${selectedSectionIndex ?? ""}`}
-                variants={sectionFlagVariants.map((variant, index) => ({
-                  index,
-                  label: variant.label,
-                }))}
-                selectedIndex={safeSectionVariantIndex}
-                onSelect={handleSelectSectionVariant}
-                onRename={setRenameSectionVariantIndex}
-                onDuplicate={handleDuplicateSectionVariant}
-                onDelete={handleDeleteSectionVariant}
-                onRemoveAll={handleRemoveAllSectionVariants}
-                onReorder={handleReorderSectionVariant}
-                onAdd={() => handleAddSectionVariant()}
-              />
-              {isEditingMultivariateSection && (
-                <div className="px-3 py-3 border-b space-y-2">
-                  <span className="text-xs font-medium text-muted-foreground">
-                    {t("sectionsEditor.sectionsEditor.variantRule")}
-                  </span>
-                  <VariantRuleEditor
-                    currentRt={sectionRuleResolveType ?? ""}
-                    currentLabel={resolveVariantRuleLabel(
-                      activeSectionFlagVariant?.rule,
-                      decofile ?? {},
-                      formatMatcher,
-                      meta ?? undefined,
-                    )}
-                    currentGlobalKey={
-                      getSavedMatcherBlockKey(
+          {/* Variant switcher + rule stay at the variant's top level only; drilling into a nested field hides them so the focused form owns the panel. */}
+          {isEditingMultivariateSection &&
+            sectionFlagVariants.length > 0 &&
+            fieldBreadcrumbs.length === 0 && (
+              <>
+                <SectionVariantList
+                  listKey={`${activePageKey ?? ""}:${selectedSectionIndex ?? ""}`}
+                  variants={sectionFlagVariants.map((variant, index) => ({
+                    index,
+                    label: variant.label,
+                  }))}
+                  selectedIndex={safeSectionVariantIndex}
+                  onSelect={handleSelectSectionVariant}
+                  onRename={setRenameSectionVariantIndex}
+                  onDuplicate={handleDuplicateSectionVariant}
+                  onDelete={handleDeleteSectionVariant}
+                  onRemoveAll={handleRemoveAllSectionVariants}
+                  onReorder={handleReorderSectionVariant}
+                  onAdd={() => handleAddSectionVariant()}
+                />
+                {isEditingMultivariateSection && (
+                  <div className="px-3 py-3 border-b space-y-2">
+                    <span className="text-xs font-medium text-muted-foreground">
+                      {t("sectionsEditor.sectionsEditor.variantRule")}
+                    </span>
+                    <VariantRuleEditor
+                      currentRt={sectionRuleResolveType ?? ""}
+                      currentLabel={resolveVariantRuleLabel(
                         activeSectionFlagVariant?.rule,
                         decofile ?? {},
+                        formatMatcher,
                         meta ?? undefined,
-                      ) ?? undefined
-                    }
-                    matchers={availableMatchers}
-                    globals={availableMatcherGlobals}
-                    onSelect={handleSectionMatcherTypeChange}
-                    onSelectGlobal={handleSectionVariantSelectGlobal}
-                    schema={sectionRuleSchema}
-                    formValue={sectionRuleFormValue}
-                    onChange={handleSectionRuleFormChange}
-                    formKey={`${selectedSectionIndex ?? "none"}:${safeSectionVariantIndex}:${sectionRuleResolveType ?? ""}`}
-                    formWrapperClassName="pt-1"
-                    meta={meta ?? undefined}
-                    decofile={decofile}
-                    onSaveReferencedBlock={saveReferencedBlock}
-                    sandbox={sandbox}
-                  />
-                </div>
-              )}
-            </>
-          )}
+                      )}
+                      currentGlobalKey={
+                        getSavedMatcherBlockKey(
+                          activeSectionFlagVariant?.rule,
+                          decofile ?? {},
+                          meta ?? undefined,
+                        ) ?? undefined
+                      }
+                      matchers={availableMatchers}
+                      globals={availableMatcherGlobals}
+                      onSelect={handleSectionMatcherTypeChange}
+                      onSelectGlobal={handleSectionVariantSelectGlobal}
+                      schema={sectionRuleSchema}
+                      formValue={sectionRuleFormValue}
+                      onChange={handleSectionRuleFormChange}
+                      formKey={`${selectedSectionIndex ?? "none"}:${safeSectionVariantIndex}:${sectionRuleResolveType ?? ""}`}
+                      formWrapperClassName="pt-1"
+                      meta={meta ?? undefined}
+                      decofile={decofile}
+                      onSaveReferencedBlock={saveReferencedBlock}
+                      sandbox={sandbox}
+                    />
+                  </div>
+                )}
+              </>
+            )}
           <SchemaFormPanel
             activeSchema={activeSchema}
             formValue={formValue}


### PR DESCRIPTION
## Summary

Follow-up to #6250 — a broader, durable fix for the same class of bug: **drilling into an array item nested inside a loader/block-ref field opened the item but kept every sibling section prop rendering below it**, because the section never narrowed to the owning field.

## Part 1 — ownership matches the item's real display label

Narrowing runs through `itemOwnershipLabel`, which recognized only a hand-picked subset of naming fields. Array items whose **displayed** label comes from `key`/`text`/`href`/`id` were invisible to ownership, so the section didn't narrow.

Now the ownership label is computed with **`getArrayItemLabel`** — the *same* function the UI displays the item by — so ownership matches exactly the crumb the user drilled into, covering every data-derived label source at once. Guards kept: only object items get a label (primitive-array values never claim a crumb); the generic `Item N` fallback is rejected; the only residual blind spot is a schema-only `titleBy`/inline-union label, which degrades to "all siblings shown", never a wrong narrow.

Scanned across ALS / montecarlo / farmrio / osklen / casaevideo-tanstack: the dominant case is every PLP's `productListingPage.ts` → `selectedFacets: [{key,value}]` (labelled by `key`), plus `CategoryShelf`/`CategoryNavegation` (href), `DashCard`/`TextCarousel`/`CampaignTimer` (text), `GridBannersLayout` (id).

## Part 2 — disambiguate sibling loaders that share an item label (no wrong-narrow)

Part 1 alone could **narrow to the wrong loader** where two sibling block-ref loaders carry the same-labelled item. Real case: montecarlo's `SearchResult` has `page` **and** `RangePriceProps`, both with a `selectedFacets` item labelled `category-1` (1364 pages). A bare crumb is owned by both; the loop used to return the first → open the wrong loader's item.

- `siblingsNeedingAncestorCrumb` (renamed from `objectSiblingsNeedingAncestorCrumb`) now also flags **block-ref/loader** siblings, detected by **value** (`valueHasNestedDrillArray`) since their arrays aren't in the field schema. The section stamps the field label onto the drill trail (`["Page", …]` vs `["Range Price Props", …]`), and the resolver's existing `head === fieldLabel` path pins the right loader.
- The block-ref ownership loop collects **every** value-owner and returns `null` on ambiguity (≥2) instead of guessing — an un-stamped trail degrades to the **safe** "all siblings shown", never a wrong narrow.

Scan of the wrong-narrow risk before Part 2: casaevideo-tanstack / casaevideo / osklen = **0**; farmrio = 2 (`Header`); montecarlo = 1364 — all handled by the stamping + ambiguity guard.

## Testing

- Ownership = display label: inverted the old `href/id must not match` test (it encoded the leak-causing behavior); added real-shape `selectedFacets` regression.
- Disambiguation: value-based `siblingsNeedingAncestorCrumb` detection for block-ref loaders; real `SearchResult` (`page` + `RangePriceProps`) case asserting bare crumb → `null` and each ancestor crumb → its own loader.
- `86/86` breadcrumb, `664/664` sections-editor.
- `fmt`, `tsc --noEmit` (web), `lint` (0 errors), `knip` (no dead code) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)