### PR TITLE
fix(jira): don't retry non-idempotent writes in the client

### DIFF
--- a/apps/api/src/jira/client.test.ts
+++ b/apps/api/src/jira/client.test.ts
@@ -204,4 +204,56 @@ describe("JiraClient", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  it("does not retry addComment on a transient error — a resubmit would duplicate the comment", async () => {
+    let callCount = 0;
+    const originalFetch = globalThis.fetch;
+    const mockFetch = mock(async () => {
+      callCount++;
+      return new Response(JSON.stringify({ error: "Service Unavailable" }), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    try {
+      const client = new JiraClient(
+        "https://acme.atlassian.net",
+        "user@example.com",
+        "token",
+      );
+      await expect(client.addComment("ISSUE-1", "hi")).rejects.toThrow("503");
+      expect(callCount).toBe(1); // No retry — a write must not be resubmitted
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("does not retry transitionIssue on a transient error — a resubmit could double-transition", async () => {
+    let callCount = 0;
+    const originalFetch = globalThis.fetch;
+    const mockFetch = mock(async () => {
+      callCount++;
+      return new Response(JSON.stringify({ error: "Service Unavailable" }), {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    try {
+      const client = new JiraClient(
+        "https://acme.atlassian.net",
+        "user@example.com",
+        "token",
+      );
+      await expect(client.transitionIssue("ISSUE-1", "31")).rejects.toThrow(
+        "503",
+      );
+      expect(callCount).toBe(1); // No retry — a write must not be resubmitted
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });

--- a/apps/api/src/jira/client.ts
+++ b/apps/api/src/jira/client.ts
@@ -129,36 +129,45 @@ export class JiraClient {
     this.authHeader = `Basic ${Buffer.from(`${email}:${apiToken}`).toString("base64")}`;
   }
 
-  private async request<T>(path: string, init?: RequestInit): Promise<T> {
-    return retry(
-      async () => {
-        const response = await fetch(`${this.baseUrl}${path}`, {
-          ...init,
-          headers: {
-            Authorization: this.authHeader,
-            Accept: "application/json",
-            ...(init?.body ? { "Content-Type": "application/json" } : {}),
-          },
-          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
-        });
-        const body = await response.text().catch(() => "");
-        if (!response.ok) {
-          throw new Error(
-            `Jira ${path} failed (${response.status}): ${body.slice(0, 300)}`,
-          );
-        }
-        // Transition POSTs answer 204 with an empty body.
-        return (body === "" ? undefined : JSON.parse(body)) as T;
-      },
-      {
-        maxAttempts: 3,
-        minTimeout: 100,
-        maxTimeout: 5000,
-        multiplier: 2,
-        jitter: 1,
-        isRetriable: isRetriableError,
-      },
-    );
+  /**
+   * `idempotent: false` skips retrying — a timeout/network error can happen
+   * after Jira already applied the write, so resubmitting a mutation (create
+   * a comment, transition an issue) risks doing it twice. Reads and the
+   * idempotent transition-status GET are safe to retry.
+   */
+  private async request<T>(
+    path: string,
+    init?: RequestInit,
+    { idempotent = true }: { idempotent?: boolean } = {},
+  ): Promise<T> {
+    const attempt = async () => {
+      const response = await fetch(`${this.baseUrl}${path}`, {
+        ...init,
+        headers: {
+          Authorization: this.authHeader,
+          Accept: "application/json",
+          ...(init?.body ? { "Content-Type": "application/json" } : {}),
+        },
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+      const body = await response.text().catch(() => "");
+      if (!response.ok) {
+        throw new Error(
+          `Jira ${path} failed (${response.status}): ${body.slice(0, 300)}`,
+        );
+      }
+      // Transition POSTs answer 204 with an empty body.
+      return (body === "" ? undefined : JSON.parse(body)) as T;
+    };
+    if (!idempotent) return attempt();
+    return retry(attempt, {
+      maxAttempts: 3,
+      minTimeout: 100,
+      maxTimeout: 5000,
+      multiplier: 2,
+      jitter: 1,
+      isRetriable: isRetriableError,
+    });
   }
 
   /** Cheapest authenticated call — used to validate credentials on save. */
@@ -286,6 +295,7 @@ export class JiraClient {
         method: "POST",
         body: JSON.stringify({ transition: { id: transitionId } }),
       },
+      { idempotent: false },
     );
   }
 
@@ -312,6 +322,7 @@ export class JiraClient {
     return this.request(
       `/rest/api/3/issue/${encodeURIComponent(issueId)}/comment`,
       { method: "POST", body: JSON.stringify({ body: textToAdf(text) }) },
+      { idempotent: false },
     );
   }
 }


### PR DESCRIPTION
Follows #6274 (adds retry logic to the Jira client).

**Bug**: `JiraClient.request()` wraps every call — reads and writes alike — in the same `retry()` with `isRetriable` gated only on HTTP status/network-error class. `addComment` (POST creating a comment) and `transitionIssue` (POST moving an issue's status) go through this same path. If the request times out or the connection drops *after* Jira applied the write but *before* the response reaches us, that's indistinguishable from a lost request and gets retried — silently duplicating the comment, or resubmitting a transition that's no longer valid because the issue already moved (visible to the tenant as a spurious error or a skipped status).

**Fix**: `request()` now takes an `{ idempotent }` option (default `true`). The two mutation call sites (`addComment`, `transitionIssue`) pass `idempotent: false`, which skips `retry()` entirely — a single attempt, same as before #6274 shipped. Reads (`myself`, `listBoards`, `getBoardColumns`, `listBoardIssues`, `listBacklogIssueIds`, `listTransitions`, `getStatusName`) keep retrying unchanged.

**Regression tests**: added two cases in `client.test.ts` asserting `addComment` and `transitionIssue` each make exactly one fetch call on a transient 503, instead of retrying.

**Verify**: `bun test apps/api/src/jira/client.test.ts` (15 pass, including the 2 new tests). Also ran `cd apps/api && bunx tsc --noEmit` and `bunx oxlint apps/api/src/jira/client.ts apps/api/src/jira/client.test.ts` — both clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate Jira writes by skipping retries for non-idempotent requests. Previously all requests retried on transient errors; now writes attempt once, while reads keep retrying.

- Adds `{ idempotent }` option to `JiraClient.request()` (default `true`).
- Sets `{ idempotent: false }` for `addComment` and `transitionIssue`; all read endpoints unchanged.
- Side effect: transient errors on writes now fail fast instead of retrying, avoiding duplicate comments or invalid double-transitions.

**Verification**
- Adds regression tests ensuring `addComment` and `transitionIssue` make a single fetch on a 503.

<sup>Written for commit 9c506efd3ee046c442748086c86c98a538aef928. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

