### PR TITLE
fix(assets-tab): gate assets tab on project name, not metadata.siteSlug

### DIFF
--- a/apps/web/src/layouts/main-panel-tabs/assets-tab.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/assets-tab.tsx
@@ -1,6 +1,6 @@
 /**
  * Assets tab — a native, per-site browser over the S3 bucket associated with
- * this site's `metadata.siteSlug` (matched via `matchSiteSlugConfig`). Replaces
+ * this project's name (matched via `matchSiteSlugConfig`). Replaces
  * the deco.cx admin-MCP `fetch_assets` iframe view: it lists, uploads, and
  * deletes objects directly against the configured bucket using the same
  * FILE_* tools the CMS file picker uses. The tab only appears when a bucket is
@@ -63,10 +63,8 @@ import {
 export function AssetsTab({ virtualMcpId }: { virtualMcpId: string }) {
   const entity = useVirtualMCP(virtualMcpId);
   const configs = useFileConfigs();
-  const siteSlug =
-    (entity?.metadata as { siteSlug?: string | null } | undefined)?.siteSlug ??
-    null;
-  const config = matchSiteSlugConfig(configs, siteSlug);
+  const siteName = entity?.title ?? null;
+  const config = matchSiteSlugConfig(configs, siteName);
 
   if (!config) {
     return <NoBucketState />;

--- a/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -290,16 +290,14 @@ export function useMainPanelTabs(ctx: {
 
   /**
    * Assets is a per-site tab: it shows whenever an S3 bucket is associated to
-   * this site's slug (managed `deco-assets-<slug>` or a BYOB bucket). Uses the
-   * non-suspense configs query so the bar never blocks on the bucket list.
+   * this project's name (managed `deco-assets-<name>` or a BYOB bucket). Uses
+   * the non-suspense configs query so the bar never blocks on the bucket list.
    */
-  const siteSlug =
-    (entity?.metadata as { siteSlug?: string | null } | undefined)?.siteSlug ??
-    null;
+  const siteName = entity?.title ?? null;
   const fileConfigsQuery = useFileConfigsQuery();
   const showAssetsTab = !!matchSiteSlugConfig(
     fileConfigsQuery.data?.configs ?? [],
-    siteSlug,
+    siteName,
   );
 
   const { activeTab: rawActiveTab, mainOpen: rawMainOpen } =


### PR DESCRIPTION
## Summary

Follow-up to #6292 (which fixed the same root cause for `/choose-editor`). The Assets tab's show/hide rule and the tab body both derived the site slug from `entity.metadata.siteSlug`, so a project without that metadata set never showed the Assets tab. Key off the project **name** (`title`) instead.

- `use-main-panel-tabs.ts` — the tab **visibility** rule now passes `entity.title`.
- `assets-tab.tsx` — the tab **body** resolves its bucket from `entity.title`.

Both go through the existing `matchSiteSlugConfig`, which lowercases the input and also matches `deco-assets-<name>` buckets, so nothing else changed.

## Testing

- `bun run --cwd=apps/web check` passes.
- `bun run fmt` clean.

## Note

Same caveat as #6292: `title` is a free-form display name while the match target is a strict lowercase slug (`deco-assets-<slug>`). A project titled `"Deco CMS"` won't match `decocms`. Fine if projects import with the exact slug as the title; if titles can diverge we'd slugify the title before comparing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gates the Assets tab by project name instead of `metadata.siteSlug`, so projects without a `siteSlug` still see the tab when a matching bucket exists. Old behavior hid the tab and failed bucket resolution if `siteSlug` was missing; new behavior uses `entity.title` for both.

- Replaces `entity.metadata.siteSlug` with `entity.title` in the tab visibility rule and tab body; both call `matchSiteSlugConfig`, which lowercases input and matches `deco-assets-<name>`.
- Side effect: the tab shows only when the bucket name matches the project title; if titles diverge from slugs, the tab will not appear. If this becomes an issue, we should slugify `title` before matching. No migrations required.

<sup>Written for commit c5e742e38d147f3b1b454f1db32b6f760e8e04a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6296?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

