### PR TITLE
fix(settings): route a merged sidebar row at its first visible tab

### DIFF
--- a/apps/web/src/layouts/settings-layout.tsx
+++ b/apps/web/src/layouts/settings-layout.tsx
@@ -239,12 +239,16 @@ function useSettingsSidebarGroups(): SettingsNavGroup[] {
   return groups
     .map((group) => ({
       ...group,
-      items: group.items.filter((item) => {
-        if (item.group) return visibleTabs[item.group].length > 0;
-        if (loading || error) return true;
-        if (item.privilegedOnly) return isPrivileged;
-        if (!item.requires) return true;
-        return isPrivileged || capabilities[item.requires];
+      items: group.items.flatMap((item) => {
+        if (item.group) {
+          // Route the row at the first tab the member can actually open.
+          const [firstTab] = visibleTabs[item.group];
+          return firstTab ? [{ ...item, to: firstTab.to }] : [];
+        }
+        if (loading || error) return [item];
+        if (item.privilegedOnly) return isPrivileged ? [item] : [];
+        if (!item.requires) return [item];
+        return isPrivileged || capabilities[item.requires] ? [item] : [];
       }),
     }))
     .filter((group) => group.items.length > 0);


### PR DESCRIPTION
Follows #6249, the two-tier settings sidebar collapse.

**Bug**: `useSettingsSidebarGroups` gated a merged row's visibility on `visibleTabs[item.group].length > 0`, but the Link's `to` stayed hardcoded to the sidebar item's own `to` (the group's *first* tab route) regardless of which tabs the member can actually see.

Concretely, the Billing group has tabs `plan` (requires `members:manage`), `ai-providers` (requires `ai-providers:manage`), `infra`. A member with `ai-providers:manage` but not `members:manage` sees the "Billing" row in the sidebar (group is visible because the ai-providers tab is visible) but clicking it navigates to `/$org/settings/billing` — the plan/usage page they don't have access to — instead of `/$org/settings/ai-providers`, the one tab they can open.

**Fix**: for a merged row, resolve `to` to the group's first *visible* tab instead of the item's own hardcoded route. Sign-in-gated behavior of each page is unchanged; this only fixes which route the sidebar row points at.

**How to verify**: `cd apps/web && bunx tsc --noEmit` (was previously green, stays green) — this is a pure client-side routing fix with no new state, so no new test is needed; existing behavior (row visibility, active-state highlighting via `groupRoutes`) is untouched.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/web), `bunx oxlint apps/web/src/layouts/settings-layout.tsx` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes merged settings sidebar rows to the first visible tab the member can open. Previously these rows always linked to the group’s first tab, which could be inaccessible; page auth and visibility remain unchanged.

- In `useSettingsSidebarGroups`, grouped items now set `to` to the first entry in `visibleTabs[group]` and are omitted if none exist.
- Active-state highlighting and visibility logic are unchanged; no new state.
- Pure client-side change in `apps/web/src/layouts/settings-layout.tsx`; no migrations or config updates required.

<sup>Written for commit 9a4bd5afee621e464b62ead5c7973e4475b34377. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6270?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

