### PR TITLE
fix(sandbox): drain the discarded 401 response before retrying the proxy

### DIFF
--- a/packages/sandbox/server/provider/agent-sandbox/runner.ts
+++ b/packages/sandbox/server/provider/agent-sandbox/runner.ts
@@ -781,6 +781,12 @@ export class AgentSandboxProvider implements SandboxProvider {
           (await this.getRecord(handle).catch(() => null)) ??
           (await this.resurrectByHandle(handle).catch(() => null));
         if (fresh) {
+          // Drain the discarded 401 response so its connection is released.
+          try {
+            await resp.body?.cancel();
+          } catch {
+            /* ignore */
+          }
           activeRec = fresh;
           resp = await proxyDaemonRequest(
             fresh.daemonUrl,


### PR DESCRIPTION
**What**: `AgentSandboxProvider.proxyDaemonRequest` retries once when the daemon returns 401 (stale cached token after a pool pod is recreated). On that path it discards the original 401 `Response` and replaces `resp` with a fresh fetch, but never consumed or canceled the discarded response's body.

**Why a maintainer wants this**: an unconsumed `fetch` response body keeps its underlying connection from being released back to the pool instead of being reused — on a proxy hot-path (every tool-exec/git/CMS request that hits a recreated pool pod) this is a real, repeatable per-request leak, not a one-off. The exact same failure mode is already guarded against three lines above in the same function's `previewUrlPattern` branch (`await resp.body?.cancel()`), so this closes the one branch that pattern was left out of.

**Fix**: before discarding the stale 401 `resp` and reassigning it to the retry's response, `cancel()` its body (best-effort, matching the existing pattern in this file).

**Verification**:
- `cd packages/sandbox && bunx tsc --noEmit` — clean
- `bun test packages/sandbox/server/provider/agent-sandbox/runner.test.ts` — 22 pass, 0 fail
- `bunx oxlint packages/sandbox/server/provider/agent-sandbox/runner.ts` — 0 warnings/errors
- `bun run fmt` — clean

Behavior-preserving: the returned `Response` and its status/body are unaffected; only the already-discarded 401 response's body is drained. Full CI runs the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drains the body of a discarded 401 daemon response in `AgentSandboxProvider.proxyDaemonRequest` before retrying, releasing the connection and preventing leak under pool-pod recreation. Previously the 401 body was left unconsumed; now it is canceled before the retry. No change to returned response or status.

- Calls `await resp.body?.cancel()` before replacing `resp` on the 401-retry path, mirroring the existing `previewUrlPattern` branch.
- Reduces connection pool pressure on the proxy hot path; no migrations or config changes.

<sup>Written for commit e94c54d00539dadb734c608b10e5099956b14c93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

