### PR TITLE
fix: match choose-editor and assets tab by project name, not metadata.siteSlug

### DIFF
--- a/apps/api/src/api/routes/editor-resolve.ts
+++ b/apps/api/src/api/routes/editor-resolve.ts
@@ -8,7 +8,7 @@
  *
  * Resolution is relative to the authenticated user: the same storefront can be
  * imported into several orgs, so we scan the orgs the caller is a member of and
- * return every project whose `metadata.siteSlug` matches `site` (lowercased).
+ * return every project whose name (`title`) matches `site` (lowercased).
  * That makes access implicit (orgs the caller isn't in never appear — no leak,
  * no false 403) and lets `/choose-editor` offer a picker when the site lives in
  * more than one of the caller's orgs. Instance-level: no org in the URL path.
@@ -78,7 +78,7 @@ export function createEditorResolveRoutes() {
       if (!org.slug || isOrgArchived(org)) continue;
       const vms = await ctx.storage.virtualMcps.list(org.id);
       for (const vm of vms) {
-        if (vm.metadata?.siteSlug?.toLowerCase() !== slug) continue;
+        if (vm.title.toLowerCase() !== slug) continue;
         matches.push({
           orgSlug: org.slug,
           orgName: org.name ?? org.slug,

--- a/packages/e2e/tests/editor-resolve.spec.ts
+++ b/packages/e2e/tests/editor-resolve.spec.ts
@@ -53,9 +53,10 @@ async function createProjectForSite(
     "COLLECTION_VIRTUAL_MCP_CREATE",
     {
       data: {
-        title: `Editor resolve e2e ${siteSlug}`,
+        // The project name (`title`) is what editor-resolve matches on.
+        title: siteSlug,
         connections: [],
-        metadata: { instructions: null, siteSlug },
+        metadata: { instructions: null },
       },
     },
   );


### PR DESCRIPTION
## Summary

Two related fixes so a project without `metadata.siteSlug` set still resolves correctly. Both now key off the project **name** (`title`) instead.

**1. `/choose-editor` resolver** (`apps/api/src/api/routes/editor-resolve.ts`)
The storefront "." shortcut lands on `/choose-editor` → `/api/_editor-resolve`. It matched projects by `vm.metadata?.siteSlug`, so a project without that metadata hit the "Não encontramos este site" dead-end.
```diff
- if (vm.metadata?.siteSlug?.toLowerCase() !== slug) continue;
+ if (vm.title.toLowerCase() !== slug) continue;
```

**2. Assets tab visibility** (`apps/web/src/layouts/main-panel-tabs/{use-main-panel-tabs.ts,assets-tab.tsx}`)
Same root cause: the tab's show/hide rule and the tab body both derived the slug from `entity.metadata.siteSlug`. Now they pass `entity.title` to the existing `matchSiteSlugConfig` (which lowercases and also matches `deco-assets-<name>` buckets).

## Testing

- Updated `packages/e2e/tests/editor-resolve.spec.ts` — fixture now creates projects with `title: siteSlug` (dropping `metadata.siteSlug`), exercising the name-based match over the wire. Casing / multi-org / non-member / anon / 400 assertions unchanged.
- `bun run --cwd=apps/api check` and `bun run --cwd=apps/web check` pass.
- `bun run fmt` clean.

## Note / follow-up

Project titles are free-form display names while the match target is a strict lowercase slug (`[a-z0-9-]`, `deco-assets-<slug>`). A project titled `"Deco CMS"` won't match `decocms` / `deco-cms`. Fine if projects are imported with the exact slug as the title; if titles can diverge, we'd slugify the title before comparing — happy to add that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)