### PR TITLE
fix(jira): let the HTTP status decide retriability before substring sniffing

### DIFF
--- a/apps/api/src/jira/client.test.ts
+++ b/apps/api/src/jira/client.test.ts
@@ -170,6 +170,35 @@ describe("JiraClient", () => {
     }
   });
 
+  it("does not retry a 400 whose body happens to contain a network-ish word", async () => {
+    let callCount = 0;
+    const originalFetch = globalThis.fetch;
+    const mockFetch = mock(async () => {
+      callCount++;
+      return new Response(
+        JSON.stringify({
+          errorMessages: [
+            "The value 'network' does not exist for the field 'status'.",
+          ],
+        }),
+        { status: 400, headers: { "Content-Type": "application/json" } },
+      );
+    });
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    try {
+      const client = new JiraClient(
+        "https://acme.atlassian.net",
+        "user@example.com",
+        "token",
+      );
+      await expect(client.myself()).rejects.toThrow("400");
+      expect(callCount).toBe(1); // The status, not the body text, decides
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("retries on 429 rate limit error", async () => {
     let callCount = 0;
     const originalFetch = globalThis.fetch;

--- a/apps/api/src/jira/client.ts
+++ b/apps/api/src/jira/client.ts
@@ -67,7 +67,14 @@ const ISSUE_FIELDS =
  */
 function isRetriableError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  // Retry on timeout (AbortError) or network errors.
+  // A known status wins over the substring checks below (Jira's own error body can contain words like "network" or "timeout").
+  const statusMatch = message.match(/failed \((\d+)\)/);
+  if (statusMatch && statusMatch[1]) {
+    const status = parseInt(statusMatch[1], 10);
+    // Retry 5xx and 429 (rate limit); do NOT retry 4xx (auth, not found, etc.).
+    return status >= 500 || status === 429;
+  }
+  // No status — a raw fetch/network throw. Retry on timeout (AbortError) or network errors.
   if (
     message.includes("AbortError") ||
     message.includes("fetch") ||
@@ -77,13 +84,6 @@ function isRetriableError(error: unknown): boolean {
     message.includes("ECONNRESET")
   ) {
     return true;
-  }
-  // Retry on 5xx server errors; extract from message "Jira {path} failed ({status})".
-  const statusMatch = message.match(/failed \((\d+)\)/);
-  if (statusMatch && statusMatch[1]) {
-    const status = parseInt(statusMatch[1], 10);
-    // Retry 5xx and 429 (rate limit); do NOT retry 4xx (auth, not found, etc.).
-    return status >= 500 || status === 429;
   }
   // Unknown error — retry with caution.
   return true;


### PR DESCRIPTION
Follows #6274/#6278 (the Jira client's new retry logic).

`isRetriableError` checked substrings (`"network"`, `"timeout"`, `"fetch"`, ...) against the *entire* error message before checking the extracted HTTP status. Our own errors are formatted as `Jira {path} failed ({status}): {body}`, and that message includes up to 300 chars of Jira's raw response body — so a 4xx error whose body text happens to contain one of those words (e.g. a JQL validation error naming a status called "network", or any error copy mentioning a timeout/network condition) would get retried even though the status says it's permanent (auth, not-found, bad request). The substring checks are meant only for raw fetch/network throws that never reach the status-extraction step.

Why it matters: this is fresh, actively-relied-on code (the retry wrapper landed last week) and the substring heuristic silently overrides the documented 4xx-no-retry contract in exactly the case it claims to handle (`// do NOT retry 4xx`) whenever the response body happens to contain one of those common English words.

Fix: check the extracted status first — if the message matches our own `failed (\d+)` format, the status alone decides. The substring heuristic now only runs for messages with no status, i.e. genuine fetch-level throws.

Added a test: a 400 response whose body contains the word "network" must not be retried (previously it would have retried once, wasting the request against a permanent failure).

Reviewer check: `cd apps/api && bun test src/jira/client.test.ts`

Verified locally: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bun test apps/api/src/jira/client.test.ts` (16 pass), `bunx oxlint apps/api/src/jira/client.ts apps/api/src/jira/client.test.ts` (0 errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors HTTP status in Jira client's retry logic to prevent accidental retries of permanent 4xx errors. Previously, substring checks for "network"/"timeout"/"fetch" ran first and could override the "do not retry 4xx" rule when those words appeared in the response body.

- When the message matches "failed (status)", status alone decides: retry 5xx and 429; never retry 4xx.
- Substring heuristic now applies only when no status is present (true fetch/network errors).
- Adds a test ensuring a 400 whose body includes "network" is not retried.

<sup>Written for commit 10f1c0c708d47987db153176d48336570f0ce512. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

