### PR TITLE
fix(fast-preview): keep device toggle visible in production preview

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -1675,34 +1675,37 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   ) : null;
 
   const canVisualEdit = display.mode === "sandbox";
-  const floatingPreviewControls = canVisualEdit ? (
+  // Device toggle works on any live iframe; visual-editor toggle is sandbox-only.
+  const floatingPreviewControls = previewSurfaceActive ? (
     <div className="absolute bottom-4 left-1/2 z-20 -translate-x-1/2 scale-125">
       <div className="flex items-center gap-0.5 rounded-full border bg-background/60 p-1 shadow-lg backdrop-blur-md">
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <ToolbarIconButton
-              onClick={() => toggleEditingMode("visual")}
-              aria-pressed={editingMode === "visual"}
-              aria-label={t("sandbox.preview.visualEditor")}
-              active={editingMode === "visual"}
-              disabled={!canVisualEdit}
-              className="rounded-full"
-              data-tour={TOUR_ANCHORS.visualEditor}
-            >
-              <CursorClick01 size={16} />
-            </ToolbarIconButton>
-          </TooltipTrigger>
-          <TooltipContent side="top">
-            {t("sandbox.preview.visualEditor")}
-          </TooltipContent>
-        </Tooltip>
-        <div className="mx-0.5 h-5 w-px bg-border" />
+        {canVisualEdit && (
+          <>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <ToolbarIconButton
+                  onClick={() => toggleEditingMode("visual")}
+                  aria-pressed={editingMode === "visual"}
+                  aria-label={t("sandbox.preview.visualEditor")}
+                  active={editingMode === "visual"}
+                  className="rounded-full"
+                  data-tour={TOUR_ANCHORS.visualEditor}
+                >
+                  <CursorClick01 size={16} />
+                </ToolbarIconButton>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                {t("sandbox.preview.visualEditor")}
+              </TooltipContent>
+            </Tooltip>
+            <div className="mx-0.5 h-5 w-px bg-border" />
+          </>
+        )}
         <Tooltip>
           <TooltipTrigger asChild>
             <ToolbarIconButton
               onClick={handleDeviceToggle}
               aria-label={t(DEVICE_LABEL_KEYS[previewDeviceSize])}
-              disabled={!canVisualEdit}
               className="rounded-full"
               data-tour={TOUR_ANCHORS.device}
             >


### PR DESCRIPTION
## Summary

The floating preview pill (visual-editor toggle + device/viewport switcher) was gated on `display.mode === "sandbox"`, so the device toggle disappeared in **production / deco-content previews** (e.g. the `farmrio` site). Users expected the desktop/mobile/tablet switcher to keep showing there.

The device effect (iframe width + `deviceHint` query param) already works on any live preview iframe — including `production` mode — so nothing but the button's visibility was gating it out.

## Changes

`apps/web/src/components/sandbox/preview/preview.tsx`:
- Render the floating pill whenever a preview surface is active (`previewSurfaceActive`, i.e. `display.mode !== "none"`) instead of sandbox-only.
- Keep the **visual-editor toggle** gated to sandbox mode (wrapped with its divider in a fragment).
- The **device toggle** is now always visible/clickable in the pill; removed its `disabled={!canVisualEdit}`.

## Testing

- `bun run --cwd=apps/web check` ✅
- `bun run fmt` ✅

## Notes

Edge case left as-is: in mobile "blocks" mode the canvas is `BlocksPanel` (no iframe), so the device toggle has no iframe to resize there. The primary production/desktop case works correctly. Happy to hide the pill in that specific mobile-blocks context if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the device toggle visible and clickable in production and deco-content previews by rendering the floating preview pill whenever a preview surface is active. Previously the pill was sandbox-only, so the device switcher disappeared; now only the visual-editor toggle remains sandbox-only.

**Review notes**
- Change the pill’s render condition from sandbox-only to any active preview surface; keep the visual-editor toggle gated to sandbox mode (with its divider) and enable the device toggle.
- Mobile “blocks” mode has no iframe, so the device toggle has no effect there; behavior unchanged.
- No API or config changes; no migration required.

<sup>Written for commit a7103016268c30566d337e0861285d6ddcd2738e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6279?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

