### PR TITLE
fix(ci): install Playwright browsers from the pinned version, not npx

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -162,26 +162,41 @@ jobs:
             console.log("created bucket", process.env.S3_BUCKET);
           '
 
+      # Key on the RESOLVED Playwright version, not a hash of the manifest: the
+      # manifest carries a caret range, so its hash does not change when the
+      # lockfile resolves a new version — and the cache would then serve
+      # browsers built for a different Playwright than the tests run against.
+      - name: Resolve Playwright version
+        id: playwright-version
+        working-directory: packages/e2e
+        run: |
+          version=$(node -p "require('@playwright/test/package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Cache Playwright browsers
         id: cache-playwright
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('packages/e2e/package.json') }}
-          # On a key rotation (any packages/e2e dep bump) the fallback restores
-          # the previous browsers and `playwright install` downloads only the
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+          # On a key rotation (a Playwright bump) the fallback restores the
+          # previous browsers and `playwright install` downloads only the
           # missing version instead of a full cold install.
           restore-keys: |
             playwright-${{ runner.os }}-
 
       # Browser binary only (Playwright's own CDN, no apt involved) — kept
       # separate from the system deps below so an Ubuntu mirror outage can
-      # never block the download that actually has to succeed.
+      # never block the download that actually has to succeed. Invoked via
+      # ./node_modules/.bin/playwright, never `npx playwright`: npx ignores the
+      # lockfile and resolves from the registry, so a cache miss would install
+      # browsers for the LATEST release while the tests run against the pinned
+      # one — a mismatch a warm cache hides.
       - name: Install Playwright chromium
         if: steps.cache-playwright.outputs.cache-hit != 'true'
         working-directory: packages/e2e
         timeout-minutes: 5
-        run: npx playwright install chromium
+        run: ./node_modules/.bin/playwright install chromium
 
       # Everything chromium links against is already in the runner image — the
       # only thing this step downloads is ~21 MB of font packages. So a total
@@ -191,7 +206,7 @@ jobs:
         uses: ./.github/actions/apt-mirror-fallback
         continue-on-error: true
         with:
-          run: cd packages/e2e && npx playwright install-deps chromium
+          run: cd packages/e2e && ./node_modules/.bin/playwright install-deps chromium
 
       - name: Create data directory
         run: mkdir -p data

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,26 +211,41 @@ jobs:
       - name: Setup Bun and install dependencies
         uses: ./.github/actions/setup-bun
 
+      # Key on the RESOLVED Playwright version, not a hash of the manifest: the
+      # manifest carries a caret range, so its hash does not change when the
+      # lockfile resolves a new version — and the cache would then serve
+      # browsers built for a different Playwright than the tests run against.
+      - name: Resolve Playwright version
+        id: playwright-version
+        working-directory: apps/web
+        run: |
+          version=$(node -p "require('@playwright/test/package.json').version")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Cache Playwright browsers
         id: cache-playwright
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-ct-${{ runner.os }}-${{ hashFiles('apps/web/package.json') }}
-          # On a key rotation (playwright version bump) the fallback restores
-          # the previous browsers and `playwright install` downloads only the
+          key: playwright-ct-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+          # On a key rotation (a Playwright bump) the fallback restores the
+          # previous browsers and `playwright install` downloads only the
           # missing version instead of everything.
           restore-keys: |
             playwright-ct-${{ runner.os }}-
 
       # Browser binary only (Playwright's own CDN, no apt involved) — kept
       # separate from the system deps below so an Ubuntu mirror outage can
-      # never block the download that actually has to succeed.
+      # never block the download that actually has to succeed. Invoked via
+      # ./node_modules/.bin/playwright, never `npx playwright`: npx ignores the
+      # lockfile and resolves from the registry, so a cache miss would install
+      # browsers for the LATEST release while the tests run against the pinned
+      # one — a mismatch a warm cache hides.
       - name: Install Playwright chromium
         if: steps.cache-playwright.outputs.cache-hit != 'true'
         working-directory: apps/web
         timeout-minutes: 5
-        run: npx playwright install chromium
+        run: ./node_modules/.bin/playwright install chromium
 
       # Everything chromium links against is already in the runner image — the
       # only thing this step downloads is ~21 MB of font packages. So a total
