### PR TITLE
fix(assets): sort newest-first and lay out as a mosaic

### DIFF
--- a/apps/api/src/file-storage/file-config-s3.test.ts
+++ b/apps/api/src/file-storage/file-config-s3.test.ts
@@ -6,13 +6,12 @@ import {
   isImageKey,
   type ListedObject,
   matchScanPage,
-  monthShardPrefixes,
   nextScanStep,
+  parseOffsetCursor,
   type ScanCandidate,
   stsCredentialProvider,
 } from "./file-config-s3";
 import type { FileConfigInfo } from "../storage/types";
-import { buildObjectKey } from "./upload-policy";
 
 function info(overrides: Partial<FileConfigInfo>): FileConfigInfo {
   return {
@@ -113,69 +112,23 @@ describe("isImageKey", () => {
   });
 });
 
-describe("monthShardPrefixes", () => {
-  test("lists months newest-first, crossing the year boundary", () => {
-    // 2026-02 walking back 4 months -> Feb, Jan 2026, Dec, Nov 2025.
-    expect(
-      monthShardPrefixes("uploads/", new Date("2026-02-15T00:00:00Z"), 4),
-    ).toEqual([
-      "uploads/2026/02/",
-      "uploads/2026/01/",
-      "uploads/2025/12/",
-      "uploads/2025/11/",
-    ]);
+describe("parseOffsetCursor", () => {
+  test("null/undefined/empty cursor is the first page (offset 0)", () => {
+    expect(parseOffsetCursor(null)).toBe(0);
+    expect(parseOffsetCursor(undefined)).toBe(0);
+    expect(parseOffsetCursor("")).toBe(0);
   });
 
-  test("zero-pads the month to match buildObjectKey's yyyy/mm shard", () => {
-    expect(monthShardPrefixes("", new Date("2026-08-13T18:44:00Z"), 1)).toEqual(
-      ["2026/08/"],
-    );
+  test("parses a positive integer offset", () => {
+    expect(parseOffsetCursor("50")).toBe(50);
+    expect(parseOffsetCursor("200")).toBe(200);
   });
 
-  test("uses UTC (keys are UTC-stamped) to derive the month", () => {
-    expect(monthShardPrefixes("", new Date("2026-09-01T00:30:00Z"), 2)).toEqual(
-      ["2026/09/", "2026/08/"],
-    );
-  });
-
-  test("count of zero yields no probes", () => {
-    expect(
-      monthShardPrefixes("p/", new Date("2026-08-13T00:00:00Z"), 0),
-    ).toEqual([]);
-  });
-
-  test("January is followed by the previous December (immediate wrap)", () => {
-    expect(
-      monthShardPrefixes("p/", new Date("2026-01-01T00:00:00Z"), 2),
-    ).toEqual(["p/2026/01/", "p/2025/12/"]);
-  });
-
-  test("walks back across multiple years for large counts", () => {
-    // Guards the year-decrement wrap when count exceeds 12 months.
-    expect(
-      monthShardPrefixes("", new Date("2026-01-15T00:00:00Z"), 14),
-    ).toEqual([
-      "2026/01/",
-      "2025/12/",
-      "2025/11/",
-      "2025/10/",
-      "2025/09/",
-      "2025/08/",
-      "2025/07/",
-      "2025/06/",
-      "2025/05/",
-      "2025/04/",
-      "2025/03/",
-      "2025/02/",
-      "2025/01/",
-      "2024/12/",
-    ]);
-  });
-
-  test("a fresh key's shard matches its month's probe (no drift vs buildObjectKey)", () => {
-    const key = buildObjectKey({ prefix: "uploads/", filename: "photo.png" });
-    const [probe] = monthShardPrefixes("uploads/", new Date(), 1);
-    expect(key.startsWith(probe!)).toBe(true);
+  test("unparseable or non-positive cursors fall back to offset 0", () => {
+    // Stale old-format (S3 continuation-token) cursors must restart, not throw.
+    for (const bad of ["abc", "-5", "0", "NaN"]) {
+      expect(parseOffsetCursor(bad)).toBe(0);
+    }
   });
 });
 

--- a/apps/api/src/file-storage/file-config-s3.ts
+++ b/apps/api/src/file-storage/file-config-s3.ts
@@ -19,7 +19,6 @@ import type {
 import type { OrgSiteStoragePort } from "../storage/ports";
 import type { FileConfigInfo } from "../storage/types";
 import { provisionTenantS3Credentials } from "./tenant-credentials";
-import { monthShardSegment } from "./upload-policy";
 
 export interface FileConfigContext {
   info: FileConfigInfo;
@@ -254,60 +253,20 @@ export interface ListObjectsResult {
   nextCursor: string | null;
 }
 
-/**
- * How many month shards page 1 walks back, newest first, before the broad
- * lexicographic fallback. Wide enough to surface recent uploads in buckets
- * quiet for a few months; each is enumerated in full and the merged set is
- * sorted by lastModified, then truncated to the page size.
- */
-const MONTH_SHARD_PROBES = 6;
-
-/**
- * Safety cap on pages (1000 keys each) enumerated per month shard. A month is
- * listed in full so sorting by lastModified yields a true newest-first order
- * (a single capped LIST returns UUID-lexicographic order, hiding the freshest
- * upload behind older ones). This bounds the work if a single month ever holds
- * a pathological number of objects; realistic image buckets stay well under
- * one page.
- */
-const MONTH_SHARD_MAX_PAGES = 5;
-
-/**
- * Month-shard key prefixes to probe, newest first: `<bucketPrefix><yyyy>/<mm>/`
- * for the current month walking back `count` months, crossing year boundaries
- * (`2026/01/` -> `2025/12/`). Shares `monthShardSegment` with `buildObjectKey`
- * so a fresh upload is always fetched by its month's probe instead of being
- * truncated behind older months in a year-wide lexicographic listing.
- */
-export function monthShardPrefixes(
-  bucketPrefix: string,
-  now: Date,
-  count: number,
-): string[] {
-  const prefixes: string[] = [];
-  let year = now.getUTCFullYear();
-  let month = now.getUTCMonth() + 1; // 1-12
-  for (let i = 0; i < count; i++) {
-    prefixes.push(`${bucketPrefix}${monthShardSegment(year, month)}`);
-    month -= 1;
-    if (month === 0) {
-      month = 12;
-      year -= 1;
-    }
-  }
-  return prefixes;
-}
+/** Page cap (1000 keys each) for the full-prefix enumerate-then-sort listing; bounds work on huge buckets at ~50k keys. */
+const LIST_MAX_PAGES = 50;
 
 /** Raw S3 object fields the listing helpers reason about. */
 type RawS3Object = { Key?: string; Size?: number; LastModified?: Date };
 
-/**
- * Enumerate every object directly under `prefix`, paginating up to `maxPages`
- * pages of 1000. Listing the shard in full (rather than one capped LIST) is
- * what lets the caller sort by lastModified into a true newest-first order — a
- * single page comes back in UUID-lexicographic order, which buries the freshest
- * upload behind older keys in a busy month.
- */
+/** Pure: parse the pagination cursor into a zero-based offset into the recency-sorted set; unparseable/non-positive → 0. */
+export function parseOffsetCursor(cursor?: string | null): number {
+  if (!cursor) return 0;
+  const n = Number.parseInt(cursor, 10);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+/** Enumerate every object under `prefix` (empty = whole bucket), up to `maxPages` pages of 1000, so the caller can sort by lastModified. */
 async function listAllUnderPrefix(
   client: S3Client,
   bucket: string,
@@ -321,7 +280,7 @@ async function listAllUnderPrefix(
     const res = await client.send(
       new ListObjectsV2Command({
         Bucket: bucket,
-        Prefix: prefix,
+        Prefix: prefix || undefined,
         MaxKeys: 1000,
         ContinuationToken: token,
       }),
@@ -334,14 +293,10 @@ async function listAllUnderPrefix(
 }
 
 /**
- * List a page of bucket objects, newest first. S3 ListObjectsV2 sorts only
- * lexicographically, so page 1 enumerates the newest month shard in full (see
- * `monthShardPrefixes` / `listAllUnderPrefix`), walking back to older months
- * only if it doesn't fill the page, plus a broad-prefix fallback for legacy
- * keys and the continuation token; results are merged, de-duped, sorted by
- * lastModified DESC, and truncated to the page size. Cursor pages walk the
- * broad namespace in S3's lexicographic key order (older objects first, NOT
- * re-sorted by lastModified), skipping the month shards page 1 already returned.
+ * List a page of bucket objects, newest first. S3 sorts only lexicographically
+ * (never by upload recency, for any key layout), so we enumerate the whole
+ * prefix (bounded by `LIST_MAX_PAGES`), sort by lastModified DESC, and paginate
+ * in memory via an offset cursor (`parseOffsetCursor`), not an S3 token.
  */
 export async function listObjects(params: {
   ctx: FileConfigContext;
@@ -371,93 +326,21 @@ export async function listObjects(params: {
     });
   }
 
-  const monthShardPrefixesList = monthShardPrefixes(
+  const raw = await listAllUnderPrefix(
+    client,
+    params.ctx.info.bucket,
     bucketPrefix,
-    new Date(),
-    MONTH_SHARD_PROBES,
+    LIST_MAX_PAGES,
   );
+  const sorted = raw
+    .filter((obj) => obj.Key && !obj.Key.endsWith("/"))
+    .map((obj) => toListedObject(obj, params.ctx))
+    .sort(byLastModifiedDesc);
 
-  // Subsequent pages walk the broad namespace via continuation token —
-  // skip the date-shard probes (already returned on page 1) and filter
-  // any keys under those prefixes out of the response so we don't
-  // duplicate what page 1 already showed.
-  if (params.cursor) {
-    const response = await client.send(
-      new ListObjectsV2Command({
-        Bucket: params.ctx.info.bucket,
-        Prefix: bucketPrefix || undefined,
-        MaxKeys: target,
-        ContinuationToken: params.cursor,
-      }),
-    );
-    return finalize(
-      response,
-      params.ctx,
-      target,
-      false,
-      monthShardPrefixesList,
-    );
-  }
-
-  const seen = new Map<string, ListedObject>();
-  const absorb = (objs: RawS3Object[]) => {
-    for (const obj of objs) {
-      if (!obj.Key || obj.Key.endsWith("/") || seen.has(obj.Key)) continue;
-      seen.set(obj.Key, toListedObject(obj, params.ctx));
-    }
-  };
-
-  // Newest month first; every key in it outranks any older month, so we only walk back if it doesn't fill the page.
-  const [newestMonth, ...olderMonths] = monthShardPrefixesList;
-  if (newestMonth) {
-    absorb(
-      await listAllUnderPrefix(
-        client,
-        params.ctx.info.bucket,
-        newestMonth,
-        MONTH_SHARD_MAX_PAGES,
-      ),
-    );
-  }
-  if (seen.size < target && olderMonths.length > 0) {
-    // Fan the remaining months out concurrently — we already know we need them.
-    const older = await Promise.all(
-      olderMonths.map((prefix) =>
-        listAllUnderPrefix(
-          client,
-          params.ctx.info.bucket,
-          prefix,
-          MONTH_SHARD_MAX_PAGES,
-        ),
-      ),
-    );
-    for (const objs of older) absorb(objs);
-  }
-
-  // Runs unconditionally to expose nextCursor and reach legacy/older keys not under the month shards.
-  const broadMaxKeys = Math.max(1, target - seen.size);
-  const broadRes = await client.send(
-    new ListObjectsV2Command({
-      Bucket: params.ctx.info.bucket,
-      Prefix: bucketPrefix || undefined,
-      MaxKeys: broadMaxKeys,
-    }),
-  );
-  for (const obj of broadRes.Contents ?? []) {
-    if (seen.size >= target) break;
-    if (!obj.Key || obj.Key.endsWith("/") || seen.has(obj.Key)) continue;
-    // Month-shard keys were already pulled via dedicated probes; skip to avoid duping.
-    if (monthShardPrefixesList.some((p) => obj.Key!.startsWith(p))) continue;
-    seen.set(obj.Key, toListedObject(obj, params.ctx));
-  }
-  const nextCursor = broadRes.IsTruncated
-    ? (broadRes.NextContinuationToken ?? null)
-    : null;
-
-  // Full-month enumeration over-fetches, so sort by recency and keep one page.
-  const items = Array.from(seen.values())
-    .sort(byLastModifiedDesc)
-    .slice(0, target);
+  const offset = parseOffsetCursor(params.cursor);
+  const items = sorted.slice(offset, offset + target);
+  const nextOffset = offset + items.length;
+  const nextCursor = nextOffset < sorted.length ? String(nextOffset) : null;
   return { items, nextCursor };
 }
 
@@ -612,33 +495,4 @@ export function byLastModifiedDesc(a: ListedObject, b: ListedObject): number {
   if (!a.lastModified) return 1;
   if (!b.lastModified) return -1;
   return b.lastModified.localeCompare(a.lastModified);
-}
-
-function finalize(
-  response: {
-    Contents?: Array<{ Key?: string; Size?: number; LastModified?: Date }>;
-    IsTruncated?: boolean;
-    NextContinuationToken?: string;
-  },
-  ctx: FileConfigContext,
-  target: number,
-  sort: boolean,
-  skipPrefixes: readonly string[] = [],
-): ListObjectsResult {
-  const items = (response.Contents ?? [])
-    .filter(
-      (obj) =>
-        obj.Key &&
-        !obj.Key.endsWith("/") &&
-        !skipPrefixes.some((p) => obj.Key!.startsWith(p)),
-    )
-    .slice(0, target)
-    .map((obj) => toListedObject(obj, ctx));
-  if (sort) items.sort(byLastModifiedDesc);
-  return {
-    items,
-    nextCursor: response.IsTruncated
-      ? (response.NextContinuationToken ?? null)
-      : null,
-  };
 }

--- a/apps/api/src/file-storage/upload-policy.ts
+++ b/apps/api/src/file-storage/upload-policy.ts
@@ -124,12 +124,8 @@ export function sanitizeFilename(input: string): string {
   return base.slice(0, 80);
 }
 
-/**
- * The `<yyyy>/<mm>/` date shard a key lives under (UTC, month zero-padded).
- * Single source of truth for the shard format: `buildObjectKey` stamps it on
- * write and `listObjects` probes it on read, so they must never diverge.
- */
-export function monthShardSegment(year: number, month: number): string {
+/** The `<yyyy>/<mm>/` date shard a key lives under (UTC, month zero-padded); stamped on write by `buildObjectKey`. */
+function monthShardSegment(year: number, month: number): string {
   return `${year}/${String(month).padStart(2, "0")}/`;
 }
 

--- a/apps/web/src/layouts/main-panel-tabs/assets-tab.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/assets-tab.tsx
@@ -44,6 +44,7 @@ import { cn } from "@decocms/ui/lib/utils.ts";
 import { useVirtualMCP } from "@/sdk";
 import { useT } from "@/i18n/use-t.ts";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import { useElementWidth } from "@/hooks/use-element-width";
 import { type FileConfigInfo, useFileConfigs } from "@/hooks/use-file-configs";
 import {
   type PickerObject,
@@ -91,6 +92,32 @@ function NoBucketState() {
       </div>
     </div>
   );
+}
+
+/**
+ * Column count for the masonry grid, keyed off the measured container width
+ * (thresholds mirror the old Tailwind sm/md/lg breakpoints). `-1` means "not
+ * measured yet" — it re-renders with the real width before paint, so the
+ * fallback is only a momentary default and never a visible layout.
+ */
+function assetColumnCount(width: number): number {
+  if (width < 0 || width < 640) return 2;
+  if (width < 768) return 3;
+  if (width < 1024) return 4;
+  return 5;
+}
+
+/**
+ * Distributes items round-robin across `count` columns so reading order stays
+ * left-to-right, top-to-bottom (item 0,1,2… fill the first visual row). Cards
+ * keep their natural height within each column — a mosaic with no fixed row
+ * height and no leftover space — while preserving the source order, which a
+ * pure CSS `columns` layout would scramble into column-major order.
+ */
+function distributeIntoColumns<T>(items: T[], count: number): T[][] {
+  const columns: T[][] = Array.from({ length: count }, () => []);
+  items.forEach((item, i) => columns[i % count]!.push(item));
+  return columns;
 }
 
 function AssetsBrowser({ config }: { config: FileConfigInfo }) {
@@ -151,8 +178,10 @@ function AssetsBrowser({ config }: { config: FileConfigInfo }) {
     handleFiles(e.dataTransfer.files);
   }
 
+  const [gridWidth, gridRef] = useElementWidth();
   const pages = objectsQuery.data?.pages ?? [];
   const items = pages.flatMap((p) => p.items);
+  const columns = distributeIntoColumns(items, assetColumnCount(gridWidth));
   const activeSearch = debouncedSearch.trim();
   const isSearching =
     search !== debouncedSearch ||
@@ -243,13 +272,21 @@ function AssetsBrowser({ config }: { config: FileConfigInfo }) {
             />
           )
         ) : (
-          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5">
-            {items.map((item) => (
-              <AssetCard
-                key={item.key}
-                item={item}
-                onDelete={() => setPendingDelete(item)}
-              />
+          <div ref={gridRef} className="flex items-start gap-3">
+            {columns.map((column, columnIndex) => (
+              <div
+                // Column buckets are positional, so the index is the identity.
+                key={columnIndex}
+                className="flex min-w-0 flex-1 flex-col gap-3"
+              >
+                {column.map((item) => (
+                  <AssetCard
+                    key={item.key}
+                    item={item}
+                    onDelete={() => setPendingDelete(item)}
+                  />
+                ))}
+              </div>
             ))}
           </div>
         )}
@@ -319,20 +356,22 @@ function AssetCard({
         target="_blank"
         rel="noreferrer"
         title={item.key}
-        className="flex aspect-square items-center justify-center transition hover:ring-2 hover:ring-primary"
+        className="block transition hover:ring-2 hover:ring-inset hover:ring-primary"
       >
         {isImage ? (
           <img
             src={item.publicUrl}
             alt={item.key}
             loading="lazy"
-            className="h-full w-full object-cover"
+            className="block h-auto w-full"
             onError={(e) => {
               (e.target as HTMLImageElement).style.display = "none";
             }}
           />
         ) : (
-          <File02 size={28} className="text-muted-foreground" />
+          <div className="flex aspect-square items-center justify-center">
+            <File02 size={28} className="text-muted-foreground" />
+          </div>
         )}
       </a>
       <div className="flex items-center gap-1 border-t border-border/60 bg-background px-2 py-1.5">


### PR DESCRIPTION
## Summary

Two related fixes to the **Assets** browser (`farmrio` and any bucket with flat legacy keys):

1. **Newest-first ordering (backend).** The listing relied on S3's lexicographic order + `yyyy/mm/` month-shard probes. Buckets whose keys are flat `<unix-millis>-<uuid>.jpg` (no month folder) never matched the probes, so the fallback returned the first ~50 keys — which sort **oldest-first**. Recent uploads lived at the end of the namespace and were never fetched, so you'd never see your most recent assets.

   `listObjects` now enumerates the whole prefix (bounded by `LIST_MAX_PAGES` = 50 pages ≈ 50k keys), sorts by `lastModified` DESC, and paginates via an **offset cursor** — correct newest-first regardless of key layout (flat, `yyyy/mm/` shard, or UUID). Uploads still create month-shard keys (`buildObjectKey` unchanged). Removed the now-dead `monthShardPrefixes` / `finalize` / `MONTH_SHARD_*` helpers; added `parseOffsetCursor` with unit tests.

2. **Mosaic layout (frontend).** The grid used fixed-height rows (`aspect-square` / row height), leaving whitespace under shorter images. The grid now renders as a **round-robin masonry** (N flex columns, item `i` → column `i % N`): each card keeps the image's natural aspect ratio with no leftover space, while reading order stays left-to-right, top-to-bottom.

## Testing

- `bun test apps/api/src/file-storage/file-config-s3.test.ts` → 31 pass / 0 fail
- `bun run --cwd=apps/api check` and `bun run --cwd=apps/web check` pass
- `bun run fmt` clean; knip reports no dead code for the touched file

## Notes / trade-offs

- **Offset pagination** re-enumerates the prefix per page and can shift by one if an upload lands mid-paging — acceptable for an admin browser, and the only way to get recency order (S3 can't sort by date).
- **Cap:** buckets past ~50k objects only consider the first 50k in S3's lexicographic order. Far more generous than the previous ~50-key window; realistic image buckets are well under one page.
- **Column masonry** preserves order left-to-right but doesn't balance column heights, so the last column may end slightly shorter — the price of keeping source order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows newest assets first and renders the Assets grid as a masonry mosaic. Previously, flat-key buckets listed the oldest files first and the grid left empty space under non-square images.

- Backend: `listObjects` now enumerates the full prefix (capped at `LIST_MAX_PAGES` ≈ 50k keys), sorts by `lastModified` DESC, and paginates via an offset cursor. Replaces continuation-token cursors with a numeric offset parsed by `parseOffsetCursor` (non-positive/unparseable → 0). Removes month-shard probing and related helpers; `monthShardSegment` is now internal. Adds tests for the new cursor parsing. Side effects: pages can shift if uploads happen mid-browse; only the first ~50k keys are considered per prefix.
- Frontend: Assets grid uses a round-robin masonry (N flex columns) driven by `useElementWidth` so images keep natural aspect ratio with no leftover space while preserving left-to-right reading order. Non-image cards keep a square placeholder.

<sup>Written for commit e1b85502557d062d28daa219245e6ccc4e2a4f52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6290?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

