### PR TITLE
feat(assets): make the native Assets tab always-on, drop the feature flag

### DIFF
--- a/apps/web/src/components/import-from-deco-dialog.tsx
+++ b/apps/web/src/components/import-from-deco-dialog.tsx
@@ -314,12 +314,6 @@ export function ImportFromDecoDialog({
                   pinnedViews: [
                     {
                       connectionId: connId,
-                      toolName: "fetch_assets",
-                      label: "Assets",
-                      icon: null,
-                    },
-                    {
-                      connectionId: connId,
                       toolName: "get_monitor_data",
                       label: "Monitor",
                       icon: null,

--- a/apps/web/src/components/settings/navigation-settings.tsx
+++ b/apps/web/src/components/settings/navigation-settings.tsx
@@ -1,16 +1,12 @@
 import { toast } from "sonner";
 import { Switch } from "@decocms/ui/components/switch.tsx";
-import { LayoutLeft, Package } from "@untitledui/icons";
+import { LayoutLeft } from "@untitledui/icons";
 import {
   SettingsCard,
   SettingsCardItem,
   SettingsSection,
 } from "@/components/settings/settings-section";
-import {
-  useNavV2,
-  useOrgFlag,
-  useSetOrgFlag,
-} from "@/hooks/use-organization-settings";
+import { useNavV2, useSetOrgFlag } from "@/hooks/use-organization-settings";
 import { useT } from "@/i18n/use-t.ts";
 
 /**
@@ -22,7 +18,6 @@ import { useT } from "@/i18n/use-t.ts";
 export function NavigationSettings() {
   const t = useT();
   const enabled = useNavV2();
-  const nativeAssetsEnabled = useOrgFlag("native_assets_tab");
   const setFlag = useSetOrgFlag();
   return (
     <SettingsSection
@@ -41,24 +36,6 @@ export function NavigationSettings() {
               aria-label={t("settings.navigation.navV2Title")}
               onCheckedChange={(next) =>
                 setFlag.mutate("nav_v2", next, {
-                  onError: () =>
-                    toast.error(t("settings.navigation.updateError")),
-                })
-              }
-            />
-          }
-        />
-        <SettingsCardItem
-          icon={<Package size={16} />}
-          title={t("settings.navigation.nativeAssetsTitle")}
-          description={t("settings.navigation.nativeAssetsDescription")}
-          action={
-            <Switch
-              checked={nativeAssetsEnabled}
-              disabled={setFlag.isPending}
-              aria-label={t("settings.navigation.nativeAssetsTitle")}
-              onCheckedChange={(next) =>
-                setFlag.mutate("native_assets_tab", next, {
                   onError: () =>
                     toast.error(t("settings.navigation.updateError")),
                 })

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -446,9 +446,6 @@ export const settings = {
   "settings.navigation.navV2Title": "First-class navigation",
   "settings.navigation.navV2Description":
     "The sidebar lists destinations (Reports, Library, Tasks) instead of chats, and the chat list moves to the top of the chat panel. On by default for report organizations.",
-  "settings.navigation.nativeAssetsTitle": "Native Assets tab",
-  "settings.navigation.nativeAssetsDescription":
-    "Show a native Assets tab that browses the site's associated storage bucket, instead of the external admin view. Appears only on sites that have a bucket configured.",
   "settings.orgGeneral.organization": "Organization",
   "settings.mainAgent.title": "Main agent",
   "settings.mainAgent.description":

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -465,9 +465,6 @@ export const settings = {
   "settings.navigation.navV2Title": "Navegação de primeira classe",
   "settings.navigation.navV2Description":
     "A barra lateral lista destinos (Relatórios, Biblioteca, Tarefas) em vez de chats, e a lista de chats vai para o topo do painel de chat. Ativada por padrão em organizações de relatório.",
-  "settings.navigation.nativeAssetsTitle": "Aba de Assets nativa",
-  "settings.navigation.nativeAssetsDescription":
-    "Mostra uma aba de Assets nativa que navega o bucket de armazenamento associado ao site, em vez da view externa de admin. Aparece s\u00f3 em sites que t\u00eam um bucket configurado.",
   "settings.orgGeneral.organization": "Organiza\u00e7\u00e3o",
   "settings.mainAgent.title": "Agente principal",
   "settings.mainAgent.description":

--- a/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -68,11 +68,7 @@ import {
 import { useCapability } from "@/hooks/use-capability";
 import { useFileConfigsQuery } from "@/hooks/use-file-configs";
 import { matchSiteSlugConfig } from "@/components/file-picker/match-site-slug-config";
-import {
-  useNavV2,
-  useOrgFlag,
-  useReportsOnly,
-} from "@/hooks/use-organization-settings";
+import { useNavV2, useReportsOnly } from "@/hooks/use-organization-settings";
 import { useT } from "@/i18n/use-t.ts";
 
 export type AgentTabDef = {
@@ -293,19 +289,18 @@ export function useMainPanelTabs(ctx: {
   const showContentTab = hasEditableDecoContent(decofile, meta);
 
   /**
-   * Assets is a per-site tab behind the `native_assets_tab` org flag: it shows
-   * only when the flag is on AND an S3 bucket is associated to this site's slug
-   * (managed `deco-assets-<slug>` or a BYOB bucket). Uses the non-suspense
-   * configs query so the bar never blocks on the bucket list.
+   * Assets is a per-site tab: it shows whenever an S3 bucket is associated to
+   * this site's slug (managed `deco-assets-<slug>` or a BYOB bucket). Uses the
+   * non-suspense configs query so the bar never blocks on the bucket list.
    */
-  const nativeAssetsTabEnabled = useOrgFlag("native_assets_tab");
   const siteSlug =
     (entity?.metadata as { siteSlug?: string | null } | undefined)?.siteSlug ??
     null;
   const fileConfigsQuery = useFileConfigsQuery();
-  const showAssetsTab =
-    nativeAssetsTabEnabled &&
-    !!matchSiteSlugConfig(fileConfigsQuery.data?.configs ?? [], siteSlug);
+  const showAssetsTab = !!matchSiteSlugConfig(
+    fileConfigsQuery.data?.configs ?? [],
+    siteSlug,
+  );
 
   const { activeTab: rawActiveTab, mainOpen: rawMainOpen } =
     resolveActiveTabAndOpen({

--- a/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -445,6 +445,8 @@ export function useMainPanelTabs(ctx: {
     });
   }
   for (const pv of pinnedViews) {
+    // Retired admin-MCP view, now the native Assets tab: drop stale pins.
+    if (pv.toolName === "fetch_assets") continue;
     const id = formatPinnedViewTabId(pv.connectionId, pv.toolName);
     pinnedTabMap.set(id, {
       id,

--- a/packages/shared/src/organization/schema.ts
+++ b/packages/shared/src/organization/schema.ts
@@ -173,12 +173,6 @@ export const OrgFlagsSchema = z.object({
     .describe(
       "When a report import creates a task board item without an assignee, delegate it to the Super Agent automatically instead of leaving it unassigned.",
     ),
-  native_assets_tab: z
-    .boolean()
-    .optional()
-    .describe(
-      "Show the native Assets tab (a browser over the site's associated S3 bucket) instead of relying on the external admin-MCP fetch_assets view. Off by default while in development.",
-    ),
 });
 
 export type OrgFlags = z.infer<typeof OrgFlagsSchema>;

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -127,7 +127,6 @@ export interface StudioToolIO {
             auto_merge?: boolean | undefined;
             cheap_reviewer_model?: boolean | undefined;
             auto_assign_report_tasks_to_super_agent?: boolean | undefined;
-            native_assets_tab?: boolean | undefined;
           }
         | null
         | undefined;
@@ -196,7 +195,6 @@ export interface StudioToolIO {
             auto_merge?: boolean | undefined;
             cheap_reviewer_model?: boolean | undefined;
             auto_assign_report_tasks_to_super_agent?: boolean | undefined;
-            native_assets_tab?: boolean | undefined;
           }
         | undefined;
       main_agent_id?: string | null | undefined;
@@ -265,7 +263,6 @@ export interface StudioToolIO {
             auto_merge?: boolean | undefined;
             cheap_reviewer_model?: boolean | undefined;
             auto_assign_report_tasks_to_super_agent?: boolean | undefined;
-            native_assets_tab?: boolean | undefined;
           }
         | null
         | undefined;


### PR DESCRIPTION
## Summary

Removes the `native_assets_tab` feature flag and makes the **native per-site Assets tab always-on**. The external admin-MCP assets UI is being removed (decocms/admin-mcp#30), so the native tab is now the assets experience — no reason to keep it gated.

- **`use-main-panel-tabs.ts`**: the Assets tab shows whenever an S3 bucket is associated to the site's `siteSlug` (`matchSiteSlugConfig`), dropping the flag gate. The `?main=assets` fallback guard stays (falls back to default when no bucket).
- **`OrgFlagsSchema`**: removed `native_assets_tab`; regenerated tool contracts.
- **Navigation settings**: removed the toggle (added in #6257) + its en/pt-br i18n keys.

## Context / sequencing

Builds on #6251 (native tab + flag) and #6257 (settings toggle), both merged. Pairs with decocms/admin-mcp#30 (removes the `fetch_assets` UI). Net effect once all land: every site with an associated bucket gets the native Assets tab; nothing to toggle.

Still open as a follow-up: Studio import (`import-from-deco-dialog.tsx`) currently creates the `fetch_assets` pinned view on deco.cx import — that becomes a no-op tab once admin-mcp#30 ships and should be dropped separately.

## Testing notes
- `tsc --noEmit` passes (shared / web / api); `oxlint` clean on touched files; `bun run fmt` applied. No remaining references to `native_assets_tab`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the per-site Assets tab always-on when a site has an associated S3 bucket and removes the `native_assets_tab` feature flag and settings toggle. Replaces the admin-MCP `fetch_assets` view: we no longer pin it on import and we skip existing `fetch_assets` pins at render, so users see the native tab instead. The `?main=assets` fallback still drops to the default tab if no bucket is configured.

**Review and rollout**
- Remove any code using `useOrgFlag("native_assets_tab")` and stop sending/expecting this flag in org settings; tool contracts updated.
- Do not rely on a `fetch_assets` pinned view after import; the native per-site Assets tab is the source of truth.
- No data migration required: stale `fetch_assets` pins are ignored at render time.
- Coordinates with decocms/admin-mcp#30.

<sup>Written for commit 8f4cf9cd2e41a7c963a648a101edfe577be9c51b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