@@ -240,7 +255,7 @@ jobs:
         uses: ./.github/actions/apt-mirror-fallback
         continue-on-error: true
         with:
-          run: cd apps/web && npx playwright install-deps chromium
+          run: cd apps/web && ./node_modules/.bin/playwright install-deps chromium
 
       - name: Run component tests
         run: bun run --cwd=apps/web test:ct


### PR DESCRIPTION
The cold-cache Playwright install path installs browsers for a **different Playwright than the tests run against**. A warm cache hides it, so it almost never fires — but it is one cache eviction or runner-image change away from a red build.

## The bug

`npx playwright install` ignores the lockfile and resolves Playwright from the registry:

| | version | chromium build |
|---|---|---|
| `bun.lock` pins `@playwright/test` | 1.59.1 | **1217** |
| `npx playwright` resolves | 1.62.1 (current release) | **1234** |

So a cache miss downloads build 1234, the tests look for 1217, and every browser test dies with:

```
browserType.launch: Executable doesn't exist at
  ~/.cache/ms-playwright/chromium_headless_shell-1217/chrome-headless-shell-linux64/chrome-headless-shell
```

Two things kept this hidden. The install is gated on `cache-hit != 'true'`, and the Playwright cache essentially always hits. And the cache key is `hashFiles('<dir>/package.json')` — the manifest carries the caret range `^1.58.2`, so its hash does **not** change when the lockfile resolves a new version. The key could not rotate on the one input that determines which browsers are correct.

I hit this by running these same workflows on a CI provider with a separate cache namespace, which forced a genuine cold install: **35 of 80 e2e tests failed**. After this change, on the same cold path, **80 passed / 0 failed**.

## The fix

- **Invoke `./node_modules/.bin/playwright`** at all four call sites (browser install and `install-deps`, in both `e2e.yml` and `test.yml`) so the install always matches the pinned, installed library. Checked rather than assumed: bun does not hoist playwright to the root, but `packages/e2e/node_modules/.bin/playwright` and `apps/web/node_modules/.bin/playwright` both exist and both report 1.59.1, and each step already runs in the matching directory.

- **Key the browser cache on the resolved Playwright version**, via a small step that reads it out of the installed package. This also invalidates any cache already holding mismatched browsers — which matters, because a poisoned cache would otherwise keep serving the wrong build after the first fix.

Also corrects the key-rotation comment, which described the old `hashFiles()` behaviour ("any dep bump") rather than what the key now tracks.

Upstream's apt-mirror-fallback structure for these steps is preserved unchanged.

## Verification

Both providers ran the cold install path on this change, since rotating the cache key forces a miss:

- **Cold download, verified end to end:** cache miss on `playwright-Linux-1.59.1` → `./node_modules/.bin/playwright install chromium` → `Chrome Headless Shell 147.0.7727.15 (chromium-headless-shell v1217)` → 80 passed.
- **GitHub Actions:** the restore-key fallback hit, so `cache-hit` was false and the cold path ran through the fixed binary — 79 passed on `e2e-shard (1)`. Note the download itself was short-circuited because the restored cache already held 1217, so this run validates the invocation rather than the download.

Local checks: `bun run fmt` clean, both `Resolve Playwright version` commands verified to emit `1.59.1` from their respective directories, and `playwright install --dry-run` confirms 1.59.1 wants build 1217.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI to install Playwright browsers from the pinned local `@playwright/test` version and keys the cache to that version. Previously, `npx playwright install` ignored the lockfile and the cache key used the manifest hash, so cold caches installed browsers for the latest Playwright while tests ran the pinned version, causing browser launch failures.

- Invoke `./node_modules/.bin/playwright` for both install and install-deps in `.github/workflows/e2e.yml` and `.github/workflows/test.yml` (four call sites).
- Add a “Resolve Playwright version” step in each workflow to read `require('@playwright/test/package.json').version`.
- Key the browser cache to the resolved version; fallback restore remains. This rotates existing caches and may trigger a one-time download.
- Preserve the existing apt-mirror-fallback structure. No migration actions for developers.

<sup>Written for commit 265d118e6345e52edababfdcc117046c7144428a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6259?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

