### PR TITLE
fix(sandbox): relay org-fs config on resume/adopt, not just on provision

### DIFF
--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -1119,6 +1119,12 @@ export class AgentSandboxProvider implements SandboxProvider {
           // likely expired. Forward the freshly-minted one so authenticated git
           // keeps working. No-op when unchanged / public clone.
           await this.refreshDaemonGitCredential(rec, opts);
+          // Same staleness risk applies to the org-fs sidecar config on a long-resumed pod.
+          await this.relayOrgFsConfig(
+            rec.daemonUrl,
+            rec.token,
+            opts.orgFsConfigJson,
+          );
           return this.finish(
             rec,
             ops,
@@ -1164,6 +1170,11 @@ export class AgentSandboxProvider implements SandboxProvider {
           // Same as resume: the adopted pod's daemon holds a clone credential
           // from an earlier provision that may have lapsed. Rotate it.
           await this.refreshDaemonGitCredential(adopted, opts);
+          await this.relayOrgFsConfig(
+            adopted.daemonUrl,
+            adopted.token,
+            opts.orgFsConfigJson,
+          );
           return this.finish(
             adopted,
             ops,


### PR DESCRIPTION
Follows #6266 ("re-mint the org-fs token instead of replaying the expired one").

#6266 fixed the daemonBootId-mismatch rebootstrap path and cold resurrect to re-relay a fresh `orgFsConfigJson` to a pod's sidecar, because Better Auth deletes the fs-scoped API key at expiry: replaying a stale config 401s every WebDAV call and the agent sees `Input/output error` on every `org/` path for the sandbox's whole life.

The *resume* and *adopt* paths in `ensureLocked` (a long-lived pod whose bootId hasn't changed — the common case, not a pod restart) already call `refreshDaemonGitCredential(rec, opts)` to rotate the stale git clone credential using the fresh `opts` the caller minted for this ensure call, but never call the sibling `relayOrgFsConfig` for `opts.orgFsConfigJson`. So a sandbox that's been resumed/adopted (not rebootstrapped) keeps whatever org-fs config was relayed at its last provision/rebootstrap indefinitely — the exact bug #6266 fixed, just reachable through a different, more common path.

Fix: relay `opts.orgFsConfigJson` on resume and adopt too, mirroring the existing git-credential-refresh call right next to it. `relayOrgFsConfig` is a no-op when the config is unset and best-effort (catches its own errors), so this can't regress an unaffected sandbox.

Net diff: +11/-0, two call sites, same pattern already used and tested at the provision/rebootstrap sites in this file.

Verification: `cd packages/sandbox && bunx tsc --noEmit` (clean) and `bunx oxlint packages/sandbox/server/provider/agent-sandbox/runner.ts` (0 warnings/errors). No new unit test — the resume/adopt flow requires k8s fakes/integration setup this repo's other tests for this file don't provide either; `relayOrgFsConfig` and its error handling are exercised by the existing provision-path callers. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relays `orgFsConfigJson` to the sandbox daemon on resume and adopt, not only on provision/rebootstrap, so long-lived pods don’t keep stale org-fs credentials that cause 401s and “Input/output error” on `org/` paths. Previously, these paths refreshed the git credential but left the org-fs config unchanged.

**Review notes**
- Adds `relayOrgFsConfig(daemonUrl, token, opts.orgFsConfigJson)` next to existing `refreshDaemonGitCredential` in resume and adopt branches of `ensureLocked`.
- `relayOrgFsConfig` is a no-op when unset and is best-effort; behavior change is limited to ensuring fresh config on resume/adopt.
- Only `packages/sandbox/server/provider/agent-sandbox/runner.ts` changed; mirrors the provision/rebootstrap pattern already in this file.

<sup>Written for commit f3d4905b3294d31851232436d727ce618728174e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6272?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

