### PR TITLE
fix(sandbox): re-mint the org-fs token instead of replaying the expired one

### DIFF
--- a/apps/api/src/sandbox/lifecycle.ts
+++ b/apps/api/src/sandbox/lifecycle.ts
@@ -23,6 +23,10 @@ import { buildCloneInfo } from "@/shared/github-clone-info";
 import { CredentialVault } from "@/encryption/credential-vault";
 import { getSettings } from "@/settings";
 import { parseGithubOwnerRepo } from "@/sandbox/parse-github-clone-url";
+import { mintOrgFsConfigJson } from "@/file-storage/mount/provisioning";
+import { OrgRepoSyncStorage } from "@/storage/org-repo-syncs";
+import { auth } from "@/auth";
+import { getPublicUrl } from "@/core/server-constants";
 
 // Stashed on globalThis so they survive Bun's `--hot` reload. The preview
 // reverse-proxy registered at the top of `apps/api/src/index.ts` is wired
@@ -187,6 +191,29 @@ async function instantiate(
             { bufferMs: mintOpts?.bufferMs },
           );
           return cloneUrl;
+        },
+        // Same lifetime problem as mintCloneUrl; see mintOrgFsConfig's docs.
+        mintOrgFsConfig: async (tenant) => {
+          if (!tenant.orgSlug) return null;
+          const json = await mintOrgFsConfigJson(
+            {
+              boundAuth: {
+                apiKey: {
+                  create: (data) =>
+                    auth.api.createApiKey({
+                      body: { ...data, userId: tenant.userId },
+                    }),
+                },
+              },
+              storage: { orgRepoSyncs: new OrgRepoSyncStorage(db) },
+            },
+            {
+              orgSlug: tenant.orgSlug,
+              orgId: tenant.orgId,
+              baseUrl: getPublicUrl(),
+            },
+          );
+          return json ?? null;
         },
       });
     }

--- a/packages/sandbox/server/provider/agent-sandbox/runner.test.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "bun:test";
 import type { EnsureOptions } from "../types";
