### PR TITLE
docs(self-hosting): publish the Linux desktop support matrix and prerequisites

### DIFF
--- a/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/linux-desktop-support.mdx
+++ b/apps/docs/client/src/content/deco-studio/en/studio/self-hosting/linux-desktop-support.mdx
@@ -1,0 +1,123 @@
+---
+title: Linux Desktop Support
+description: Supported architecture, prerequisites, and known limitations for the Linux desktop app
+icon: Laptop
+---
+
+import Callout from "../../../../../components/ui/Callout.astro";
+
+<Callout type="warning">
+  Linux support is **beta**. Only x86_64 is built; ARM64 is out of scope for
+  now (see [Deferred scope](#deferred-scope)).
+</Callout>
+
+## Supported architecture and package
+
+- **x86_64 AppImage only.** There is no `aarch64` build yet.
+- Built and boot-smoke-tested on **Ubuntu 22.04** in CI.
+- The bundled AppImage runtime is **static** — it does not link `libfuse.so.2`,
+  so it does not need `libfuse2` on disk to self-extract. It still needs a
+  working FUSE **kernel** interface to self-mount (see below).
+
+## Runtime prerequisites
+
+The app is built against **WebKitGTK 4.1** (`libwebkit2gtk-4.1`) and GTK3. A
+host without those libraries cannot launch the window. If your distribution
+only ships an older WebKitGTK (4.0), the AppImage will fail to start.
+
+## FUSE and the `org/` filesystem
+
+The shared `org/` filesystem mount (one per organization, shared across that
+org's sandboxes) uses `rclone mount` over FUSE on Linux — the macOS
+equivalent is `rclone nfsmount`. This needs:
+
+- `/dev/fuse` present on the host.
+- A `fusermount3` (fuse3) or `fusermount` (fuse2) helper on `PATH`.
+
+Both the AppImage's own self-mount and the org filesystem mount degrade
+gracefully when FUSE is unavailable:
+
+- The AppImage falls back to `--appimage-extract-and-run` (slower start, no
+  self-mount, works everywhere).
+- The org filesystem falls back to an **empty `org/` directory** for the
+  sandbox rather than failing to start. You can also force this fallback with
+  `DECOCMS_DISABLE_ORG_FS=1` if a FUSE mount ever wedges.
+
+## Desktop credential storage
+
+Access and refresh tokens are stored through the [D-Bus Secret
+Service](https://specifications.freedesktop.org/secret-service-spec/latest/)
+(via the `keyring` crate) — the same mechanism GNOME Keyring and KWallet
+implement. **There is no plaintext-on-disk fallback**: if no Secret Service
+provider is running, credential reads and writes fail outright rather than
+degrading silently.
+
+Tested providers: **GNOME Keyring** and **KWallet**. A minimal window manager
+or headless session without either running will not be able to sign in.
+
+## Preview-origin isolation (known limitation)
+
+By default, the desktop app's local control origin on Linux is a plain
+`http://localhost` origin, not HTTPS — the same origin the self-test harness
+has always used. An opt-in HTTPS origin (a per-host WebKitGTK certificate
+exception, no OS-level trust store integration) is available behind
+`DECOCMS_LINUX_SECURE_ORIGIN=1`, off by default for the first release because
+a webview trust failure would leave an AppImage user with no window and no
+package manager to reinstall from.
+
+Until isolated secure origins are the default, treat the Linux desktop app's
+preview iframe origin as less isolated than macOS's. See #6282 for the
+follow-up to make the secure origin the Linux default.
+
+## Install, verify, update, uninstall
+
+Installation is the same one-line installer used for macOS
+(`curl -fsSL https://studio.decocms.com/install.sh | sh`), which detects
+Linux and:
+
+1. Reads the version off the rolling `native-updates` channel manifest
+   (a fixed URL, throttled to promote only once every platform's assets are
+   published — so it can lag head by a few releases, but never names a
+   version that didn't ship for Linux).
+2. Downloads and verifies the AppImage:
+   - **With `minisign` installed**: verifies the tarball against the
+     minisign public key embedded in the installer script — an anchor from a
+     different origin (`studio.decocms.com`) than the GitHub CDN serving the
+     release, so this is genuine authenticity verification.
+   - **Without `minisign`**: falls back to the published `.sha256`, which only
+     detects a corrupted or truncated download — digest and binary share an
+     origin, so this is not a security guarantee. Install `minisign` for a
+     real verification.
+3. Installs to `~/.local/bin/deco-studio`, with a `~/.local/share/applications`
+   launcher entry and icon, replacing any previous install in place.
+4. Probes for FUSE and falls back to `--appimage-extract-and-run` when
+   unavailable.
+
+**Update**: the installed app polls the same `native-updates` channel and
+applies updates on quit — signature-verified with the same minisign key.
+**Uninstall**: remove `~/.local/bin/deco-studio`,
+`~/.local/share/applications/deco-studio.desktop`, its icon under
+`~/.local/share/icons/hicolor/256x256/apps/`, and
+`~/.local/share/deco-studio/` (the verification stamp). There is no automated
+rollback; reinstall a prior version from the [release
+list](https://github.com/decocms/studio/releases) if needed.
+
+## Troubleshooting
+
+- **App won't launch / "damaged" or mount errors**: run the AppImage directly
+  with `--appimage-extract-and-run` to rule out a FUSE problem.
+- **Blank window on startup**: confirm `libwebkit2gtk-4.1` is installed —
+  older distributions may only carry 4.0, which is incompatible.
+- **Can't sign in / credential errors**: confirm a Secret Service provider
+  (GNOME Keyring or KWallet) is running — `systemctl --user status
+  gnome-keyring-daemon` or your desktop environment's equivalent.
+- **`org/` directory is empty**: FUSE is unavailable or the mount failed; this
+  is the designed fallback, not a crash. Check `/dev/fuse` and that
+  `fusermount3`/`fusermount` are on `PATH`.
+- **Logs**: application logs and monitoring data live under the app's
+  `DATA_DIR` — see the Self-Hosting → Monitoring page in this guide.
+
+## Deferred scope
+
+Explicitly out of scope for this release: Linux **ARM64**, `.deb`, `.rpm`,
+AUR/COPR, Flatpak, and Snap packaging. Only the x86_64 AppImage is supported.

--- a/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/linux-desktop-support.mdx
+++ b/apps/docs/client/src/content/deco-studio/pt-br/studio/self-hosting/linux-desktop-support.mdx
@@ -1,0 +1,132 @@
+---
+title: Suporte ao Linux (Desktop)
+description: Arquitetura suportada, pré-requisitos e limitações conhecidas do app desktop no Linux
+icon: Laptop
+---
+
+import Callout from "../../../../../components/ui/Callout.astro";
+
+<Callout type="warning">
+  O suporte ao Linux está em **beta**. Apenas x86_64 é compilado; ARM64 está
+  fora do escopo por enquanto (veja [Escopo adiado](#escopo-adiado)).
+</Callout>
+
+## Arquitetura e pacote suportados
+
+- **Apenas AppImage x86_64.** Ainda não há build `aarch64`.
+- Compilado e testado (boot-smoke) em **Ubuntu 22.04** no CI.
+- O runtime do AppImage empacotado é **estático** — ele não faz link com
+  `libfuse.so.2`, então não precisa de `libfuse2` instalado no disco para se
+  auto-extrair. Ainda assim precisa de uma interface FUSE do **kernel**
+  funcional para se auto-montar (veja abaixo).
+
+## Pré-requisitos de runtime
+
+O app é compilado contra **WebKitGTK 4.1** (`libwebkit2gtk-4.1`) e GTK3. Um
+host sem essas bibliotecas não consegue abrir a janela. Se sua distribuição
+só tiver um WebKitGTK mais antigo (4.0), o AppImage falhará ao iniciar.
+
+## FUSE e o filesystem `org/`
+
+O mount compartilhado do filesystem `org/` (um por organização, compartilhado
+entre os sandboxes dessa organização) usa `rclone mount` sobre FUSE no
+Linux — o equivalente no macOS é `rclone nfsmount`. Isso exige:
+
+- `/dev/fuse` presente no host.
+- Um helper `fusermount3` (fuse3) ou `fusermount` (fuse2) no `PATH`.
+
+Tanto a auto-montagem do próprio AppImage quanto o mount do filesystem `org/`
+degradam de forma controlada quando o FUSE não está disponível:
+
+- O AppImage cai para `--appimage-extract-and-run` (início mais lento, sem
+  auto-montagem, funciona em qualquer lugar).
+- O filesystem `org/` cai para um diretório `org/` **vazio** no sandbox em vez
+  de falhar ao iniciar. Você também pode forçar esse fallback com
+  `DECOCMS_DISABLE_ORG_FS=1` caso um mount FUSE trave.
+
+## Armazenamento de credenciais no desktop
+
+Tokens de acesso e refresh são armazenados através do [D-Bus Secret
+Service](https://specifications.freedesktop.org/secret-service-spec/latest/)
+(via a crate `keyring`) — o mesmo mecanismo que o GNOME Keyring e o KWallet
+implementam. **Não há fallback em texto plano no disco**: se nenhum provedor
+de Secret Service estiver rodando, leituras e escritas de credenciais falham
+diretamente, em vez de degradar silenciosamente.
+
+Provedores testados: **GNOME Keyring** e **KWallet**. Uma sessão headless ou
+com um gerenciador de janelas mínimo, sem nenhum dos dois rodando, não
+conseguirá fazer login.
+
+## Isolamento da origem de preview (limitação conhecida)
+
+Por padrão, a origem de controle local do app desktop no Linux é uma origem
+`http://localhost` simples, não HTTPS — a mesma origem que o harness de
+self-test sempre usou. Uma origem HTTPS opt-in (uma exceção de certificado
+por host no WebKitGTK, sem integração com o armazém de confiança do SO) está
+disponível via `DECOCMS_LINUX_SECURE_ORIGIN=1`, desligada por padrão neste
+primeiro lançamento porque uma falha de confiança no webview deixaria um
+usuário de AppImage sem janela e sem gerenciador de pacotes para reinstalar.
+
+Até que a origem segura isolada seja o padrão no Linux, trate a origem do
+iframe de preview do app desktop no Linux como menos isolada que a do macOS.
+Veja a issue #6282 para o acompanhamento que torna a origem segura o padrão
+no Linux.
+
+## Instalação, verificação, atualização e desinstalação
+
+A instalação usa o mesmo instalador de uma linha do macOS
+(`curl -fsSL https://studio.decocms.com/install.sh | sh`), que detecta o
+Linux e:
+
+1. Lê a versão a partir do manifesto do canal rolante `native-updates` (uma
+   URL fixa, com promoção limitada para só acontecer depois que os artefatos
+   de toda plataforma forem publicados — então pode ficar algumas versões
+   atrás do HEAD, mas nunca aponta para uma versão que não foi lançada para
+   Linux).
+2. Baixa e verifica o AppImage:
+   - **Com `minisign` instalado**: verifica o tarball contra a chave pública
+     minisign embutida no script do instalador — uma âncora de uma origem
+     diferente (`studio.decocms.com`) da CDN do GitHub que serve o release,
+     portanto uma verificação de autenticidade genuína.
+   - **Sem `minisign`**: cai para o `.sha256` publicado, que só detecta um
+     download corrompido ou truncado — o digest e o binário compartilham a
+     mesma origem, então isso não é uma garantia de segurança. Instale o
+     `minisign` para uma verificação real.
+3. Instala em `~/.local/bin/deco-studio`, com uma entrada de launcher em
+   `~/.local/share/applications` e ícone, substituindo qualquer instalação
+   anterior no lugar.
+4. Verifica a disponibilidade do FUSE e cai para
+   `--appimage-extract-and-run` quando indisponível.
+
+**Atualização**: o app instalado consulta o mesmo canal `native-updates` e
+aplica atualizações ao fechar — verificadas por assinatura com a mesma chave
+minisign. **Desinstalação**: remova `~/.local/bin/deco-studio`,
+`~/.local/share/applications/deco-studio.desktop`, seu ícone em
+`~/.local/share/icons/hicolor/256x256/apps/` e `~/.local/share/deco-studio/`
+(o carimbo de verificação). Não há rollback automatizado; reinstale uma
+versão anterior a partir da [lista de
+releases](https://github.com/decocms/studio/releases) se necessário.
+
+## Solução de problemas
+
+- **O app não abre / erro "damaged" ou de mount**: rode o AppImage
+  diretamente com `--appimage-extract-and-run` para descartar um problema de
+  FUSE.
+- **Janela em branco ao iniciar**: confirme que `libwebkit2gtk-4.1` está
+  instalado — distribuições mais antigas podem só ter a 4.0, que é
+  incompatível.
+- **Não consegue fazer login / erros de credencial**: confirme que um
+  provedor de Secret Service (GNOME Keyring ou KWallet) está rodando —
+  `systemctl --user status gnome-keyring-daemon` ou o equivalente do seu
+  ambiente desktop.
+- **Diretório `org/` está vazio**: o FUSE está indisponível ou o mount
+  falhou; esse é o fallback previsto, não uma falha. Verifique `/dev/fuse` e
+  se `fusermount3`/`fusermount` estão no `PATH`.
+- **Logs**: os logs da aplicação e os dados de monitoramento ficam sob o
+  `DATA_DIR` do app — veja a página Self-Hosting → Monitoring neste guia.
+
+## Escopo adiado
+
+Explicitamente fora de escopo neste lançamento: **ARM64** para Linux,
+`.deb`, `.rpm`, AUR/COPR, Flatpak e Snap. Apenas o AppImage x86_64 é
+suportado.

--- a/apps/docs/client/src/utils/navigation.ts
+++ b/apps/docs/client/src/utils/navigation.ts
@@ -72,6 +72,7 @@ export async function getNavigationLinks(
     "studio/self-hosting/quickstart",
     "studio/self-hosting/authentication",
     "studio/self-hosting/monitoring",
+    "studio/self-hosting/linux-desktop-support",
     "studio/self-hosting/deploy/docker-compose",
     "studio/self-hosting/deploy/kubernetes",
   ];


### PR DESCRIPTION
Closes #6283.

Linux desktop support (v1) landed through #5556, but there was no page documenting what's actually supported and required — the exit criterion in #6283 was a maintained Linux support page whose claims match the acceptance evidence.

Adds `apps/docs/client/src/content/deco-studio/{en,pt-br}/studio/self-hosting/linux-desktop-support.mdx` and registers it in the docs nav order (`navigation.ts`). Every factual claim in the page is grounded in the actual code/CI, not invented:

- Architecture/package (x86_64 AppImage, static runtime, no libfuse2 needed) — `.github/workflows/release-native.yaml`'s `libfuse.so.2` linkage check.
- Tested distro (Ubuntu 22.04) and WebKitGTK 4.1 / GTK3 deps — same workflow's `Install Linux system deps` step.
- FUSE / `org/` filesystem requirement, degrade-to-empty-dir behavior, and the `DECOCMS_DISABLE_ORG_FS` escape hatch — `apps/native/crates/local-api/src/sandbox/org_mount.rs`.
- Desktop credential storage via D-Bus Secret Service (`keyring` crate, no plaintext fallback) — `apps/native/crates/upstream/src/tokens.rs`.
- Preview-origin isolation limitation and the `DECOCMS_LINUX_SECURE_ORIGIN` opt-in, with a link to #6282 (the hardening follow-up named in the issue) — `apps/native/src-tauri/src/setup.rs`.
- Install/verify/update/uninstall paths (minisign vs. sha256-only verification, `~/.local/bin` install, update channel) — `apps/web/public/install.sh`.
- Deferred scope (ARM64, .deb/.rpm/AUR/COPR/Flatpak/Snap) — taken directly from the issue body.

A maintainer can review by reading the new page against the cited source files, or `bun run --cwd=apps/docs docs:dev` to preview it (page appears under Self-Hosting).

Locally ran `bun run fmt` (clean) and `bunx oxlint apps/docs/client/src/utils/navigation.ts` (0 warnings/errors) — this is a docs-only change plus one array-literal edit, so no typecheck/test target applies. Full CI validates the docs build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publishes a Linux Desktop Support page (en and pt-br) and adds it to Self-Hosting navigation. This documents what the v1 Linux build supports and requires, satisfying #6283’s acceptance criteria.

- The page is grounded in CI/code: AppImage runtime/linkage and Linux deps in `.github/workflows/release-native.yaml`, FUSE/org filesystem in `apps/native/crates/local-api/src/sandbox/org_mount.rs`, Secret Service storage in `apps/native/crates/upstream/src/tokens.rs`, secure-origin opt-in in `apps/native/src-tauri/src/setup.rs`, and install/update paths in `apps/web/public/install.sh`.
- New docs at `apps/docs/client/src/content/deco-studio/en/studio/self-hosting/linux-desktop-support.mdx` and `.../pt-br/...`, registered via `apps/docs/client/src/utils/navigation.ts`.
- Preview locally with `bun run --cwd=apps/docs docs:dev`. Docs-only change; CI validates the docs build.

<sup>Written for commit ecbe6071a7ccec63896ce9247bef6b7d489fd9c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

