### PR TITLE
ci: survive a degraded Ubuntu mirror in the Playwright/apt steps

### DIFF
--- a/.github/actions/apt-mirror-fallback/action.yml
+++ b/.github/actions/apt-mirror-fallback/action.yml
@@ -1,0 +1,100 @@
+name: Run an apt command with Ubuntu mirror fallback
+description: >-
+  Run a command that installs Ubuntu packages, retrying it against a different
+  Ubuntu mirror each time it stalls.
+
+  GitHub's hosted runners point apt at a mirrorlist (`/etc/apt/apt-mirrors.txt`)
+  whose first entry is `azure.archive.ubuntu.com`. When that mirror degrades it
+  does not fail — it crawls (37 kB/s measured on 2026-08-19, so a 21 MB font
+  download could not finish inside 5 minutes), and apt's own mirrorlist fallback
+  only triggers on a hard error, never on a slow transfer. This action gives
+  each mirror a hard wall-clock budget instead: blow the budget, rewrite the
+  mirrorlist to the next mirror, try again.
+
+inputs:
+  run:
+    description: >-
+      Shell command to run. Include `apt-get update` — the mirror changes
+      underneath it between attempts, so its package lists must be refetched.
+    required: true
+  timeout-seconds:
+    description: Wall-clock budget for one mirror's attempt.
+    default: "120"
+  mirrors:
+    description: >-
+      Ubuntu archive mirrors to try, in order, one per line. Every entry must
+      carry the -security pocket as well as the release pocket, because the
+      runner's sources point both at this one mirrorlist.
+    default: |
+      http://azure.archive.ubuntu.com/ubuntu/
+      http://mirrors.edge.kernel.org/ubuntu/
+      http://archive.ubuntu.com/ubuntu/
+
+runs:
+  using: composite
+  steps:
+    - name: Run with Ubuntu mirror fallback
+      shell: bash
+      env:
+        APT_FALLBACK_RUN: ${{ inputs.run }}
+        APT_FALLBACK_TIMEOUT: ${{ inputs.timeout-seconds }}
+        APT_FALLBACK_MIRRORS: ${{ inputs.mirrors }}
+      run: |
+        set -uo pipefail
+
+        # Bound apt's own network waits so a dead connection fails inside the
+        # per-mirror budget instead of consuming all of it.
+        sudo tee /etc/apt/apt.conf.d/99-ci-mirror-fallback >/dev/null <<'APTCONF'
+        Acquire::Retries "2";
+        Acquire::http::Timeout "20";
+        Acquire::https::Timeout "20";
+        APTCONF
+
+        # A timed-out attempt leaves apt-get/dpkg alive holding the dpkg lock,
+        # which would fail the next mirror for the wrong reason. Kill and repair.
+        reset_apt() {
+          sudo pkill -9 -x apt-get 2>/dev/null || true
+          sudo pkill -9 -x dpkg 2>/dev/null || true
+          sudo dpkg --configure -a >/dev/null 2>&1 || true
+        }
+
+        # The mirrorlist is a GitHub-hosted-image thing: on any other runner the
+        # sources do not point at it, so switching mirrors is a no-op and only
+        # the timeout-and-retry half of this action does any work. Say so rather
+        # than claim a fallback we did not get.
+        MIRRORLIST=/etc/apt/apt-mirrors.txt
+        if [ ! -f "$MIRRORLIST" ]; then
+          echo "::warning::${MIRRORLIST} not found — this runner does not use a mirrorlist, so attempts will retry the same mirror"
+        fi
+
+        mirrors=()
+        while IFS= read -r line; do
+          line="${line%$'\r'}"
+          [ -n "${line//[[:space:]]/}" ] || continue
+          mirrors+=("$line")
+        done <<< "$APT_FALLBACK_MIRRORS"
+        if [ "${#mirrors[@]}" -eq 0 ]; then
+          echo "::error::apt-mirror-fallback: no mirrors configured"
+          exit 1
+        fi
+
+        for mirror in "${mirrors[@]}"; do
+          echo "::group::apt via ${mirror}"
+          # One mirror per attempt, deliberately: leaving the others in the file
+          # would let apt silently fall back inside an attempt, which is exactly
+          # the behaviour that fails to trigger on a merely-slow mirror.
+          if [ -f "$MIRRORLIST" ]; then
+            printf '%s\n' "$mirror" | sudo tee "$MIRRORLIST" >/dev/null
+          fi
+          if timeout "$APT_FALLBACK_TIMEOUT" bash -c "$APT_FALLBACK_RUN"; then
+            echo "::endgroup::"
+            echo "apt succeeded via ${mirror}"
+            exit 0
+          fi
+          reset_apt
+          echo "::endgroup::"
+          echo "::warning::Ubuntu mirror ${mirror} failed or exceeded ${APT_FALLBACK_TIMEOUT}s — falling back to the next mirror"
+        done
+
+        echo "::error::every Ubuntu mirror failed: ${mirrors[*]}"
+        exit 1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,6 +15,9 @@ on:
   pull_request:
     branches:
       - main
