### PR TITLE
feat(settings): add Native Assets tab toggle in navigation settings

### DIFF
--- a/apps/web/src/components/settings/navigation-settings.tsx
+++ b/apps/web/src/components/settings/navigation-settings.tsx
@@ -1,12 +1,16 @@
 import { toast } from "sonner";
 import { Switch } from "@decocms/ui/components/switch.tsx";
-import { LayoutLeft } from "@untitledui/icons";
+import { LayoutLeft, Package } from "@untitledui/icons";
 import {
   SettingsCard,
   SettingsCardItem,
   SettingsSection,
 } from "@/components/settings/settings-section";
-import { useNavV2, useSetOrgFlag } from "@/hooks/use-organization-settings";
+import {
+  useNavV2,
+  useOrgFlag,
+  useSetOrgFlag,
+} from "@/hooks/use-organization-settings";
 import { useT } from "@/i18n/use-t.ts";
 
 /**
@@ -18,6 +22,7 @@ import { useT } from "@/i18n/use-t.ts";
 export function NavigationSettings() {
   const t = useT();
   const enabled = useNavV2();
+  const nativeAssetsEnabled = useOrgFlag("native_assets_tab");
   const setFlag = useSetOrgFlag();
   return (
     <SettingsSection
@@ -36,6 +41,24 @@ export function NavigationSettings() {
               aria-label={t("settings.navigation.navV2Title")}
               onCheckedChange={(next) =>
                 setFlag.mutate("nav_v2", next, {
+                  onError: () =>
+                    toast.error(t("settings.navigation.updateError")),
+                })
+              }
+            />
+          }
+        />
+        <SettingsCardItem
+          icon={<Package size={16} />}
+          title={t("settings.navigation.nativeAssetsTitle")}
+          description={t("settings.navigation.nativeAssetsDescription")}
+          action={
+            <Switch
+              checked={nativeAssetsEnabled}
+              disabled={setFlag.isPending}
+              aria-label={t("settings.navigation.nativeAssetsTitle")}
+              onCheckedChange={(next) =>
+                setFlag.mutate("native_assets_tab", next, {
                   onError: () =>
                     toast.error(t("settings.navigation.updateError")),
                 })

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -446,6 +446,9 @@ export const settings = {
   "settings.navigation.navV2Title": "First-class navigation",
   "settings.navigation.navV2Description":
     "The sidebar lists destinations (Reports, Library, Tasks) instead of chats, and the chat list moves to the top of the chat panel. On by default for report organizations.",
+  "settings.navigation.nativeAssetsTitle": "Native Assets tab",
+  "settings.navigation.nativeAssetsDescription":
+    "Show a native Assets tab that browses the site's associated storage bucket, instead of the external admin view. Appears only on sites that have a bucket configured.",
   "settings.orgGeneral.organization": "Organization",
   "settings.mainAgent.title": "Main agent",
   "settings.mainAgent.description":

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -465,6 +465,9 @@ export const settings = {
   "settings.navigation.navV2Title": "Navegação de primeira classe",
   "settings.navigation.navV2Description":
     "A barra lateral lista destinos (Relatórios, Biblioteca, Tarefas) em vez de chats, e a lista de chats vai para o topo do painel de chat. Ativada por padrão em organizações de relatório.",
+  "settings.navigation.nativeAssetsTitle": "Aba de Assets nativa",
+  "settings.navigation.nativeAssetsDescription":
+    "Mostra uma aba de Assets nativa que navega o bucket de armazenamento associado ao site, em vez da view externa de admin. Aparece s\u00f3 em sites que t\u00eam um bucket configurado.",
   "settings.orgGeneral.organization": "Organiza\u00e7\u00e3o",
   "settings.mainAgent.title": "Agente principal",
   "settings.mainAgent.description":


### PR DESCRIPTION
## Summary

Exposes the `native_assets_tab` org flag (added in #6251) as a **Switch in the Navigation settings** section, so it can be toggled from the UI instead of calling `ORGANIZATION_SETTINGS_UPDATE` by hand. Uses the same `useSetOrgFlag` pattern as the existing `nav_v2` toggle.

- Reads the resolved value via `useOrgFlag("native_assets_tab")` (default-off) and writes an explicit true/false.
- Second `SettingsCardItem` in the existing Navigation card (rendered with a divider).
- i18n en + pt-br.

Follow-up to #6251 (now merged), which added the flag and the native per-site Assets tab it gates.

## Testing notes
- `tsc --noEmit` passes (web); `oxlint` clean on touched files; `bun run fmt` applied.
- Manual: Settings → Navigation shows the "Native Assets tab" switch; flipping it persists the flag and the per-site Assets tab appears on sites with an associated bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a switch in Navigation settings to toggle the `native_assets_tab` organization flag from the UI. Previously this flag was only settable via `ORGANIZATION_SETTINGS_UPDATE`; enabling it now shows a native Assets tab on sites with a configured bucket.

- Reads the flag with useOrgFlag (default off) and writes explicit true/false via useSetOrgFlag; disables the switch while pending and shows an error toast on failure.
- Adds a second item to the existing Navigation settings card; includes en and pt-br i18n strings.
- No API or schema changes; no migration required.

<sup>Written for commit d320a0b2441a185686fccd4f806faf13f5c187ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6257?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