-import { earlierShutdown, laterShutdown, stripEnsureOpts } from "./runner";
+import {
+  earlierShutdown,
+  freshOrgFsConfigJson,
+  laterShutdown,
+  stripEnsureOpts,
+} from "./runner";
 
 describe("stripEnsureOpts", () => {
   it("retains orgFsConfigJson so resurrection replays org-fs mounts", () => {
@@ -121,5 +126,47 @@ describe("laterShutdown", () => {
 
   it("treats an unparseable shutdownTime as no commitment", () => {
     expect(laterShutdown("not-a-date", target)).toBe(target.toISOString());
+  });
+});
+
+describe("freshOrgFsConfigJson", () => {
+  const tenant = { orgId: "org_1", userId: "usr_1", orgSlug: "acme" };
+  const stale: EnsureOptions = {
+    tenant,
+    orgFsConfigJson: '{"token":"expired"}',
+  };
+
+  it("replaces the persisted config with a freshly minted one", async () => {
+    const fresh = await freshOrgFsConfigJson(
+      stale,
+      async () => '{"token":"live"}',
+    );
+    expect(fresh).toBe('{"token":"live"}');
+  });
+
+  // A dead org-fs key 401s every WebDAV call and the agent sees EIO on every
+  // `org/` path, so the fallback must never be "no mounts".
+  it("falls back to the persisted config when the minter declines", async () => {
+    expect(await freshOrgFsConfigJson(stale, async () => null)).toBe(
+      stale.orgFsConfigJson,
+    );
+  });
+
+  it("falls back when the minter throws", async () => {
+    const fresh = await freshOrgFsConfigJson(stale, async () => {
+      throw new Error("mint down");
+    });
+    expect(fresh).toBe(stale.orgFsConfigJson);
+  });
+
+  it("keeps the persisted config when the row has no tenant to scope a key to", async () => {
+    const untenanted: EnsureOptions = { orgFsConfigJson: '{"token":"old"}' };
+    let called = false;
+    const fresh = await freshOrgFsConfigJson(untenanted, async () => {
+      called = true;
+      return '{"token":"live"}';
+    });
+    expect(fresh).toBe('{"token":"old"}');
+    expect(called).toBe(false);
   });
 });

--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -457,6 +457,20 @@ export interface AgentSandboxProviderOptions {
     repo: NonNullable<EnsureOptions["repo"]>,
     opts?: { bufferMs?: number },
   ) => Promise<string | null>;
+  /**
+   * Re-mint a fresh `orgFsConfigJson` for a tenant. Same lifetime problem as
+   * `mintCloneUrl`: the config persisted in `ensureOpts` embeds an fs-scoped
+   * API key from first provision, and Better Auth deletes that key once it
+   * expires — so replaying the persisted config on recovery mounts org-fs with
+   * a credential that no longer exists. Every WebDAV call then 401s and the
+   * agent sees `Input/output error` on every `org/` path, silently, for the
+   * life of the sandbox. Returns null when it can't mint (no org slug, mint
+   * error); the runner then falls back to the persisted config. Must never
+   * throw.
+   */
+  mintOrgFsConfig?: (
+    tenant: NonNullable<EnsureOptions["tenant"]>,
+  ) => Promise<string | null>;
 }
 
 export class AgentSandboxProvider implements SandboxProvider {
@@ -501,6 +515,8 @@ export class AgentSandboxProvider implements SandboxProvider {
   private readonly sentinelToken: string | null;
   /** See {@link AgentSandboxProviderOptions.mintCloneUrl}. */
   private readonly mintCloneUrl: AgentSandboxProviderOptions["mintCloneUrl"];
+  /** See {@link AgentSandboxProviderOptions.mintOrgFsConfig}. */
+  private readonly mintOrgFsConfig: AgentSandboxProviderOptions["mintOrgFsConfig"];
   /** See {@link AgentSandboxProviderOptions.tenantPools}. */
   private readonly tenantPools: readonly TenantPool[];
   private readonly tenantPoolRefreshMs: number;
@@ -545,6 +561,7 @@ export class AgentSandboxProvider implements SandboxProvider {
     const trimmedSentinel = opts.sentinelToken?.trim() ?? "";
     this.sentinelToken = trimmedSentinel.length > 0 ? trimmedSentinel : null;
     this.mintCloneUrl = opts.mintCloneUrl;
+    this.mintOrgFsConfig = opts.mintOrgFsConfig;
     this.tenantPools =
       this.sentinelToken !== null ? (opts.tenantPools ?? []) : [];
     if (this.sentinelToken === null && (opts.tenantPools?.length ?? 0) > 0) {
@@ -1601,6 +1618,32 @@ export class AgentSandboxProvider implements SandboxProvider {
   }
 
   /**
+   * Return persisted `EnsureOptions` with both embedded credentials re-minted:
+   * the git cloneUrl (~55min GitHub App token) and the org-fs config (an
+   * fs-scoped API key Better Auth deletes at expiry). Both are baked in at
+   * first provision, so every path that replays a persisted blob — pod
+   * recreated under a live claim, resurrection after operator eviction — must
+   * go through here or it hands the sandbox a dead credential. Best-effort:
+   * each re-mint falls back to the persisted value.
+   */
+  private async withFreshCredentials(
+    opts: EnsureOptions,
+  ): Promise<EnsureOptions> {
+    return {
+      ...opts,
+      ...(opts.repo ? { repo: await this.withFreshCloneUrl(opts.repo) } : {}),
+      ...(opts.orgFsConfigJson
+        ? {
+            orgFsConfigJson: await freshOrgFsConfigJson(
+              opts,
+              this.mintOrgFsConfig,
+            ),
+          }
+        : {}),
+    };
+  }
+
+  /**
    * Keep the git credential fresh in long-lived sandboxes this replica serves.
    * A pod alive past the clone token's ~55min expiry with no recovery event
    * would push a dead credential on shutdown and lose the user's work; recovery
@@ -2142,14 +2185,10 @@ export class AgentSandboxProvider implements SandboxProvider {
     // so a bootId change there is informational only.
     if (state.daemonBootId && state.daemonBootId !== live.bootId) {
       if (this.sentinelToken !== null) {
-        // Re-clone with a live credential — the persisted cloneUrl's token has
-        // usually lapsed by the time a pool pod is recreated under the claim.
-        const rebootstrapOpts: EnsureOptions | null = state.ensureOpts?.repo
-          ? {
-              ...state.ensureOpts,
-              repo: await this.withFreshCloneUrl(state.ensureOpts.repo),
-            }
-          : (state.ensureOpts ?? null);
+        // Persisted credentials have usually lapsed by pod recreation.
+        const rebootstrapOpts: EnsureOptions | null = state.ensureOpts
+          ? await this.withFreshCredentials(state.ensureOpts)
+          : null;
         const ok = await this.rebootstrapDaemon(
           live.daemonUrl,
           state.token,
@@ -2340,15 +2379,8 @@ export class AgentSandboxProvider implements SandboxProvider {
     if (!row) return null;
     const persistedOpts = (row.state as Partial<PersistedK8sState>).ensureOpts;
     if (!persistedOpts) return null;
-    // The persisted cloneUrl carries the first-provision token, long expired by
-    // now. Re-mint so the reprovision (and the downstream credential rotation)
-    // uses a live credential instead of the dead one.
-    const opts: EnsureOptions = persistedOpts.repo
-      ? {
-          ...persistedOpts,
-          repo: await this.withFreshCloneUrl(persistedOpts.repo),
-        }
-      : persistedOpts;
+    // Persisted credentials carry first-provision tokens, long expired by now.
+    const opts = await this.withFreshCredentials(persistedOpts);
     // The row must resolve back to the handle we were asked to resurrect.
     // Structurally guaranteed now that both derive from `id.projectRef`, which
     // is the point of asserting it: if a future ref encoding breaks the
@@ -3045,6 +3077,30 @@ function tenantAttrs(tenant: RunnerTenant | null): {
     user_id: tenant?.userId ?? "",
     runner_kind: RUNNER_KIND,
   };
+}
+
+/**
+ * Re-mint the org-fs config for a set of persisted `EnsureOptions`, falling
+ * back to the persisted one whenever the minter is absent, declines, or throws
+ * — org-fs mounts are additive, so a mint failure must degrade to the old
+ * behaviour rather than strip the mounts. Needs `opts.tenant` (the org the key
+ * is scoped to); rows persisted without it keep the stale config.
+ */
+export async function freshOrgFsConfigJson(
+  opts: EnsureOptions,
+  mint: AgentSandboxProviderOptions["mintOrgFsConfig"],
+): Promise<string | undefined> {
+  if (!mint || !opts.tenant) return opts.orgFsConfigJson;
+  try {
+    return (await mint(opts.tenant)) ?? opts.orgFsConfigJson;
+  } catch (err) {
+    console.warn(
+      `[${LOG_LABEL}] org-fs credential re-mint failed: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    return opts.orgFsConfigJson;
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

`ensureOpts.orgFsConfigJson` embeds an fs-scoped API key minted at first provision. Every recovery path replayed it verbatim:

- `rehydrate()` — warm-pool pod recreated under a live claim → `rebootstrapDaemon`
- `resurrectByHandle()` — reprovision after operator idle-TTL eviction

Better Auth deletes an API key once it expires (`ORG_FS_KEY_TTL_SECONDS` = 7d), so the sidecar ends up mounting org-fs with a credential that **no longer has a row in `apikey`**. rclone attaches the FUSE mounts fine, then every WebDAV call 401s and the agent sees `Input/output error` on every `org/` path — silently, for the life of the sandbox.

This is exactly the bug `mintCloneUrl` already exists to fix for the *other* credential baked into the same persisted blob ("the cloneUrl persisted in `ensureOpts` embeds a ~55min GitHub App token from first provision"). The org-fs token was persisted the same way and never got the same refresh hook.

## Change

- `AgentSandboxProviderOptions.mintOrgFsConfig` — mirrors `mintCloneUrl`, wired in `apps/api/src/sandbox/lifecycle.ts` to the existing `mintOrgFsConfigJson` over an ambient Better Auth + `OrgRepoSyncStorage`.
- `withFreshCredentials(opts)` — one helper that refreshes **both** embedded credentials, replacing the two hand-rolled `withFreshCloneUrl` spreads at the replay sites.
- Best-effort, same as the clone-url re-mint: a declined or throwing minter falls back to the persisted config. org-fs mounts are additive, so a mint failure must degrade to the old behaviour rather than strip the mounts.

## Evidence (prod, 2026-08-19)

- Pod `studio-sandbox-prod-ttlhc` (org `deco-studio`): 8,768 `[org-fs] change-feed poll failed OrgFsApiError: Unauthorized status: 401` lines in ~30 min, across three different threads it served.
- Its `/run/orgfs/config.json` bearer token has no row in `apikey`; freshest `orgfs-deco-studio` key belongs to a different user.
- `sandbox_runner_state` for `handle=ephemeral-813dbc858d18b146` holds that dead token in `state.ensureOpts.orgFsConfigJson`.
- `org-fs … input/output error` runs 100–500/day for at least the last 6 days.
- Thread `thrd_0Zsrk1iEf_4R7x9K00TRX` (docs automation) hit `mkdir /app/org/.outputs/…: input/output error` and lost its memory write.

## Testing

- `bun test packages/sandbox/server/provider/agent-sandbox/` — 115 pass, incl. 4 new `freshOrgFsConfigJson` cases (fresh replaces / declines falls back / throws falls back / no tenant skips the mint).
- `bun run --cwd=packages/sandbox check`, `bun run --cwd=apps/api check`, `bun run lint` (0 errors), `bun run fmt`.

## Follow-ups (not in this PR)

- **Ceiling:** this refreshes on pod-recreation/resurrection events only. A claim that stays live past 7 days without either event still ages out. Idle TTL is 15 min, so that window isn't reachable today — tie the key TTL to the sandbox lifecycle if that changes.
- **Existing stale rows** keep 401ing until their next recovery event; deleting the affected `sandbox_runner_state` rows clears them immediately.
- **Separate issue:** `sandbox_runner_state.state` also persists raw `x-access-token:ghs_…` clone URLs in prod Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps hosted hosted-harness runs at dequeue and refreshes the org-fs credential on sandbox recovery. Previously, runs parked after dequeue on a per-pod gate and went silent while waiting; now per-pod caps apply before dequeue with global priority ordering, and the gate heartbeats while the child is ENQUEUED. Replay paths now re-mint the org-fs token instead of remounting with an expired key that caused 401/EIOs.

- Hosted runs and queues
  - Replace the partitioned hosted queue with two unpartitioned queues: `HOSTED_HARNESS_QUEUE` (in-process) and `HOSTED_HARNESS_SANDBOXED_QUEUE` (sandboxed), each capped per pod via `workerConcurrency` from settings.
  - Remove the in-process gate and its `/hosted-run-pending` endpoint; rely on the DBOS ENQUEUED backlog for autoscaling. Add a local `hosted_runs.active` up-down counter for visibility.
  - Enqueue child workflows with `priorityEnabled` so ordering applies across pods; drop the cancelled-while-parked check. The parent gate publishes `waiting-capacity` via `heartbeatWhileQueued` until the child dequeues.
  - Action: delete any KEDA metrics-api trigger or scrape for `/hosted-run-pending`; ensure caps are set via `DECOPILOT_MAX_CONCURRENT_HOSTED_RUNS` and `SANDBOX_MAX_CONCURRENT_HOSTED_RUNS`.

- Sandbox org-fs credential
  - Add `mintOrgFsConfig` (wired to `mintOrgFsConfigJson` + `OrgRepoSyncStorage`) and `withFreshCredentials()` to refresh both the Git clone URL and `orgFsConfigJson` during `rehydrate` and `resurrectByHandle`.
  - Best-effort: if minting declines or throws, fall back to the persisted config so org-fs mounts remain present.
  - Note: existing sandboxes pick up a fresh token on their next recovery event; to clear immediately, delete affected `sandbox_runner_state` rows.

<sup>Written for commit b10ea42ea3f600b27d2eeba970d15704fc60f343. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6266?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