+  # Both triggers above skip `.github/**`-only changes, so a CI-infrastructure
+  # fix cannot validate itself. Dispatch runs the suite on demand from any branch.
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -171,19 +174,24 @@ jobs:
           restore-keys: |
             playwright-${{ runner.os }}-
 
+      # Browser binary only (Playwright's own CDN, no apt involved) — kept
+      # separate from the system deps below so an Ubuntu mirror outage can
+      # never block the download that actually has to succeed.
       - name: Install Playwright chromium
         if: steps.cache-playwright.outputs.cache-hit != 'true'
         working-directory: packages/e2e
-        # apt's mirror stalls silently — run 32264701513 sat 11 minutes with no
-        # output before the job was cancelled. Fail fast and re-runnable instead.
         timeout-minutes: 5
-        run: npx playwright install chromium --with-deps
+        run: npx playwright install chromium
 
+      # Everything chromium links against is already in the runner image — the
+      # only thing this step downloads is ~21 MB of font packages. So a total
+      # mirror outage costs us glyph coverage, not a red build; if a library
+      # ever really is missing, chromium fails to launch and the suite says so.
       - name: Install Playwright chromium system deps
-        if: steps.cache-playwright.outputs.cache-hit == 'true'
-        working-directory: packages/e2e
-        timeout-minutes: 5
-        run: npx playwright install-deps chromium
+        uses: ./.github/actions/apt-mirror-fallback
+        continue-on-error: true
+        with:
+          run: cd packages/e2e && npx playwright install-deps chromium
 
       - name: Create data directory
         run: mkdir -p data

--- a/.github/workflows/sandbox-daemon.yml
+++ b/.github/workflows/sandbox-daemon.yml
@@ -21,6 +21,9 @@ on:
   pull_request:
     branches:
       - main
+  # Both triggers above skip `.github/**`-only changes, so a CI-infrastructure
+  # fix cannot validate itself. Dispatch runs the suite on demand from any branch.
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -87,7 +90,9 @@ jobs:
           cache-dependency-path: packages/sandbox/daemon-go/go.sum
 
       - name: Install ripgrep
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
+        uses: ./.github/actions/apt-mirror-fallback
+        with:
+          run: sudo apt-get update && sudo apt-get install -y ripgrep
 
       - name: Go vet and unit tests
         working-directory: packages/sandbox/daemon-go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,9 @@ on:
   pull_request:
     branches:
       - main
+  # Both triggers above skip `.github/**`-only changes, so a CI-infrastructure
+  # fix cannot validate itself. Dispatch runs the suite on demand from any branch.
+  workflow_dispatch:
 
 # A force-push to a PR obsoletes the in-flight run — cancel it instead of
 # letting 6 jobs run to completion. Pushes to main all run (no cancel) so
@@ -198,7 +201,9 @@ jobs:
     needs: changes
     if: needs.changes.outputs.web == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # Headroom for the worst case of the mirror fallback below: 5 min for the
+    # browser download plus 3 mirrors x 2 min for the system deps.
+    timeout-minutes: 20
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -218,19 +223,24 @@ jobs:
           restore-keys: |
             playwright-ct-${{ runner.os }}-
 
+      # Browser binary only (Playwright's own CDN, no apt involved) — kept
+      # separate from the system deps below so an Ubuntu mirror outage can
+      # never block the download that actually has to succeed.
       - name: Install Playwright chromium
         if: steps.cache-playwright.outputs.cache-hit != 'true'
         working-directory: apps/web
-        # apt's mirror stalls silently — run 32264701513 sat 11 minutes with no
-        # output before the job was cancelled. Fail fast and re-runnable instead.
         timeout-minutes: 5
-        run: npx playwright install chromium --with-deps
+        run: npx playwright install chromium
 
+      # Everything chromium links against is already in the runner image — the
+      # only thing this step downloads is ~21 MB of font packages. So a total
+      # mirror outage costs us glyph coverage, not a red build; if a library
+      # ever really is missing, chromium fails to launch and the suite says so.
       - name: Install Playwright chromium system deps
-        if: steps.cache-playwright.outputs.cache-hit == 'true'
-        working-directory: apps/web
-        timeout-minutes: 5
-        run: npx playwright install-deps chromium
+        uses: ./.github/actions/apt-mirror-fallback
+        continue-on-error: true
+        with:
+          run: cd apps/web && npx playwright install-deps chromium
 
       - name: Run component tests
         run: bun run --cwd=apps/web test:ct


