### PR TITLE
feat(fast-preview): new-branch button starts a CMS thread from a coding session

### DIFF
--- a/apps/web/src/components/chat/chat-context.tsx
+++ b/apps/web/src/components/chat/chat-context.tsx
@@ -197,8 +197,8 @@ export interface ChatTaskContextValue {
   taskId: string;
   openTask: (taskId: string) => void;
   /** Creates a thread and navigates to it. `runtime: "sandbox"` starts a
-   *  sandbox-backed coding session continuing the current branch. */
-  createTask: (opts?: { runtime?: ThreadRuntime }) => string;
+   *  coding session; `branch` overrides the carried-over current branch. */
+  createTask: (opts?: { runtime?: ThreadRuntime; branch?: string }) => string;
   createTaskWithMessage: (params: {
     message: SendMessageParams;
     virtualMcpId?: string;
@@ -685,13 +685,18 @@ export function ChatContextProvider({
   // task's branch so the new thread lands on the same warm sandbox. The
   // route loader's useEnsureTask will see the row already exists on its
   // GET and skip the create-on-404 fallback.
-  const createTask = (opts?: { runtime?: ThreadRuntime }): string => {
+  const createTask = (opts?: {
+    runtime?: ThreadRuntime;
+    branch?: string;
+  }): string => {
     const newId = crypto.randomUUID();
+    // A caller-supplied branch wins over the active task's branch carry-over.
+    const branch = opts?.branch ?? currentBranch;
     void threadActions
       .create({
         id: newId,
         virtual_mcp_id: virtualMcpId,
-        ...(currentBranch ? { branch: currentBranch } : {}),
+        ...(branch ? { branch } : {}),
         ...(opts?.runtime ? { runtime: opts.runtime } : {}),
       })
       .then(() => navigateToTask(newId))

--- a/apps/web/src/components/chat/pills/branch-pill.tsx
+++ b/apps/web/src/components/chat/pills/branch-pill.tsx
@@ -21,6 +21,7 @@ interface Props {
   sandboxMap: SandboxMap | undefined;
   value: string | null | undefined;
   onChange: (branch: string) => void;
+  onCreateBranch?: (branch: string) => void;
   locked: boolean;
   placement?: "chat" | "header";
 }

--- a/apps/web/src/components/chat/pills/chat-mode-row.tsx
+++ b/apps/web/src/components/chat/pills/chat-mode-row.tsx
@@ -3,6 +3,7 @@ import type { VirtualMCPEntity } from "@decocms/shared/sdk/types";
 import { useOptionalChatStream, useOptionalChatTask } from "../context";
 import { BranchPill } from "./branch-pill";
 import { getActiveGithubRepo } from "@/lib/github-repo";
+import { shouldStartBranchAsCms } from "@/sdk/fast-preview";
 import { useProjectContext } from "@/sdk";
 import { authClient } from "@/lib/auth-client";
 import { branchUserLabel } from "@decocms/shared/branch-name";
@@ -45,6 +46,11 @@ export function ChatModeRow({ virtualMcp, currentBranch }: SmartProps) {
   const locked =
     (stream?.messages ?? []).length > 0 || (taskCtx?.isThreadLocked ?? false);
   const setCurrentTaskBranch = taskCtx?.setCurrentTaskBranch;
+  const createTask = taskCtx?.createTask;
+  const createBranchAsCms = shouldStartBranchAsCms(
+    virtualMcp?.metadata,
+    taskCtx?.activeTask?.metadata,
+  );
 
   const githubRepo = getActiveGithubRepo(virtualMcp);
   const connectionId = githubRepo?.connectionId;
@@ -72,6 +78,13 @@ export function ChatModeRow({ virtualMcp, currentBranch }: SmartProps) {
         value={currentBranch}
         onChange={(next) => {
           if (setCurrentTaskBranch) void setCurrentTaskBranch(next);
+        }}
+        onCreateBranch={(next) => {
+          if (createBranchAsCms && createTask) {
+            createTask({ branch: next });
+          } else if (setCurrentTaskBranch) {
+            void setCurrentTaskBranch(next);
+          }
         }}
         locked={locked}
         placement="chat"

--- a/apps/web/src/components/thread/github/branch-picker.tsx
+++ b/apps/web/src/components/thread/github/branch-picker.tsx
@@ -52,6 +52,11 @@ interface Props {
   sandboxMap: SandboxMap | undefined;
   value: string | null | undefined;
   onChange: (branch: string) => void;
+  /** Called instead of `onChange` when the user creates a brand-new branch via
+   *  the "New" button, letting callers treat branch *creation* differently from
+   *  switching to an existing branch (Fast Preview projects start a fresh CMS
+   *  thread on it). Falls back to `onChange` when omitted. */
+  onCreateBranch?: (branch: string) => void;
   /** When true, the trigger is disabled — the user can't open the
    *  picker. The tooltip still surfaces the current branch on hover. */
   disabled?: boolean;
@@ -78,6 +83,7 @@ export function BranchPicker({
   sandboxMap,
   value,
   onChange,
+  onCreateBranch,
   disabled = false,
   placement = "chat",
 }: Props) {
@@ -149,6 +155,12 @@ export function BranchPicker({
 
   const pick = (name: string) => {
     onChange(name);
+    setOpen(false);
+  };
+
+  // Creating a branch is a distinct intent from switching to an existing one.
+  const create = (name: string) => {
+    (onCreateBranch ?? onChange)(name);
     setOpen(false);
   };
 
@@ -257,7 +269,7 @@ export function BranchPicker({
                 size="sm"
                 className="h-7 shrink-0"
                 onClick={() =>
-                  pick(search.trim() || generateBranchName(userLabel))
+                  create(search.trim() || generateBranchName(userLabel))
                 }
               >
                 {search.trim()

--- a/apps/web/src/sdk/fast-preview.test.ts
+++ b/apps/web/src/sdk/fast-preview.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { resolveFastPreview } from "./fast-preview";
+import { resolveFastPreview, shouldStartBranchAsCms } from "./fast-preview";
 
 const FP_PROJECT = {
   fastPreview: true,
@@ -26,5 +26,31 @@ describe("resolveFastPreview", () => {
       resolveFastPreview({ previewServerUrl: "https://acme.com" }).active,
     ).toBe(false);
     expect(resolveFastPreview({}, { runtime: "cms" }).active).toBe(false);
+  });
+});
+
+describe("shouldStartBranchAsCms", () => {
+  test("true from a sandbox coding session on a fast-preview project", () => {
+    expect(shouldStartBranchAsCms(FP_PROJECT, { runtime: "sandbox" })).toBe(
+      true,
+    );
+  });
+
+  test("false when already in CMS — the in-place switch stays CMS", () => {
+    expect(shouldStartBranchAsCms(FP_PROJECT)).toBe(false);
+    expect(shouldStartBranchAsCms(FP_PROJECT, undefined)).toBe(false);
+    expect(shouldStartBranchAsCms(FP_PROJECT, {})).toBe(false);
+    expect(shouldStartBranchAsCms(FP_PROJECT, { runtime: "cms" })).toBe(false);
+  });
+
+  test("false without the fast-preview capability, even from a sandbox", () => {
+    expect(shouldStartBranchAsCms({ fastPreview: true }, {})).toBe(false);
+    expect(
+      shouldStartBranchAsCms(
+        { previewServerUrl: "https://acme.com" },
+        { runtime: "sandbox" },
+      ),
+    ).toBe(false);
+    expect(shouldStartBranchAsCms({}, { runtime: "sandbox" })).toBe(false);
   });
 });

--- a/apps/web/src/sdk/fast-preview.ts
+++ b/apps/web/src/sdk/fast-preview.ts
@@ -24,3 +24,20 @@ export function resolveFastPreview(
   );
   return { previewServerUrl, active: runtime === "cms" };
 }
+
+/**
+ * Whether creating a brand-new branch should start a fresh CMS thread instead
+ * of reusing the current session. True only when the project supports Fast
+ * Preview but the active thread is a sandbox coding session: the runtime stamp
+ * is per-thread and immutable, so the only way a new branch lands in CMS is a
+ * new (unstamped) thread. When already in CMS — or without the capability — the
+ * in-place branch switch already yields the right runtime.
+ */
+export function shouldStartBranchAsCms(
+  metadata: Parameters<typeof resolveFastPreview>[0],
+  threadMetadata?: Parameters<typeof resolveFastPreview>[1],
+): boolean {
+  const projectSupportsCms = resolveFastPreview(metadata).active;
+  const sessionIsCms = resolveFastPreview(metadata, threadMetadata).active;
+  return projectSupportsCms && !sessionIsCms;
+}


### PR DESCRIPTION
## Summary

On a Fast Preview project, clicking the branch picker's **"New"** button while in a coding session (sandbox thread) was creating the new branch in **sandbox** mode. It should start in **CMS** mode — Fast Preview projects are CMS-first, and a brand-new branch shouldn't inherit the sandbox you happened to be in.

### Why it happened

Runtime is a **per-thread, immutable stamp** (`thread.metadata.runtime`). The "New" button called `setBranch` on the *current* thread, so a `runtime: "sandbox"` thread just re-pointed to the new branch and stayed sandbox. The only way a new branch lands in CMS is a **fresh unstamped thread** (unstamped ⇒ resolves to `cms` on a Fast-Preview-capable project).

### The fix

- New pure helper `shouldStartBranchAsCms(vmMeta, threadMeta)` in `sdk/fast-preview.ts`: true only when the project supports Fast Preview **and** the active thread is a sandbox session.
- `BranchPicker` gains an `onCreateBranch` callback wired only to the "New"/create button (falls back to `onChange` when omitted), so branch *creation* is distinguishable from switching to an existing branch.
- `createTask` accepts a `branch` override so the new CMS thread lands on the freshly created branch.
- `ChatModeRow` routes "New": when `shouldStartBranchAsCms`, create a new (unstamped ⇒ CMS) thread; otherwise keep the existing in-place `setBranch`.

### Behavior

| Situation | Before | After |
|---|---|---|
| Sandbox session, Fast Preview project | new branch = sandbox ❌ | **new branch = CMS (new thread)** ✅ |
| Already in CMS | in-place switch (stays CMS) | unchanged |
| Non-Fast-Preview project | in-place switch | unchanged |
| Selecting an **existing** branch | in-place switch | unchanged (out of scope) |

**UX note:** from a coding session, "New" now opens a fresh CMS thread, so the URL changes (a genuinely new session on the new branch). Existing-branch selection still switches in place.

## Testing

- `bun test apps/web/src/sdk/fast-preview.test.ts` — 3 new cases for `shouldStartBranchAsCms` (6 pass)
- `bun test .../chat-mode-row.test.tsx` (4 pass)
- `bun run --cwd=apps/web check` (typecheck) ✅
- `bun run lint` (0 errors) ✅, `knip` clean, `bun run fmt` applied

No wire/API contract change — `ThreadCreateData` already accepted `branch` + `runtime`; the change is web-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Creating a new branch from a sandbox coding session in Fast Preview projects now opens a fresh CMS thread on that branch. Previously, the "New" button re-pointed the current sandbox thread to the new branch, keeping it in sandbox; now it respects the CMS-first workflow and starts CMS.

- Add `shouldStartBranchAsCms(vmMeta, threadMeta)` in `sdk/fast-preview.ts` to decide when to start CMS.
- `BranchPicker` gains `onCreateBranch` for the "New" button; it falls back to `onChange` when omitted (no migration required).
- `createTask` accepts an optional `branch` so the new CMS thread lands on the created branch.
- `ChatModeRow` uses `onCreateBranch`: when `shouldStartBranchAsCms` is true, it creates a new (unstamped ⇒ CMS) thread; otherwise it calls `setCurrentTaskBranch`.
- Unchanged: switching to an existing branch, already-in-CMS sessions, and non–Fast Preview projects.
- UX note: from a coding session, "New" opens a new thread, so the URL changes.

<sup>Written for commit e573636432a3341e72e6bba3d37033fd66a4bfb3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6258?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

