### PR TITLE
fix(jira): make the board picker searchable and name boards the way Jira does

### DIFF
--- a/apps/api/src/jira/client.ts
+++ b/apps/api/src/jira/client.ts
@@ -14,10 +14,17 @@ const REQUEST_TIMEOUT_MS = 15_000;
 
 export interface JiraBoard {
   id: number;
+  /**
+   * The board's own name. For team-managed projects Jira auto-generates this as
+   * "<KEY> board" and never shows it in its own UI, so on its own it is not
+   * what a human recognizes — pair it with `projectName`.
+   */
   name: string;
   type: string;
   /** Project the board lives in, when Jira exposes it. */
   projectKey?: string;
+  /** The project's name — what Jira's own board header shows. */
+  projectName?: string;
 }
 
 export interface JiraBoardColumn {
@@ -176,7 +183,7 @@ export class JiraClient {
           id: number;
           name: string;
           type: string;
-          location?: { projectKey?: string };
+          location?: { projectKey?: string; projectName?: string };
         }>;
         isLast: boolean;
       }>(`/rest/agile/1.0/board?startAt=${startAt}&maxResults=50`);
@@ -186,6 +193,7 @@ export class JiraClient {
           name: board.name,
           type: board.type,
           projectKey: board.location?.projectKey,
+          projectName: board.location?.projectName,
         })),
       );
       if (page.isLast || page.values.length === 0) break;

