### PR TITLE
fix(decofile): squash-rebase Fast Preview syncs instead of leaving a merge commit

### DIFF
--- a/apps/api/src/api/routes/decofile.ts
+++ b/apps/api/src/api/routes/decofile.ts
@@ -32,6 +32,7 @@ import {
   type DecofilePatch,
 } from "@/decofile/commit-coalescer";
 import { signDraftToken, verifyDraftToken } from "@/decofile/draft-token";
+import { githubGitRebase } from "@/decofile/git-compat";
 import { GitHubApiError, type GitDataClient } from "@/decofile/github-git-data";
 import { readDecofileSnapshot } from "@/decofile/read-decofile";
 import type { Env } from "../hono-env";
@@ -309,12 +310,17 @@ export function createDecofileRoutes() {
       if (baseBranch === scope.branch) {
         return c.json({ error: "Branch is already the default branch" }, 400);
       }
+      const message = `chore(decofile): publish ${scope.branch}`;
       try {
-        const sha = await client.mergeBranch(
-          baseBranch,
-          scope.branch,
-          `chore(decofile): publish ${scope.branch}`,
-        );
+        let sha: string | null;
+        try {
+          sha = await client.mergeBranch(baseBranch, scope.branch, message);
+        } catch (err) {
+          if (!(err instanceof GitHubApiError && err.status === 409)) throw err;
+          // Sync branch-wins first; the branch then sits on base and this FFs.
+          await githubGitRebase(client, scope.branch, baseBranch);
+          sha = await client.mergeBranch(baseBranch, scope.branch, message);
+        }
         return sha
           ? c.json({ result: "merged", sha })
           : c.json({ result: "up-to-date" });

--- a/apps/api/src/api/routes/sandbox-proxy.ts
+++ b/apps/api/src/api/routes/sandbox-proxy.ts
@@ -918,16 +918,10 @@ export const createSandboxRoutes = () => {
         try {
           const body = (await c.req.json().catch(() => ({}))) as {
             base?: string;
-            onConflict?: string;
           };
           const client = await fastPreviewGitClient(c);
           const base = body.base ?? (await client.getDefaultBranch());
-          await githubGitRebase(
-            client,
-            claim.branch,
-            base,
-            body.onConflict === "branch-wins" ? "branch-wins" : "fail",
-          );
+          await githubGitRebase(client, claim.branch, base);
           return c.json({ ok: true }, 200, SANDBOX_PROXY_CACHE_HEADERS);
         } catch (err) {
           return fastPreviewGitError(c, err);

--- a/apps/api/src/decofile/git-compat.ts
+++ b/apps/api/src/decofile/git-compat.ts
@@ -120,56 +120,104 @@ export async function githubGitDiff(
   };
 }
 
-/** What to do when merging base into the branch hits a git-level conflict. */
-export type RebaseConflictStrategy = "fail" | "branch-wins";
-
 /**
- * "Rebase" equivalent: bring the branch up to date with `base` by merging
- * base INTO the branch server-side (GitHub /merges). A true rebase needs a
- * working tree; a merge commit achieves the same "branch contains latest
- * base" postcondition the dialog's flow wants before publishing.
+ * Bring the branch up to date with `base`, leaving it as ONE commit whose only
+ * parent is the base head — a squash-rebase, not a merge, because a merge's
+ * resolution lives only in its tree and `git rebase` drops merge commits. Clean
+ * merges take GitHub's 3-way tree; conflicts always take
+ * {@link buildBranchWinsTree} and the cost documented there.
  *
- * `onConflict: "branch-wins"` is the non-technical-user path: on a git-level
- * conflict, build the merge commit ourselves — base's tree with every path
- * the branch touched since the merge base replayed on top, so the branch's
- * content wins for its own edits while everything else catches up to base.
- * Deliberately branch-favoured: the person syncing is the person editing,
- * and silently losing THEIR block edit is the one outcome a CMS must never
- * pick. Both parents are recorded, so nothing from base is lost from
- * history.
+ * The forced ref update has no compare-and-swap (GitHub takes no `If-Match` on
+ * refs); re-reading the head right before it is the closest available lease.
  */
 export async function githubGitRebase(
   client: GitDataClient,
   branch: string,
   base: string,
-  onConflict: RebaseConflictStrategy = "fail",
 ): Promise<void> {
-  try {
-    await client.mergeBranch(
-      branch,
-      base,
-      `chore(decofile): merge ${base} into ${branch}`,
-    );
-    return;
-  } catch (err) {
-    if (!(err instanceof GitHubApiError && err.status === 409)) throw err;
-    if (onConflict !== "branch-wins") {
-      throw new GitHubApiError(
-        409,
-        "POST",
-        "merges",
-        `Merge conflict updating ${branch} from ${base} — resolve on GitHub`,
+  for (let attempt = 1; ; attempt++) {
+    // Read first: the pre-force check re-reads it, catching any later autosave.
+    const branchHead = await client.getHeadSha(branch);
+    const compared = await client.compareDetailed(base, branch);
+
+    // Already one commit on base: nothing to bring in, nothing to flatten.
+    if (compared.behindBy === 0 && compared.aheadBy <= 1) return;
+
+    const baseHead = await client.getHeadSha(base);
+
+    // No commits of its own: a fast-forward, which needs no force.
+    if (compared.aheadBy === 0) {
+      try {
+        await client.updateRef(branch, baseHead);
+        return;
+      } catch (err) {
+        // 422 = an autosave landed since the compare; rebuild on the new head.
+        if (!(err instanceof GitHubApiError && err.status === 422)) throw err;
+        if (attempt >= MERGE_CAS_ATTEMPTS) throw err;
+        continue;
+      }
+    }
+
+    let treeSha: string;
+    let branchWon = false;
+    // `mergeBranch` moves the ref onto the merge commit it creates.
+    let mergedSha: string | null = null;
+    try {
+      const mergeSha = await client.mergeBranch(
+        branch,
+        base,
+        `chore(decofile): merge ${base} into ${branch}`,
       );
+      if (mergeSha === null) {
+        // Branch already contains base but is >1 commit ahead: flatten as-is.
+        treeSha = await client.getCommitTreeSha(branchHead);
+      } else {
+        treeSha = await client.getCommitTreeSha(mergeSha);
+        mergedSha = mergeSha;
+      }
+    } catch (err) {
+      if (!(err instanceof GitHubApiError && err.status === 409)) throw err;
+      treeSha = await buildBranchWinsTree(
+        client,
+        compared.files,
+        branchHead,
+        baseHead,
+      );
+      branchWon = true;
+    }
+
+    const expectedHead = mergedSha ?? branchHead;
+    try {
+      const commitSha = await client.createCommit({
+        message: squashMessage(
+          branch,
+          base,
+          branchWon,
+          compared.commitMessages,
+        ),
+        treeSha,
+        parentShas: [baseHead],
+      });
+
+      if ((await client.getHeadSha(branch)) !== expectedHead) {
+        // An autosave landed mid-sync: rebuild on the new head, never force over it.
+        if (attempt < MERGE_CAS_ATTEMPTS) continue;
+        throw new GitHubApiError(
+          409,
+          "PATCH",
+          `git/refs/heads/${branch}`,
+          `${branch} kept changing while syncing with ${base}; try again`,
+        );
+      }
+      await client.updateRef(branch, commitSha, { force: true });
+      return;
+    } catch (err) {
+      await undoAbandonedMerge(client, branch, mergedSha, branchHead);
+      throw err;
     }
   }
-  await mergeBranchWins(client, branch, base);
 }
 
-/**
- * GitHub's compare endpoint returns at most 300 files; beyond that the
- * change-set is silently truncated, and replaying a truncated set would
- * DROP the branch's remaining edits from the merge. Fail loudly instead.
- */
 const MERGE_REPLAY_FILE_CAP = 300;
 
 const MERGE_CAS_ATTEMPTS = 3;
@@ -192,14 +240,14 @@ export function buildMergeTreeEntries(
     sha: string;
     previousFilename?: string;
   }>,
-  branchBlobByPath: Map<string, { sha: string }>,
+  branchBlobByPath: Map<string, { sha: string; mode?: string }>,
 ): TreeWriteEntry[] {
   const byPath = new Map<string, TreeWriteEntry>();
   for (const f of files) {
     const blob = branchBlobByPath.get(f.filename);
     byPath.set(f.filename, {
       path: f.filename,
-      mode: "100644",
+      mode: blob?.mode ?? "100644",
       type: "blob",
       sha: f.status === "removed" || !blob ? null : blob.sha,
     });
@@ -292,60 +340,91 @@ export async function githubGitDiscard(
   }
 }
 
-async function mergeBranchWins(
+type ComparedFile = Awaited<
+  ReturnType<GitDataClient["compareDetailed"]>
+>["files"][number];
+
+/**
+ * The branch-wins tree: base's tree with every path the branch changed since
+ * the merge base (the three-dot compare set) replaced by the branch's version,
+ * whole file. The same resolution the merge commit used to carry — only where
+ * it lands has changed.
+ */
+async function buildBranchWinsTree(
+  client: GitDataClient,
+  files: ComparedFile[],
+  branchHead: string,
+  baseHead: string,
+): Promise<string> {
+  if (files.length >= MERGE_REPLAY_FILE_CAP) {
+    throw new GitHubApiError(
+      409,
+      "POST",
+      "merges",
+      `Too many changed files on the branch to auto-merge (${files.length}); resolve on GitHub`,
+    );
+  }
+
+  // Blob shas AND modes come from the branch tree — compare carries no modes.
+  const branchTree = await client.getTreeRecursive(
+    await client.getCommitTreeSha(branchHead),
+  );
+  const branchBlobByPath = new Map(
+    branchTree.filter((e) => e.type === "blob").map((e) => [e.path, e]),
+  );
+
+  return client.createTree(
+    await client.getCommitTreeSha(baseHead),
+    buildMergeTreeEntries(files, branchBlobByPath),
+  );
+}
+
+/**
+ * `mergeBranch` advances the branch ref before the squash can replace it. When
+ * the squash then fails, roll the ref back so a sync that reported failure
+ * leaves no merge commit behind — but only while nothing else has landed on it,
+ * since a rollback is itself a force.
+ */
+async function undoAbandonedMerge(
   client: GitDataClient,
   branch: string,
-  base: string,
+  mergedSha: string | null,
+  branchHead: string,
 ): Promise<void> {
-  for (let attempt = 1; ; attempt++) {
-    const branchHead = await client.getHeadSha(branch);
-    const baseHead = await client.getHeadSha(base);
-    // Three-dot compare: every path the branch changed since the merge base —
-    // exactly the set where the branch's version must win.
-    const { files } = await client.compareDetailed(base, branch);
-    if (files.length >= MERGE_REPLAY_FILE_CAP) {
-      throw new GitHubApiError(
-        409,
-        "POST",
-        "merges",
-        `Too many changed files on ${branch} to auto-merge (${files.length}); resolve on GitHub`,
-      );
-    }
+  if (mergedSha === null) return;
+  try {
+    if ((await client.getHeadSha(branch)) !== mergedSha) return;
+    await client.updateRef(branch, branchHead, { force: true });
+  } catch {
+    // Best effort: the caller needs to see the original failure, not this one.
+  }
+}
 
-    // Real blob shas + modes come from the branch tree, not the compare
-    // entries — compare doesn't carry file modes.
-    const branchTree = await client.getTreeRecursive(
-      await client.getCommitTreeSha(branchHead),
-    );
-    const branchBlobByPath = new Map(
-      branchTree.filter((e) => e.type === "blob").map((e) => [e.path, e]),
-    );
+/**
+ * Collapsing N commits into one would drop the `Co-authored-by:` trailers the
+ * coalescer stamps per editor, and those trailers are how GitHub attributes the
+ * work. Re-emit the distinct ones on the squash.
+ */
+function squashMessage(
+  branch: string,
+  base: string,
+  branchWon: boolean,
+  collapsed: string[],
+): string {
+  const subject = branchWon
+    ? `chore(decofile): sync ${branch} with ${base} (branch content wins)`
+    : `chore(decofile): sync ${branch} with ${base}`;
+  const trailers = collectCoAuthorTrailers(collapsed);
+  return trailers.length > 0 ? `${subject}\n\n${trailers.join("\n")}` : subject;
+}
 
-    const entries = buildMergeTreeEntries(files, branchBlobByPath);
-
-    const treeSha = await client.createTree(
-      await client.getCommitTreeSha(baseHead),
-      entries,
-    );
-    const commitSha = await client.createCommit({
-      message: `chore(decofile): merge ${base} into ${branch} (branch content wins)`,
-      treeSha,
-      parentShas: [branchHead, baseHead],
-    });
-    try {
-      await client.updateRef(branch, commitSha);
-      return;
-    } catch (err) {
-      // Non-fast-forward: an autosave landed mid-merge. Rebuild from the new
-      // head so the fresh edit is part of the replay instead of clobbered.
-      if (
-        err instanceof GitHubApiError &&
-        err.status === 422 &&
-        attempt < MERGE_CAS_ATTEMPTS
-      ) {
-        continue;
-      }
-      throw err;
+function collectCoAuthorTrailers(messages: string[]): string[] {
+  const seen = new Set<string>();
+  for (const message of messages) {
+    for (const line of message.split("\n")) {
+      const trimmed = line.trim();
+      if (/^Co-authored-by:\s/i.test(trimmed)) seen.add(trimmed);
     }
   }
+  return [...seen];
 }

--- a/apps/api/src/decofile/github-git-data.ts
+++ b/apps/api/src/decofile/github-git-data.ts
@@ -106,7 +106,8 @@ export interface TreeEntry {
 /** Tree write entry — `sha: null` deletes the path (Git Data API contract). */
 export interface TreeWriteEntry {
   path: string;
-  mode: "100644";
+  /** Git file mode: "100644" for a new file, else the source entry's own. */
+  mode: string;
   type: "blob";
   sha: string | null;
 }
@@ -141,8 +142,20 @@ export interface GitDataClient {
     /** One parent for a plain commit; two (ours, theirs) for a merge commit. */
     parentShas: string[];
   }): Promise<string>;
-  /** Non-forced ref update; throws GitHubApiError(422) on non-fast-forward. */
-  updateRef(branch: string, sha: string): Promise<void>;
+  /**
+   * Ref update, non-forced by default: a concurrent writer makes it fail
+   * non-fast-forward (GitHubApiError 422) instead of being clobbered, which is
+   * the commit coalescer's multi-replica safety property.
+   *
+   * `force: true` rewrites history and there is NO compare-and-swap available:
+   * GitHub's ref API accepts no `If-Match`, so a forced caller must re-read the
+   * head itself immediately before forcing (see `githubGitRebase`).
+   */
+  updateRef(
+    branch: string,
+    sha: string,
+    opts?: { force?: boolean },
+  ): Promise<void>;
   /** Create `refs/heads/<branch>` at `sha`; GitHubApiError(422) if it exists. */
   createRef(branch: string, sha: string): Promise<void>;
   /** Returns the merge commit sha, or null when base already contains head. */
@@ -178,6 +191,12 @@ export interface GitDataClient {
       sha: string;
       previousFilename?: string;
     }>;
+    /**
+     * Messages of the commits on `head` that `base` lacks — the set a
+     * squash collapses. GitHub caps this list at 250 entries; a longer branch
+     * is truncated, so it feeds attribution, never correctness.
+     */
+    commitMessages: string[];
   }>;
 }
 
@@ -345,13 +364,13 @@ export function createGitDataClient(params: {
       return json.sha;
     },
 
-    async updateRef(branch, sha) {
+    async updateRef(branch, sha, opts) {
       await call(
         "PATCH",
         `${repoBase}/git/refs/heads/${encodeRefPath(branch)}`,
         {
           sha,
-          force: false,
+          force: opts?.force === true,
         },
       );
     },
@@ -411,6 +430,7 @@ export function createGitDataClient(params: {
           sha: string;
           previous_filename?: string;
         }>;
+        commits?: Array<{ commit?: { message?: string } }>;
       }>(
         "GET",
         `${repoBase}/compare/${encodeRefPath(base)}...${encodeRefPath(head)}`,
@@ -427,6 +447,9 @@ export function createGitDataClient(params: {
             ? { previousFilename: f.previous_filename }
             : {}),
         })),
+        commitMessages: (json.commits ?? [])
+          .map((c) => c.commit?.message ?? "")
+          .filter((m) => m.length > 0),
       };
     },
   };

--- a/apps/web/src/components/thread/github/cms-header-actions.tsx
+++ b/apps/web/src/components/thread/github/cms-header-actions.tsx
@@ -210,13 +210,7 @@ export function CmsHeaderActions({ virtualMcpId }: Props) {
 
   const getLatest = useMutation({
     mutationFn: async (target: { branch: string; base: string }) => {
-      await rebaseGitBranch(
-        org.slug,
-        virtualMcpId,
-        target.branch,
-        target.base,
-        { onConflict: "branch-wins" },
-      );
+      await rebaseGitBranch(org.slug, virtualMcpId, target.branch, target.base);
       return target;
     },
     /** Invalidates drift AND the editor's content: the merge moved the head. */
@@ -410,7 +404,6 @@ export function CmsHeaderActions({ virtualMcpId }: Props) {
           openPullRequest={pr?.state === "open" ? pr : null}
           onPullRequestChanged={refreshPrState}
           onPublished={() => publishCompletion.mutateAsync()}
-          rebaseOnConflict="branch-wins"
         />
       ) : null}
     </>

--- a/apps/web/src/components/thread/github/cms-publish-popover.tsx
+++ b/apps/web/src/components/thread/github/cms-publish-popover.tsx
@@ -431,9 +431,7 @@ function CmsPublishContent({
         );
       }
       try {
-        await rebaseGitBranch(orgSlug, virtualMcpId, branch, baseBranch, {
-          onConflict: "branch-wins",
-        });
+        await rebaseGitBranch(orgSlug, virtualMcpId, branch, baseBranch);
       } catch (error) {
         throw new PublishStepError(
           error instanceof Error

--- a/apps/web/src/components/thread/github/publish-dialog.tsx
+++ b/apps/web/src/components/thread/github/publish-dialog.tsx
@@ -97,14 +97,6 @@ export interface PublishDialogProps {
   onPullRequestChanged?: () => void | Promise<void>;
   /** Called after a successful publish (squash-merge to base). */
   onPublished?: () => void | Promise<void>;
-  /**
-   * Conflict strategy for the publish flow's sync-with-base step. Fast Preview
-   * passes "branch-wins" so a conflicting base never 409s the publish — the
-   * server auto-merges with the branch's content winning for every path it
-   * touched (same strategy as the header's "Get latest"). Unset = fail on
-   * conflict, the sandboxed vibecoding default.
-   */
-  rebaseOnConflict?: "branch-wins";
 }
 
 export function PublishDialog(props: PublishDialogProps) {
@@ -145,7 +137,6 @@ function PublishDialogBody({
   openPullRequest = null,
   onPullRequestChanged,
   onPublished,
-  rebaseOnConflict,
 }: PublishDialogProps) {
   const t = useT();
   const githubClient = useMCPClient({
@@ -379,13 +370,7 @@ function PublishDialogBody({
       }
 
       try {
-        await rebaseGitBranch(
-          orgSlug,
-          virtualMcpId,
-          branch,
-          baseBranch,
-          rebaseOnConflict ? { onConflict: rebaseOnConflict } : undefined,
-        );
+        await rebaseGitBranch(orgSlug, virtualMcpId, branch, baseBranch);
       } catch (error) {
         throw new PublishFlowError(
           error instanceof Error

--- a/apps/web/src/components/thread/github/sandbox-git-api.ts
+++ b/apps/web/src/components/thread/github/sandbox-git-api.ts
@@ -187,27 +187,25 @@ export async function publishGitChanges(
   await parseJson(res);
 }
 
+/**
+ * Sync the branch with `base`. On a git-level conflict the server resolves
+ * branch-wins — the branch's content wins for every path it touched. Not
+ * negotiable per call: a conflict dialog is worse than a branch-favoured merge
+ * for the non-technical editor, and the sandbox daemon has never offered the
+ * choice either.
+ */
 export async function rebaseGitBranch(
   orgSlug: string,
   virtualMcpId: string,
   branch: string,
   base: string,
-  opts?: {
-    /**
-     * "branch-wins": on a git-level conflict the server auto-merges with the
-     * branch's content winning for every path it touched — the sandbox-less
-     * Sync path for non-technical users, where a conflict dialog is worse
-     * than a branch-favoured merge.
-     */
-    onConflict?: "branch-wins";
-  },
 ): Promise<void> {
   const res = await sandboxFetch(
     buildSandboxGitUrl(orgSlug, virtualMcpId, branch, "rebase"),
     {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ base, ...opts }),
+      body: JSON.stringify({ base }),
     },
   );
   await parseJson(res);

--- a/packages/e2e/fixtures/fast-preview.ts
+++ b/packages/e2e/fixtures/fast-preview.ts
@@ -1,0 +1,169 @@
+/**
+ * Wiring for sandbox-less Fast Preview projects, shared by the specs that
+ * exercise them (`decofile-api`, `fast-preview-git-sync`).
+ *
+ * All GitHub traffic lands on the local Git Data stub (`github-stub.ts`, wired
+ * via GITHUB_API_BASE_URL in the Playwright config) — nothing reaches
+ * api.github.com. The GitHub token mint is short-circuited by pre-seeding an
+ * unexpired downstream token on the repo-scoped child connection.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { APIRequestContext } from "@playwright/test";
+import { callSelfMcpTool, createHttpConnection } from "./mcp-tools";
+import { expect } from "./test";
+
+const GITHUB_STUB_ORIGIN = `http://localhost:${process.env.GITHUB_STUB_PORT ?? "4102"}`;
+
+export interface StubRepoInspection {
+  defaultBranch: string;
+  mergeMode: string;
+  refs: Record<string, string>;
+  commits: Array<{ sha: string; message: string; parents: string[] }>;
+  branches: Record<string, { headSha: string; files: Record<string, string> }>;
+}
+
+export async function seedStubRepo(
+  ctx: APIRequestContext,
+  params: {
+    owner: string;
+    repo: string;
+    defaultBranch?: string;
+    branches?: Record<string, { files?: Record<string, string> } | null>;
+    mergeMode?: "merge" | "conflict" | "blocked";
+  },
+): Promise<void> {
+  const res = await ctx.post(`${GITHUB_STUB_ORIGIN}/__admin/repos`, {
+    data: params,
+  });
+  expect(res.ok()).toBe(true);
+}
+
+export async function inspectStubRepo(
+  ctx: APIRequestContext,
+  owner: string,
+  repo: string,
+): Promise<StubRepoInspection> {
+  const res = await ctx.get(
+    `${GITHUB_STUB_ORIGIN}/__admin/repos/${owner}/${repo}`,
+  );
+  expect(res.ok()).toBe(true);
+  return (await res.json()) as StubRepoInspection;
+}
+
+/** Flip merge behavior on a seeded repo without re-seeding its history. */
+export async function setStubMergeMode(
+  ctx: APIRequestContext,
+  owner: string,
+  repo: string,
+  mergeMode: "merge" | "conflict" | "blocked",
+): Promise<void> {
+  const res = await ctx.post(
+    `${GITHUB_STUB_ORIGIN}/__admin/repos/${owner}/${repo}/config`,
+    { data: { mergeMode } },
+  );
+  expect(res.ok()).toBe(true);
+}
+
+export interface FastPreviewProject {
+  org: string;
+  owner: string;
+  repo: string;
+  vmcpId: string;
+  childConnectionId: string;
+}
+
+/**
+ * Full Fast Preview project wiring: repo-scoped GitHub child + unexpired
+ * downstream token + a virtual MCP carrying the Fast Preview gate.
+ * `repoScopeMode` picks which real repo-child shape to seed; the two resolve
+ * credentials down different paths (see `client-for-repo`), and the default is
+ * the one every repo imported since refreshable grants landed actually has.
+ */
+export async function createFastPreviewProject(
+  ctx: APIRequestContext,
+  org: string,
+  params: {
+    owner: string;
+    repo: string;
+    repoScopeMode?: "refreshable" | "legacy-mint";
+  },
+): Promise<FastPreviewProject> {
+  const { owner, repo, repoScopeMode = "refreshable" } = params;
+
+  const sourceConnectionId =
+    repoScopeMode === "legacy-mint"
+      ? (
+          await createHttpConnection(ctx, org, {
+            title: `Org GitHub ${Date.now()}`,
+            url: "https://example.com/mcp",
+          })
+        ).id
+      : undefined;
+
+  const child = await callSelfMcpTool<{ item: { id: string } }>(
+    ctx,
+    org,
+    "COLLECTION_CONNECTIONS_CREATE",
+    {
+      data: {
+        title: `GitHub: ${owner}/${repo}`,
+        app_name: "mcp-github",
+        connection_type: "HTTP",
+        connection_url: "https://example.com/mcp",
+        metadata: {
+          repoScope: {
+            ...(sourceConnectionId ? { sourceConnectionId } : {}),
+            installationId: 1,
+            repositoryId: 99,
+            owner,
+            repo,
+            permissions: { contents: "write" },
+          },
+        },
+      },
+    },
+  );
+  const childConnectionId = child.item.id;
+  expect(childConnectionId).toBeTruthy();
+
+  // Unexpired token: read back directly, or short-circuits the legacy mint.
+  const tokenRes = await ctx.post(
+    `/api/${org}/connections/${childConnectionId}/oauth-token`,
+    {
+      data: { accessToken: "ghs_e2e_dummy", expiresIn: 3600 },
+      headers: { "Content-Type": "application/json" },
+    },
+  );
+  expect(tokenRes.ok()).toBe(true);
+
+  const vmcp = await callSelfMcpTool<{ item: { id: string } }>(
+    ctx,
+    org,
+    "COLLECTION_VIRTUAL_MCP_CREATE",
+    {
+      data: {
+        title: `${repo} ${Date.now()}`,
+        metadata: {
+          fastPreview: true,
+          previewServerUrl: `https://${repo}.example.com`,
+          githubRepo: {
+            owner,
+            name: repo,
+            url: `https://github.com/${owner}/${repo}`,
+            installationId: 1,
+            connectionId: childConnectionId,
+          },
+        },
+        connections: [{ connection_id: childConnectionId }],
+      },
+    },
+  );
+  const vmcpId = vmcp.item.id;
+  expect(vmcpId).toBeTruthy();
+
+  return { org, owner, repo, vmcpId, childConnectionId };
+}
+
+/** Unique owner per test run keeps the stub's repo namespace parallel-safe. */
+export const uniqueOwner = (): string => `e2e-${randomUUID().slice(0, 12)}`;

--- a/packages/e2e/fixtures/github-stub.ts
+++ b/packages/e2e/fixtures/github-stub.ts
@@ -31,7 +31,7 @@
  *   POST  /repos/{o}/{r}/merges                       -> 201 {sha} / 204 / 409 / 405
  *   GET   /repos/{o}/{r}/pulls?state&base&head        -> [ { number, html_url } ]
  *   POST  /repos/{o}/{r}/pulls                        -> { number, html_url }
- *   GET   /repos/{o}/{r}/compare/{base}...{head}      -> { ahead_by, behind_by }
+ *   GET   /repos/{o}/{r}/compare/{base}...{head}      -> { ahead_by, behind_by, merge_base_commit, files, commits }
  *
  * Test-only admin endpoints (no auth):
  *   GET  /health
@@ -48,6 +48,12 @@ import {
   type ServerResponse,
 } from "node:http";
 
+/**
+ * `merge` always succeeds; `blocked` always 405s (protected base). `conflict`
+ * ARMS content-conflict detection — it 409s only when both sides changed the
+ * same path since the merge base, so a merge that is genuinely clean still
+ * goes through.
+ */
 type MergeMode = "merge" | "conflict" | "blocked";
 
 interface CommitRecord {
@@ -175,6 +181,24 @@ function filesAtCommit(
     out[path] = repo.blobs.get(blobSha) ?? "";
   }
   return out;
+}
+
+/**
+ * True when some path was changed on BOTH sides since the merge base, to
+ * different content — i.e. a real content conflict rather than a clean merge.
+ */
+function diverges(
+  targetFiles: Map<string, string>,
+  headFiles: Map<string, string>,
+  baseFiles: Map<string, string>,
+): boolean {
+  for (const path of new Set([...headFiles.keys(), ...targetFiles.keys()])) {
+    const at = baseFiles.get(path);
+    const inHead = headFiles.get(path);
+    const inTarget = targetFiles.get(path);
+    if (inHead !== at && inTarget !== at && inHead !== inTarget) return true;
+  }
+  return false;
 }
 
 /**
@@ -622,7 +646,17 @@ async function handleRepos(
       json(res, 204); // base already contains head
       return;
     }
-    if (repo.mergeMode === "conflict") {
+    const mergeBase = mergeBaseOf(repo, baseSha, headSha);
+    const merged = new Map(treeOfCommit(repo, baseSha));
+    const headFiles = treeOfCommit(repo, headSha);
+    const baseFiles = mergeBase
+      ? treeOfCommit(repo, mergeBase)
+      : new Map<string, string>();
+    // `conflict` ARMS detection rather than forcing it — see `mergeMode`.
+    if (
+      repo.mergeMode === "conflict" &&
+      diverges(merged, headFiles, baseFiles)
+    ) {
       json(res, 409, { message: "Merge conflict" });
       return;
     }
@@ -630,14 +664,6 @@ async function handleRepos(
       json(res, 405, { message: "Base branch is protected" });
       return;
     }
-    // Apply head's diff-since-merge-base onto base (head wins) — enough merge
-    // fidelity for decofile publishes; conflicts are simulated via mergeMode.
-    const mergeBase = mergeBaseOf(repo, baseSha, headSha);
-    const merged = new Map(treeOfCommit(repo, baseSha));
-    const headFiles = treeOfCommit(repo, headSha);
-    const baseFiles = mergeBase
-      ? treeOfCommit(repo, mergeBase)
-      : new Map<string, string>();
     for (const path of new Set([...headFiles.keys(), ...baseFiles.keys()])) {
       const inHead = headFiles.get(path);
       if (inHead === baseFiles.get(path)) continue; // unchanged on head
@@ -714,9 +740,49 @@ async function handleRepos(
     }
     const baseReach = reachableFrom(repo, baseSha);
     const headReach = reachableFrom(repo, headSha);
+    const ahead = [...headReach].filter((sha) => !baseReach.has(sha));
+    const mergeBase = mergeBaseOf(repo, baseSha, headSha);
+    if (!mergeBase) {
+      // Unrelated histories: real GitHub 404s rather than inventing a base.
+      notFound(res);
+      return;
+    }
+    // Three-dot set; the stub never renames, so `previous_filename` is absent.
+    const mergeBaseFiles = treeOfCommit(repo, mergeBase);
+    const headFiles = treeOfCommit(repo, headSha);
+    const files: Array<{ filename: string; status: string; sha: string }> = [];
+    for (const path of new Set([
+      ...mergeBaseFiles.keys(),
+      ...headFiles.keys(),
+    ])) {
+      const before = mergeBaseFiles.get(path);
+      const after = headFiles.get(path);
+      if (before === after) continue;
+      if (after === undefined) {
+        files.push({
+          filename: path,
+          status: "removed",
+          sha: before as string,
+        });
+      } else {
+        files.push({
+          filename: path,
+          status: before === undefined ? "added" : "modified",
+          sha: after,
+        });
+      }
+    }
     json(res, 200, {
-      ahead_by: [...headReach].filter((sha) => !baseReach.has(sha)).length,
+      ahead_by: ahead.length,
       behind_by: [...baseReach].filter((sha) => !headReach.has(sha)).length,
+      merge_base_commit: { sha: mergeBase },
+      files,
+      commits: repo.commitLog
+        .filter((sha) => ahead.includes(sha))
+        .map((sha) => ({
+          sha,
+          commit: { message: repo.commits.get(sha)?.message ?? "" },
+        })),
     });
     return;
   }

--- a/packages/e2e/tests/decofile-api.spec.ts
+++ b/packages/e2e/tests/decofile-api.spec.ts
@@ -24,12 +24,16 @@
  */
 
 import { randomUUID } from "node:crypto";
-import type { APIRequestContext } from "@playwright/test";
 import { signUpViaApi } from "../fixtures/auth-api";
-import { callSelfMcpTool, createHttpConnection } from "../fixtures/mcp-tools";
+import { callSelfMcpTool } from "../fixtures/mcp-tools";
+import {
+  createFastPreviewProject,
+  type FastPreviewProject,
+  inspectStubRepo,
+  seedStubRepo,
+  uniqueOwner,
+} from "../fixtures/fast-preview";
 import { expect, newApiContext, test } from "../fixtures/test";
-
-const GITHUB_STUB_ORIGIN = `http://localhost:${process.env.GITHUB_STUB_PORT ?? "4102"}`;
 
 /** Serialization the decofile writer uses for a block file. */
 const blockFileContent = (value: unknown): string =>
@@ -41,145 +45,6 @@ interface DecofileGetBody {
   apiHost?: string;
   decofile: Record<string, unknown>;
 }
-
-interface StubRepoInspection {
-  defaultBranch: string;
-  mergeMode: string;
-  refs: Record<string, string>;
-  commits: Array<{ sha: string; message: string; parents: string[] }>;
-  branches: Record<string, { headSha: string; files: Record<string, string> }>;
-}
-
-async function seedStubRepo(
-  ctx: APIRequestContext,
-  params: {
-    owner: string;
-    repo: string;
-    defaultBranch?: string;
-    branches?: Record<string, { files?: Record<string, string> } | null>;
-    mergeMode?: "merge" | "conflict" | "blocked";
-  },
-): Promise<void> {
-  const res = await ctx.post(`${GITHUB_STUB_ORIGIN}/__admin/repos`, {
-    data: params,
-  });
-  expect(res.ok()).toBe(true);
-}
-
-async function inspectStubRepo(
-  ctx: APIRequestContext,
-  owner: string,
-  repo: string,
-): Promise<StubRepoInspection> {
-  const res = await ctx.get(
-    `${GITHUB_STUB_ORIGIN}/__admin/repos/${owner}/${repo}`,
-  );
-  expect(res.ok()).toBe(true);
-  return (await res.json()) as StubRepoInspection;
-}
-
-interface FastPreviewProject {
-  org: string;
-  owner: string;
-  repo: string;
-  vmcpId: string;
-  childConnectionId: string;
-}
-
-/**
- * Full Fast Preview project wiring: repo-scoped GitHub child + unexpired
- * downstream token + a virtual MCP carrying the Fast Preview gate.
- * `repoScopeMode` picks which real repo-child shape to seed; the two resolve
- * credentials down different paths (see `client-for-repo`), and the default is
- * the one every repo imported since refreshable grants landed actually has.
- */
-async function createFastPreviewProject(
-  ctx: APIRequestContext,
-  org: string,
-  params: {
-    owner: string;
-    repo: string;
-    repoScopeMode?: "refreshable" | "legacy-mint";
-  },
-): Promise<FastPreviewProject> {
-  const { owner, repo, repoScopeMode = "refreshable" } = params;
-
-  const sourceConnectionId =
-    repoScopeMode === "legacy-mint"
-      ? (
-          await createHttpConnection(ctx, org, {
-            title: `Org GitHub ${Date.now()}`,
-            url: "https://example.com/mcp",
-          })
-        ).id
-      : undefined;
-
-  const child = await callSelfMcpTool<{ item: { id: string } }>(
-    ctx,
-    org,
-    "COLLECTION_CONNECTIONS_CREATE",
-    {
-      data: {
-        title: `GitHub: ${owner}/${repo}`,
-        app_name: "mcp-github",
-        connection_type: "HTTP",
-        connection_url: "https://example.com/mcp",
-        metadata: {
-          repoScope: {
-            ...(sourceConnectionId ? { sourceConnectionId } : {}),
-            installationId: 1,
-            repositoryId: 99,
-            owner,
-            repo,
-            permissions: { contents: "write" },
-          },
-        },
-      },
-    },
-  );
-  const childConnectionId = child.item.id;
-  expect(childConnectionId).toBeTruthy();
-
-  // Unexpired token: read back directly, or short-circuits the legacy mint.
-  const tokenRes = await ctx.post(
-    `/api/${org}/connections/${childConnectionId}/oauth-token`,
-    {
-      data: { accessToken: "ghs_e2e_dummy", expiresIn: 3600 },
-      headers: { "Content-Type": "application/json" },
-    },
-  );
-  expect(tokenRes.ok()).toBe(true);
-
-  const vmcp = await callSelfMcpTool<{ item: { id: string } }>(
-    ctx,
-    org,
-    "COLLECTION_VIRTUAL_MCP_CREATE",
-    {
-      data: {
-        title: `${repo} ${Date.now()}`,
-        metadata: {
-          fastPreview: true,
-          previewServerUrl: `https://${repo}.example.com`,
-          githubRepo: {
-            owner,
-            name: repo,
-            url: `https://github.com/${owner}/${repo}`,
-            installationId: 1,
-            connectionId: childConnectionId,
-          },
-        },
-        connections: [{ connection_id: childConnectionId }],
-      },
-    },
-  );
-  const vmcpId = vmcp.item.id;
-  expect(vmcpId).toBeTruthy();
-
-  return { org, owner, repo, vmcpId, childConnectionId };
-}
-
-/** Unique owner per test run keeps the stub's repo namespace parallel-safe. */
-const uniqueOwner = (): string => `e2e-${randomUUID().slice(0, 12)}`;
 
 const decofileUrl = (p: FastPreviewProject, branch: string): string =>
   `/api/${p.org}/decofile/${p.vmcpId}/${branch}`;
@@ -851,7 +716,9 @@ test.describe("decofile API", () => {
     }
   });
 
-  test("publish surfaces a merge conflict as 409", async ({ playwright }) => {
+  test("publish resolves a conflict branch-wins instead of refusing", async ({
+    playwright,
+  }) => {
     const ctx = await newApiContext(playwright);
     try {
       const user = await signUpViaApi(ctx);
@@ -865,19 +732,36 @@ test.describe("decofile API", () => {
         defaultBranch: "main",
         mergeMode: "conflict",
         branches: {
-          main: { files: { ".deco/blocks/Hero.json": '{"title":"live"}' } },
-          draft: {
-            files: { ".deco/blocks/Hero.json": '{"title":"draft"}' },
-          },
+          main: { files: { ".deco/blocks/Hero.json": '{"title":"seed"}' } },
+          draft: { files: { ".deco/blocks/Hero.json": '{"title":"seed"}' } },
         },
       });
       const project = await createFastPreviewProject(ctx, org, { owner, repo });
 
+      // Both sides move the SAME block, so the publish merge genuinely
+      // conflicts and the route has to sync the branch before it can land.
+      const writeBlock = async (branch: string, title: string) => {
+        const res = await ctx.patch(decofileUrl(project, branch), {
+          data: { set: { Hero: { title } } },
+          headers: { "Content-Type": "application/json" },
+        });
+        expect(res.ok()).toBe(true);
+      };
+      await writeBlock("draft", "editor");
+      await writeBlock("main", "live");
+
       const publishRes = await ctx.post(
         `${decofileUrl(project, "draft")}/publish`,
       );
-      expect(publishRes.status()).toBe(409);
-      expect(await publishRes.json()).toEqual({ error: "merge-conflict" });
+      expect(publishRes.status()).toBe(200);
+      expect((await publishRes.json()).result).toBe("merged");
+
+      // The editor's block is what went live.
+      const admin = await inspectStubRepo(ctx, owner, repo);
+      const live = admin.branches["main"]?.files ?? {};
+      expect(JSON.parse(live[".deco/blocks/Hero.json"] as string)).toEqual({
+        title: "editor",
+      });
     } finally {
       await ctx.dispose();
     }

--- a/packages/e2e/tests/fast-preview-git-sync.spec.ts
+++ b/packages/e2e/tests/fast-preview-git-sync.spec.ts
@@ -1,0 +1,229 @@
+/**
+ * End-to-end contract for "Get latest" on a sandbox-less Fast Preview project:
+ *
+ *   POST /api/:org/sandbox/:virtualMcpId/:branch/git/rebase   { base }
+ *
+ * The contract this suite pins is the SHAPE of the result, because that is what
+ * everything downstream depends on: after a sync the branch is exactly ONE
+ * commit whose single parent is the base head. It is not a merge commit — a
+ * merge's conflict resolution lives only in its tree, and `git rebase` drops
+ * merge commits, so anyone who pulled the branch and rebased onto the base got
+ * the resolved conflicts back.
+ *
+ * Content resolution is asserted alongside it and is deliberately
+ * branch-favoured, with no way to ask for anything else: on a git-level
+ * conflict the branch's version of every file it touched wins WHOLE FILE,
+ * while files only the base changed come along.
+ *
+ * All GitHub traffic lands on the local Git Data stub (fixtures/github-stub.ts).
+ * Contract shapes are INLINED (black-box suite — no app imports).
+ */
+
+import type { APIRequestContext } from "@playwright/test";
+import { signUpViaApi } from "../fixtures/auth-api";
+import {
+  createFastPreviewProject,
+  type FastPreviewProject,
+  inspectStubRepo,
+  seedStubRepo,
+  setStubMergeMode,
+  type StubRepoInspection,
+  uniqueOwner,
+} from "../fixtures/fast-preview";
+import { expect, newApiContext, test } from "../fixtures/test";
+
+const decofileUrl = (p: FastPreviewProject, branch: string): string =>
+  `/api/${p.org}/decofile/${p.vmcpId}/${branch}`;
+
+const rebaseUrl = (p: FastPreviewProject, branch: string): string =>
+  `/api/${p.org}/sandbox/${p.vmcpId}/${branch}/git/rebase`;
+
+/** One decofile write = one commit on `branch`. */
+async function writeBlock(
+  ctx: APIRequestContext,
+  project: FastPreviewProject,
+  branch: string,
+  key: string,
+  value: unknown,
+): Promise<void> {
+  const res = await ctx.patch(decofileUrl(project, branch), {
+    data: { set: { [key]: value } },
+    headers: { "Content-Type": "application/json" },
+  });
+  expect(res.ok()).toBe(true);
+}
+
+function commitOf(
+  repo: StubRepoInspection,
+  sha: string,
+): { sha: string; message: string; parents: string[] } {
+  const commit = repo.commits.find((c) => c.sha === sha);
+  expect(commit, `commit ${sha} missing from the stub log`).toBeTruthy();
+  return commit as { sha: string; message: string; parents: string[] };
+}
+
+test.describe("fast preview git sync", () => {
+  test("a clean sync leaves the branch as ONE commit parented on base, keeping base-only files", async ({
+    playwright,
+  }) => {
+    const ctx = await newApiContext(playwright);
+    try {
+      const user = await signUpViaApi(ctx);
+      const owner = uniqueOwner();
+      const repo = "site";
+      const project = await createFastPreviewProject(ctx, user.orgSlug, {
+        owner,
+        repo,
+      });
+      await seedStubRepo(ctx, {
+        owner,
+        repo,
+        defaultBranch: "main",
+        branches: {
+          main: { files: { ".deco/blocks/Hero.json": '{"n":1}\n' } },
+          draft: { files: { ".deco/blocks/Hero.json": '{"n":1}\n' } },
+        },
+      });
+
+      // Several commits on the branch, and one on base it does not have.
+      await writeBlock(ctx, project, "draft", "Hero", { n: 2 });
+      await writeBlock(ctx, project, "draft", "Hero", { n: 3 });
+      await writeBlock(ctx, project, "main", "Footer", { f: 1 });
+
+      const before = await inspectStubRepo(ctx, owner, repo);
+      const baseHead = before.refs["main"] as string;
+
+      const res = await ctx.post(rebaseUrl(project, "draft"), {
+        data: { base: "main" },
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status()).toBe(200);
+
+      const after = await inspectStubRepo(ctx, owner, repo);
+      const head = commitOf(after, after.refs["draft"] as string);
+      // THE contract: one commit, one parent, and that parent is the base head.
+      expect(head.parents).toEqual([baseHead]);
+      expect(after.refs["main"]).toBe(baseHead);
+
+      const files = after.branches["draft"]?.files ?? {};
+      expect(JSON.parse(files[".deco/blocks/Hero.json"] as string)).toEqual({
+        n: 3,
+      });
+      // Base-only work survives the sync.
+      expect(JSON.parse(files[".deco/blocks/Footer.json"] as string)).toEqual({
+        f: 1,
+      });
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
+  test("a conflict resolves branch-wins — nothing in the body asks for it — keeping the one-commit shape and the branch's whole file", async ({
+    playwright,
+  }) => {
+    const ctx = await newApiContext(playwright);
+    try {
+      const user = await signUpViaApi(ctx);
+      const owner = uniqueOwner();
+      const repo = "site";
+      const project = await createFastPreviewProject(ctx, user.orgSlug, {
+        owner,
+        repo,
+      });
+      await seedStubRepo(ctx, {
+        owner,
+        repo,
+        defaultBranch: "main",
+        branches: {
+          main: { files: { ".deco/blocks/Hero.json": '{"n":1}\n' } },
+          draft: { files: { ".deco/blocks/Hero.json": '{"n":1}\n' } },
+        },
+      });
+
+      await writeBlock(ctx, project, "draft", "Hero", { editor: "wins" });
+      await writeBlock(ctx, project, "main", "Hero", { base: "loses" });
+      await writeBlock(ctx, project, "main", "Footer", { f: 1 });
+      await setStubMergeMode(ctx, owner, repo, "conflict");
+
+      const before = await inspectStubRepo(ctx, owner, repo);
+      const baseHead = before.refs["main"] as string;
+
+      const res = await ctx.post(rebaseUrl(project, "draft"), {
+        data: { base: "main" },
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(res.status()).toBe(200);
+
+      const after = await inspectStubRepo(ctx, owner, repo);
+      const head = commitOf(after, after.refs["draft"] as string);
+      expect(head.parents).toEqual([baseHead]);
+      expect(head.message).toContain("branch content wins");
+
+      const files = after.branches["draft"]?.files ?? {};
+      // Whole-file branch-wins: the editor's block, not the base's.
+      expect(JSON.parse(files[".deco/blocks/Hero.json"] as string)).toEqual({
+        editor: "wins",
+      });
+      // A path only the base touched is untouched by the overwrite.
+      expect(JSON.parse(files[".deco/blocks/Footer.json"] as string)).toEqual({
+        f: 1,
+      });
+    } finally {
+      await ctx.dispose();
+    }
+  });
+
+  test("syncing an already-current branch is a no-op — no new commit, no force-push", async ({
+    playwright,
+  }) => {
+    const ctx = await newApiContext(playwright);
+    try {
+      const user = await signUpViaApi(ctx);
+      const owner = uniqueOwner();
+      const repo = "site";
+      const project = await createFastPreviewProject(ctx, user.orgSlug, {
+        owner,
+        repo,
+      });
+      await seedStubRepo(ctx, {
+        owner,
+        repo,
+        defaultBranch: "main",
+        branches: {
+          main: { files: { ".deco/blocks/Hero.json": '{"n":1}\n' } },
+          draft: { files: { ".deco/blocks/Hero.json": '{"n":1}\n' } },
+        },
+      });
+
+      // Drift on both sides, so the FIRST call really squashes something.
+      await writeBlock(ctx, project, "draft", "Hero", { n: 2 });
+      await writeBlock(ctx, project, "draft", "Hero", { n: 3 });
+      await writeBlock(ctx, project, "main", "Footer", { f: 1 });
+
+      const before = await inspectStubRepo(ctx, owner, repo);
+      const draftHeadBefore = before.refs["draft"] as string;
+
+      const first = await ctx.post(rebaseUrl(project, "draft"), {
+        data: { base: "main" },
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(first.status()).toBe(200);
+
+      const settled = await inspectStubRepo(ctx, owner, repo);
+      const head = settled.refs["draft"] as string;
+      expect(head).not.toBe(draftHeadBefore);
+      expect(commitOf(settled, head).parents).toEqual([before.refs["main"]]);
+
+      const second = await ctx.post(rebaseUrl(project, "draft"), {
+        data: { base: "main" },
+        headers: { "Content-Type": "application/json" },
+      });
+      expect(second.status()).toBe(200);
+
+      const after = await inspectStubRepo(ctx, owner, repo);
+      expect(after.refs["draft"]).toBe(head);
+    } finally {
+      await ctx.dispose();
+    }
+  });
+});


### PR DESCRIPTION
## Why

"Get latest" brought `base` into a Fast Preview branch with a **merge commit**. A merge's conflict resolution lives only in its *tree*, and `git rebase` drops merge commits — so anyone who pulled the branch and ran `git rebase origin/main` had every original commit replayed against the moved base and got back the exact conflicts the sync had just resolved.

Seen on `deco-sites/faststore-fila` `staging`: the sync reported success and the branch was 0 behind `main`, yet a local rebase still conflicted on 13 files.

## What changed

**Squash-rebase instead of a merge commit.** The branch now ends as ONE commit whose single parent is the base head, so the same local rebase is a no-op. Content resolution is unchanged: a clean merge takes GitHub's own 3-way tree, a conflict takes the whole-file branch-wins tree.

**branch-wins is no longer selectable.** The `onConflict` / `RebaseConflictStrategy` parameter is gone. Publish previously passed nothing and therefore defaulted to `"fail"`, so the same branch got opposite behavior from two buttons — "Get latest" overwrote, "Publish" blocked with "resolve on GitHub". Now both resolve the same way, matching the sandbox daemon (which has always used `-X theirs` and ignored the flag entirely).

> ⚠️ This removes the `rebaseOnConflict` prop added by #6192 this morning. Same end behavior, one less knob — flag it if that plumbing was wanted.

**`POST /decofile/:vmcp/:branch/publish`** answered `merge-conflict` 409 when base had moved. It now syncs branch-wins and retries, which fast-forwards. The 405 → open-a-PR fallback still wraps both attempts.

**Concurrency.** A squash is never a fast-forward, so the ref update is forced — giving up the non-forced 422 the commit coalescer relies on. GitHub accepts no `If-Match` on refs, so the head is re-read immediately before the force and the attempt rebuilds when an autosave landed. A failed squash rolls the merge back, so a sync that reports failure leaves no merge commit behind.

**Two smaller fixes** the review surfaced: `Co-authored-by:` trailers from the collapsed commits are carried onto the squash (a squash would otherwise drop per-editor attribution), and file modes are preserved instead of being flattened to `100644` (a branch-wins sync used to strip the exec bit off any script the branch edited).

## Testing

- **New** `packages/e2e/tests/fast-preview-git-sync.spec.ts` — clean sync → one commit parented on base with base-only files kept; conflict → branch-wins with the whole file, nothing in the request body asking for it; already-current → true no-op.
- **Inverted** `decofile-api.spec.ts` "publish surfaces a merge conflict as 409" → "publish resolves a conflict branch-wins instead of refusing", asserting the editor's block is what lands on `main`.
- The stub's `mergeMode: "conflict"` now **arms** content-conflict detection rather than forcing every merge to 409 — otherwise the publish route's sync-then-retry would 409 on the retry and the old test would have kept passing for the wrong reason.
- Fast Preview fixtures moved to `packages/e2e/fixtures/fast-preview.ts` so both specs share them.

16/16 e2e, 70/70 `apps/api/src/decofile` unit tests, `bun run check` / `lint` / `fmt` / `knip` clean.

## Affected areas

Fast Preview (sandbox-less) projects only. Sandbox-backed projects never reach this code — they proxy to the Go daemon's `RebaseOntoBase`, which is untouched. No UI change beyond deleting a prop.

## Follow-ups

- Existing branches already carrying a bad merge commit are **not** repaired by this; the next sync flattens the shape but the earlier whole-file overwrite stands.
- Force-pushing is right for per-user minted branches but rewrites history on a shared long-lived one like `staging`. Not gated here, per an explicit call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Squash-rebases Fast Preview “Get latest” onto the base instead of creating a merge commit. The branch now remains as one commit parented on the base head, making local rebases no-ops; conflicts always resolve branch‑wins, and Publish now syncs branch‑wins and retries instead of returning 409.

**Key changes**
- Replaces merge with a squash in server `githubGitRebase`: clean merges use GitHub’s 3‑way tree; conflicts build a whole‑file branch‑wins tree. Forces the ref with a head re-read (no ref CAS on GitHub) and rolls back a merge if the squash fails. Preserves `Co-authored-by:` trailers and file modes.
- Removes conflict strategy knobs. `onConflict`/`RebaseConflictStrategy` and the `rebaseOnConflict` UI prop are deleted; “Get latest” and Publish now share the same branch‑wins policy.
- Publish route handles moved base by syncing branch‑wins and merging; 405 still falls back to open a PR.
- Affects Fast Preview (sandbox‑less) projects only; the sandbox Go daemon path is unchanged.

**Rollout and migration**
- Remove any `onConflict` options passed to `rebaseGitBranch` and delete `rebaseOnConflict` props; no replacement.
- Existing branches with earlier merge commits are not auto-repaired; the next sync flattens history but preserves any prior whole‑file overwrites.
- Syncs force‑push the branch; acceptable for per‑user branches, but avoid on shared long‑lived branches.

<sup>Written for commit dc118cf05318861c5f0a51b449275e45af1431c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6268?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

