### PR TITLE
fix(task-board): model a linked thread's lastActiveAt in the output schema

### DIFF
--- a/apps/api/src/tools/task-board/schema.test.ts
+++ b/apps/api/src/tools/task-board/schema.test.ts
@@ -100,4 +100,36 @@ describe("TaskBoardItemSchema – proxy round-trip validation", () => {
         .retryAttempts,
     ).toBe(2);
   });
+
+  // Same bug class, a different field: threads always carry lastActiveAt.
+  it("accepts a linked thread with lastActiveAt (previously rejected)", async () => {
+    const result = await roundTrip({
+      item: {
+        ...baseItem,
+        threads: [
+          {
+            threadId: "thread_1",
+            virtualMcpId: null,
+            status: "in_progress",
+            title: "Fix the thing",
+            lastMessage: null,
+            hasPreview: false,
+            failureKind: null,
+            hasMessages: true,
+            costUsd: null,
+            createdAt: "2024-01-01T00:00:00.000Z",
+            lastActiveAt: "2024-01-01T00:05:00.000Z",
+          },
+        ],
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(
+      (
+        result.structuredContent as {
+          item: { threads: { lastActiveAt: string }[] };
+        }
+      ).item.threads[0]?.lastActiveAt,
+    ).toBe("2024-01-01T00:05:00.000Z");
+  });
 });

--- a/apps/api/src/tools/task-board/schema.ts
+++ b/apps/api/src/tools/task-board/schema.ts
@@ -38,6 +38,9 @@ const TaskBoardItemThreadSchema = z.object({
   /** USD this run has cost so far; null when the harness recorded none. */
   costUsd: z.number().nullable(),
   createdAt: z.string(),
+  /** Newest of the thread's `updated_at` / `last_progress_at` — the stall
+   *  reaper's heartbeat, present on every `TaskBoardItemThreadRef`. */
+  lastActiveAt: z.string(),
 });
 
 /** A tag attached to a task, plus who attached it and when. */

--- a/apps/web/src/layouts/task-board/build-task-chat-context.test.ts
+++ b/apps/web/src/layouts/task-board/build-task-chat-context.test.ts
@@ -13,6 +13,7 @@ const thread = (o: Partial<TaskBoardItemThread>): TaskBoardItemThread => ({
   hasMessages: false,
   costUsd: null,
   createdAt: "",
+  lastActiveAt: "",
   ...o,
 });
 

--- a/packages/shared/src/entities.ts
+++ b/packages/shared/src/entities.ts
@@ -125,6 +125,9 @@ export interface TaskBoardItemThreadRef {
    *  when nothing was recorded — not the same as free. */
   costUsd: number | null;
   createdAt: string;
+  /** Newest of the thread's `updated_at` / `last_progress_at` — the stall
+   *  reaper's heartbeat, mirrored from `apps/api/src/storage/types.ts`. */
+  lastActiveAt: string;
 }
 
 /** A tag attached to a task, plus who attached it and when. */

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -324,6 +324,7 @@ export interface StudioToolIO {
           hasMessages: boolean;
           costUsd: number | null;
           createdAt: string;
+          lastActiveAt: string;
         }[];
         tags: {
           id: string;
@@ -378,6 +379,7 @@ export interface StudioToolIO {
           hasMessages: boolean;
           costUsd: number | null;
           createdAt: string;
+          lastActiveAt: string;
         }[];
         tags: {
           id: string;
@@ -451,6 +453,7 @@ export interface StudioToolIO {
           hasMessages: boolean;
           costUsd: number | null;
           createdAt: string;
+          lastActiveAt: string;
         }[];
         tags: {
           id: string;


### PR DESCRIPTION
Follows #6275's exact bug class, found while re-auditing `packages/shared/src/task-board.*` after that fix landed.

`TaskBoardItemThreadRef` (`apps/api/src/storage/types.ts`) has always carried `lastActiveAt` — the newest of `updated_at`/`last_progress_at`, the stall reaper's heartbeat — and `attachThreads` always returns it, but the closed `TaskBoardItemThreadSchema` in `apps/api/src/tools/task-board/schema.ts` never modeled it. Since the schema is a closed `z.object()` (no `.catchall`), Ajv rejects the extra property with 'must NOT have additional properties' the instant a task has any linked thread, surfacing as `-32602: Structured content does not match the tool's output schema` on `TASK_BOARD_ITEM_CREATE`/`LIST`/`UPDATE` etc. for any MCP client that lists tools first and re-validates `structuredContent` (e.g. the studio proxy's `client.callTool`) — i.e. every board with at least one run.

Failure scenario: any org whose task board has a card with a linked thread (essentially every active board) gets `-32602` from the proxy on list/create/update calls that return that item.

Fix mirrors #6275: model the field for real in `schema.ts`, `packages/shared/src/entities.ts` (the shared `TaskBoardItemThreadRef`), and the generated `packages/shared/src/tools/tool-io.ts` (regenerated by hand-adding the field in its 3 occurrences, matching the generator's own output shape — the generator itself produced an unrelated 7000-line diff on this box so I didn't run it live). Added a regression test in `schema.test.ts` reproducing the exact proxy-side Ajv round-trip with a linked thread — verified it fails with `-32602` on the pre-fix schema (via `git stash` of just schema.ts) and passes post-fix. Also fixed a web test fixture (`build-task-chat-context.test.ts`) that the now-required field broke at typecheck.

Reviewer check: `bun test apps/api/src/tools/task-board/schema.test.ts`

Locally ran: `bun run fmt`, `bunx tsc --noEmit` in `apps/api`, `packages/shared`, and `apps/web` (all clean), `bun test apps/api/src/tools/task-board/schema.test.ts` and `apps/web/src/layouts/task-board/{build-task-chat-context,config}.test.ts` (all pass), `bunx oxlint` on every changed file (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Models lastActiveAt on task-board thread refs in the output schema so Ajv no longer rejects linked threads. Previously the closed schema omitted lastActiveAt; clients that re-validate tool output returned -32602 on list/create/update when any item had a linked thread. Now the schema and shared types include lastActiveAt and validation passes.

- Adds lastActiveAt to `apps/api/src/tools/task-board/schema.ts`, `packages/shared/src/entities.ts`, and the generated `packages/shared/src/tools/tool-io.ts`; updates tests, including an Ajv round-trip regression in `apps/api/src/tools/task-board/schema.test.ts`.
- Required action: if you construct `TaskBoardItemThread`/`TaskBoardItemThreadRef` in code or tests, include lastActiveAt (e.g., updated fixture in `apps/web/src/layouts/task-board/build-task-chat-context.test.ts`).
- Review tips: run `bun test apps/api/src/tools/task-board/schema.test.ts`; double-check the manual edits in `packages/shared/src/tools/tool-io.ts` match generator output.
- No runtime API shape change: attachThreads already returns lastActiveAt; this aligns the schema and types with existing responses.

<sup>Written for commit ea5638ee82a158adfa5a99cd7ed71e792e7cfa21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