### PR DESCRIPTION
## What broke

`azure.archive.ubuntu.com` — the first entry in the hosted runner's `/etc/apt/apt-mirrors.txt` — degraded to **~37 kB/s**. `playwright install-deps chromium` downloads ~21 MB of font packages, which cannot finish inside the step's 5-minute budget at that rate.

apt's own mirrorlist fallback never fired: it triggers on a *hard error*, never on a *slow transfer*. So every attempt sat on the same crawling mirror until the step timed out.

Failing runs on `main`: [32278546205](https://github.com/decocms/studio/actions/runs/32278546205) (E2E, shards 1 and 2), [32278546215](https://github.com/decocms/studio/actions/runs/32278546215) (web-component-tests).

```
Get:2 http://azure.archive.ubuntu.com/ubuntu noble/universe amd64 fonts-ipafont-gothic all [3513 kB]
##[error]The action 'Install Playwright chromium system deps' has timed out after 5 minutes.
```

(Shard 2 did drift to `archive.ubuntu.com` mid-update and still timed out — by then most of the budget was already gone.)

## The fix

**New composite action `.github/actions/apt-mirror-fallback`.** It gives each mirror a hard wall-clock budget; when the budget blows it rewrites the mirrorlist to the next mirror and retries. Mirrors, in order:

| mirror | why |
| --- | --- |
| `azure.archive.ubuntu.com` | in-region, normally the fastest |
| `mirrors.edge.kernel.org` | Fastly-backed, independent of Azure |
| `archive.ubuntu.com` | Canonical's own |

All three serve the `-security` pocket, which matters because the runner points both its release and security sources at this single mirrorlist. One mirror per attempt, deliberately — leaving the others in the file would let apt silently fall back *inside* an attempt, which is exactly the behaviour that fails to trigger on a merely-slow mirror. It also bounds apt's own connect/read timeouts, and kills + `dpkg --configure -a`s the apt state a timed-out attempt leaves behind so the next mirror doesn't fail on a stale lock.

**Split the browser download off the deps install.** The chromium binary comes from Playwright's CDN and genuinely must succeed, so it no longer rides behind apt via `--with-deps`.

**The deps step is `continue-on-error`.** Every shared library chromium links against is already in the runner image (the failing log shows all of them as `already the newest version`) — the only thing that step actually downloads is fonts, and there are no screenshot assertions in either suite. A total mirror outage should cost glyph coverage, not a red build. A genuinely missing library still surfaces loudly, as a chromium launch failure in the tests themselves.

**Same action for the sandbox-daemon `ripgrep` install**, which had the identical exposure.

**`workflow_dispatch` on the three workflows.** Their push *and* PR triggers both skip `.github/**`-only changes, so a CI-infrastructure fix had no way to validate itself. (Takes effect once this is on `main`.)

## Testing

- Extracted the action's shell body and ran it under GitHub's exact shell (`bash --noprofile --norc -eo pipefail`) with stubbed `sudo`/`timeout` across four cases: all mirrors fail → exit 1 with `::error::`; third mirror succeeds → exit 0 after two `::warning::`s; first mirror succeeds → exit 0, no retries; empty mirror list → exit 1. All as expected.
- All four YAML files parse.
- Verified all three mirrors serve `dists/noble-security/Release` (`200`, 0.5 s / 1.1 s / 2.5 s).
- The PR carries a **`TEMP:` commit** adding `apps/web/.ci-validation-marker` purely to flip the `changes` gate so this PR's own CI exercises the changed steps. **It must be dropped before merge** — I'll remove it once CI is green.

## Affected areas

CI only. No application code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens CI against slow Ubuntu mirrors in apt-backed steps. Previously `playwright install-deps chromium` and `apt-get install` could stall on `azure.archive.ubuntu.com` and time out; now each attempt has a wall-clock budget with mirror fallback, and the Chromium download no longer rides behind apt.

- New composite action `.github/actions/apt-mirror-fallback`: time-boxes each attempt, rotates `/etc/apt/apt-mirrors.txt` across `azure.archive.ubuntu.com` → `mirrors.edge.kernel.org` → `archive.ubuntu.com`, bounds apt connect/read via `Acquire::*` timeouts, and cleans dpkg locks between retries.
- Split Playwright steps: `npx playwright install chromium` runs alone; `npx playwright install-deps chromium` runs via the fallback action and is `continue-on-error` (fonts may be skipped; missing libs still fail at runtime).
- Route `ripgrep` install in the sandbox-daemon workflow through the same action.
- Add `workflow_dispatch` to `e2e`, `test`, and `sandbox-daemon`; bump the web component test job timeout to 20 minutes for worst-case fallback.
- CI-only change; no app code affected.

<sup>Written for commit 767e3a17fb981a0f9d90b828aa80b3186284d462. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

