### PR TITLE
fix(task-board): TASK_ADD_REPO missed the pod on a bare thread sandbox key

### DIFF
--- a/apps/api/src/tools/task-board/add-repo.ts
+++ b/apps/api/src/tools/task-board/add-repo.ts
@@ -258,7 +258,16 @@ export const TASK_ADD_REPO = defineTool({
      * registered" — every one a task that could not clone, so never shipped,
      * after the model had already been paid for.
      */
-    const branch = await resolveSandboxBranchForThread(ctx, { threadId });
+    const branch = await resolveSandboxBranchForThread(ctx, {
+      threadId,
+      // The branch the run was DISPATCHED on. Passing it is what makes the
+      // shared derivation keep a bare `thread:<id>` key (its `runBranch`
+      // pinning rule) — omitted, a repo-less run fell through to `"ephemeral"`
+      // and missed the pod it is executing in. Safe to pass raw: a real git ref
+      // in this column does not match the bare key, so it falls through to the
+      // same derivation as before.
+      runBranch: thread.branch,
+    });
     const sandboxUserId = await resolveSandboxUserId(ctx, branch, userId);
     const { provider, kind } = await resolveSandboxProvider(ctx, {
       userId: sandboxUserId,


### PR DESCRIPTION
## Summary

An autonomous task run that starts with **no repo** is dispatched on the bare synthetic key `thread:<id>`, and clones mid-run via `TASK_ADD_REPO`. That tool re-derives the sandbox key through the shared `resolveSandboxBranchForThread` — but passed only `threadId`, omitting `runBranch`.

`resolveSandboxBranch`'s bare-key pinning rule is gated on `runBranch === threadBranch(threadId)`. With `runBranch` absent, `threadRepo` null (no repo yet) and `agentRepo` undefined, resolution fell straight through to `"ephemeral"`. That key is never in the thread's `sandboxMap`, so `waitForSandboxRecord` exhausted its budget and the tool threw:

> `No sandbox is registered for this run (thread thrd_…), so there is nowhere to clone into.`

…for the pod it was running inside. Every other caller of the derivation (`dispatch-run.ts`, decopilot `tools.ts`) already passes the run's branch.

## Evidence (prod)

`thrd_ei0fCjuQxc7NFOX_O9wOM` — `threads.branch = thread:thrd_ei0fCjuQxc7NFOX_O9wOM`, and `metadata.sandboxMap` holds a live `agent-sandbox` record under exactly that key. The run called `TASK_ADD_REPO` three times, got the error each time, gave up, wrote a "hard blocker" comment and moved the task back to triage.

Across prod, 102 threads have hit that error. Split by whether the branch column is the bare key:

| day | bare key | other |
|---|---|---|
| 08-19 | 4 | 0 |
| 08-18 | 2 | 0 |
| 08-15 | 1 | 0 |
| 08-14 | 3 | 0 |
| 08-13 | 15 | 33 |
| ≤08-12 | 7 | 34 |

The `other` column is the previously-fixed keying bug (git ref in `threads.branch`). Since that fix, **100% of remaining failures are this one** — 32 threads total, 10 of them after 08-14. Each is a full model turn paid for and nothing shipped.

## Change

One argument. `runBranch: thread.branch`.

Safe to pass raw — the objection recorded in the file's comment ("NOT `threads.branch` raw") is handled by the derivation itself: a real git ref does not equal `thread:<id>`, so it falls through to the same path as before. Only the exact bare key pins.

## Testing

`resolveSandboxBranch` already pins this behavior ("a repo-less run pinned to its own bare key does not join the ephemeral pool") — the pure function was right, the caller wasn't feeding it. 20/20 pass in `apps/api/src/tools/sandbox/thread-repo.test.ts`.

Not unit-testable at the caller (needs a real `StudioContext`, and mocks are banned) — an e2e that dispatches a repo-less sandbox-hosted run and calls `TASK_ADD_REPO` is the right tier and is not included here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Passes the run’s branch to `resolveSandboxBranchForThread` so repo-less runs dispatched on the bare thread key (`thread:<id>`) resolve the registered sandbox. Previously the tool omitted `runBranch`, fell back to "ephemeral", and threw "No sandbox is registered for this run", blocking clone and delivery.

**Notes for review**
- Change: add `runBranch: thread.branch` to the derivation call; this pins the bare thread key. Non-bare git refs fall through unchanged.
- Impact: repo-less autonomous runs now clone into their existing sandbox instead of failing; addresses the remaining sandbox lookup errors in prod.
- Tests: behavior is covered by existing `resolveSandboxBranch` tests; no new caller-level tests added.

<sup>Written for commit eba8ec63c7a5b589dbc14ed1189cc53b6dc46dfb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6291?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

