### PR TITLE
fix(fast-preview): render global sections without the dev server

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -86,7 +86,10 @@ import {
 } from "@/components/sections-editor/page-path-utils";
 import { decoBlockFileViewPath } from "@/components/sections-editor/deco-block-key";
 import { findLivePageResolveType } from "@/components/sections-editor/section-catalog";
-import { buildGlobalSectionPreviewUrl } from "@/components/sections-editor/section-preview-url";
+import {
+  buildGlobalSectionPreviewUrl,
+  resolveSectionPreviewBase,
+} from "@/components/sections-editor/section-preview-url";
 import { useFastPreviewDraftUrl } from "@/components/sections-editor/use-fast-preview-draft-url";
 import { decofileWriteMutationKey } from "@/components/sections-editor/decofile-api";
 import { useCreatePage } from "@/components/sections-editor/use-create-page";
@@ -367,6 +370,13 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     inset?.entity?.id === virtualMcpId &&
     resolveFastPreview(inset.entity.metadata, activeThreadMeta).active;
 
+  // Base for the `/live/previews` global-section render: production under Fast Preview (no dev server), else the sandbox dev server.
+  const sectionPreviewBase = resolveSectionPreviewBase({
+    sandboxUrl: previewUrl,
+    previewServerUrl,
+    fastPreviewActive: fastPreviewEnabled,
+  });
+
   // Decofile pages/global sections for the URL bar dropdown. Not gated on the
   // dev server: when it's down we read the committed `.deco/*.gen.json` snapshot
   // so the dropdown still lists pages; the live routes take over once it's up.
@@ -619,7 +629,8 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
         ? // Fast Preview's draft route honours the variant matcher override like the sandbox dev server, so append it here too.
           withVariantMatcherOverride(
             withDeviceHint(
-              draftPreviewUrl ??
+              directPreviewUrl ??
+                draftPreviewUrl ??
                 new URL(resolvedPath, display.iframeBase!).href,
               previewDeviceSize,
             ),
@@ -706,7 +717,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   const sharedTarget = workspace.state.target;
   // oxlint-disable-next-line ban-use-effect/ban-use-effect -- synchronizes the independent Blocks selection with the mounted Preview iframe
   useEffect(() => {
-    if (!sharedTarget || !previewUrl || !meta) return;
+    if (!sharedTarget || !sectionPreviewBase || !meta) return;
     if (sharedTarget.kind === "page") {
       const params = pathParamsByPage[sharedTarget.key] ?? {};
       intendedPathRef.current = fillPathTemplate(sharedTarget.path, params);
@@ -735,12 +746,16 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
         setActiveLoaderKey(null);
         setActiveGlobalSection(section);
         setDirectPreviewUrl(
-          buildGlobalSectionPreviewUrl(previewUrl, livePageRt, section.key),
+          buildGlobalSectionPreviewUrl(
+            sectionPreviewBase,
+            livePageRt,
+            section.key,
+          ),
         );
       }
     }
     // oxlint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps -- derived helpers must not retrigger selection synchronization every render
-  }, [sharedTarget, previewUrl, meta, pathParamsByPage]);
+  }, [sharedTarget, sectionPreviewBase, meta, pathParamsByPage]);
 
   // Publish the page Preview is showing to the shared workspace so the Blocks
   // panel follows it — Blocks has no page navigator, it edits whatever page
@@ -1122,7 +1137,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   };
 
   const navigatePreviewToGlobalSection = (section: GlobalSectionEntry) => {
-    if (!previewUrl || !meta) {
+    if (!sectionPreviewBase || !meta) {
       toast.error(t("sandbox.preview.previewMetadataNotReady"));
       return;
     }
@@ -1130,7 +1145,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     intendedPathRef.current = null;
     const livePageRt = findLivePageResolveType(meta);
     const url = buildGlobalSectionPreviewUrl(
-      previewUrl,
+      sectionPreviewBase,
       livePageRt,
       section.key,
     );


### PR DESCRIPTION
## Summary

Under Fast Preview there is no sandbox dev server, so `previewUrl` (the dev-server URL) is always `null`. Navigating the preview to a **global section** required that `previewUrl`, so clicking a global section always tripped the *"Preview metadata not ready yet"* toast — even on sites whose schema resolves fine via the production `/live/_meta` fallback (Fresh/Deno sites with no committed `.deco/meta.gen.json`, e.g. `deco-sites/farmrio`).

## Fix

- Route the `/live/previews` global-section render through `resolveSectionPreviewBase` — the production deployment under Fast Preview, the sandbox dev server otherwise (the same rule the **Add Section** gallery already uses). In non-fast mode this resolves back to `previewUrl`, so the gate is byte-for-byte unchanged there.
- Apply it in all three call sites: the `navigatePreviewToGlobalSection` handler, the Blocks→Preview sync effect, and the readiness gate/toast.
- Let the production-mode iframe honour `directPreviewUrl` (`directPreviewUrl ?? draftPreviewUrl ?? …`) so the built section URL actually renders in the frame. The section URL sits on the same origin as `iframeBase` (`previewServerUrl`), so the native-shell origin registration already covers it.

## Why it's safe for sites without a committed `meta.gen.json`

`useLiveMeta` resolves the schema `live → committed → production`. Sites like farmrio (no committed snapshot) fall through to production `/live/_meta`, which is exactly the origin `sectionPreviewBase` points at under Fast Preview — everything aligns. When there's neither a committed snapshot nor a linked production site, `meta` stays unavailable (502) and the toast still fires, which is correct.

## Testing

- `tsc --noEmit` (apps/web): clean
- `bun test` for `section-preview-url` + `section-catalog`: 24 pass. The base-resolution logic the fix depends on (`resolveSectionPreviewBase`, incl. the fast-preview→production case) is already covered.
- `bun run lint`: 0 errors, no warnings in the changed file
- `bun run fmt`: applied

The remaining change is component wiring, which is e2e territory (a unit test would need the mocks banned in the unit tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes global-section preview in Fast Preview by resolving the preview base to production when the dev server is unavailable. Previously clicks always failed with the “Preview metadata not ready yet” toast because `previewUrl` was null; now global sections render as expected.

- Route `/live/previews` through resolveSectionPreviewBase (production in Fast Preview, dev server otherwise), matching the Add Section gallery. Non-fast mode resolves back to `previewUrl`, so behavior is unchanged there.
- Apply the base in three places: the navigate-to-global-section handler, the Blocks→Preview sync effect, and the readiness gate/toast (guards now check the resolved base).
- Let the production-mode iframe honor `directPreviewUrl` (`directPreviewUrl ?? draftPreviewUrl ?? …`) so the built section URL loads.
- Sites without a committed `meta.gen.json` keep resolving via production `/live/_meta`. If neither a committed snapshot nor a linked production site exists, the toast still appears (no change).

<sup>Written for commit 6624ec5b47bd043d9db7003abc54a7734f7e2a3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6264?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