--- a/apps/api/src/tools/jira/index.ts
+++ b/apps/api/src/tools/jira/index.ts
@@ -250,6 +250,7 @@ export const JIRA_BOARDS_LIST = defineTool({
         name: z.string(),
         type: z.string(),
         projectKey: z.string().optional(),
+        projectName: z.string().optional(),
       }),
     ),
   }),

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -45,6 +45,8 @@ export const settings = {
   "settings.jira.boardDescription":
     "The board's visible cards are mirrored — its Backlog tab, epics and sub-tasks are not.",
   "settings.jira.boardPlaceholder": "Select a board",
+  "settings.jira.boardSearchPlaceholder": "Search boards…",
+  "settings.jira.noBoardsMatch": "No board matches that search",
   "settings.jira.loadingBoards": "Loading boards…",
   "settings.jira.mappingLabel": "Column mapping",
   "settings.jira.mappingDescription":

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -47,6 +47,8 @@ export const settings = {
   "settings.jira.boardDescription":
     "Os cards visíveis do board são espelhados — a aba Backlog, epics e sub-tasks não.",
   "settings.jira.boardPlaceholder": "Selecione um board",
+  "settings.jira.boardSearchPlaceholder": "Buscar boards…",
+  "settings.jira.noBoardsMatch": "Nenhum board corresponde à busca",
   "settings.jira.loadingBoards": "Carregando boards…",
   "settings.jira.mappingLabel": "Mapeamento de colunas",
   "settings.jira.mappingDescription":

--- a/apps/web/src/views/settings/jira-board-labels.test.ts
+++ b/apps/web/src/views/settings/jira-board-labels.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "bun:test";
+import {
+  boardLabels,
+  boardSearchFilter,
+  boardSearchText,
+} from "./jira-board-labels";
+
+describe("boardLabels", () => {
+  it("leads with the project, because that is what Jira's own UI shows", () => {
+    // A team-managed project: Jira auto-named the board "OS board" and shows
+    // the project name in its board header, so the board name alone is useless.
+    expect(
+      boardLabels({
+        id: 1,
+        name: "OS board",
+        projectKey: "OS",
+        projectName: "Acme <> Example | Squad Sites",
+      }),
+    ).toEqual({
+      primary: "Acme <> Example | Squad Sites",
+      secondary: "OS board · OS",
+    });
+  });
+
+  it("keeps the board name visible so sibling boards stay distinguishable", () => {
+    const project = { projectKey: "ABC", projectName: "Example Project" };
+    const demands = boardLabels({ id: 2, name: "Demands", ...project });
+    const epics = boardLabels({ id: 3, name: "Epics", ...project });
+    expect(demands.primary).toBe(epics.primary);
+    expect(demands.secondary).not.toBe(epics.secondary);
+  });
+
+  it("falls back to the board name when Jira reports no project", () => {
+    expect(boardLabels({ id: 4, name: "Standalone board" })).toEqual({
+      primary: "Standalone board",
+      secondary: "",
+    });
+  });
+
+  it("collapses the whitespace people type into project names", () => {
+    expect(
+      boardLabels({ id: 5, name: " b ", projectName: "Two  spaces   here " })
+        .primary,
+    ).toBe("Two spaces here");
+  });
+});
+
+describe("boardSearchText", () => {
+  it("stays unique for same-named boards in different projects", () => {
+    const a = boardSearchText({
+      id: 10,
+      name: "03. Tasks",
+      projectName: "Project A",
+    });
+    const b = boardSearchText({
+      id: 11,
+      name: "03. Tasks",
+      projectName: "Project B",
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("stays unique even when project AND board name collide", () => {
+    const same = { name: "Board", projectName: "Project" };
+    expect(boardSearchText({ id: 12, ...same })).not.toBe(
+      boardSearchText({ id: 13, ...same }),
+    );
+  });
+});
+
+describe("boardSearchFilter", () => {
+  const label = "Acme <> Example | Squad Sites OS board · OS #1610";
+
+  it("matches a substring, ignoring case", () => {
+    expect(boardSearchFilter(label, "squad")).toBe(1);
+    expect(boardSearchFilter(label, "SQUAD")).toBe(1);
+  });
+
+  it("requires every term, in any order", () => {
+    expect(boardSearchFilter(label, "sites squad")).toBe(1);
+    expect(boardSearchFilter(label, "squad missing")).toBe(0);
+  });
+
+  it("ignores accents, which nobody types", () => {
+    expect(boardSearchFilter("01. Épicos · Análise", "epicos")).toBe(1);
+    expect(boardSearchFilter("01. Épicos · Análise", "analise")).toBe(1);
+  });
+
+  it("finds a board by id", () => {
+    expect(boardSearchFilter(label, "1610")).toBe(1);
+  });
+
+  it("keeps everything when the search is empty or blank", () => {
+    expect(boardSearchFilter(label, "")).toBe(1);
+    expect(boardSearchFilter(label, "   ")).toBe(1);
+  });
+
+  it("rejects a subsequence, which is what the fuzzy default got wrong", () => {
+    // "sites" must not match "Custo Médio - Protheus | 01. Épicos" just because
+    // those letters appear scattered across it.
+    expect(
+      boardSearchFilter("Custo Medio - Protheus | 01. Epicos", "sites"),
+    ).toBe(0);
+  });
+});

--- a/apps/web/src/views/settings/jira-board-labels.ts
+++ b/apps/web/src/views/settings/jira-board-labels.ts
@@ -1,0 +1,74 @@
+/**
+ * Naming and searching Jira boards in the picker.
+ *
+ * Split out from the settings view because both rules are subtle enough to
+ * regress silently: what a human calls a board is not what Jira's API calls it,
+ * and the search has to survive a list of dozens of near-identical names.
+ */
+
+export interface JiraBoardSummary {
+  id: number;
+  name: string;
+  projectKey?: string;
+  projectName?: string;
+}
+
+export interface JiraBoardLabels {
+  /** What the trigger shows and what we persist. */
+  primary: string;
+  /** Qualifier line under it — may be empty. */
+  secondary: string;
+}
+
+/**
+ * Jira's `board.name` is not what people recognize: for team-managed projects it
+ * auto-generates "<KEY> board" and never shows it anywhere in its own UI, where
+ * the board header carries the PROJECT name instead. So the project leads, and
+ * the board's own name qualifies it — which is what disambiguates the
+ * company-managed case, where one project legitimately owns several boards
+ * ("… - Demandas", "… - Épicos").
+ */
+export function boardLabels(board: JiraBoardSummary): JiraBoardLabels {
+  // Project names arrive with whatever spacing someone typed into Jira.
+  const project = board.projectName?.replace(/\s+/g, " ").trim();
+  const name = board.name.trim();
+  if (!project) return { primary: name, secondary: board.projectKey ?? "" };
+  return {
+    primary: project,
+    secondary: [name, board.projectKey].filter(Boolean).join(" · "),
+  };
+}
+
+/**
+ * The option's search text. Ends with the board id because the Combobox
+ * resolves a pick by LABEL, and one Jira site can hold several boards with the
+ * same name in different projects — three "03. Tarefas" is a real shape, and
+ * without the id they would collapse into one option that selects the wrong
+ * board. Searching by id is a harmless side effect.
+ */
+export function boardSearchText(board: JiraBoardSummary): string {
+  const { primary, secondary } = boardLabels(board);
+  return [primary, secondary, `#${board.id}`].filter(Boolean).join(" ");
+}
+
+function fold(text: string): string {
+  return text
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toLowerCase();
+}
+
+/**
+ * Diacritic- and case-insensitive substring match, every term required.
+ *
+ * cmdk's fuzzy default scores subsequences, which is fine for a short menu and
+ * useless here: these names are long and share most of their words, so a
+ * five-letter query matched a third of the list. Accents matter too — nobody
+ * types "Épicos".
+ */
+export function boardSearchFilter(value: string, search: string): number {
+  const needle = fold(search).trim();
+  if (!needle) return 1;
+  const haystack = fold(value);
+  return needle.split(/\s+/).every((term) => haystack.includes(term)) ? 1 : 0;
+}

--- a/apps/web/src/views/settings/jira.tsx
+++ b/apps/web/src/views/settings/jira.tsx
@@ -10,6 +10,9 @@ import { useState } from "react";
 import { toast } from "sonner";
 import { Button } from "@decocms/ui/components/button.tsx";
 import { Input } from "@decocms/ui/components/input.tsx";
+import { Check, ChevronSelectorVertical } from "@untitledui/icons";
+import { cn } from "@decocms/ui/lib/utils.ts";
+import { Combobox } from "@decocms/ui/components/combobox.tsx";
 import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
 import { Switch } from "@decocms/ui/components/switch.tsx";
 import {
@@ -35,6 +38,11 @@ import {
   SettingsPage,
   SettingsSection,
 } from "@/components/settings/settings-section";
+import {
+  boardLabels,
+  boardSearchFilter,
+  boardSearchText,
+} from "./jira-board-labels";
 import { useT } from "@/i18n/use-t.ts";
 import type { TranslationKey } from "@/i18n/en";
 import {
@@ -338,6 +346,25 @@ function SyncSettings({ integration }: { integration: JiraIntegration }) {
   const runSync = useRunJiraSync();
   const boards = useJiraBoards(true);
   const hasMapping = Object.keys(integration.statusMapping).length > 0;
+  const boardOptions = (boards.data ?? []).map((board) => {
+    const { primary, secondary } = boardLabels(board);
+    return {
+      value: String(board.id),
+      label: boardSearchText(board),
+      primary,
+      secondary,
+    };
+  });
+  // Prefer the live list so an integration saved before this labeling still
+  // reads correctly, then the stored label while the list loads. Null when no
+  // board is picked — a stored name from a cleared board must not read as a
+  // selection.
+  const selectedBoardLabel = integration.boardId
+    ? (boardOptions.find((option) => option.value === integration.boardId)
+        ?.primary ??
+      integration.boardName ??
+      integration.boardId)
+    : null;
 
   return (
     <SubSection
@@ -354,18 +381,61 @@ function SyncSettings({ integration }: { integration: JiraIntegration }) {
               {t("settings.jira.boardDescription")}
             </p>
           </div>
-          <Select
-            value={integration.boardId ?? undefined}
-            onValueChange={(boardId) =>
+          <Combobox
+            options={boardOptions}
+            value={integration.boardId ?? ""}
+            width="w-72"
+            triggerClassName="shrink-0"
+            placeholder={t("settings.jira.boardPlaceholder")}
+            searchPlaceholder={t("settings.jira.boardSearchPlaceholder")}
+            filter={boardSearchFilter}
+            emptyMessage={
+              boards.isPending
+                ? t("settings.jira.loadingBoards")
+                : t("settings.jira.noBoardsMatch")
+            }
+            renderTrigger={() => (
+              <Button
+                variant="outline"
+                role="combobox"
+                className="w-72 justify-between font-normal"
+              >
+                <span className="truncate">
+                  {selectedBoardLabel ?? t("settings.jira.boardPlaceholder")}
+                </span>
+                <ChevronSelectorVertical className="opacity-50 shrink-0" />
+              </Button>
+            )}
+            renderItem={(option, isSelected) => (
+              <div className="flex items-start gap-2 min-w-0 w-full">
+                <div className="min-w-0 flex-1">
+                  <p className="truncate">{option.primary as string}</p>
+                  <p className="text-xs text-muted-foreground truncate">
+                    {option.secondary as string}
+                  </p>
+                </div>
+                <Check
+                  className={cn(
+                    "mt-0.5 shrink-0",
+                    isSelected ? "opacity-100" : "opacity-0",
+                  )}
+                />
+              </div>
+            )}
+            onChange={(boardId) => {
+              if (!boardId || boardId === integration.boardId) return;
               upsert.mutate(
                 // New board = new columns, so the old mapping resets with it —
                 // and the sync goes off with it, because an enabled sync with no
                 // mapping is exactly what the server refuses.
                 {
                   boardId,
+                  // A display cache only (the sync keys off boardId), so store
+                  // the label people recognize rather than Jira's internal
+                  // board name, which is "<KEY> board" for team-managed projects.
                   boardName:
-                    boards.data?.find((b) => String(b.id) === boardId)?.name ??
-                    null,
+                    boardOptions.find((option) => option.value === boardId)
+                      ?.primary ?? null,
                   statusMapping: {},
                   enabled: false,
                 },
@@ -375,28 +445,9 @@ function SyncSettings({ integration }: { integration: JiraIntegration }) {
                       errorMessage(err, t("settings.jira.saveFailed")),
                     ),
                 },
-              )
-            }
-          >
-            <SelectTrigger className="w-64 shrink-0">
-              <SelectValue placeholder={t("settings.jira.boardPlaceholder")}>
-                {integration.boardName ?? integration.boardId ?? undefined}
-              </SelectValue>
-            </SelectTrigger>
-            <SelectContent>
-              {boards.isPending && (
-                <SelectItem value="__loading__" disabled>
-                  {t("settings.jira.loadingBoards")}
-                </SelectItem>
-              )}
-              {(boards.data ?? []).map((board) => (
-                <SelectItem key={board.id} value={String(board.id)}>
-                  {board.name}
-                  {board.projectKey ? ` (${board.projectKey})` : ""}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
+              );
+            }}
+          />
         </div>
 
         {integration.boardId && (

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -4935,6 +4935,7 @@ export interface StudioToolIO {
         name: string;
         type: string;
         projectKey?: string | undefined;
+        projectName?: string | undefined;
       }[];
     };
   };

--- a/packages/ui/src/components/combobox.tsx
+++ b/packages/ui/src/components/combobox.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Check, ChevronSelectorVertical } from "@untitledui/icons";
-import { ReactNode, useState } from "react";
+import { ComponentProps, ReactNode, useState } from "react";
 
 import { cn } from "../lib/utils.ts";
 import { Button } from "./button.tsx";
@@ -33,6 +33,10 @@ export interface ComboboxProps {
   renderItem?: (option: ComboboxOption, isSelected: boolean) => ReactNode;
   emptyMessage?: string;
   searchPlaceholder?: string;
+  /** Override how the search matches. Omitted keeps cmdk's fuzzy default, which
+   *  scores subsequences — fine for short lists, noisy once there are dozens of
+   *  similarly-worded options. */
+  filter?: ComponentProps<typeof Command>["filter"];
 }
 
 export function Combobox({
@@ -47,6 +51,7 @@ export function Combobox({
   renderItem,
   emptyMessage = "No results found.",
   searchPlaceholder = "Search...",
+  filter,
 }: ComboboxProps) {
   const selectedOption = options.find((option) => option.value === value);
   const [open, setOpen] = useState(false);
@@ -73,7 +78,7 @@ export function Combobox({
         className={cn("p-0", contentClassName)}
         style={{ width: "var(--radix-popover-trigger-width)" }}
       >
-        <Command>
+        <Command filter={filter}>
           <CommandInput placeholder={searchPlaceholder} className="h-9" />
           <CommandList>
             <CommandEmpty>{emptyMessage}</CommandEmpty>


### PR DESCRIPTION
## Summary

Follow-up on #6238. Three problems with the Jira board picker, one of which
crashed the page.

## It showed a name nobody recognizes

The picker rendered `board.name`. For a **team-managed** project Jira
auto-generates that as `"<KEY> board"` and never shows it in its own UI — the
board header carries the **project** name instead. So a board that reads
`Deco <> Acme | Squad Sites` in Jira showed up here as `OS board`, and there was
no way to tell which board you were selecting.

The picker now leads with the project name and keeps the board's own name as a
qualifier line underneath. That also fixes the **company-managed** case, where
one project legitimately owns several boards — labeling by project alone would
render three identical rows for `… - Demandas` / `… - Épicos` / `… - Cancelado`.

`board_name` is a display cache (the sync keys off `board_id`, nothing reads the
name), so it now stores the label people recognize. The trigger prefers the live
board list, so an integration saved before this change reads correctly with no
migration.

## It could not be searched

One real instance has **62 boards** in a flat menu. It is a `Combobox` now.

cmdk's fuzzy default was not good enough on this data: it scores subsequences, so
a five-letter query matched a third of the list — `sites` returned **18 of 62**,
including `Custo Médio - Protheus | 01. Épicos`, whose only crime is containing
those letters in order. The filter is a diacritic-folding substring match that
requires every term, which takes `sites` to **2**, resolves `squad sites` to
**1**, and lets `epicos` find the accented ones.

That needed one additive prop on the shared `Combobox`: `filter`, passed through
to `Command` and defaulting to cmdk's behavior, so no existing consumer changes.

## Picking a board crashed the page

```
Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.
  The above error occurred in the <Text> component
```

That is the chunk error boundary's "Something went wrong / Try again" screen.
Cause: the old code passed **children** to `<SelectValue>`. Radix owns that text
node — it clones the selected item's `SelectItemText` — so on the first selection
it tried to remove a node that was no longer its child. Reproduced on the
pre-change code and gone after, because the Combobox has no `SelectValue` at all.
The page's other selects pass no children and were never affected.

Worth a separate look: `components/chat/select-model/decopilot.tsx:736` passes
children to `SelectValue` the same way, so it carries the same latent crash.

## One subtlety worth knowing

The option label ends with the board id deliberately. `Combobox` resolves a pick
by **label**, and one site can hold several boards with the same name in
different projects — three `03. Tarefas` is real data — so without the id they
collapse into one option that selects the wrong board. Searching by id is a
harmless side effect. (The label-keyed lookup is arguably the component's bug;
not fixing it here to keep this off other consumers' paths.)

## Before / after

Rendered against stubbed tool responses, so every board and project name below is
synthetic — this repo is public. The shapes are the real ones: a team-managed
project whose board Jira auto-named `SS board`, sibling boards inside one
company-managed project, repeated board names across projects, and a board with no
project at all.

**The picker, open.** Before: one flat menu, no search, and the rows are Jira's
internal board names with a bare project key. After: searchable, with the project
leading and the board name qualifying it.

| Before | After |
| --- | --- |
| <img width="480" alt="Flat board menu showing internal board names" src="https://raw.githubusercontent.com/decocms/studio/680c377b01585caac7c782d9792f99002bfb015b/screenshots/jira-board-picker/1a-before-open.png"> | <img width="480" alt="Searchable board picker showing project names" src="https://raw.githubusercontent.com/decocms/studio/680c377b01585caac7c782d9792f99002bfb015b/screenshots/jira-board-picker/1b-after-open.png"> |

**Searching.** `squad` narrows 62 boards to the one you meant:

<img width="700" alt="Board picker filtered by the term squad" src="https://raw.githubusercontent.com/decocms/studio/680c377b01585caac7c782d9792f99002bfb015b/screenshots/jira-board-picker/3-after-search.png">

**Picking a board with nothing selected yet.** This is the crash, and the state it
needs: the first selection moves Radix's `SelectValue` from placeholder to a
value. Before, the page died; after, the same click just works.

| Before | After |
| --- | --- |
| <img width="480" alt="Something went wrong: Failed to execute removeChild on Node" src="https://raw.githubusercontent.com/decocms/studio/680c377b01585caac7c782d9792f99002bfb015b/screenshots/jira-board-picker/2-before-crash.png"> | <img width="480" alt="Board selected, mapping rows rendered, no crash" src="https://raw.githubusercontent.com/decocms/studio/680c377b01585caac7c782d9792f99002bfb015b/screenshots/jira-board-picker/4-after-first-pick-ok.png"> |

## Testing

Labeling and search are pure functions in their own module with **12 unit tests**:
team-managed vs company-managed shapes, a board with no project at all,
whitespace Jira accepts in project names, id-uniqueness when names collide, accent
folding, multi-term AND, and the subsequence match the fuzzy default got wrong.

Exercised against a real Jira Cloud site with 62 boards on a local dev org: the
crash reproduced before and is gone after, the trigger and dropdown show the
project-led label, and the search numbers above are measured from that instance.
`bun run check`, `lint`, `bunx knip` and the unit tests are green.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Jira board picker searchable and labels boards the way Jira does, and fixes a selection crash. Previously it showed `board.name` (often "<KEY> board"), had no search, and could crash on first selection; now it shows project-led labels with the board name as a qualifier in a searchable `Combobox` and selects safely.

- Changes to review
  - Replace Select with `Combobox` in settings: trigger shows the project name; qualifier line shows board name and project key; option label ends with "#id" to keep picks unique; selected label prefers the live list, then stored label.
  - Add board naming/search module with unit tests; search uses diacritic-folding, case-insensitive substring matching where all terms must match; supports searching by id.
  - Fix crash by removing `SelectValue` usage; `Combobox` avoids the removed-child issue.
  - Extend shared `Combobox` with optional `filter` prop passed to `cmdk`’s `Command`; default behavior unchanged for other consumers.
  - API/types: include `projectName` on Jira boards in the API client, tool schema, and shared IO.
  - i18n: add board search placeholder and "no match" messages.

- Rollout notes
  - No migration required: `board_name` is display-only and now stores the project-led label; existing integrations render correctly.
  - Changing the board clears the column mapping and disables sync as before.

<sup>Written for commit c7c8f86060ae685c5eecfe8609d64980dcf9545b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


