### PR TITLE
fix(connection): honor an explicit null connection_url on update

### DIFF
--- a/apps/api/src/tools/connection/update.test.ts
+++ b/apps/api/src/tools/connection/update.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { stripImmutableUpdateFields } from "./update";
+import {
+  resolveFinalConnectionUrl,
+  stripImmutableUpdateFields,
+} from "./update";
 
 describe("stripImmutableUpdateFields", () => {
   test("drops organization_id so a connection can't be reassigned to another org", () => {
@@ -33,5 +36,31 @@ describe("stripImmutableUpdateFields", () => {
       title: "New title",
       description: "New description",
     });
+  });
+});
+
+describe("resolveFinalConnectionUrl", () => {
+  test("keeps the existing URL when connection_url is omitted", () => {
+    expect(
+      resolveFinalConnectionUrl({ title: "New title" }, "https://old.invalid"),
+    ).toBe("https://old.invalid");
+  });
+
+  test("clears the URL when the caller explicitly sends null", () => {
+    expect(
+      resolveFinalConnectionUrl(
+        { connection_type: "STDIO", connection_url: null },
+        "https://old.invalid",
+      ),
+    ).toBeNull();
+  });
+
+  test("applies a new URL when provided", () => {
+    expect(
+      resolveFinalConnectionUrl(
+        { connection_url: "https://new.invalid" },
+        "https://old.invalid",
+      ),
+    ).toBe("https://new.invalid");
   });
 });

--- a/apps/api/src/tools/connection/update.ts
+++ b/apps/api/src/tools/connection/update.ts
@@ -59,6 +59,21 @@ export function stripImmutableUpdateFields(
 }
 
 /**
+ * `connection_url` is nullable, so `data.connection_url ?? existing` would
+ * silently keep the old URL when a caller explicitly clears it (e.g.
+ * switching connection_type to STDIO). Only fall back when the field was
+ * omitted, not when it was explicitly set to null.
+ */
+export function resolveFinalConnectionUrl(
+  data: ConnectionUpdateData,
+  existingConnectionUrl: string | null,
+): string | null {
+  return data.connection_url !== undefined
+    ? data.connection_url
+    : existingConnectionUrl;
+}
+
+/**
  * Input schema for updating connections
  */
 const UpdateInputSchema = z.object({
@@ -128,7 +143,10 @@ export const COLLECTION_CONNECTIONS_UPDATE = defineTool({
     // Validate VIRTUAL connections if connection_type or connection_url is being updated
     const finalConnectionType =
       data.connection_type ?? existing.connection_type;
-    let finalConnectionUrl = data.connection_url ?? existing.connection_url;
+    let finalConnectionUrl = resolveFinalConnectionUrl(
+      data,
+      existing.connection_url,
+    );
 
     if (finalConnectionType === "VIRTUAL") {
       const virtualMcpId = parseVirtualUrl(finalConnectionUrl);


### PR DESCRIPTION
COLLECTION_CONNECTIONS_UPDATE resolved `finalConnectionUrl` with `data.connection_url ?? existing.connection_url`. `connection_url` is a nullable field, so a caller that explicitly sends `connection_url: null` (e.g. switching a connection from HTTP to STDIO, where the URL should be cleared) got the *old* URL silently persisted instead — `null ?? existing` evaluates to `existing`, the same `??`-based null/empty-string fallback trap this bot has flagged before in other files (settings-alias, pod-name).

Failure scenario: an org admin updates an existing HTTP connection to `connection_type: "STDIO"` and passes `connection_url: null` to clear the now-irrelevant URL. The stored row keeps the stale HTTP URL instead of `null`.

Fix: extracted the resolution into a small pure helper, `resolveFinalConnectionUrl`, that only falls back to the existing value when the field was *omitted* (`undefined`), not when it was explicitly set to `null`. Added a regression test (`update.test.ts`) that pins this: I verified it fails against the old `??` expression (reverted the call site locally, confirmed the test caught it) before restoring the fix.

Reviewer check: `bun test ./apps/api/src/tools/connection/update.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on both changed files — all clean. Full CI covers the rest (integration/e2e).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors an explicit null `connection_url` on connection update. Previously, sending `connection_url: null` kept the old URL; now it clears the URL. This fixes updates like switching HTTP to STDIO where the URL should be removed.

- Extracts `resolveFinalConnectionUrl` and uses it in `COLLECTION_CONNECTIONS_UPDATE` to fall back only when `connection_url` is omitted (`undefined`).
- Adds unit tests for omitted, null, and new URL cases. Run: `bun test apps/api/src/tools/connection/update.test.ts`.
- No schema changes. If clients want to keep the existing URL, omit `connection_url`; sending `null` now clears it.

<sup>Written for commit 1a4784740832bd0dcce1c8c54f105142fa8eebc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6276?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

