### PR TITLE
fix(sections-editor): keep plainSchema for deeply-nested multivariate widgets

### DIFF
--- a/apps/web/src/components/sections-editor/resolve-schema.test.ts
+++ b/apps/web/src/components/sections-editor/resolve-schema.test.ts
@@ -4,6 +4,7 @@ import {
   isFreeformPropsSchema,
   resolveSchema,
   type LiveMeta,
+  type SchemaProperty,
 } from "./resolve-schema";
 
 function metaWithSchema(blockSchema: Record<string, unknown>): LiveMeta {
@@ -712,6 +713,52 @@ describe("resolveSchema – plainSchema on block-ref", () => {
     expect(image?.type).toBe("block-ref");
     expect(image?.plainSchema).toBeDefined();
     expect(image?.plainSchema?.type).toBe("string");
+    expect(image?.plainSchema?.format).toBe("image-uri");
+  });
+
+  test("populates plainSchema for a multivariate flag nested past the eager depth cap", () => {
+    // Real farmrio MediaKits: the ImageWidget anyOf sits ~7 objects deep (loader → mediaKits[] → content → desktop → media union → image). eagerBranchSchema's depth cap used to null the plain image-uri branch there, demoting the field to a block-ref "Image Variants" picker instead of an image widget with variants.
+    const imageWidgetAnyOf = {
+      title: "Imagem",
+      anyOf: [
+        { type: "string", format: "image-uri", title: "ImageWidget" },
+        {
+          title: "Image Variants",
+          type: "object",
+          required: ["__resolveType"],
+          properties: {
+            __resolveType: {
+              type: "string",
+              enum: ["website/flags/multivariate/image.ts"],
+              default: "website/flags/multivariate/image.ts",
+            },
+            variants: { type: "array", items: { type: "object" } },
+          },
+        },
+      ],
+    };
+    let nested: Record<string, unknown> = {
+      type: "object",
+      properties: { image: imageWidgetAnyOf },
+    };
+    for (let i = 0; i < 7; i++) {
+      nested = { type: "object", properties: { child: nested } };
+    }
+    const meta = metaWithSchema(nested);
+
+    let node: SchemaProperty | null | undefined = resolveSchema(
+      "site/sections/Test.tsx",
+      meta,
+    );
+    for (let i = 0; i < 7; i++) {
+      node = node?.properties?.child;
+    }
+    const image = node?.properties?.image;
+    expect(image?.type).toBe("block-ref");
+    expect(image?.anyOfRefs?.[0]?.resolveType).toBe(
+      "website/flags/multivariate/image.ts",
+    );
+    expect(image?.plainSchema).toBeDefined();
     expect(image?.plainSchema?.format).toBe("image-uri");
   });
 

--- a/apps/web/src/components/sections-editor/resolve-schema.ts
+++ b/apps/web/src/components/sections-editor/resolve-schema.ts
@@ -731,13 +731,10 @@ export function resolveSchema(
           const nonLoaderBranches = nonNull.filter(
             (a) => !loaderBranches.includes(a),
           );
+          // Built directly (not eagerBranchSchema) so its depth cap can't null this leaf and demote the field to a block-ref picker at deep nesting.
           const plainSchema =
-            nonLoaderBranches.length === 1
-              ? eagerBranchSchema(
-                  nonLoaderBranches[0]!,
-                  depth + 1,
-                  nonNull.length,
-                )
+            nonLoaderBranches.length === 1 && !cyclicUnion
+              ? buildProperty(nonLoaderBranches[0]!, depth + 1, unionSeen)
               : undefined;
 
           return {


### PR DESCRIPTION
## Summary

In Studio's Content editor, an `ImageWidget` (or any multivariate-flag widget) buried deep in an object/union/array tree rendered as an **"Image Variants" block-ref picker** instead of an image widget with variant support.

Reported on farmrio loader `MediaKitsCentralizados` (`site/loaders/Layouts/MediaKits.tsx`): the `image` field sits ~7 levels deep — loader → `mediaKits[]` → content → desktop → `media` discriminated union → ImageMedia → `image`.

<img width="600" alt="Image field rendering as an 'Image Variants' dropdown" src="https://github.com/user-attachments/assets/placeholder" />

## Root cause

`ImageWidget` is `anyOf: [{type:string, format:image-uri}, <flag: website/flags/multivariate/image.ts>]`. `resolveSchema` correctly emits `{type:"block-ref", anyOfRefs:[flag], plainSchema:<image-uri branch>}`, and `schema-form`'s `isMultivariateBlockRef` uses `plainSchema` to render a `MultivariateFieldWrapper` whose inner field is the image widget.

But `plainSchema` was computed via `eagerBranchSchema`, whose depth cap (`branchDepth < MAX_BUILD_PROPERTY_DEPTH`, =8) returns `undefined` at deep nesting. With `plainSchema` nulled, `isMultivariateBlockRef` returned `false` and the field fell through to the `AnyOfField` picker.

The loader branches are lazily re-resolvable on selection, so the cap makes sense for them — but the plain leaf branch has no lazy fallback and must not be gated by it.

Verified by running `resolveSchema` against farmrio's real `/live/_meta`.

## Fix

Build the single non-loader branch directly with `buildProperty` (cycle guard preserved; `buildProperty`'s own guards keep it bounded) instead of `eagerBranchSchema`.

## Not a fresh regression

Latent since image-variant support was added (#4189) — the feature only ever covered shallow `image: ImageWidget` props. #4223 refactored the mechanism to `eagerBranchSchema` but kept the same depth behavior.

## Testing

- Regression test in `resolve-schema.test.ts`: nests the ImageWidget `anyOf` 7 levels; **fails without the fix** (`plainSchema` undefined at N≥7) and passes with it (`format: "image-uri"`).
- `bun test apps/web/src/components/sections-editor/` → 667 pass, 0 fail
- `bun run --cwd=apps/web check` (tsc) clean; `bun run lint` no new errors; `bun run fmt` applied.
- No farmrio-side change needed — the bug was entirely in Studio's schema renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes deep multivariate widgets rendering as a block-ref picker by preserving plainSchema. Previously, deeply nested `ImageWidget` (and similar) showed an “Image Variants” picker; now it renders the image widget with variant support.

- Build the single non-loader branch with `buildProperty` (not `eagerBranchSchema`) to avoid the depth cap nulling `plainSchema`; keep the cycle guard and rely on `buildProperty`’s bounds.
- Scope: only when there is exactly one non-loader branch and the union is not cyclic; loader branches remain lazy-resolvable.
- Adds a regression test nesting the widget 7 levels; it fails without the fix and passes with it.
- No migrations or consumer changes required.

<sup>Written for commit ee34f4284a6aed5fc14aca1b5378ce3ea02efd3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

