### PR TITLE
fix(settings): pin Sign Out to the bottom of the settings sidebar

### DIFF
--- a/apps/web/src/layouts/settings-layout.tsx
+++ b/apps/web/src/layouts/settings-layout.tsx
@@ -413,8 +413,8 @@ export function SettingsSidebar() {
           </SidebarGroup>
         ))}
 
-        {/* Sign Out */}
-        <SidebarGroup className="pt-0 pr-0 pb-0 pl-0">
+        {/* Sign Out — pinned to the bottom, away from the Advanced disclosure */}
+        <SidebarGroup className="mt-auto pt-0 pr-0 pb-0 pl-0">
           <div className="mx-2 my-2 border-t border-border/50" />
           <SidebarGroupContent>
             <SidebarMenu className="gap-0.5">
@@ -488,8 +488,8 @@ export function SettingsSidebarMobile({ onClose }: { onClose: () => void }) {
           </div>
         ))}
 
-        {/* Sign Out */}
-        <div className="flex flex-col gap-0.5">
+        {/* Sign Out — pinned to the bottom, away from the Advanced disclosure */}
+        <div className="mt-auto flex flex-col gap-0.5">
           <div className="h-px bg-border/50 my-2" />
           <button
             type="button"


### PR DESCRIPTION
## Summary
The **Sair** (Sign Out) row was rendering directly below the collapsed **Avançado** (Advanced) disclosure, making it look like part of that group. This pins it to the bottom of the settings sidebar, visually separated from the nav groups above.

## Changes
- Added `mt-auto` to the Sign Out group in both the desktop (`SettingsSidebar`) and mobile (`SettingsSidebarMobile`) settings sidebars, pushing it to the bottom of the sidebar content (above the version footer).

## Testing
- Verified visually: Sign Out now sits at the bottom, away from the Advanced disclosure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the Sign Out row to the bottom of the settings sidebar on desktop and mobile to prevent it from appearing inside the Advanced group. Previously it sat directly below the collapsed Advanced disclosure; now it stays at the bottom above the footer with no behavior change.

- Adds `mt-auto` to the Sign Out container in `SettingsSidebar` and `SettingsSidebarMobile`.
- Verify on desktop and mobile that Sign Out stays pinned at the bottom and the separator renders once.
- DOM order and tab order are unchanged; no copy, routes, or permissions changed.

<sup>Written for commit 6fbb3222c54aa0a20ff463d2048aa005bdcf58a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6287?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

