### PR TITLE
feat(fast-preview): submit-for-review reuses the publish popover

### DIFF
--- a/apps/web/src/components/thread/github/cms-header-actions.tsx
+++ b/apps/web/src/components/thread/github/cms-header-actions.tsx
@@ -52,13 +52,15 @@ import {
   readLastPreviewPage,
 } from "../../sandbox/preview/last-preview-page.ts";
 import { useChatTask } from "../../chat/index";
-import { CmsPublishPopover } from "./cms-publish-popover.tsx";
+import {
+  CmsPublishPopover,
+  type CmsPublishMode,
+} from "./cms-publish-popover.tsx";
 import {
   isCmsStateSettling,
   selectCmsHeaderButton,
   type CmsAction,
 } from "./cms-panel-state.ts";
-import { PublishDialog } from "./publish-dialog.tsx";
 import {
   fetchGitStatus,
   hasPublishableLocalWork,
@@ -93,8 +95,8 @@ export function CmsHeaderActions({ virtualMcpId }: Props) {
   const { data: session } = authClient.useSession();
   const vm = useVirtualMCP(virtualMcpId);
   const { currentBranch: branch, setCurrentTaskBranch } = useChatTask();
-  const [publishOpen, setPublishOpen] = useState(false);
-  const [popoverOpen, setPopoverOpen] = useState(false);
+  /** Which content surface is open — one popover, two modes. */
+  const [surface, setSurface] = useState<CmsPublishMode | null>(null);
 
   const attachment = resolveGithubAttachment(vm);
   const githubRepo =
@@ -313,10 +315,10 @@ export function CmsHeaderActions({ virtualMcpId }: Props) {
   const dispatch = (action: CmsAction) => {
     switch (action) {
       case "publish":
-        setPopoverOpen(true);
+        setSurface("publish");
         return;
       case "request-approval":
-        setPublishOpen(true);
+        setSurface("review");
         return;
       case "get-latest":
         if (!githubHeadBranch || getLatest.isPending) return;
@@ -362,8 +364,11 @@ export function CmsHeaderActions({ virtualMcpId }: Props) {
     <>
       {branch ? (
         <CmsPublishPopover
-          open={popoverOpen}
-          onOpenChange={setPopoverOpen}
+          open={surface !== null}
+          mode={surface ?? "publish"}
+          onOpenChange={(open) => {
+            if (!open) setSurface(null);
+          }}
           orgSlug={org.slug}
           orgId={org.id}
           virtualMcpId={virtualMcpId}
@@ -375,7 +380,7 @@ export function CmsHeaderActions({ virtualMcpId }: Props) {
           publishPolicy={normalizePublishPolicy(vm?.metadata?.publishPolicy)}
           draftPreviewUrl={draftPreview.url}
           destinationHost={draftPreview.host}
-          onRequestApproval={() => setPublishOpen(true)}
+          onRequestApproval={() => setSurface("review")}
           openPullRequest={pr?.state === "open" ? pr : null}
           onPullRequestChanged={refreshPrState}
           onPublished={() => publishCompletion.mutateAsync()}
@@ -385,27 +390,6 @@ export function CmsHeaderActions({ virtualMcpId }: Props) {
       ) : (
         splitButton
       )}
-      {branch ? (
-        <PublishDialog
-          open={publishOpen}
-          onOpenChange={setPublishOpen}
-          orgSlug={org.slug}
-          orgId={org.id}
-          virtualMcpId={virtualMcpId}
-          branch={branch}
-          baseBranch={baseBranch}
-          githubConnectionId={githubRepo.connectionId ?? ""}
-          owner={githubRepo.owner}
-          repo={githubRepo.name}
-          previewUrl={draftPreview.url ?? previewServerUrl}
-          publishPolicy={normalizePublishPolicy(vm?.metadata?.publishPolicy)}
-          dialogIntent="open-pr"
-          headSha={branchMeta.kind === "ready" ? branchMeta.headSha : null}
-          openPullRequest={pr?.state === "open" ? pr : null}
-          onPullRequestChanged={refreshPrState}
-          onPublished={() => publishCompletion.mutateAsync()}
-        />
-      ) : null}
     </>
   );
 }

--- a/apps/web/src/components/thread/github/cms-header-actions.tsx
+++ b/apps/web/src/components/thread/github/cms-header-actions.tsx
@@ -95,8 +95,14 @@ export function CmsHeaderActions({ virtualMcpId }: Props) {
   const { data: session } = authClient.useSession();
   const vm = useVirtualMCP(virtualMcpId);
   const { currentBranch: branch, setCurrentTaskBranch } = useChatTask();
-  /** Which content surface is open — one popover, two modes. */
-  const [surface, setSurface] = useState<CmsPublishMode | null>(null);
+  /** One popover, two modes. `mode` outlives `open` so the closing animation
+   *  doesn't flash the other mode's labels on its way out. */
+  const [surface, setSurface] = useState<{
+    open: boolean;
+    mode: CmsPublishMode;
+  }>({ open: false, mode: "publish" });
+  const openSurface = (mode: CmsPublishMode) =>
+    setSurface({ open: true, mode });
 
   const attachment = resolveGithubAttachment(vm);
   const githubRepo =
@@ -315,10 +321,10 @@ export function CmsHeaderActions({ virtualMcpId }: Props) {
   const dispatch = (action: CmsAction) => {
     switch (action) {
       case "publish":
-        setSurface("publish");
+        openSurface("publish");
         return;
       case "request-approval":
-        setSurface("review");
+        openSurface("review");
         return;
       case "get-latest":
         if (!githubHeadBranch || getLatest.isPending) return;
@@ -364,10 +370,10 @@ export function CmsHeaderActions({ virtualMcpId }: Props) {
     <>
       {branch ? (
         <CmsPublishPopover
-          open={surface !== null}
-          mode={surface ?? "publish"}
+          open={surface.open}
+          mode={surface.mode}
           onOpenChange={(open) => {
-            if (!open) setSurface(null);
+            if (!open) setSurface((current) => ({ ...current, open: false }));
           }}
           orgSlug={org.slug}
           orgId={org.id}
@@ -380,7 +386,7 @@ export function CmsHeaderActions({ virtualMcpId }: Props) {
           publishPolicy={normalizePublishPolicy(vm?.metadata?.publishPolicy)}
           draftPreviewUrl={draftPreview.url}
           destinationHost={draftPreview.host}
-          onRequestApproval={() => setSurface("review")}
+          onRequestApproval={() => openSurface("review")}
           openPullRequest={pr?.state === "open" ? pr : null}
           onPullRequestChanged={refreshPrState}
           onPublished={() => publishCompletion.mutateAsync()}

--- a/apps/web/src/components/thread/github/cms-publish-change-card.tsx
+++ b/apps/web/src/components/thread/github/cms-publish-change-card.tsx
@@ -1,0 +1,235 @@
+/**
+ * One changed page, block, or file as a card: what it is, what changed under
+ * it, and — once expanded — the raw diff. Expansion and the armed discard
+ * confirmation are both exclusive across the list, so the popover owns both
+ * and drives them through props.
+ */
+
+import { cn } from "@decocms/ui/lib/utils.ts";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@decocms/ui/components/tooltip.tsx";
+import { ChevronRight, File06, LayoutAlt01, Trash01 } from "@untitledui/icons";
+import { useT, type TFunction } from "@/i18n/use-t.ts";
+import { GitDiffList } from "./git-diff-list.tsx";
+import {
+  countPageSections,
+  type PublishChange,
+  type PublishChangeStatus,
+} from "./publish-change-summary.ts";
+import type { GitDiffResult } from "./sandbox-git-api.ts";
+
+/** Stable identity for a card across summary recomputes. */
+export function changeId(change: PublishChange): string {
+  return change.blockKey ?? change.filepaths[0] ?? change.name;
+}
+
+function statusLabel(status: PublishChangeStatus, t: TFunction) {
+  return status === "new"
+    ? t("thread.publishPopover.chipNew")
+    : status === "removed"
+      ? t("thread.publishPopover.chipRemoved")
+      : t("thread.publishPopover.chipEdited");
+}
+
+/** Status is carried by the icon color (lime = added); the title names it for
+ *  anyone who can't rely on color alone. */
+function changeIcon(change: PublishChange, t: TFunction) {
+  const Icon = change.kind === "block" ? LayoutAlt01 : File06;
+  return (
+    <span title={statusLabel(change.status, t)} className="flex shrink-0">
+      <Icon
+        className={cn(
+          "size-4",
+          change.status === "new" && "text-brand",
+          change.status === "edited" && "text-warning",
+          change.status === "removed" && "text-destructive",
+        )}
+      />
+    </span>
+  );
+}
+
+function changeDetail(change: PublishChange, t: TFunction) {
+  if (change.kind === "page") return change.pagePath;
+  if (change.kind !== "block") return null;
+  return change.isSiteApp
+    ? t("thread.publishPopover.siteConfiguration")
+    : t("thread.publishPopover.globalSection");
+}
+
+/** A new page is summarized by its size; everything else by what it touched. */
+function changeSubLines(change: PublishChange, t: TFunction): string[] {
+  if (change.kind === "page" && change.status === "new") {
+    return [
+      t("thread.publishPopover.newPageSections", {
+        count: countPageSections(change.toJson),
+      }),
+    ];
+  }
+  return change.sections.map((section) =>
+    section.fields.length > 0
+      ? `${section.name} — ${section.fields
+          .slice(0, 4)
+          .map((f) => f.label)
+          .join(", ")}`
+      : section.name,
+  );
+}
+
+interface PublishChangeCardProps {
+  change: PublishChange;
+  /** The whole publish diff; the card slices out its own files. */
+  diff: GitDiffResult | null;
+  expanded: boolean;
+  onToggleExpanded: () => void;
+  /** Armed = this card shows Cancel/Discard; only one card may be armed. */
+  confirming: boolean;
+  onConfirmingChange: (confirming: boolean) => void;
+  onDiscard: () => void;
+  isPublishing: boolean;
+  isDiscarding: boolean;
+}
+
+export function PublishChangeCard({
+  change,
+  diff,
+  expanded,
+  onToggleExpanded,
+  confirming,
+  onConfirmingChange,
+  onDiscard,
+  isPublishing,
+  isDiscarding,
+}: PublishChangeCardProps) {
+  const t = useT();
+
+  const detail = changeDetail(change, t);
+  const subLines = changeSubLines(change, t);
+  const rawDiff: GitDiffResult = {
+    diffs: Object.fromEntries(
+      change.filepaths.flatMap((p) => {
+        const entry = diff?.diffs[p];
+        return entry ? [[p, entry] as const] : [];
+      }),
+    ),
+  };
+  const canExpand = Object.keys(rawDiff.diffs).length > 0;
+
+  // Collapsed card = one big expand target; inner controls stop propagation.
+  return (
+    <div
+      className={cn(
+        "rounded-lg border bg-card px-3 py-2.5",
+        canExpand && !expanded && "cursor-pointer",
+      )}
+      data-change-id={changeId(change)}
+      onClick={canExpand && !expanded ? onToggleExpanded : undefined}
+    >
+      <div
+        className={cn(
+          "flex items-center gap-2.5",
+          canExpand && "cursor-pointer",
+        )}
+        onClick={
+          canExpand
+            ? (e) => {
+                e.stopPropagation();
+                onToggleExpanded();
+              }
+            : undefined
+        }
+      >
+        {changeIcon(change, t)}
+        <button
+          type="button"
+          className="flex min-w-0 flex-1 items-center gap-2 text-left"
+          disabled={!canExpand}
+          aria-expanded={canExpand ? expanded : undefined}
+        >
+          <span className="truncate text-sm font-medium">{change.name}</span>
+          {detail ? (
+            <span className="truncate text-xs text-muted-foreground">
+              {detail}
+            </span>
+          ) : null}
+        </button>
+        {confirming ? (
+          <div className="flex shrink-0 items-center gap-1.5">
+            <button
+              type="button"
+              className="text-xs text-muted-foreground hover:text-foreground"
+              onClick={(e) => {
+                e.stopPropagation();
+                onConfirmingChange(false);
+              }}
+            >
+              {t("thread.publishDialog.cancel")}
+            </button>
+            <button
+              type="button"
+              className="text-xs font-medium text-destructive disabled:opacity-50"
+              onClick={(e) => {
+                e.stopPropagation();
+                onConfirmingChange(false);
+                onDiscard();
+              }}
+              disabled={isDiscarding}
+            >
+              {t("thread.publishPopover.discard")}
+            </button>
+          </div>
+        ) : (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  aria-label={t("thread.publishPopover.discard")}
+                  className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-destructive disabled:opacity-50"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onConfirmingChange(true);
+                  }}
+                  disabled={isPublishing || isDiscarding}
+                >
+                  <Trash01 className="size-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {t("thread.publishPopover.discard")}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
+        {canExpand ? (
+          <ChevronRight
+            className={cn(
+              "size-3.5 shrink-0 text-muted-foreground transition-transform",
+              expanded && "rotate-90",
+            )}
+          />
+        ) : null}
+      </div>
+      {!expanded && subLines.length > 0 ? (
+        <div className="mt-1 space-y-0.5 pl-[26px] text-xs text-muted-foreground">
+          {subLines.map((line, lineIndex) => (
+            <div key={`${lineIndex}-${line}`} className="truncate">
+              {line}
+            </div>
+          ))}
+        </div>
+      ) : null}
+      {expanded ? (
+        <div className="-mx-3 mt-2 border-t pt-1">
+          <div className="scroll-fade max-h-72 overflow-y-auto overscroll-contain [scrollbar-width:thin]">
+            <GitDiffList diff={rawDiff} hideFileRows editorHeight="220px" />
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/thread/github/cms-publish-popover.tsx
+++ b/apps/web/src/components/thread/github/cms-publish-popover.tsx
@@ -423,13 +423,28 @@ function CmsPublishContent({
   const canSubmit =
     !isPublishing && summary.count > 0 && (isReview || gate.allowed);
 
-  const noteTitle = () =>
-    note.trim().split("\n")[0]?.trim() ||
-    t("thread.publishDialog.changesFrom", { branch: githubHeadBranch });
-  const noteBody = () => {
+  /** The note is the commit message and the PR title/body in both modes. */
+  const noteParts = () => {
     const lines = note.trim().split("\n");
-    return lines.slice(1).join("\n").trim() || undefined;
+    const title =
+      lines[0]?.trim() ||
+      t("thread.publishDialog.changesFrom", { branch: githubHeadBranch });
+    const body = lines.slice(1).join("\n").trim() || undefined;
+    return { title, body, message: [title, body].filter(Boolean).join("\n\n") };
   };
+
+  /** One definition of the PR both modes open — or update, when one is open. */
+  const openPr = (title: string, body?: string) =>
+    openPullRequestForBranch(githubClient, {
+      owner,
+      repo,
+      branch: githubHeadBranch,
+      title,
+      body,
+      base: baseBranch,
+      coAuthor,
+      existing: existingOpenPr,
+    });
 
   const handlePublish = async () => {
     publishLockRef.current = true;
@@ -437,9 +452,7 @@ function CmsPublishContent({
     setPublishError(undefined);
     let openedPr: CreatedPullRequest | undefined;
     try {
-      const title = noteTitle();
-      const body = noteBody();
-      const message = [title, body].filter(Boolean).join("\n\n");
+      const { title, body, message } = noteParts();
 
       try {
         await publishGitChanges(orgSlug, virtualMcpId, branch, message);
@@ -462,16 +475,7 @@ function CmsPublishContent({
         );
       }
       try {
-        openedPr = await openPullRequestForBranch(githubClient, {
-          owner,
-          repo,
-          branch: githubHeadBranch,
-          title,
-          body,
-          base: baseBranch,
-          coAuthor,
-          existing: existingOpenPr,
-        });
+        openedPr = await openPr(title, body);
       } catch (error) {
         throw new PublishStepError(
           error instanceof Error
@@ -545,21 +549,10 @@ function CmsPublishContent({
     setIsPublishing(true);
     setPublishError(undefined);
     try {
-      const title = noteTitle();
-      const body = noteBody();
-      const message = [title, body].filter(Boolean).join("\n\n");
+      const { title, body, message } = noteParts();
 
       await publishGitChanges(orgSlug, virtualMcpId, branch, message);
-      const pr = await openPullRequestForBranch(githubClient, {
-        owner,
-        repo,
-        branch: githubHeadBranch,
-        title,
-        body,
-        base: baseBranch,
-        coAuthor,
-        existing: existingOpenPr,
-      });
+      const pr = await openPr(title, body);
 
       toast.success(
         t("thread.publishDialog.submittedForReview", { prNumber: pr.number }),

--- a/apps/web/src/components/thread/github/cms-publish-popover.tsx
+++ b/apps/web/src/components/thread/github/cms-publish-popover.tsx
@@ -159,6 +159,8 @@ export function CmsPublishPopover(props: CmsPublishPopoverProps) {
       <PopoverContent
         align="end"
         sideOffset={8}
+        // The menu that opened this returns focus to its trigger as it closes.
+        onFocusOutside={(event) => event.preventDefault()}
         className="flex max-h-[min(720px,85vh)] w-[420px] flex-col gap-0 overflow-hidden p-0"
       >
         <CmsPublishBody {...props} publishLockRef={publishLockRef} />

--- a/apps/web/src/components/thread/github/cms-publish-popover.tsx
+++ b/apps/web/src/components/thread/github/cms-publish-popover.tsx
@@ -2,9 +2,9 @@
  * Fast Preview's content-first publish surface: an anchored popover (modal on
  * narrow viewports) that renders the diff as pages and blocks by name, an
  * editable version note, and the review gate as a visible check row — no git
- * vocabulary. The publish flow underneath is the same push → sync → PR →
- * squash-merge sequence as {@link PublishDialog}, which vibecoding mode (and
- * the request-approval intent) keeps unchanged.
+ * vocabulary. `publish` mode runs the push → sync → PR → squash-merge sequence
+ * of {@link PublishDialog}; `review` mode stops at the PR. Only vibecoding mode
+ * still uses {@link PublishDialog}.
  */
 
 import { useMCPClient } from "@/sdk";
@@ -30,6 +30,7 @@ import {
   ChevronRight,
   Eye,
   File06,
+  GitPullRequest,
   Globe01,
   LayoutAlt01,
   Loading01,
@@ -94,9 +95,14 @@ function useNarrowViewport(): boolean {
   );
 }
 
+/** `publish` merges to production; `review` stops at the pull request. */
+export type CmsPublishMode = "publish" | "review";
+
 export interface CmsPublishPopoverProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  /** Defaults to `publish`; see the module doc for what each mode runs. */
+  mode?: CmsPublishMode;
   orgSlug: string;
   orgId: string;
   virtualMcpId: string;
@@ -109,7 +115,7 @@ export interface CmsPublishPopoverProps {
   /** Draft URL + destination host from useFastPreviewDraftUrl. */
   draftPreviewUrl: string | null;
   destinationHost: string | null;
-  /** Blocked gate: route to the existing request-approval (open PR) dialog. */
+  /** Blocked gate: hand this surface over to review mode. */
   onRequestApproval: () => void;
   /** When set, publish updates this open PR instead of opening a new one. */
   openPullRequest?: PrSummary | null;
@@ -249,13 +255,14 @@ function GhostCard({ subline }: { subline?: boolean }) {
   );
 }
 
-function CmsPublishSkeleton() {
+function CmsPublishSkeleton({ mode }: { mode: CmsPublishMode }) {
   const t = useT();
+  const HeaderIcon = mode === "review" ? GitPullRequest : Globe01;
   return (
     <>
       <div className="space-y-1.5 px-4 py-3">
         <div className="flex items-center gap-2">
-          <Globe01 className="size-4 shrink-0 text-muted-foreground" />
+          <HeaderIcon className="size-4 shrink-0 text-muted-foreground" />
           <Ghost className="h-3.5 w-48" />
         </div>
         <Ghost className="ml-6 h-2.5 w-36" />
@@ -278,8 +285,15 @@ function CmsPublishSkeleton() {
           <Eye className="size-4" />
           {t("thread.publishPopover.preview")}
         </Button>
-        <Button type="button" variant="brand" className="flex-1" disabled>
-          {t("thread.publishPopover.publish")}
+        <Button
+          type="button"
+          variant={mode === "review" ? "default" : "brand"}
+          className="flex-1"
+          disabled
+        >
+          {mode === "review"
+            ? t("thread.publishPopover.submitForReview")
+            : t("thread.publishPopover.publish")}
         </Button>
       </div>
     </>
@@ -292,7 +306,7 @@ function CmsPublishBody(
   },
 ) {
   return (
-    <Suspense fallback={<CmsPublishSkeleton />}>
+    <Suspense fallback={<CmsPublishSkeleton mode={props.mode ?? "publish"} />}>
       <CmsPublishContent {...props} />
     </Suspense>
   );
@@ -301,6 +315,7 @@ function CmsPublishBody(
 function CmsPublishContent({
   publishLockRef,
   onOpenChange,
+  mode = "publish",
   orgSlug,
   orgId,
   virtualMcpId,
@@ -383,7 +398,10 @@ function CmsPublishContent({
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
   const summary = summarizePublishChanges(gitDiff);
+  const isReview = mode === "review";
+  const HeaderIcon = isReview ? GitPullRequest : Globe01;
 
+  // Submitting for review IS the escalation the gate asks for — never judge it.
   const { gate } = useResolvedPublishGate({
     orgSlug,
     virtualMcpId,
@@ -391,7 +409,7 @@ function CmsPublishContent({
     status: gitStatus,
     diff: gitDiff,
     policy: publishPolicy,
-    judgeEnabled: true,
+    judgeEnabled: !isReview,
   });
 
   const commitToOpenPr = openPullRequest?.state === "open";
@@ -400,7 +418,8 @@ function CmsPublishContent({
     : undefined;
   const githubHeadBranch = readGitHeadBranch(gitStatus) ?? branch;
 
-  const canPublish = !isPublishing && summary.count > 0 && gate.allowed;
+  const canSubmit =
+    !isPublishing && summary.count > 0 && (isReview || gate.allowed);
 
   const noteTitle = () =>
     note.trim().split("\n")[0]?.trim() ||
@@ -518,6 +537,52 @@ function CmsPublishContent({
     }
   };
 
+  /** Review mode's flow: push, then open (or update) the PR — no merge. */
+  const handleSubmitForReview = async () => {
+    publishLockRef.current = true;
+    setIsPublishing(true);
+    setPublishError(undefined);
+    try {
+      const title = noteTitle();
+      const body = noteBody();
+      const message = [title, body].filter(Boolean).join("\n\n");
+
+      await publishGitChanges(orgSlug, virtualMcpId, branch, message);
+      const pr = await openPullRequestForBranch(githubClient, {
+        owner,
+        repo,
+        branch: githubHeadBranch,
+        title,
+        body,
+        base: baseBranch,
+        coAuthor,
+        existing: existingOpenPr,
+      });
+
+      toast.success(
+        t("thread.publishDialog.submittedForReview", { prNumber: pr.number }),
+        {
+          action: {
+            label: t("thread.publishDialog.viewOnGithub"),
+            onClick: () =>
+              window.open(pr.htmlUrl, "_blank", "noopener,noreferrer"),
+          },
+        },
+      );
+      onOpenChange(false);
+      await onPullRequestChanged?.();
+    } catch (error) {
+      setPublishError(
+        error instanceof Error
+          ? error.message
+          : t("thread.publishDialog.failedSubmitForReview"),
+      );
+    } finally {
+      publishLockRef.current = false;
+      setIsPublishing(false);
+    }
+  };
+
   const handleDiscard = async (change: PublishChange) => {
     setDiscardConfirmId(null);
     setIsDiscarding(true);
@@ -559,8 +624,15 @@ function CmsPublishContent({
     }
   };
 
-  const headerTitle =
-    summary.count === 0
+  const headerTitle = isReview
+    ? summary.count === 0
+      ? t("thread.publishPopover.submitForReview")
+      : summary.count === 1
+        ? t("thread.publishPopover.submitOneForReview")
+        : t("thread.publishPopover.submitCountForReview", {
+            count: summary.count,
+          })
+    : summary.count === 0
       ? t("thread.publishPopover.publish")
       : summary.count === 1
         ? t("thread.publishPopover.publishOneInProduction")
@@ -568,7 +640,13 @@ function CmsPublishContent({
             count: summary.count,
           });
 
-  const lastPublishLine = (() => {
+  /** Review mode names the PR it will update; publish mode, the last release. */
+  const subLine = (() => {
+    if (isReview && commitToOpenPr) {
+      return t("thread.publishPopover.updatesPullRequest", {
+        number: openPullRequest.number,
+      });
+    }
     const pr = lastPublishedPr;
     if (!pr?.mergedAt) return null;
     const when = formatTimeAgo(new Date(pr.mergedAt));
@@ -578,8 +656,9 @@ function CmsPublishContent({
       : t("thread.publishPopover.lastPublished", { when });
   })();
 
-  const publishLabel =
-    summary.count === 1
+  const primaryLabel = isReview
+    ? t("thread.publishPopover.submitForReview")
+    : summary.count === 1
       ? t("thread.publishPopover.publishOne")
       : summary.count > 1
         ? t("thread.publishPopover.publishCount", { count: summary.count })
@@ -756,7 +835,7 @@ function CmsPublishContent({
   };
 
   const gateRow = (() => {
-    if (summary.count === 0) return null;
+    if (isReview || summary.count === 0) return null;
     if (gate.pending) {
       return (
         <div className="flex items-center gap-2 border-t px-4 py-2.5 text-xs text-muted-foreground">
@@ -781,7 +860,7 @@ function CmsPublishContent({
     <>
       <div className="space-y-0.5 px-4 py-3">
         <div className="flex items-center gap-2 text-sm font-medium">
-          <Globe01 className="size-4 shrink-0 text-muted-foreground" />
+          <HeaderIcon className="size-4 shrink-0 text-muted-foreground" />
           <span className="truncate">{headerTitle}</span>
           {summary.count > 1 ? (
             discardAllConfirm ? (
@@ -817,10 +896,8 @@ function CmsPublishContent({
             )
           ) : null}
         </div>
-        {lastPublishLine ? (
-          <div className="pl-6 text-xs text-muted-foreground">
-            {lastPublishLine}
-          </div>
+        {subLine ? (
+          <div className="pl-6 text-xs text-muted-foreground">{subLine}</div>
         ) : null}
       </div>
       <div className="border-t" />
@@ -832,10 +909,14 @@ function CmsPublishContent({
           <div className="flex flex-col items-center gap-1 py-10 text-center">
             <CheckCircle className="mb-1 size-5 text-success" />
             <p className="text-sm font-medium">
-              {t("thread.publishPopover.everythingLive")}
+              {isReview
+                ? t("thread.publishPopover.nothingToSubmit")
+                : t("thread.publishPopover.everythingLive")}
             </p>
             <p className="text-xs text-muted-foreground">
-              {t("thread.publishPopover.emptyHint")}
+              {isReview
+                ? t("thread.publishPopover.submitEmptyHint")
+                : t("thread.publishPopover.emptyHint")}
             </p>
           </div>
         ) : (
@@ -856,12 +937,18 @@ function CmsPublishContent({
             </div>
             <div className="space-y-1.5 border-t px-4 py-3">
               <span className="text-[13px] font-medium">
-                {t("thread.publishPopover.versionNote")}
+                {isReview
+                  ? t("thread.publishPopover.reviewNote")
+                  : t("thread.publishPopover.versionNote")}
               </span>
               <Textarea
                 value={note}
                 onChange={(e) => setNote(e.target.value)}
-                placeholder={t("thread.publishPopover.versionNotePlaceholder")}
+                placeholder={
+                  isReview
+                    ? t("thread.publishPopover.reviewNotePlaceholder")
+                    : t("thread.publishPopover.versionNotePlaceholder")
+                }
                 rows={2}
                 className="resize-none text-[13px]"
                 disabled={isPublishing}
@@ -885,14 +972,11 @@ function CmsPublishContent({
             <Eye className="size-4" />
             {t("thread.publishPopover.preview")}
           </Button>
-          {summary.count > 0 && !gate.allowed && !gate.pending ? (
+          {!isReview && summary.count > 0 && !gate.allowed && !gate.pending ? (
             <Button
               type="button"
               className="flex-1"
-              onClick={() => {
-                onOpenChange(false);
-                onRequestApproval();
-              }}
+              onClick={onRequestApproval}
               disabled={isPublishing}
             >
               {t("thread.publishPopover.requestApproval")}
@@ -900,17 +984,19 @@ function CmsPublishContent({
           ) : (
             <Button
               type="button"
-              variant="brand"
+              variant={isReview ? "default" : "brand"}
               className="flex-1"
-              onClick={handlePublish}
-              disabled={!canPublish}
+              onClick={isReview ? handleSubmitForReview : handlePublish}
+              disabled={!canSubmit}
             >
               {isPublishing ? (
                 <Loading01 className="size-4 animate-spin" />
               ) : null}
               {isPublishing
-                ? t("thread.publishPopover.publishing")
-                : publishLabel}
+                ? isReview
+                  ? t("thread.publishPopover.submitting")
+                  : t("thread.publishPopover.publishing")
+                : primaryLabel}
             </Button>
           )}
         </div>

--- a/apps/web/src/components/thread/github/cms-publish-popover.tsx
+++ b/apps/web/src/components/thread/github/cms-publish-popover.tsx
@@ -1,14 +1,9 @@
 /**
- * Fast Preview's content-first publish surface: an anchored popover (modal on
- * narrow viewports) that renders the diff as pages and blocks by name, an
- * editable version note, and the review gate as a visible check row — no git
- * vocabulary. `publish` mode runs the push → sync → PR → squash-merge sequence
- * of {@link PublishDialog}; `review` mode stops at the PR. Only vibecoding mode
- * still uses {@link PublishDialog}.
+ * Fast Preview's content-first publish surface — presentation only: reads come
+ * from {@link useCmsPublishState}, writes from {@link useCmsPublishActions}.
  */
 
 import { useMCPClient } from "@/sdk";
-import { useSuspenseQuery } from "@tanstack/react-query";
 import { Button } from "@decocms/ui/components/button.tsx";
 import { Dialog, DialogContent } from "@decocms/ui/components/dialog.tsx";
 import {
@@ -18,23 +13,12 @@ import {
 } from "@decocms/ui/components/popover.tsx";
 import { Textarea } from "@decocms/ui/components/textarea.tsx";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@decocms/ui/components/tooltip.tsx";
-import { cn } from "@decocms/ui/lib/utils.ts";
-import {
   AlertTriangle,
   CheckCircle,
-  ChevronRight,
   Eye,
-  File06,
   GitPullRequest,
   Globe01,
-  LayoutAlt01,
   Loading01,
-  Trash01,
 } from "@untitledui/icons";
 import {
   Suspense,
@@ -43,40 +27,29 @@ import {
   useSyncExternalStore,
   type ReactNode,
 } from "react";
-import { toast } from "sonner";
 import { useT } from "@/i18n/use-t.ts";
 import { authClient } from "@/lib/auth-client.ts";
 import { coAuthorFromSessionUser } from "@/lib/co-author-identity.ts";
 import { formatTimeAgo } from "@/lib/format-time.ts";
-import { GitDiffList } from "./git-diff-list.tsx";
-import {
-  openPullRequestForBranch,
-  squashMergePullRequest,
-  type CreatedPullRequest,
-} from "./github-pr-api.ts";
+import { cn } from "@decocms/ui/lib/utils.ts";
+import { changeId, PublishChangeCard } from "./cms-publish-change-card.tsx";
 import { lastPublishAttribution } from "./pr-attribution.ts";
 import {
   buildAutoNote,
-  countPageSections,
   summarizePublishChanges,
   type PublishChange,
-  type PublishChangeStatus,
 } from "./publish-change-summary.ts";
+import type { PublishTarget } from "./publish-flow.ts";
+import { readGitHeadBranch, type PublishPolicy } from "./sandbox-git-api.ts";
+import type { PrSummary } from "./use-pr-data.ts";
 import {
-  combinePublishDiffs,
-  discardGitFiles,
-  fetchGitDiff,
-  fetchGitStatus,
-  hasGitLocalWork,
-  publishGitChanges,
-  readGitHeadBranch,
-  rebaseGitBranch,
-  type GitDiffResult,
-  type GitStatus,
-  type PublishPolicy,
-} from "./sandbox-git-api.ts";
-import { fetchLastPublishedPr, type PrSummary } from "./use-pr-data.ts";
+  useCmsPublishActions,
+  type CmsPublishMode,
+} from "./use-cms-publish-actions.ts";
+import { useCmsPublishState } from "./use-cms-publish-state.ts";
 import { useResolvedPublishGate } from "@/components/sandbox/hooks/use-publish-gate.ts";
+
+export type { CmsPublishMode };
 
 const NARROW_VIEWPORT_QUERY = "(max-width: 479px)";
 
@@ -94,9 +67,6 @@ function useNarrowViewport(): boolean {
     () => false,
   );
 }
-
-/** `publish` merges to production; `review` stops at the pull request. */
-export type CmsPublishMode = "publish" | "review";
 
 export interface CmsPublishPopoverProps {
   open: boolean;
@@ -167,74 +137,6 @@ export function CmsPublishPopover(props: CmsPublishPopoverProps) {
       </PopoverContent>
     </Popover>
   );
-}
-
-class PublishStepError extends Error {
-  constructor(
-    message: string,
-    readonly step: "push" | "sync" | "open-pr" | "merge",
-    readonly pr?: CreatedPullRequest,
-  ) {
-    super(message);
-    this.name = "PublishStepError";
-  }
-}
-
-function statusLabel(status: PublishChangeStatus, t: ReturnType<typeof useT>) {
-  return status === "new"
-    ? t("thread.publishPopover.chipNew")
-    : status === "removed"
-      ? t("thread.publishPopover.chipRemoved")
-      : t("thread.publishPopover.chipEdited");
-}
-
-/** Status is carried by the icon color (lime = added); the title names it for
- *  anyone who can't rely on color alone. */
-function changeIcon(change: PublishChange, t: ReturnType<typeof useT>) {
-  const Icon = change.kind === "block" ? LayoutAlt01 : File06;
-  return (
-    <span title={statusLabel(change.status, t)} className="flex shrink-0">
-      <Icon
-        className={cn(
-          "size-4",
-          change.status === "new" && "text-brand",
-          change.status === "edited" && "text-warning",
-          change.status === "removed" && "text-destructive",
-        )}
-      />
-    </span>
-  );
-}
-
-/** Stable identity for a card across summary recomputes. */
-function changeId(change: PublishChange): string {
-  return change.blockKey ?? change.filepaths[0] ?? change.name;
-}
-
-/** One suspense load: git state and last-publish arrive together, so the
- *  popover goes straight from a single loading state to the final render.
- *  Failures land in `loadError` / a null `lastPublishedPr` (rendered inline)
- *  rather than throwing to an error boundary. */
-interface PublishStateData {
-  status: GitStatus | null;
-  diff: GitDiffResult | null;
-  lastPublishedPr: PrSummary | null;
-  loadError: string | null;
-}
-
-function publishStateQueryKey(
-  orgSlug: string,
-  virtualMcpId: string,
-  branch: string,
-  baseBranch: string,
-) {
-  return [
-    "cms-publish-popover-state",
-    orgSlug,
-    virtualMcpId,
-    branch,
-    baseBranch,
-  ] as const;
 }
 
 function Ghost({ className }: { className?: string }) {
@@ -343,61 +245,30 @@ function CmsPublishContent({
     orgSlug,
   });
   const { data: session } = authClient.useSession();
-  const coAuthor = coAuthorFromSessionUser(session?.user);
 
-  const publishState = useSuspenseQuery<PublishStateData>({
-    queryKey: publishStateQueryKey(orgSlug, virtualMcpId, branch, baseBranch),
-    queryFn: async (): Promise<PublishStateData> => {
-      const lastPublishedPromise = fetchLastPublishedPr(githubClient, {
-        owner,
-        repo,
-        base: baseBranch,
-      }).catch(() => null);
-      try {
-        const status = await fetchGitStatus(orgSlug, virtualMcpId, branch);
-        const baseDiff =
-          (status.aheadOfBase ?? 0) > 0
-            ? await fetchGitDiff(orgSlug, virtualMcpId, branch, {
-                base: baseBranch,
-              })
-            : null;
-        const workingDiff = hasGitLocalWork(status)
-          ? await fetchGitDiff(orgSlug, virtualMcpId, branch)
-          : null;
-        return {
-          status,
-          diff: combinePublishDiffs(baseDiff, workingDiff),
-          lastPublishedPr: await lastPublishedPromise,
-          loadError: null,
-        };
-      } catch (error) {
-        return {
-          status: null,
-          diff: null,
-          lastPublishedPr: await lastPublishedPromise,
-          loadError: error instanceof Error ? error.message : String(error),
-        };
-      }
-    },
-    staleTime: 0,
-    gcTime: 0,
-  });
   const {
     status: gitStatus,
     diff: gitDiff,
     lastPublishedPr,
     loadError,
-  } = publishState.data;
+    refresh,
+  } = useCmsPublishState({
+    githubClient,
+    orgSlug,
+    virtualMcpId,
+    branch,
+    baseBranch,
+    owner,
+    repo,
+  });
 
-  const [isPublishing, setIsPublishing] = useState(false);
-  const [publishError, setPublishError] = useState<string>();
   const [note, setNote] = useState(() =>
     gitDiff ? buildAutoNote(summarizePublishChanges(gitDiff)) : "",
   );
-  const [discardConfirmId, setDiscardConfirmId] = useState<string | null>(null);
   const [discardAllConfirm, setDiscardAllConfirm] = useState(false);
-  const [isDiscarding, setIsDiscarding] = useState(false);
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  /** Only one card may arm its discard at a time — it is a one-click destroy. */
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
 
   const summary = summarizePublishChanges(gitDiff);
   const isReview = mode === "review";
@@ -415,209 +286,43 @@ function CmsPublishContent({
   });
 
   const commitToOpenPr = openPullRequest?.state === "open";
-  const existingOpenPr = commitToOpenPr
-    ? { number: openPullRequest.number, htmlUrl: openPullRequest.htmlUrl }
-    : undefined;
-  const githubHeadBranch = readGitHeadBranch(gitStatus) ?? branch;
+  const target: PublishTarget = {
+    orgSlug,
+    virtualMcpId,
+    branch,
+    baseBranch,
+    githubClient,
+    owner,
+    repo,
+    headBranch: readGitHeadBranch(gitStatus) ?? branch,
+    coAuthor: coAuthorFromSessionUser(session?.user),
+    existingOpenPr: commitToOpenPr
+      ? { number: openPullRequest.number, htmlUrl: openPullRequest.htmlUrl }
+      : undefined,
+  };
+
+  const {
+    isPublishing,
+    isDiscarding,
+    publishError,
+    submit,
+    discardChange,
+    discardAll,
+  } = useCmsPublishActions({
+    mode,
+    target,
+    note,
+    diff: gitDiff,
+    destinationHost,
+    publishLockRef,
+    onOpenChange,
+    refresh,
+    onPullRequestChanged,
+    onPublished,
+  });
 
   const canSubmit =
     !isPublishing && summary.count > 0 && (isReview || gate.allowed);
-
-  /** The note is the commit message and the PR title/body in both modes. */
-  const noteParts = () => {
-    const lines = note.trim().split("\n");
-    const title =
-      lines[0]?.trim() ||
-      t("thread.publishDialog.changesFrom", { branch: githubHeadBranch });
-    const body = lines.slice(1).join("\n").trim() || undefined;
-    return { title, body, message: [title, body].filter(Boolean).join("\n\n") };
-  };
-
-  /** One definition of the PR both modes open — or update, when one is open. */
-  const openPr = (title: string, body?: string) =>
-    openPullRequestForBranch(githubClient, {
-      owner,
-      repo,
-      branch: githubHeadBranch,
-      title,
-      body,
-      base: baseBranch,
-      coAuthor,
-      existing: existingOpenPr,
-    });
-
-  const handlePublish = async () => {
-    publishLockRef.current = true;
-    setIsPublishing(true);
-    setPublishError(undefined);
-    let openedPr: CreatedPullRequest | undefined;
-    try {
-      const { title, body, message } = noteParts();
-
-      try {
-        await publishGitChanges(orgSlug, virtualMcpId, branch, message);
-      } catch (error) {
-        throw new PublishStepError(
-          error instanceof Error
-            ? error.message
-            : t("thread.publishDialog.failedPushChanges"),
-          "push",
-        );
-      }
-      try {
-        await rebaseGitBranch(orgSlug, virtualMcpId, branch, baseBranch);
-      } catch (error) {
-        throw new PublishStepError(
-          error instanceof Error
-            ? error.message
-            : t("thread.publishDialog.failedRebase"),
-          "sync",
-        );
-      }
-      try {
-        openedPr = await openPr(title, body);
-      } catch (error) {
-        throw new PublishStepError(
-          error instanceof Error
-            ? error.message
-            : t("thread.publishDialog.failedOpenPullRequest"),
-          "open-pr",
-        );
-      }
-      try {
-        await squashMergePullRequest(githubClient, {
-          owner,
-          repo,
-          pullNumber: openedPr.number,
-          commitTitle: title,
-          commitMessage: body,
-          coAuthor,
-        });
-      } catch (error) {
-        throw new PublishStepError(
-          error instanceof Error
-            ? error.message
-            : t("thread.publishDialog.failedMergePullRequest"),
-          "merge",
-          openedPr,
-        );
-      }
-
-      toast.success(
-        destinationHost
-          ? t("thread.publishPopover.publishedTo", { host: destinationHost })
-          : t("thread.publishDialog.publishedTo", { baseBranch }),
-      );
-      onOpenChange(false);
-      await onPullRequestChanged?.();
-      await onPublished?.();
-    } catch (error) {
-      if (
-        error instanceof PublishStepError &&
-        error.step === "merge" &&
-        error.pr
-      ) {
-        const msg = t("thread.publishDialog.mergeFailed", {
-          prNumber: error.pr.number,
-          message: error.message,
-        });
-        setPublishError(msg);
-        toast.error(msg, {
-          action: {
-            label: t("thread.publishDialog.viewPr"),
-            onClick: () =>
-              window.open(error.pr!.htmlUrl, "_blank", "noopener,noreferrer"),
-          },
-        });
-        await onPullRequestChanged?.();
-        return;
-      }
-      setPublishError(
-        error instanceof Error
-          ? error.message
-          : t("thread.publishDialog.failedPublish"),
-      );
-    } finally {
-      publishLockRef.current = false;
-      setIsPublishing(false);
-    }
-  };
-
-  /** Review mode's flow: push, then open (or update) the PR — no merge. */
-  const handleSubmitForReview = async () => {
-    publishLockRef.current = true;
-    setIsPublishing(true);
-    setPublishError(undefined);
-    try {
-      const { title, body, message } = noteParts();
-
-      await publishGitChanges(orgSlug, virtualMcpId, branch, message);
-      const pr = await openPr(title, body);
-
-      toast.success(
-        t("thread.publishDialog.submittedForReview", { prNumber: pr.number }),
-        {
-          action: {
-            label: t("thread.publishDialog.viewOnGithub"),
-            onClick: () =>
-              window.open(pr.htmlUrl, "_blank", "noopener,noreferrer"),
-          },
-        },
-      );
-      onOpenChange(false);
-      await onPullRequestChanged?.();
-    } catch (error) {
-      setPublishError(
-        error instanceof Error
-          ? error.message
-          : t("thread.publishDialog.failedSubmitForReview"),
-      );
-    } finally {
-      publishLockRef.current = false;
-      setIsPublishing(false);
-    }
-  };
-
-  const handleDiscard = async (change: PublishChange) => {
-    setDiscardConfirmId(null);
-    setIsDiscarding(true);
-    try {
-      await discardGitFiles(orgSlug, virtualMcpId, branch, change.filepaths);
-      toast.success(
-        t("thread.publishPopover.discarded", { name: change.name }),
-      );
-      await publishState.refetch();
-    } catch (error) {
-      toast.error(
-        error instanceof Error
-          ? error.message
-          : t("thread.publishPopover.failedDiscard"),
-      );
-    } finally {
-      setIsDiscarding(false);
-    }
-  };
-
-  const handleDiscardAll = async () => {
-    if (!gitDiff) return;
-    setDiscardAllConfirm(false);
-    setIsDiscarding(true);
-    try {
-      const allFiles = Object.keys(gitDiff.diffs);
-      if (allFiles.length === 0) return;
-      await discardGitFiles(orgSlug, virtualMcpId, branch, allFiles);
-      toast.success(t("thread.publishDialog.allChangesDiscarded"));
-      await publishState.refetch();
-    } catch (error) {
-      toast.error(
-        error instanceof Error
-          ? error.message
-          : t("thread.publishPopover.failedDiscard"),
-      );
-    } finally {
-      setIsDiscarding(false);
-    }
-  };
 
   const headerTitle = isReview
     ? summary.count === 0
@@ -664,159 +369,6 @@ function CmsPublishContent({
     window.open(draftPreviewUrl, "_blank", "noopener,noreferrer");
   };
 
-  const renderCard = (change: PublishChange) => {
-    const id = changeId(change);
-    const confirming = discardConfirmId === id;
-    const expanded = expandedId === id;
-    const detail =
-      change.kind === "page"
-        ? change.pagePath
-        : change.kind === "block"
-          ? change.isSiteApp
-            ? t("thread.publishPopover.siteConfiguration")
-            : t("thread.publishPopover.globalSection")
-          : null;
-    const subLines =
-      change.kind === "page" && change.status === "new"
-        ? [
-            t("thread.publishPopover.newPageSections", {
-              count: countPageSections(change.toJson),
-            }),
-          ]
-        : change.sections.map((section) =>
-            section.fields.length > 0
-              ? `${section.name} — ${section.fields
-                  .slice(0, 4)
-                  .map((f) => f.label)
-                  .join(", ")}`
-              : section.name,
-          );
-    const rawDiff: GitDiffResult = {
-      diffs: Object.fromEntries(
-        change.filepaths.flatMap((p) => {
-          const entry = gitDiff?.diffs[p];
-          return entry ? [[p, entry] as const] : [];
-        }),
-      ),
-    };
-    const canExpand = Object.keys(rawDiff.diffs).length > 0;
-    const toggleExpanded = () => setExpandedId(expanded ? null : id);
-
-    // Collapsed card = one big expand target; inner controls stop propagation.
-    return (
-      <div
-        key={id}
-        className={cn(
-          "rounded-lg border bg-card px-3 py-2.5",
-          canExpand && !expanded && "cursor-pointer",
-        )}
-        data-change-id={id}
-        onClick={canExpand && !expanded ? toggleExpanded : undefined}
-      >
-        <div
-          className={cn(
-            "flex items-center gap-2.5",
-            canExpand && "cursor-pointer",
-          )}
-          onClick={
-            canExpand
-              ? (e) => {
-                  e.stopPropagation();
-                  toggleExpanded();
-                }
-              : undefined
-          }
-        >
-          {changeIcon(change, t)}
-          <button
-            type="button"
-            className="flex min-w-0 flex-1 items-center gap-2 text-left"
-            disabled={!canExpand}
-            aria-expanded={canExpand ? expanded : undefined}
-          >
-            <span className="truncate text-sm font-medium">{change.name}</span>
-            {detail ? (
-              <span className="truncate text-xs text-muted-foreground">
-                {detail}
-              </span>
-            ) : null}
-          </button>
-          {confirming ? (
-            <div className="flex shrink-0 items-center gap-1.5">
-              <button
-                type="button"
-                className="text-xs text-muted-foreground hover:text-foreground"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setDiscardConfirmId(null);
-                }}
-              >
-                {t("thread.publishDialog.cancel")}
-              </button>
-              <button
-                type="button"
-                className="text-xs font-medium text-destructive disabled:opacity-50"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  void handleDiscard(change);
-                }}
-                disabled={isDiscarding}
-              >
-                {t("thread.publishPopover.discard")}
-              </button>
-            </div>
-          ) : (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    aria-label={t("thread.publishPopover.discard")}
-                    className="flex size-6 shrink-0 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-destructive disabled:opacity-50"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setDiscardConfirmId(id);
-                    }}
-                    disabled={isPublishing || isDiscarding}
-                  >
-                    <Trash01 className="size-3.5" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>
-                  {t("thread.publishPopover.discard")}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          )}
-          {canExpand ? (
-            <ChevronRight
-              className={cn(
-                "size-3.5 shrink-0 text-muted-foreground transition-transform",
-                expanded && "rotate-90",
-              )}
-            />
-          ) : null}
-        </div>
-        {!expanded && subLines.length > 0 ? (
-          <div className="mt-1 space-y-0.5 pl-[26px] text-xs text-muted-foreground">
-            {subLines.map((line, lineIndex) => (
-              <div key={`${lineIndex}-${line}`} className="truncate">
-                {line}
-              </div>
-            ))}
-          </div>
-        ) : null}
-        {expanded ? (
-          <div className="-mx-3 mt-2 border-t pt-1">
-            <div className="scroll-fade max-h-72 overflow-y-auto overscroll-contain [scrollbar-width:thin]">
-              <GitDiffList diff={rawDiff} hideFileRows editorHeight="220px" />
-            </div>
-          </div>
-        ) : null}
-      </div>
-    );
-  };
-
   const renderGroup = (label: string, changes: PublishChange[]) => {
     if (changes.length === 0) return null;
     return (
@@ -824,7 +376,27 @@ function CmsPublishContent({
         <div className="px-0.5 text-[11px] font-medium tracking-wider text-muted-foreground uppercase">
           {label}
         </div>
-        {changes.map(renderCard)}
+        {changes.map((change) => {
+          const id = changeId(change);
+          return (
+            <PublishChangeCard
+              key={id}
+              change={change}
+              diff={gitDiff}
+              expanded={expandedId === id}
+              onToggleExpanded={() =>
+                setExpandedId(expandedId === id ? null : id)
+              }
+              confirming={confirmingId === id}
+              onConfirmingChange={(confirming) =>
+                setConfirmingId(confirming ? id : null)
+              }
+              onDiscard={() => void discardChange(change)}
+              isPublishing={isPublishing}
+              isDiscarding={isDiscarding}
+            />
+          );
+        })}
       </div>
     );
   };
@@ -873,7 +445,10 @@ function CmsPublishContent({
                 <button
                   type="button"
                   className="font-medium text-destructive disabled:opacity-50"
-                  onClick={handleDiscardAll}
+                  onClick={() => {
+                    setDiscardAllConfirm(false);
+                    void discardAll();
+                  }}
                   disabled={isDiscarding}
                 >
                   {t("thread.publishPopover.discard")}
@@ -981,7 +556,7 @@ function CmsPublishContent({
               type="button"
               variant={isReview ? "default" : "brand"}
               className="flex-1"
-              onClick={isReview ? handleSubmitForReview : handlePublish}
+              onClick={() => void submit()}
               disabled={!canSubmit}
             >
               {isPublishing ? (

--- a/apps/web/src/components/thread/github/publish-dialog.tsx
+++ b/apps/web/src/components/thread/github/publish-dialog.tsx
@@ -29,10 +29,13 @@ import { authClient } from "@/lib/auth-client.ts";
 import { coAuthorFromSessionUser } from "@/lib/co-author-identity.ts";
 import { GitDiffList } from "./git-diff-list.tsx";
 import {
-  openPullRequestForBranch,
-  squashMergePullRequest,
-  type CreatedPullRequest,
-} from "./github-pr-api.ts";
+  notifySubmittedForReview,
+  publishMessageParts,
+  reportPublishFailure,
+  runPublishFlow,
+  runSubmitForReviewFlow,
+  type PublishTarget,
+} from "./publish-flow.ts";
 import type { PrSummary } from "./use-pr-data.ts";
 import { useSandboxStart } from "@/components/sandbox/hooks/use-sandbox-start";
 import { publishToBaseLabel } from "./publish-label.ts";
@@ -48,25 +51,12 @@ import {
   hasLocalWorkToPush,
   hasUnpublishedWork,
   isSandboxUnreachable,
-  publishGitChanges,
   readGitHeadBranch,
-  rebaseGitBranch,
   shouldUseBaseDiff,
   type GitDiffResult,
   type GitStatus,
   type PublishPolicy,
 } from "./sandbox-git-api.ts";
-
-class PublishFlowError extends Error {
-  constructor(
-    message: string,
-    readonly step: "push" | "rebase" | "open-pr" | "merge",
-    readonly pr?: CreatedPullRequest,
-  ) {
-    super(message);
-    this.name = "PublishFlowError";
-  }
-}
 
 export type PublishDialogIntent = "open-pr" | "publish-only";
 
@@ -339,8 +329,27 @@ function PublishDialogBody({
     (showSubmitForReviewButton || hasLocalUnpublished) &&
     (diffCount > 0 || hasLocalUnpublished);
 
-  const commitMessage = () =>
-    [publishTitle.trim(), publishBody.trim()].filter(Boolean).join("\n\n");
+  const publishTarget: PublishTarget = {
+    orgSlug,
+    virtualMcpId,
+    branch,
+    baseBranch,
+    githubClient,
+    owner,
+    repo,
+    headBranch: githubHeadBranch,
+    coAuthor,
+    existingOpenPr,
+  };
+
+  const messageParts = () =>
+    publishMessageParts({
+      title: publishTitle,
+      body: publishBody,
+      fallbackTitle: t("thread.publishDialog.changesFrom", {
+        branch: githubHeadBranch,
+      }),
+    });
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (isPublishing || isSubmittingForReview) return;
@@ -350,74 +359,8 @@ function PublishDialogBody({
   const handlePublish = async () => {
     setIsPublishing(true);
     setPublishError(undefined);
-    let openedPr: CreatedPullRequest | undefined;
     try {
-      const prTitle =
-        publishTitle.trim() ||
-        t("thread.publishDialog.changesFrom", { branch: githubHeadBranch });
-      const prBody = publishBody.trim() || undefined;
-      const message = commitMessage() || prTitle;
-
-      try {
-        await publishGitChanges(orgSlug, virtualMcpId, branch, message);
-      } catch (error) {
-        throw new PublishFlowError(
-          error instanceof Error
-            ? error.message
-            : t("thread.publishDialog.failedPushChanges"),
-          "push",
-        );
-      }
-
-      try {
-        await rebaseGitBranch(orgSlug, virtualMcpId, branch, baseBranch);
-      } catch (error) {
-        throw new PublishFlowError(
-          error instanceof Error
-            ? error.message
-            : t("thread.publishDialog.failedRebase"),
-          "rebase",
-        );
-      }
-
-      try {
-        openedPr = await openPullRequestForBranch(githubClient, {
-          owner,
-          repo,
-          branch: githubHeadBranch,
-          title: prTitle,
-          body: prBody,
-          base: baseBranch,
-          coAuthor,
-          existing: existingOpenPr,
-        });
-      } catch (error) {
-        throw new PublishFlowError(
-          error instanceof Error
-            ? error.message
-            : t("thread.publishDialog.failedOpenPullRequest"),
-          "open-pr",
-        );
-      }
-
-      try {
-        await squashMergePullRequest(githubClient, {
-          owner,
-          repo,
-          pullNumber: openedPr.number,
-          commitTitle: prTitle,
-          commitMessage: prBody,
-          coAuthor,
-        });
-      } catch (error) {
-        throw new PublishFlowError(
-          error instanceof Error
-            ? error.message
-            : t("thread.publishDialog.failedMergePullRequest"),
-          "merge",
-          openedPr,
-        );
-      }
+      await runPublishFlow(publishTarget, messageParts(), t);
 
       toast.success(t("thread.publishDialog.publishedTo", { baseBranch }));
       handleOpenChange(false);
@@ -427,31 +370,9 @@ function PublishDialogBody({
       await onPullRequestChanged?.();
       await onPublished?.();
     } catch (error) {
-      if (
-        error instanceof PublishFlowError &&
-        error.step === "merge" &&
-        error.pr
-      ) {
-        const msg = t("thread.publishDialog.mergeFailed", {
-          prNumber: error.pr.number,
-          message: error.message,
-        });
-        setPublishError(msg);
-        toast.error(msg, {
-          action: {
-            label: t("thread.publishDialog.viewPr"),
-            onClick: () =>
-              window.open(error.pr!.htmlUrl, "_blank", "noopener,noreferrer"),
-          },
-        });
-        await onPullRequestChanged?.();
-        return;
-      }
-      setPublishError(
-        error instanceof Error
-          ? error.message
-          : t("thread.publishDialog.failedPublish"),
-      );
+      const failure = reportPublishFailure(error, t);
+      setPublishError(failure.message);
+      if (failure.pullRequestOpened) await onPullRequestChanged?.();
     } finally {
       setIsPublishing(false);
     }
@@ -506,37 +427,9 @@ function PublishDialogBody({
     setIsSubmittingForReview(true);
     setSubmitForReviewError(undefined);
     try {
-      const prTitle =
-        publishTitle.trim() ||
-        t("thread.publishDialog.changesFrom", { branch: githubHeadBranch });
-      const prBody = publishBody.trim() || undefined;
-      const message = commitMessage() || prTitle;
+      const pr = await runSubmitForReviewFlow(publishTarget, messageParts());
 
-      // GitHub requires head on the remote; push even when commits are already
-      // local-only (unpushed can read 0 until origin/<branch> exists).
-      await publishGitChanges(orgSlug, virtualMcpId, branch, message);
-
-      const pr = await openPullRequestForBranch(githubClient, {
-        owner,
-        repo,
-        branch: githubHeadBranch,
-        title: prTitle,
-        body: prBody,
-        base: baseBranch,
-        coAuthor,
-        existing: existingOpenPr,
-      });
-
-      toast.success(
-        t("thread.publishDialog.submittedForReview", { prNumber: pr.number }),
-        {
-          action: {
-            label: t("thread.publishDialog.viewOnGithub"),
-            onClick: () =>
-              window.open(pr.htmlUrl, "_blank", "noopener,noreferrer"),
-          },
-        },
-      );
+      notifySubmittedForReview(pr, t);
       handleOpenChange(false);
       await onPullRequestChanged?.();
     } catch (error) {

--- a/apps/web/src/components/thread/github/publish-flow.test.ts
+++ b/apps/web/src/components/thread/github/publish-flow.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "bun:test";
+import {
+  describePublishFailure,
+  publishMessageParts,
+  publishNoteParts,
+  PublishStepError,
+} from "./publish-flow.ts";
+
+const FALLBACK = "Changes from feature-branch";
+
+/** Stands in for the real `t`: renders the key plus its interpolations. */
+const t = ((key: string, vars?: Record<string, unknown>) =>
+  vars
+    ? `${key}(${Object.entries(vars)
+        .map(([k, v]) => `${k}=${v}`)
+        .join(",")})`
+    : key) as never;
+
+const PR = { number: 42, htmlUrl: "https://github.com/o/r/pull/42" };
+
+describe("publishMessageParts", () => {
+  it("uses the fallback title when the author left the title empty", () => {
+    expect(
+      publishMessageParts({ title: "  ", body: "", fallbackTitle: FALLBACK }),
+    ).toEqual({ title: FALLBACK, body: undefined, message: FALLBACK });
+  });
+
+  it("keeps the commit message to the body when only a body was written", () => {
+    expect(
+      publishMessageParts({
+        title: "",
+        body: "why it changed",
+        fallbackTitle: FALLBACK,
+      }),
+    ).toEqual({
+      title: FALLBACK,
+      body: "why it changed",
+      message: "why it changed",
+    });
+  });
+
+  it("joins title and body into the commit message", () => {
+    expect(
+      publishMessageParts({
+        title: " Update pricing ",
+        body: " new tiers ",
+        fallbackTitle: FALLBACK,
+      }),
+    ).toEqual({
+      title: "Update pricing",
+      body: "new tiers",
+      message: "Update pricing\n\nnew tiers",
+    });
+  });
+});
+
+describe("publishNoteParts", () => {
+  it("titles the change with the note's first line", () => {
+    expect(publishNoteParts("Update pricing", FALLBACK)).toEqual({
+      title: "Update pricing",
+      body: undefined,
+      message: "Update pricing",
+    });
+  });
+
+  it("puts every line after the first into the body", () => {
+    expect(
+      publishNoteParts("Update pricing\nnew tiers\nand a banner", FALLBACK),
+    ).toEqual({
+      title: "Update pricing",
+      body: "new tiers\nand a banner",
+      message: "Update pricing\n\nnew tiers\nand a banner",
+    });
+  });
+
+  it("falls back to the branch title for a blank note", () => {
+    expect(publishNoteParts("   \n  ", FALLBACK)).toEqual({
+      title: FALLBACK,
+      body: undefined,
+      message: FALLBACK,
+    });
+  });
+});
+
+describe("describePublishFailure", () => {
+  it("names the pull request a failed merge left behind", () => {
+    const failure = describePublishFailure(
+      new PublishStepError("merge conflict", "merge", PR),
+      t,
+    );
+    expect(failure.pullRequest).toEqual(PR);
+    expect(failure.message).toBe(
+      "thread.publishDialog.mergeFailed(prNumber=42,message=merge conflict)",
+    );
+  });
+
+  it("reports no pull request when an earlier step failed", () => {
+    expect(
+      describePublishFailure(new PublishStepError("push denied", "push"), t),
+    ).toEqual({ message: "push denied", pullRequest: null });
+  });
+
+  it("reports no pull request when the merge failed before one opened", () => {
+    expect(
+      describePublishFailure(new PublishStepError("merge blew up", "merge"), t),
+    ).toEqual({ message: "merge blew up", pullRequest: null });
+  });
+
+  it("passes a plain error's message through", () => {
+    expect(describePublishFailure(new Error("offline"), t)).toEqual({
+      message: "offline",
+      pullRequest: null,
+    });
+  });
+
+  it("falls back to the generic message for a non-Error throw", () => {
+    expect(describePublishFailure("boom", t)).toEqual({
+      message: "thread.publishDialog.failedPublish",
+      pullRequest: null,
+    });
+  });
+});

--- a/apps/web/src/components/thread/github/publish-flow.ts
+++ b/apps/web/src/components/thread/github/publish-flow.ts
@@ -1,0 +1,268 @@
+/**
+ * The one publish sequence, shared by Fast Preview's publish popover and the
+ * coding session's publish dialog. Publishing runs push → sync → open (or
+ * update) the pull request → squash-merge; submitting for review runs the same
+ * push → open-pr prefix and stops there. Neither surface owns the steps, so a
+ * change to the sequence lands here exactly once.
+ */
+
+import type { CoAuthorIdentity } from "@decocms/sandbox/shared";
+import { toast } from "sonner";
+import type { TFunction } from "@/i18n/use-t.ts";
+import {
+  openPullRequestForBranch,
+  squashMergePullRequest,
+  type CreatedPullRequest,
+  type GithubMcpClient,
+} from "./github-pr-api.ts";
+import { publishGitChanges, rebaseGitBranch } from "./sandbox-git-api.ts";
+
+/** The steps a publish runs, in order. Submitting for review stops at `open-pr`. */
+type PublishStep = "push" | "sync" | "open-pr" | "merge";
+
+/**
+ * A failure attributed to the step that produced it. `pr` is set only when the
+ * merge failed after the pull request was already opened — the work is not
+ * lost, it is sitting in that open PR.
+ */
+export class PublishStepError extends Error {
+  constructor(
+    message: string,
+    readonly step: PublishStep,
+    readonly pr?: CreatedPullRequest,
+  ) {
+    super(message);
+    this.name = "PublishStepError";
+  }
+}
+
+/**
+ * Where a publish goes: the sandbox branch it pushes, and the pull request it
+ * opens — or updates, when the branch already has one open.
+ */
+export interface PublishTarget {
+  orgSlug: string;
+  virtualMcpId: string;
+  /** Sandbox branch — what gets pushed. */
+  branch: string;
+  baseBranch: string;
+  githubClient: GithubMcpClient;
+  owner: string;
+  repo: string;
+  /** Branch name on GitHub; the sandbox's HEAD can differ from `branch`. */
+  headBranch: string;
+  coAuthor?: CoAuthorIdentity;
+  /** The branch's already-open pull request, updated instead of opening a new one. */
+  existingOpenPr?: CreatedPullRequest;
+}
+
+/** Pull-request title/body and the commit message, from one authored note. */
+interface PublishMessage {
+  title: string;
+  body?: string;
+  message: string;
+}
+
+/**
+ * Derive what the pull request and the commit are called. An empty title falls
+ * back to `fallbackTitle`; the commit message is title and body joined, and
+ * degrades to the title alone when the author wrote neither.
+ */
+export function publishMessageParts(input: {
+  title: string;
+  body: string;
+  fallbackTitle: string;
+}): PublishMessage {
+  const title = input.title.trim();
+  const body = input.body.trim();
+  const prTitle = title || input.fallbackTitle;
+  return {
+    title: prTitle,
+    body: body || undefined,
+    message: [title, body].filter(Boolean).join("\n\n") || prTitle,
+  };
+}
+
+/** Single-textarea surfaces author title and body as one note: line 1 titles it. */
+export function publishNoteParts(
+  note: string,
+  fallbackTitle: string,
+): PublishMessage {
+  const lines = note.trim().split("\n");
+  return publishMessageParts({
+    title: lines[0] ?? "",
+    body: lines.slice(1).join("\n"),
+    fallbackTitle,
+  });
+}
+
+async function runStep<T>(
+  step: PublishStep,
+  fallback: string,
+  run: () => Promise<T>,
+): Promise<T> {
+  try {
+    return await run();
+  } catch (error) {
+    throw new PublishStepError(
+      error instanceof Error ? error.message : fallback,
+      step,
+    );
+  }
+}
+
+function pushChanges(target: PublishTarget, message: string): Promise<void> {
+  return publishGitChanges(
+    target.orgSlug,
+    target.virtualMcpId,
+    target.branch,
+    message,
+  );
+}
+
+function openPullRequest(
+  target: PublishTarget,
+  parts: PublishMessage,
+): Promise<CreatedPullRequest> {
+  return openPullRequestForBranch(target.githubClient, {
+    owner: target.owner,
+    repo: target.repo,
+    branch: target.headBranch,
+    title: parts.title,
+    body: parts.body,
+    base: target.baseBranch,
+    coAuthor: target.coAuthor,
+    existing: target.existingOpenPr,
+  });
+}
+
+/**
+ * push → sync → open (or update) the pull request → squash-merge. Every failure
+ * arrives as a {@link PublishStepError}; hand it to {@link reportPublishFailure}
+ * for the presentation both surfaces share.
+ */
+export async function runPublishFlow(
+  target: PublishTarget,
+  parts: PublishMessage,
+  t: TFunction,
+): Promise<CreatedPullRequest> {
+  await runStep("push", t("thread.publishDialog.failedPushChanges"), () =>
+    pushChanges(target, parts.message),
+  );
+  await runStep("sync", t("thread.publishDialog.failedRebase"), () =>
+    rebaseGitBranch(
+      target.orgSlug,
+      target.virtualMcpId,
+      target.branch,
+      target.baseBranch,
+    ),
+  );
+  const pr = await runStep(
+    "open-pr",
+    t("thread.publishDialog.failedOpenPullRequest"),
+    () => openPullRequest(target, parts),
+  );
+  try {
+    await squashMergePullRequest(target.githubClient, {
+      owner: target.owner,
+      repo: target.repo,
+      pullNumber: pr.number,
+      commitTitle: parts.title,
+      commitMessage: parts.body,
+      coAuthor: target.coAuthor,
+    });
+  } catch (error) {
+    throw new PublishStepError(
+      error instanceof Error
+        ? error.message
+        : t("thread.publishDialog.failedMergePullRequest"),
+      "merge",
+      pr,
+    );
+  }
+  return pr;
+}
+
+/**
+ * push → open (or update) the pull request, and stop. GitHub requires the head
+ * on the remote, so this pushes even when the commits are already local-only.
+ * Failures propagate raw — each surface names its own fallback message.
+ */
+export async function runSubmitForReviewFlow(
+  target: PublishTarget,
+  parts: PublishMessage,
+): Promise<CreatedPullRequest> {
+  await pushChanges(target, parts.message);
+  return openPullRequest(target, parts);
+}
+
+/** What a publish failure means: the message to show, and the PR it left behind. */
+interface PublishFailure {
+  message: string;
+  /** Set when the merge failed after the PR opened — the work is in that PR. */
+  pullRequest: CreatedPullRequest | null;
+}
+
+/**
+ * Read a failure. A merge that failed after the pull request opened names it,
+ * so the caller can link to it and refresh its PR state; everything else is the
+ * step's own message, or the generic fallback for a non-Error throw.
+ */
+export function describePublishFailure(
+  error: unknown,
+  t: TFunction,
+): PublishFailure {
+  if (error instanceof PublishStepError && error.step === "merge" && error.pr) {
+    return {
+      message: t("thread.publishDialog.mergeFailed", {
+        prNumber: error.pr.number,
+        message: error.message,
+      }),
+      pullRequest: error.pr,
+    };
+  }
+  return {
+    message:
+      error instanceof Error
+        ? error.message
+        : t("thread.publishDialog.failedPublish"),
+    pullRequest: null,
+  };
+}
+
+/**
+ * {@link describePublishFailure} plus the toast both surfaces raise for it.
+ * `pullRequestOpened` tells the caller to refresh its PR state.
+ */
+export function reportPublishFailure(
+  error: unknown,
+  t: TFunction,
+): { message: string; pullRequestOpened: boolean } {
+  const failure = describePublishFailure(error, t);
+  const pr = failure.pullRequest;
+  if (pr) {
+    toast.error(failure.message, {
+      action: {
+        label: t("thread.publishDialog.viewPr"),
+        onClick: () => window.open(pr.htmlUrl, "_blank", "noopener,noreferrer"),
+      },
+    });
+  }
+  return { message: failure.message, pullRequestOpened: pr !== null };
+}
+
+/** Both surfaces confirm a review submission the same way: PR number + link. */
+export function notifySubmittedForReview(
+  pr: CreatedPullRequest,
+  t: TFunction,
+): void {
+  toast.success(
+    t("thread.publishDialog.submittedForReview", { prNumber: pr.number }),
+    {
+      action: {
+        label: t("thread.publishDialog.viewOnGithub"),
+        onClick: () => window.open(pr.htmlUrl, "_blank", "noopener,noreferrer"),
+      },
+    },
+  );
+}

--- a/apps/web/src/components/thread/github/use-cms-publish-actions.ts
+++ b/apps/web/src/components/thread/github/use-cms-publish-actions.ts
@@ -1,0 +1,169 @@
+/**
+ * The publish popover's write side: one `submit` entry point that publishes or
+ * submits for review depending on the mode, plus the two discard paths — and
+ * the in-flight/error state they own. The sequence itself is shared with the
+ * coding session's dialog and lives in {@link ./publish-flow.ts}.
+ */
+
+import type { MutableRefObject } from "react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { useT } from "@/i18n/use-t.ts";
+import type { PublishChange } from "./publish-change-summary.ts";
+import {
+  notifySubmittedForReview,
+  publishNoteParts,
+  reportPublishFailure,
+  runPublishFlow,
+  runSubmitForReviewFlow,
+  type PublishTarget,
+} from "./publish-flow.ts";
+import { discardGitFiles, type GitDiffResult } from "./sandbox-git-api.ts";
+
+/** `publish` merges to production; `review` stops at the pull request. */
+export type CmsPublishMode = "publish" | "review";
+
+interface CmsPublishActionsArgs {
+  mode: CmsPublishMode;
+  target: PublishTarget;
+  /** The version note, authored in the popover — title on line 1, body below. */
+  note: string;
+  diff: GitDiffResult | null;
+  /** Named in the success toast when publishing goes to a custom domain. */
+  destinationHost: string | null;
+  /** Held while a flow runs, so an outside click can't dismiss its progress. */
+  publishLockRef: MutableRefObject<boolean>;
+  onOpenChange: (open: boolean) => void;
+  refresh: () => Promise<unknown>;
+  onPullRequestChanged?: () => void | Promise<void>;
+  onPublished?: () => void | Promise<void>;
+}
+
+interface CmsPublishActions {
+  isPublishing: boolean;
+  isDiscarding: boolean;
+  publishError: string | undefined;
+  /** Publish or submit for review, per mode — the button never branches. */
+  submit: () => Promise<void>;
+  discardChange: (change: PublishChange) => Promise<void>;
+  discardAll: () => Promise<void>;
+}
+
+export function useCmsPublishActions(
+  args: CmsPublishActionsArgs,
+): CmsPublishActions {
+  const {
+    mode,
+    target,
+    note,
+    diff,
+    destinationHost,
+    publishLockRef,
+    onOpenChange,
+    refresh,
+    onPullRequestChanged,
+    onPublished,
+  } = args;
+  const t = useT();
+  const [isPublishing, setIsPublishing] = useState(false);
+  const [isDiscarding, setIsDiscarding] = useState(false);
+  const [publishError, setPublishError] = useState<string>();
+
+  const noteParts = () =>
+    publishNoteParts(
+      note,
+      t("thread.publishDialog.changesFrom", { branch: target.headBranch }),
+    );
+
+  const publish = async () => {
+    publishLockRef.current = true;
+    setIsPublishing(true);
+    setPublishError(undefined);
+    try {
+      await runPublishFlow(target, noteParts(), t);
+
+      toast.success(
+        destinationHost
+          ? t("thread.publishPopover.publishedTo", { host: destinationHost })
+          : t("thread.publishDialog.publishedTo", {
+              baseBranch: target.baseBranch,
+            }),
+      );
+      onOpenChange(false);
+      await onPullRequestChanged?.();
+      await onPublished?.();
+    } catch (error) {
+      const failure = reportPublishFailure(error, t);
+      setPublishError(failure.message);
+      if (failure.pullRequestOpened) await onPullRequestChanged?.();
+    } finally {
+      publishLockRef.current = false;
+      setIsPublishing(false);
+    }
+  };
+
+  const submitForReview = async () => {
+    publishLockRef.current = true;
+    setIsPublishing(true);
+    setPublishError(undefined);
+    try {
+      const pr = await runSubmitForReviewFlow(target, noteParts());
+
+      notifySubmittedForReview(pr, t);
+      onOpenChange(false);
+      await onPullRequestChanged?.();
+    } catch (error) {
+      setPublishError(
+        error instanceof Error
+          ? error.message
+          : t("thread.publishDialog.failedSubmitForReview"),
+      );
+    } finally {
+      publishLockRef.current = false;
+      setIsPublishing(false);
+    }
+  };
+
+  const discardFiles = async (filepaths: string[], success: string) => {
+    setIsDiscarding(true);
+    try {
+      await discardGitFiles(
+        target.orgSlug,
+        target.virtualMcpId,
+        target.branch,
+        filepaths,
+      );
+      toast.success(success);
+      await refresh();
+    } catch (error) {
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : t("thread.publishPopover.failedDiscard"),
+      );
+    } finally {
+      setIsDiscarding(false);
+    }
+  };
+
+  return {
+    isPublishing,
+    isDiscarding,
+    publishError,
+    submit: mode === "review" ? submitForReview : publish,
+    discardChange: (change) =>
+      discardFiles(
+        change.filepaths,
+        t("thread.publishPopover.discarded", { name: change.name }),
+      ),
+    discardAll: async () => {
+      if (!diff) return;
+      const allFiles = Object.keys(diff.diffs);
+      if (allFiles.length === 0) return;
+      await discardFiles(
+        allFiles,
+        t("thread.publishDialog.allChangesDiscarded"),
+      );
+    },
+  };
+}

--- a/apps/web/src/components/thread/github/use-cms-publish-state.ts
+++ b/apps/web/src/components/thread/github/use-cms-publish-state.ts
@@ -1,0 +1,112 @@
+/**
+ * The publish popover's read side. Git state and the last publish are fetched
+ * as one suspense load, so the surface goes straight from a single skeleton to
+ * its final render instead of stacking spinners. A failed load lands in
+ * `loadError` (and a null `lastPublishedPr`), rendered inline by the popover
+ * rather than thrown to an error boundary.
+ */
+
+import { useSuspenseQuery } from "@tanstack/react-query";
+import type { GithubMcpClient } from "./github-pr-api.ts";
+import {
+  combinePublishDiffs,
+  fetchGitDiff,
+  fetchGitStatus,
+  hasGitLocalWork,
+  type GitDiffResult,
+  type GitStatus,
+} from "./sandbox-git-api.ts";
+import { fetchLastPublishedPr, type PrSummary } from "./use-pr-data.ts";
+
+interface CmsPublishStateArgs {
+  githubClient: GithubMcpClient;
+  orgSlug: string;
+  virtualMcpId: string;
+  branch: string;
+  baseBranch: string;
+  owner: string;
+  repo: string;
+}
+
+interface CmsPublishState {
+  status: GitStatus | null;
+  diff: GitDiffResult | null;
+  lastPublishedPr: PrSummary | null;
+  loadError: string | null;
+  /** Re-runs the load; the popover calls it after a discard. */
+  refresh: () => Promise<unknown>;
+}
+
+type LoadedPublishState = Omit<CmsPublishState, "refresh">;
+
+function cmsPublishStateQueryKey(
+  orgSlug: string,
+  virtualMcpId: string,
+  branch: string,
+  baseBranch: string,
+) {
+  return [
+    "cms-publish-popover-state",
+    orgSlug,
+    virtualMcpId,
+    branch,
+    baseBranch,
+  ] as const;
+}
+
+export function useCmsPublishState(args: CmsPublishStateArgs): CmsPublishState {
+  const {
+    githubClient,
+    orgSlug,
+    virtualMcpId,
+    branch,
+    baseBranch,
+    owner,
+    repo,
+  } = args;
+
+  const query = useSuspenseQuery<LoadedPublishState>({
+    queryKey: cmsPublishStateQueryKey(
+      orgSlug,
+      virtualMcpId,
+      branch,
+      baseBranch,
+    ),
+    queryFn: async (): Promise<LoadedPublishState> => {
+      const lastPublishedPromise = fetchLastPublishedPr(githubClient, {
+        owner,
+        repo,
+        base: baseBranch,
+      }).catch(() => null);
+      try {
+        const status = await fetchGitStatus(orgSlug, virtualMcpId, branch);
+        const baseDiff =
+          (status.aheadOfBase ?? 0) > 0
+            ? await fetchGitDiff(orgSlug, virtualMcpId, branch, {
+                base: baseBranch,
+              })
+            : null;
+        const workingDiff = hasGitLocalWork(status)
+          ? await fetchGitDiff(orgSlug, virtualMcpId, branch)
+          : null;
+        return {
+          status,
+          diff: combinePublishDiffs(baseDiff, workingDiff),
+          lastPublishedPr: await lastPublishedPromise,
+          loadError: null,
+        };
+      } catch (error) {
+        return {
+          status: null,
+          diff: null,
+          lastPublishedPr: await lastPublishedPromise,
+          loadError: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+    staleTime: 0,
+    gcTime: 0,
+  });
+
+  return { ...query.data, refresh: () => query.refetch() };
+}

--- a/apps/web/src/i18n/en/thread.ts
+++ b/apps/web/src/i18n/en/thread.ts
@@ -192,6 +192,7 @@ export const thread = {
     "These changes need a teammate's review before going live",
   "thread.publishPopover.newPage": "New page",
   "thread.publishPopover.newPageSections": "New page with {count} sections",
+  "thread.publishPopover.nothingToSubmit": "Nothing to submit",
   "thread.publishPopover.otherGroup": "Other changes",
   "thread.publishPopover.pagesGroup": "Pages",
   "thread.publishPopover.preview": "Preview",
@@ -211,8 +212,18 @@ export const thread = {
   "thread.publishPopover.discardAllConfirm":
     "Discard every change? This can't be undone.",
   "thread.publishPopover.discardConfirm": "Discard {name}?",
+  "thread.publishPopover.reviewNote": "Note for reviewers",
+  "thread.publishPopover.reviewNotePlaceholder": "What changed and why…",
   "thread.publishPopover.reviewing": "Reviewing content…",
   "thread.publishPopover.siteConfiguration": "Site configuration",
+  "thread.publishPopover.submitCountForReview":
+    "Submit {count} changes for review",
+  "thread.publishPopover.submitEmptyHint":
+    "This chat has no changes waiting for review.",
+  "thread.publishPopover.submitForReview": "Submit for review",
+  "thread.publishPopover.submitOneForReview": "Submit 1 change for review",
+  "thread.publishPopover.submitting": "Submitting…",
   "thread.publishPopover.versionNote": "Version note",
+  "thread.publishPopover.updatesPullRequest": "Updates pull request #{number}",
   "thread.publishPopover.versionNotePlaceholder": "Describe this update…",
 } as const;

--- a/apps/web/src/i18n/pt-br/thread.ts
+++ b/apps/web/src/i18n/pt-br/thread.ts
@@ -202,6 +202,7 @@ export const thread = {
     "Estas alterações precisam da revisão de um colega antes de irem ao ar",
   "thread.publishPopover.newPage": "Página nova",
   "thread.publishPopover.newPageSections": "Página nova com {count} seções",
+  "thread.publishPopover.nothingToSubmit": "Nada para enviar",
   "thread.publishPopover.otherGroup": "Outras alterações",
   "thread.publishPopover.pagesGroup": "Páginas",
   "thread.publishPopover.preview": "Visualizar",
@@ -221,8 +222,19 @@ export const thread = {
   "thread.publishPopover.discardAllConfirm":
     "Descartar todas as alterações? Isso não pode ser desfeito.",
   "thread.publishPopover.discardConfirm": "Descartar {name}?",
+  "thread.publishPopover.reviewNote": "Nota para quem revisa",
+  "thread.publishPopover.reviewNotePlaceholder": "O que mudou e por quê…",
   "thread.publishPopover.reviewing": "Revisando conteúdo…",
   "thread.publishPopover.siteConfiguration": "Configuração do site",
+  "thread.publishPopover.submitCountForReview":
+    "Enviar {count} alterações para revisão",
+  "thread.publishPopover.submitEmptyHint":
+    "Este chat não tem alterações aguardando revisão.",
+  "thread.publishPopover.submitForReview": "Enviar para revisão",
+  "thread.publishPopover.submitOneForReview": "Enviar 1 alteração para revisão",
+  "thread.publishPopover.submitting": "Enviando…",
   "thread.publishPopover.versionNote": "Nota da versão",
+  "thread.publishPopover.updatesPullRequest":
+    "Atualiza o pull request #{number}",
   "thread.publishPopover.versionNotePlaceholder": "Descreva esta atualização…",
 } satisfies Record<keyof typeof threadEn, string>;

--- a/packages/e2e/fixtures/fast-preview.ts
+++ b/packages/e2e/fixtures/fast-preview.ts
@@ -87,9 +87,23 @@ export async function createFastPreviewProject(
     owner: string;
     repo: string;
     repoScopeMode?: "refreshable" | "legacy-mint";
+    /**
+     * MCP endpoint the repo child connection advertises. HTTP-only specs never
+     * dial it (the git surfaces go through `metadata.repoScope` + the vault
+     * token), but a BROWSER spec does: the header's PR lookup opens an MCP
+     * client against this connection on mount. Point it at a closed local port
+     * so that handshake fails immediately instead of leaving the suite waiting
+     * on an outbound connection to a real host.
+     */
+    connectionUrl?: string;
   },
 ): Promise<FastPreviewProject> {
-  const { owner, repo, repoScopeMode = "refreshable" } = params;
+  const {
+    owner,
+    repo,
+    repoScopeMode = "refreshable",
+    connectionUrl = "https://example.com/mcp",
+  } = params;
 
   const sourceConnectionId =
     repoScopeMode === "legacy-mint"
@@ -110,7 +124,7 @@ export async function createFastPreviewProject(
         title: `GitHub: ${owner}/${repo}`,
         app_name: "mcp-github",
         connection_type: "HTTP",
-        connection_url: "https://example.com/mcp",
+        connection_url: connectionUrl,
         metadata: {
           repoScope: {
             ...(sourceConnectionId ? { sourceConnectionId } : {}),

--- a/packages/e2e/tests/cms-publish-surface.spec.ts
+++ b/packages/e2e/tests/cms-publish-surface.spec.ts
@@ -1,0 +1,175 @@
+/**
+ * E2E: Fast Preview's publish surface — the header split button and the
+ * popover it opens.
+ *
+ * Regression this spec exists for: picking "Submit for review" from the split
+ * button's DROPDOWN opened the popover and then let it close itself a beat
+ * later. Radix returns focus to the dropdown's trigger as the menu unmounts,
+ * and the popover's dismissable layer counted that as focus landing outside
+ * itself. Neither the pure state machine nor the change-summary modules can see
+ * that — it only exists once a real menu and a real popover are on one page —
+ * so it survived a fully unit-tested feature and shipped.
+ *
+ * Both entry points are asserted, because they differ in exactly the way that
+ * mattered: the primary half opens the popover with no menu involved (it never
+ * regressed), the dropdown half opens the same component through a closing
+ * menu (it did).
+ *
+ * Setup is the sandbox-less Fast Preview wiring shared with `decofile-api` and
+ * `fast-preview-git-sync`: all GitHub git traffic lands on the local Git Data
+ * stub, so `/git/status` and `/git/diff` answer for real with no sandbox and no
+ * credentials. The GitHub MCP connection is deliberately dead — the PR lookup
+ * behind it must fail fast and leave the header on its no-open-PR state, which
+ * is the state that offers "Submit for review" at all.
+ *
+ * Wire-contract strings (labels, `?virtualmcpid=` param) are inlined on
+ * purpose — this suite owns its contract (see ban-e2e-app-imports).
+ */
+
+import type { Locator, Page } from "@playwright/test";
+import {
+  createFastPreviewProject,
+  seedStubRepo,
+  uniqueOwner,
+} from "../fixtures/fast-preview";
+import { callSelfMcpTool } from "../fixtures/mcp-tools";
+import { expect, test } from "../fixtures/test";
+
+/**
+ * Cold-Vite route compiles on a loaded box; the agent shell is a lazy route.
+ * Deliberately under the whole test's budget (`test.slow()` = 90s) so a header
+ * that never settles fails on THIS assertion rather than as a test timeout.
+ */
+const SHELL_TIMEOUT_MS = 60_000;
+
+/**
+ * How long the popover has to survive to prove it is not auto-closing. The
+ * regression dismissed it ~450ms after it opened (one menu-close animation plus
+ * the focus restore), so a fixed wait IS the assertion: proving that nothing
+ * happens over an interval cannot be expressed as waiting for a state.
+ */
+const STAYS_OPEN_MS = 2_000;
+
+/** UI copy — the header's split button (thread.cmsActions / headerActions). */
+const REVIEW_AND_PUBLISH = "Review & Publish";
+const MORE_ACTIONS = "More actions";
+const SUBMIT_FOR_REVIEW = "Submit for review";
+
+/** UI copy — the popover's own chrome (thread.publishPopover). */
+const VERSION_NOTE = "Version note";
+const REVIEW_NOTE = "Note for reviewers";
+/** Publish mode counts the changes into its CTA; review mode never does. */
+const PUBLISH_CTA = /^Publish( \d+ changes?)?$/;
+
+/**
+ * The popover's primary CTA in each mode. Matched as `role=button`, which is
+ * what keeps `submitCta` from also matching the same-named `role=menuitem` in
+ * the dropdown that opens it.
+ */
+function ctas(page: Page): { submit: Locator; publish: Locator } {
+  return {
+    submit: page.getByRole("button", { name: SUBMIT_FOR_REVIEW, exact: true }),
+    publish: page.getByRole("button", { name: PUBLISH_CTA }),
+  };
+}
+
+test.describe("fast preview publish surface", () => {
+  test("both the primary half and the dropdown open a popover that stays open", async ({
+    authedPage,
+  }) => {
+    // Signup + project wiring + a cold shell route compile.
+    test.slow();
+
+    const { page, orgSlug } = authedPage;
+    const api = page.context().request;
+    const owner = uniqueOwner();
+    const repo = "site";
+    const branch = "draft";
+
+    const project = await createFastPreviewProject(api, orgSlug, {
+      owner,
+      repo,
+      /** Closed port: the PR lookup must fail instantly, not dial a real host. */
+      connectionUrl: "http://127.0.0.1:1/unused",
+    });
+
+    /**
+     * `draft` sits one commit ahead of `main` with a changed block: that is
+     * what puts the header in its publishable state (aheadOfBase > 0) and what
+     * gives the popover a non-empty diff to summarize.
+     */
+    await seedStubRepo(api, {
+      owner,
+      repo,
+      defaultBranch: "main",
+      branches: {
+        main: { files: { ".deco/blocks/Hero.json": '{"n":1}\n' } },
+        [branch]: { files: { ".deco/blocks/Hero.json": '{"n":2}\n' } },
+      },
+    });
+
+    // The header reads its branch off the thread row.
+    const thread = await callSelfMcpTool<{
+      item: { id: string; branch: string | null };
+    }>(api, orgSlug, "COLLECTION_THREADS_CREATE", {
+      data: { virtual_mcp_id: project.vmcpId, branch },
+    });
+    /**
+     * The tool only honours an input branch on a repo-backed vMCP. If that ever
+     * stops holding, every assertion below degrades into "the header rendered
+     * nothing", so it is pinned here where the failure stays legible.
+     */
+    expect(thread.item.branch).toBe(branch);
+
+    await page.goto(
+      `/${orgSlug}/${thread.item.id}?virtualmcpid=${project.vmcpId}`,
+    );
+
+    const { submit, publish } = ctas(page);
+    const primary = page.getByRole("button", {
+      name: REVIEW_AND_PUBLISH,
+      exact: true,
+    });
+
+    /**
+     * The header reaches this label only once `/git/status` has answered from
+     * the stub and the PR lookup has failed — the no-open-PR, work-to-publish
+     * state that "Submit for review" belongs to.
+     */
+    await expect(primary).toBeVisible({ timeout: SHELL_TIMEOUT_MS });
+
+    // --- Entry point 1: the dropdown (the half that regressed) -------------
+    await page.getByRole("button", { name: MORE_ACTIONS }).click();
+    await page
+      .getByRole("menuitem", { name: SUBMIT_FOR_REVIEW, exact: true })
+      .click();
+
+    await expect(submit).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(REVIEW_NOTE, { exact: true })).toBeVisible();
+
+    // The regression: open now, gone a blink later.
+    await page.waitForTimeout(STAYS_OPEN_MS);
+    await expect(
+      submit,
+      "review popover dismissed itself after the dropdown returned focus to its trigger",
+    ).toBeVisible();
+
+    // Review mode never counts changes into its CTA — publish mode always does.
+    await expect(publish).toHaveCount(0);
+
+    await page.keyboard.press("Escape");
+    await expect(submit).toBeHidden();
+
+    // --- Entry point 2: the primary half -----------------------------------
+    await primary.click();
+
+    await expect(publish).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText(VERSION_NOTE, { exact: true })).toBeVisible();
+
+    await page.waitForTimeout(STAYS_OPEN_MS);
+    await expect(publish, "publish popover dismissed itself").toBeVisible();
+
+    // Two genuinely different surfaces, not one component re-labelled by accident.
+    await expect(submit).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

"Submit for review" still opened the legacy `PublishDialog` while Publish had already moved to the content-first popover (#6202). Both now render the same surface: `CmsPublishPopover` gains a `mode: "publish" | "review"` prop, and Fast Preview no longer mounts `PublishDialog` at all. Coding sessions (`header-actions.tsx`) keep the legacy dialog unchanged.

Review mode keeps every content affordance — pages/blocks cards, expand-in-place diffs, per-card and discard-all, the note field, Preview — and changes only the verb:

- **Header**: pull-request icon + "Submit N changes for review"; the subline names the PR it will update when one is open, otherwise the usual "Last published … by …".
- **Note**: labeled "Note for reviewers" ("What changed and why…"); still becomes the commit + PR title/body.
- **No gate**: the AI judge isn't run (`judgeEnabled: !isReview`) and the gate row is hidden — submitting for review *is* the escalation the gate asks for. Consequently the blocked-gate "Request approval" button flips the open popover to review mode in place (keeping whatever note was typed) instead of closing it and swapping in a modal.
- **Primary**: "Submit for review" → push, then open (or update) the PR, stopping before the merge. Same success toast + "View on GitHub" action, and no rebase — matching the previous behavior exactly.
- **Empty state**: "Nothing to submit / This chat has no changes waiting for review."

`CmsHeaderActions` now holds one `surface: "publish" | "review" | null` state instead of two booleans.

i18n: 9 new keys in `en/thread.ts`, mirrored in `pt-br/thread.ts`.

## Testing

- `bun run --cwd=apps/web check` — clean
- `bun run lint` — clean on the changed files
- `bun run fmt` / `fmt:check` — clean
- `bun test apps/web/src/components/thread/github` — 249 pass
- `knip` — clean

Not driven in a browser (needs a GitHub-attached Fast Preview project running locally) — screenshots welcome from anyone with one up.

## Follow-up

`PublishDialog`'s `rebaseOnConflict` prop now has no caller (Fast Preview was its only one). Left in place because #6268 already deletes it; that PR should still apply cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies Fast Preview “Submit for review” with the content-first publish popover and shares one publish flow across surfaces. Previously review opened `PublishDialog`; now both use one popover with a review mode. Fixes the dropdown-trigger focus bug that auto-closed the popover. No behavior change to publish; review still stops at PR open/update.

- `CmsPublishPopover` adds `mode: "publish" | "review"` (default publish). Review mode keeps all content affordances, switches to a PR header and “Note for reviewers,” and its primary pushes and opens/updates the PR without merging. The gate never runs in review; blocked publish’s “Request approval” flips the open popover to review in place and preserves the note.
- Fix: prevent `onFocusOutside` from dismissing the popover when the split-button menu returns focus to its trigger; Escape and pointer-outside still dismiss. `CmsHeaderActions` now tracks `{ open, mode }` to avoid label flash on close.
- Refactor: single publish sequence lives in `publish-flow.ts` (push → sync → open/update PR → squash-merge) with shared message parsing, failure reporting, and review submission helpers; `PublishDialog` and the popover both call it. Popover is presentation only via `use-cms-publish-state`, `use-cms-publish-actions`, and `PublishChangeCard`. Coding sessions keep the dialog UI unchanged.
- Tests: `publish-flow.test.ts` covers message derivation and merge-failed-after-open behavior; `cms-publish-surface.spec.ts` asserts both split-button entries open a popover that stays open; e2e fixture gains a configurable dead MCP URL to force fast PR-lookup failure. New i18n strings in `en/thread.ts` and `pt-br/thread.ts`.

<sup>Written for commit 1bd7da7778fef63bca63b671a88134641482a94b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

