### PR TITLE
refactor(jira): remove dead substring branch from isRetriableError

### DIFF
--- a/apps/api/src/jira/client.ts
+++ b/apps/api/src/jira/client.ts
@@ -67,25 +67,13 @@ const ISSUE_FIELDS =
  */
 function isRetriableError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  // A known status wins over the substring checks below (Jira's own error body can contain words like "network" or "timeout").
   const statusMatch = message.match(/failed \((\d+)\)/);
   if (statusMatch && statusMatch[1]) {
     const status = parseInt(statusMatch[1], 10);
     // Retry 5xx and 429 (rate limit); do NOT retry 4xx (auth, not found, etc.).
     return status >= 500 || status === 429;
   }
-  // No status — a raw fetch/network throw. Retry on timeout (AbortError) or network errors.
-  if (
-    message.includes("AbortError") ||
-    message.includes("fetch") ||
-    message.includes("timeout") ||
-    message.includes("network") ||
-    message.includes("ECONNREFUSED") ||
-    message.includes("ECONNRESET")
-  ) {
-    return true;
-  }
-  // Unknown error — retry with caution.
+  // No status — a raw fetch/network throw. Retry with caution.
   return true;
 }
 


### PR DESCRIPTION
Follows the recent hardening chain on `apps/api/src/jira/client.ts` (#6274, #6278, #6284, #6293).

In `isRetriableError`, once the response has no matched HTTP status, the function checked `message.includes("AbortError"|"fetch"|"timeout"|"network"|"ECONNREFUSED"|"ECONNRESET")` and returned `true` if any matched — but the very next line, reached whenever that check is false, is also `return true`. Both arms of the branch return the identical value, so the substring check can never change the outcome for any input; it only made the reader think there was a distinction where none exists (verified: I traced every path through the function — the only place it can return `false` is the earlier 4xx status-match branch).

Why a maintainer wants this: it's a straight complexity reduction with zero behavior change — one less thing to reason about when touching Jira retry logic, and it removes a comment ("Retry on timeout (AbortError) or network errors") that implied a distinction the code didn't actually make (e.g. `AbortSignal.timeout()` in Bun throws a `TimeoutError` whose message is "The operation timed out.", which doesn't even match the `"timeout"` substring check — so that branch's own examples weren't reliably triggering it in the first place; it only worked because the fallthrough covered it anyway).

Net diff: -13 / +1, one file, no logic change — `isRetriableError` returns the exact same value for every input before and after.

How I confirmed behavior is unchanged: read every path through the function by hand (only the status-match branch can return `false`; everything else always returned `true` before and still does), then ran the existing test suite, which exercises 503/429 retry and 401/400 no-retry paths, and it stays green.

Commands to confirm:
```
cd apps/api && bunx tsc --noEmit
bun test apps/api/src/jira/client.test.ts
bunx oxlint apps/api/src/jira/client.ts
```

Locally ran: `bun run fmt` (no changes), `bunx tsc --noEmit` in apps/api (clean), `bun test apps/api/src/jira/client.test.ts` (16 pass), `bunx oxlint apps/api/src/jira/client.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes a dead substring check in Jira `isRetriableError` to reduce confusion and complexity with no behavior change. Previously, after no status match, the function checked message substrings but still returned true; now it returns true directly.

Behavior remains: 4xx statuses return false; 5xx/429 and any non-status/network errors return true.

<sup>Written for commit 4fb6df98c8469bb7b79e9ff1c74212c70c3a42c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

