### PR TITLE
fix(github): drain the discarded 401 response before retrying branch search

### DIFF
--- a/apps/api/src/tools/github/search-branches.ts
+++ b/apps/api/src/tools/github/search-branches.ts
@@ -196,6 +196,12 @@ export const GITHUB_SEARCH_BRANCHES = defineTool({
 
     // Token revoked/rotated behind our clock: one refresh + retry, then give up.
     if (res.status === 401) {
+      // Drain the discarded 401 body so its connection is released.
+      try {
+        await res.body?.cancel();
+      } catch {
+        /* ignore */
+      }
       const refreshed = await githubConnectionAccessToken(ctx, connection, {
         forceRefresh: true,
       });


### PR DESCRIPTION
Follows #6289's same fix for the sandbox proxy — this is the analogous gap in today's freshly-merged #6273 (`GITHUB_SEARCH_BRANCHES`).

On a 401, the tool discards the first `fetch()` response and reassigns `res` to the retried call's response without ever reading the first response's body. An unconsumed `Response` body keeps its underlying connection allocated in the fetch client's pool until GC reclaims it, rather than being released back to the pool immediately — under load (branch-picker search fires on every keystroke) this can needlessly hold sockets open.

Fix: `await res.body?.cancel()` (swallowing any cancel error) before discarding the 401 response, same pattern already merged in `packages/sandbox/server/provider/agent-sandbox/runner.ts` (#6289).

No behavior change — same retry logic, same error paths, same output.

To confirm: `cd apps/api && bunx tsc --noEmit` (green), `bun test apps/api/src/tools/github/search-branches.test.ts` (10 pass), `bunx oxlint apps/api/src/tools/github/search-branches.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drains the discarded 401 response before retrying GitHub branch search so the HTTP connection is released and sockets aren’t pinned under load. Previously the first response body was left unread; now we cancel it before retrying with a refreshed token, with no user-visible behavior change.

<sup>Written for commit 38ed9b4d46a599622b14c26dd6ef5fdfe3710189. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6295?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

