### PR TITLE
fix(jira): add exponential backoff retry logic to the client

### DIFF
--- a/apps/api/src/jira/client.test.ts
+++ b/apps/api/src/jira/client.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it } from "bun:test";
+import { describe, expect, it, mock } from "bun:test";
 import {
   jiraBodyToText,
   assertBoardId,
   normalizeSiteUrl,
   textToAdf,
+  JiraClient,
 } from "./client";
 
 describe("normalizeSiteUrl", () => {
@@ -103,5 +104,104 @@ describe("textToAdf", () => {
       version: 1,
       content: [{ type: "paragraph", content: [] }],
     });
+  });
+});
+
+describe("JiraClient", () => {
+  it("retries on 503 server error and succeeds on second attempt", async () => {
+    let callCount = 0;
+    const originalFetch = globalThis.fetch;
+    const mockFetch = mock(async () => {
+      callCount++;
+      if (callCount === 1) {
+        // First call: 503 Service Unavailable
+        return new Response(JSON.stringify({ error: "Service Unavailable" }), {
+          status: 503,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      // Second call: success
+      return new Response(
+        JSON.stringify({ accountId: "test", displayName: "Test User" }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    });
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    try {
+      const client = new JiraClient(
+        "https://acme.atlassian.net",
+        "user@example.com",
+        "token",
+      );
+      const result = await client.myself();
+      expect(result).toEqual({ accountId: "test", displayName: "Test User" });
+      expect(callCount).toBe(2); // Retry happened
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("does not retry on 401 Unauthorized", async () => {
+    let callCount = 0;
+    const originalFetch = globalThis.fetch;
+    const mockFetch = mock(async () => {
+      callCount++;
+      return new Response(JSON.stringify({ error: "Invalid credentials" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    try {
+      const client = new JiraClient(
+        "https://acme.atlassian.net",
+        "user@example.com",
+        "token",
+      );
+      await expect(client.myself()).rejects.toThrow("401");
+      expect(callCount).toBe(1); // No retry on 4xx
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("retries on 429 rate limit error", async () => {
+    let callCount = 0;
+    const originalFetch = globalThis.fetch;
+    const mockFetch = mock(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return new Response(JSON.stringify({ error: "Too Many Requests" }), {
+          status: 429,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response(
+        JSON.stringify({ accountId: "test", displayName: "Test User" }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    });
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    try {
+      const client = new JiraClient(
+        "https://acme.atlassian.net",
+        "user@example.com",
+        "token",
+      );
+      const result = await client.myself();
+      expect(result).toEqual({ accountId: "test", displayName: "Test User" });
+      expect(callCount).toBe(2); // Retry happened
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 });

--- a/apps/api/src/jira/client.ts
+++ b/apps/api/src/jira/client.ts
@@ -7,6 +7,7 @@
  * that no JQL over the project can express.
  */
 
+import { retry } from "@decocms/shared/std";
 import { wikiToMarkdown } from "./wiki-markdown";
 
 const REQUEST_TIMEOUT_MS = 15_000;
@@ -52,6 +53,34 @@ export interface JiraComment {
 
 const ISSUE_FIELDS =
   "summary,status,priority,issuetype,updated,description,comment";
+
+/**
+ * Determine if a fetch error should be retried. Transient failures (5xx, timeout,
+ * network error) should retry; permanent failures (4xx, auth) should fail fast.
+ */
+function isRetriableError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  // Retry on timeout (AbortError) or network errors.
+  if (
+    message.includes("AbortError") ||
+    message.includes("fetch") ||
+    message.includes("timeout") ||
+    message.includes("network") ||
+    message.includes("ECONNREFUSED") ||
+    message.includes("ECONNRESET")
+  ) {
+    return true;
+  }
+  // Retry on 5xx server errors; extract from message "Jira {path} failed ({status})".
+  const statusMatch = message.match(/failed \((\d+)\)/);
+  if (statusMatch && statusMatch[1]) {
+    const status = parseInt(statusMatch[1], 10);
+    // Retry 5xx and 429 (rate limit); do NOT retry 4xx (auth, not found, etc.).
+    return status >= 500 || status === 429;
+  }
+  // Unknown error — retry with caution.
+  return true;
+}
 
 /**
  * "acme.atlassian.net" or a pasted URL → "https://acme.atlassian.net".
@@ -101,23 +130,35 @@ export class JiraClient {
   }
 
   private async request<T>(path: string, init?: RequestInit): Promise<T> {
-    const response = await fetch(`${this.baseUrl}${path}`, {
-      ...init,
-      headers: {
-        Authorization: this.authHeader,
-        Accept: "application/json",
-        ...(init?.body ? { "Content-Type": "application/json" } : {}),
+    return retry(
+      async () => {
+        const response = await fetch(`${this.baseUrl}${path}`, {
+          ...init,
+          headers: {
+            Authorization: this.authHeader,
+            Accept: "application/json",
+            ...(init?.body ? { "Content-Type": "application/json" } : {}),
+          },
+          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        });
+        const body = await response.text().catch(() => "");
+        if (!response.ok) {
+          throw new Error(
+            `Jira ${path} failed (${response.status}): ${body.slice(0, 300)}`,
+          );
+        }
+        // Transition POSTs answer 204 with an empty body.
+        return (body === "" ? undefined : JSON.parse(body)) as T;
       },
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-    });
-    const body = await response.text().catch(() => "");
-    if (!response.ok) {
-      throw new Error(
-        `Jira ${path} failed (${response.status}): ${body.slice(0, 300)}`,
-      );
-    }
-    // Transition POSTs answer 204 with an empty body.
-    return (body === "" ? undefined : JSON.parse(body)) as T;
+      {
+        maxAttempts: 3,
+        minTimeout: 100,
+        maxTimeout: 5000,
+        multiplier: 2,
+        jitter: 1,
+        isRetriable: isRetriableError,
+      },
+    );
   }
 
   /** Cheapest authenticated call — used to validate credentials on save. */
@@ -239,7 +280,7 @@ export class JiraClient {
   }
 
   async transitionIssue(issueId: string, transitionId: string): Promise<void> {
-    await this.request(
+    await this.request<void>(
       `/rest/api/3/issue/${encodeURIComponent(issueId)}/transitions`,
       {
         method: "POST",


### PR DESCRIPTION
## Summary

The Jira client now retries transient failures (5xx, 429, timeouts) with exponential backoff, while failing fast on client errors (4xx). Follows the focus area request to strengthen error handling, add exponential back-off, and test edge cases.

## Details

**Changes**:
- Import `retry` from `@decocms/shared/std` (repo's standard mechanism)
- Add `isRetriableError()` predicate: retries 5xx/429/timeouts, fails fast on 4xx (auth, validation, not found)
- Wrap `request()` in retry with exponential backoff: 3 attempts over 100ms–5s with jitter
- Fix type safety: explicitly declare `transitionIssue()` return type

**Tests** (3 new unit tests):
- Retry on 503 Service Unavailable, succeed on second attempt
- Do NOT retry on 401 Unauthorized (fails fast)
- Retry on 429 rate limit, succeed on second attempt

**Verification**:
- All 13 tests pass (10 original + 3 new)
- TypeScript strict mode ✅
- Oxlint (0 warnings, 0 errors) ✅
- No new dependencies (uses existing `@decocms/shared/std/retry`)
- Behavior-preserving: same success path, just resilient to transient failures

## Why

The Jira client was merged without retry logic. A single transient network blip or momentary 503 would fail the entire sync. This fix makes the client production-ready by following the proven pattern the repo already uses for similar HTTP clients.

## To verify

```bash
cd apps/api
bun test src/jira/client.test.ts
bunx tsc --noEmit
bunx oxlint src/jira/client.ts src/jira/client.test.ts
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds exponential backoff retries to the Jira client for transient failures to improve resiliency. Previously all failures surfaced immediately; now 5xx/429/timeouts and network errors retry up to 3 attempts (100ms–5s with jitter), while 4xx fail fast.

- Requests are wrapped with `retry` from `@decocms/shared/std` using an `isRetriableError` predicate (retries 5xx/429/timeouts/network; no retries on 4xx).
- Error messages include the HTTP status; 204 responses still return no body.
- Explicit return type for transitionIssue(): Promise<void>.
- Tests: added cases for 503 (retries), 401 (no retry), and 429 (retries).
- No new dependencies or configuration changes.

<sup>Written for commit 1d66dc0ba5dae3b8bdcefb0434cca16b90eeea44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6274?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

