### PR TITLE
refactor(i18n): remove 32 dead settings translation keys

### DIFF
--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -209,7 +209,6 @@ export const settings = {
   "settings.buckets.nameLabel": "Name",
   "settings.buckets.namePlaceholder": "production-uploads",
   "settings.buckets.noBucketsConfigured": "No buckets configured",
-  "settings.buckets.pageTitle": "Buckets",
   "settings.buckets.pathStyle": "path-style",
   "settings.buckets.prefix": "prefix: {prefix}",
   "settings.buckets.prefixHelperText":
@@ -446,41 +445,6 @@ export const settings = {
   "settings.joinRequestsSection.description":
     "People who requested to join via a domain in approval mode.",
   "settings.joinRequestsSection.title": "Join requests",
-  "settings.orgBrandContext.addBrand": "Add Brand",
-  "settings.orgBrandContext.addYourFirstBrand": "Add your first brand",
-  "settings.orgBrandContext.brandContext": "Brand Context",
-  "settings.orgBrandContext.brandContextDescription":
-    "Define your brand profiles. Each brand is available as an MCP prompt for AI clients.",
-  "settings.orgBrandContext.brandContextUpdated":
-    "Brand context updated successfully",
-  "settings.orgBrandContext.brandCreated": "Brand created",
-  "settings.orgBrandContext.brandDeleted": "Brand deleted",
-  "settings.orgBrandContext.brandExtractedSuccessfully":
-    "Brand extracted successfully",
-  "settings.orgBrandContext.cancel": "Cancel",
-  "settings.orgBrandContext.delete": "Delete",
-  "settings.orgBrandContext.deleteBrand": "Delete brand",
-  "settings.orgBrandContext.deleteBrandTitle": "Delete brand?",
-  "settings.orgBrandContext.deleteConfirmMessage":
-    "This will permanently delete {name}. This action cannot be undone.",
-  "settings.orgBrandContext.deleteDefaultBrandWarning":
-    "this is your organization's default brand. Deleting it will leave your organization without a default brand until you set another.",
-  "settings.orgBrandContext.deleting": "Deleting...",
-  "settings.orgBrandContext.failedCreateBrand": "Failed to create brand",
-  "settings.orgBrandContext.failedDeleteBrand": "Failed to delete brand",
-  "settings.orgBrandContext.failedExtractBrand": "Failed to extract brand",
-  "settings.orgBrandContext.failedSaveBrandContext":
-    "Failed to save brand context",
-  "settings.orgBrandContext.failedUpdateDefaultBrand":
-    "Failed to update default brand",
-  "settings.orgBrandContext.headsUp": "Heads up",
-  "settings.orgBrandContext.noBrandsConfigured": "No brands configured yet.",
-  "settings.orgBrandContext.removedAsDefaultBrand": "Removed as default brand",
-  "settings.orgBrandContext.setAsDefault": "Set as default",
-  "settings.orgBrandContext.setAsDefaultBrand": "Set as default brand",
-  "settings.orgBrandContext.thisBrand": "this brand",
-  "settings.orgBrandContext.unsetAsDefault": "Unset as default",
-  "settings.orgBrandContext.untitledBrand": "Untitled Brand",
   "settings.navigation.title": "Navigation",
   "settings.navigation.description":
     "How this organization gets around Studio.",
@@ -805,7 +769,6 @@ export const settings = {
     "Deco AI Gateway connected successfully",
   "settings.aiProviders.decoConnectError":
     "Failed to connect Deco AI Gateway: {error}",
-  "settings.billing.title": "Billing",
   "settings.billing.autoTasksTitle": "Auto tasks",
   "settings.billing.unlimitedDescription":
     "Auto-task runs are unlimited on this deployment. Tasks you create yourself are never limited either.",
@@ -823,7 +786,6 @@ export const settings = {
   "settings.billing.checkoutError": "Couldn't start checkout: {message}",
   "settings.billing.portalError": "Couldn't open billing portal: {message}",
 
-  "settings.infraBilling.pageTitle": "Infra Billing",
   "settings.infraBilling.noSites":
     "This organization doesn't own any deco.cx site yet.",
   "settings.infraBilling.siteLabel": "Sites",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -218,7 +218,6 @@ export const settings = {
   "settings.buckets.nameLabel": "Nome",
   "settings.buckets.namePlaceholder": "production-uploads",
   "settings.buckets.noBucketsConfigured": "Nenhum bucket configurado",
-  "settings.buckets.pageTitle": "Buckets",
   "settings.buckets.pathStyle": "path-style",
   "settings.buckets.prefix": "prefixo: {prefix}",
   "settings.buckets.prefixHelperText":
@@ -461,44 +460,6 @@ export const settings = {
   "settings.joinRequestsSection.description":
     "Pessoas que solicitaram entrada por um dom\u00ednio em modo de aprova\u00e7\u00e3o.",
   "settings.joinRequestsSection.title": "Solicita\u00e7\u00f5es de entrada",
-  "settings.orgBrandContext.addBrand": "Adicionar Marca",
-  "settings.orgBrandContext.addYourFirstBrand": "Adicionar sua primeira marca",
-  "settings.orgBrandContext.brandContext": "Contexto de Marca",
-  "settings.orgBrandContext.brandContextDescription":
-    "Defina seus perfis de marca. Cada marca est\u00e1 dispon\u00edvel como um prompt MCP para clientes de IA.",
-  "settings.orgBrandContext.brandContextUpdated":
-    "Contexto de marca atualizado com sucesso",
-  "settings.orgBrandContext.brandCreated": "Marca criada",
-  "settings.orgBrandContext.brandDeleted": "Marca exclu\u00edda",
-  "settings.orgBrandContext.brandExtractedSuccessfully":
-    "Marca extra\u00edda com sucesso",
-  "settings.orgBrandContext.cancel": "Cancelar",
-  "settings.orgBrandContext.delete": "Excluir",
-  "settings.orgBrandContext.deleteBrand": "Excluir marca",
-  "settings.orgBrandContext.deleteBrandTitle": "Excluir marca?",
-  "settings.orgBrandContext.deleteConfirmMessage":
-    "Isso excluir\u00e1 permanentemente {name}. Esta a\u00e7\u00e3o n\u00e3o pode ser desfeita.",
-  "settings.orgBrandContext.deleteDefaultBrandWarning":
-    "esta \u00e9 a marca padr\u00e3o da sua organiza\u00e7\u00e3o. Exclu\u00ed-la deixar\u00e1 sua organiza\u00e7\u00e3o sem uma marca padr\u00e3o at\u00e9 que voc\u00ea defina outra.",
-  "settings.orgBrandContext.deleting": "Excluindo...",
-  "settings.orgBrandContext.failedCreateBrand": "Falha ao criar marca",
-  "settings.orgBrandContext.failedDeleteBrand": "Falha ao excluir marca",
-  "settings.orgBrandContext.failedExtractBrand": "Falha ao extrair marca",
-  "settings.orgBrandContext.failedSaveBrandContext":
-    "Falha ao salvar contexto de marca",
-  "settings.orgBrandContext.failedUpdateDefaultBrand":
-    "Falha ao atualizar marca padr\u00e3o",
-  "settings.orgBrandContext.headsUp": "Aten\u00e7\u00e3o",
-  "settings.orgBrandContext.noBrandsConfigured":
-    "Nenhuma marca configurada ainda.",
-  "settings.orgBrandContext.removedAsDefaultBrand":
-    "Removido como marca padr\u00e3o",
-  "settings.orgBrandContext.setAsDefault": "Definir como padr\u00e3o",
-  "settings.orgBrandContext.setAsDefaultBrand":
-    "Definir como marca padr\u00e3o",
-  "settings.orgBrandContext.thisBrand": "esta marca",
-  "settings.orgBrandContext.unsetAsDefault": "Remover como padr\u00e3o",
-  "settings.orgBrandContext.untitledBrand": "Marca Sem T\u00edtulo",
   "settings.navigation.title": "Navegação",
   "settings.navigation.description":
     "Como esta organização circula pelo Studio.",
@@ -851,7 +812,6 @@ export const settings = {
     "Deco AI Gateway conectado com sucesso",
   "settings.aiProviders.decoConnectError":
     "Falha ao conectar o Deco AI Gateway: {error}",
-  "settings.billing.title": "Cobrança",
   "settings.billing.autoTasksTitle": "Tarefas automáticas",
   "settings.billing.unlimitedDescription":
     "As execuções de tarefas automáticas são ilimitadas neste deployment. Tarefas criadas por você também nunca têm limite.",
@@ -871,7 +831,6 @@ export const settings = {
   "settings.billing.portalError":
     "Não foi possível abrir o portal de cobrança: {message}",
 
-  "settings.infraBilling.pageTitle": "Cobrança de infra",
   "settings.infraBilling.noSites":
     "Esta organização ainda não é dona de nenhum site deco.cx.",
   "settings.infraBilling.siteLabel": "Sites",


### PR DESCRIPTION
**Source:** dead-code cleanup found while auditing `apps/web/src/i18n/{en,pt-br}/settings.ts` for key-parity/consistency issues (this repo's focus area for the tick).

**Why:** the `settings.orgBrandContext.*` block (29 keys) was a leftover from a settings-page brand-context UI; that feature now lives entirely under the `chat.brandContext.*` namespace (`apps/web/src/components/chat/message/parts/tool-call-part/brand-context.tsx`), so every `settings.orgBrandContext.*` key has zero remaining callers. Also removed `settings.buckets.pageTitle`, `settings.billing.title`, and `settings.infraBilling.pageTitle`, which are similarly unreferenced.

**Verification that behavior is unchanged:**
- `rg -rn "orgBrandContext\b" apps/web/src --include="*.ts" --include="*.tsx"` outside the i18n dirs returns zero hits (checked before deleting).
- Each of the other 3 removed keys was individually grepped for zero non-i18n references. Note: `settings.infraBilling.plan.{free,pro,enterprise}` were flagged by the same grep sweep but are actually used via a dynamic `t(\`settings.infraBilling.plan.${planType}\`)\` lookup in `infra-billing.tsx` — those were correctly left alone.
- Both en/pt-br files keep 1:1 key parity — the pt-br file's `satisfies Record<keyof typeof settingsEn, string>` constraint (a compile-time parity check) still passes.
- Net: -79 lines / +0 across the two files, pure deletion.

**Command a reviewer runs to confirm:**
```
grep -rn "orgBrandContext\|settings\.buckets\.pageTitle\|settings\.billing\.title\b\|settings\.infraBilling\.pageTitle" apps/web/src --include="*.ts" --include="*.tsx"
```
should only show the (now-removed) i18n lines are gone, with no other references.

**Local checks run:** `bun run fmt` (clean), `cd apps/web && bunx tsc --noEmit` (clean — confirms the `satisfies` key-parity check still holds), `bunx oxlint apps/web/src/i18n/en/settings.ts apps/web/src/i18n/pt-br/settings.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes 32 unused settings i18n keys to reduce dead code and keep en/pt-br parity. No behavior change; all removed keys had zero callers.

- Drops 29 `settings.orgBrandContext.*` keys; brand-context UI now lives under `chat.brandContext.*` in apps/web/src/components/chat/message/parts/tool-call-part/brand-context.tsx.
- Also removes `settings.buckets.pageTitle`, `settings.billing.title`, and `settings.infraBilling.pageTitle` (page titles provided elsewhere).
- Verified via repo-wide grep that these keys are unreferenced; retained `settings.infraBilling.plan.{free,pro,enterprise}` due to dynamic lookup.
- en/pt-br files remain 1:1; the TypeScript parity check still passes.
- No migration or rollout actions.

<sup>Written for commit b15f5133a2de3e30acf5955e3302ccd057469709. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6285?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

