### PR TITLE
perf(storage): skip the vault decrypt in create()'s existing-id check

### DIFF
--- a/apps/api/src/storage/connection.ts
+++ b/apps/api/src/storage/connection.ts
@@ -203,7 +203,12 @@ export class ConnectionStorage implements ConnectionStoragePort {
     const id = data.id ?? generatePrefixedId("conn");
     const now = new Date().toISOString();
 
-    const existing = await this.findById(id);
+    // Skip findById() here — it decrypts secrets we don't need just for the org check.
+    const existing = await this.db
+      .selectFrom("connections")
+      .select("organization_id")
+      .where("id", "=", id)
+      .executeTakeFirst();
 
     if (existing) {
       // Only allow update if same organization - prevent cross-org hijacking


### PR DESCRIPTION
Follows #6220/#6240, the same waste in the sibling code path: `create()` fetched the existing row via `findById(id)` just to read `organization_id` for the cross-org hijack check. `findById`/`deserializeConnection` decrypts `connection_token`, `configuration_state`, and every STDIO env var through the vault — all discarded immediately since only one plaintext column was read.

This makes every `create()` call (called on every connection creation, and internally by `createNew()`'s callers) pay for a vault decrypt whenever the id already exists (an explicit-id create, or an upsert-style call), scaling with how many secrets that existing connection has.

Fix: select just `organization_id` directly instead of going through `findById`/`deserializeConnection`. Same hijack-guard behavior, same `update()` delegation — just without decrypting unrelated encrypted columns.

Behavior preserved: only `existing.organization_id` was ever read from the `findById` result in this branch; the raw DB column is already plaintext (see `deserializeConnection`, which passes `organization_id` straight through with no `vault.decrypt` call).

Reviewer check: `cd apps/api && bunx tsc --noEmit` (clean) and `bunx oxlint apps/api/src/storage/connection.ts` (0 warnings/errors). `connection.integration.test.ts` covers `create()` but needs real Postgres, unavailable in this sandbox — full CI runs it.

Locally ran: `bun run fmt`, targeted `tsc --noEmit` in `apps/api`, and per-file `oxlint` on the changed file — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skips vault decrypts in connection create()’s existing-id check by selecting only organization_id. Previously create() called findById(), which decrypted secrets we didn’t use; now we read organization_id directly. Behavior is unchanged: we still prevent cross-org hijacking and delegate to update() when ids match, with lower latency and vault load on explicit-id and upsert-like creates.

- Review notes:
  - Replaces findById() with a direct select of organization_id from connections; no other logic changes.
  - organization_id is stored plaintext; no secret fields are decrypted in this path.
  - Run: cd apps/api && bunx tsc --noEmit; bunx oxlint apps/api/src/storage/connection.ts. Integration coverage for create() lives in connection.integration.test.ts (runs in CI).

<sup>Written for commit 69f829e52b5cc216c5d18396c42c068a43c1b455. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

