### PR TITLE
fix(storage): make downstream token upsert race-free

### DIFF
--- a/apps/api/src/storage/downstream-token.integration.test.ts
+++ b/apps/api/src/storage/downstream-token.integration.test.ts
@@ -113,4 +113,30 @@ describe("DownstreamTokenStorage", () => {
       .executeTakeFirst();
     expect(Number(count?.c)).toBe(1);
   });
+
+  it("should not throw on concurrent upserts for the same connection", async () => {
+    const base: DownstreamTokenData = {
+      connectionId: "conn_atomic",
+      accessToken: "access_a",
+      refreshToken: "refresh_a",
+      scope: "scope_a",
+      expiresAt: new Date(Date.now() + 3600000),
+      clientId: "client_a",
+      clientSecret: "secret_a",
+      tokenEndpoint: "https://example.com/token",
+    };
+
+    // Racing refreshes must not trip the unique index on connectionId.
+    await Promise.all([
+      storage.upsert(base),
+      storage.upsert({ ...base, accessToken: "access_b" }),
+    ]);
+
+    const count = await database.db
+      .selectFrom("downstream_tokens")
+      .select(database.db.fn.count("id").as("c"))
+      .where("connectionId", "=", "conn_atomic")
+      .executeTakeFirst();
+    expect(Number(count?.c)).toBe(1);
+  });
 });

--- a/apps/api/src/storage/downstream-token.ts
+++ b/apps/api/src/storage/downstream-token.ts
@@ -57,82 +57,52 @@ export class DownstreamTokenStorage {
     const encryptedClientSecret = data.clientSecret
       ? await this.vault.encrypt(data.clientSecret)
       : null;
+    const expiresAt = data.expiresAt?.toISOString() ?? null;
 
-    // Use transaction to prevent race conditions during upsert
-    return await this.db.transaction().execute(async (trx) => {
-      // Check for existing token within transaction
-      const existing = await trx
-        .selectFrom("downstream_tokens")
-        .select(["id", "createdAt"])
-        .where("connectionId", "=", data.connectionId)
-        .executeTakeFirst();
-
-      if (existing) {
-        // Update existing token
-        await trx
-          .updateTable("downstream_tokens")
-          .set({
-            accessToken: encryptedAccessToken,
-            refreshToken: encryptedRefreshToken,
-            scope: data.scope,
-            expiresAt: data.expiresAt?.toISOString() ?? null,
-            clientId: data.clientId,
-            clientSecret: encryptedClientSecret,
-            tokenEndpoint: data.tokenEndpoint,
-            updatedAt: now,
-          })
-          .where("id", "=", existing.id)
-          .execute();
-
-        return {
-          id: existing.id,
-          connectionId: data.connectionId,
-          accessToken: data.accessToken,
-          refreshToken: data.refreshToken,
-          scope: data.scope,
-          expiresAt: data.expiresAt,
-          createdAt: existing.createdAt as unknown as string,
-          updatedAt: now,
-          clientId: data.clientId,
-          clientSecret: data.clientSecret,
-          tokenEndpoint: data.tokenEndpoint,
-        };
-      }
-
-      // Create new token
-      const id = generatePrefixedId("dtok");
-
-      await trx
-        .insertInto("downstream_tokens")
-        .values({
-          id,
-          connectionId: data.connectionId,
+    // Atomic upsert on the connectionId unique index — race-free under concurrent calls.
+    const row = await this.db
+      .insertInto("downstream_tokens")
+      .values({
+        id: generatePrefixedId("dtok"),
+        connectionId: data.connectionId,
+        accessToken: encryptedAccessToken,
+        refreshToken: encryptedRefreshToken,
+        scope: data.scope,
+        expiresAt,
+        clientId: data.clientId,
+        clientSecret: encryptedClientSecret,
+        tokenEndpoint: data.tokenEndpoint,
+        createdAt: now as unknown as string,
+        updatedAt: now as unknown as string,
+      })
+      .onConflict((oc) =>
+        oc.column("connectionId").doUpdateSet({
           accessToken: encryptedAccessToken,
           refreshToken: encryptedRefreshToken,
           scope: data.scope,
-          expiresAt: data.expiresAt?.toISOString() ?? null,
+          expiresAt,
           clientId: data.clientId,
           clientSecret: encryptedClientSecret,
           tokenEndpoint: data.tokenEndpoint,
-          createdAt: now as unknown as string,
-          updatedAt: now as unknown as string,
-        })
-        .execute();
+          updatedAt: now,
+        }),
+      )
+      .returning(["id", "createdAt"])
+      .executeTakeFirstOrThrow();
 
-      return {
-        id,
-        connectionId: data.connectionId,
-        accessToken: data.accessToken,
-        refreshToken: data.refreshToken,
-        scope: data.scope,
-        expiresAt: data.expiresAt,
-        createdAt: now as unknown as string,
-        updatedAt: now as unknown as string,
-        clientId: data.clientId,
-        clientSecret: data.clientSecret,
-        tokenEndpoint: data.tokenEndpoint,
-      };
-    });
+    return {
+      id: row.id,
+      connectionId: data.connectionId,
+      accessToken: data.accessToken,
+      refreshToken: data.refreshToken,
+      scope: data.scope,
+      expiresAt: data.expiresAt,
+      createdAt: row.createdAt as unknown as string,
+      updatedAt: now,
+      clientId: data.clientId,
+      clientSecret: data.clientSecret,
+      tokenEndpoint: data.tokenEndpoint,
+    };
   }
 
   async delete(connectionId: string): Promise<void> {


### PR DESCRIPTION
**Source:** bug found reading `apps/api/src/storage/downstream-token.ts` (my focus area this tick was downstream token handling).

**Why a maintainer wants this:** `downstream_tokens` has a unique index on `connectionId` (migration `061-downstream-token-connection-index.ts` — 1:1 token per connection). `upsert()` did a select-then-insert-or-update inside a transaction, which is not race-free at Postgres's default READ COMMITTED isolation: two concurrent upserts for the same connection (e.g. two near-simultaneous OAuth token refreshes racing on the same downstream MCP connection) can both see "no existing row" in their SELECT and both attempt the INSERT — one of them then throws a unique-constraint violation instead of updating.

**Fix:** replace the transaction + select-then-branch with a single atomic `INSERT ... ON CONFLICT (connectionId) DO UPDATE`, the same pattern already used by `ai-provider-keys.ts`, `jira-integrations.ts`, `org-sso-config.ts`, and several other storage files in this codebase. This closes the race by construction (Postgres itself arbitrates the conflict) and is also one round trip cheaper per call (no separate SELECT, no transaction wrapper). Net diff: -68/+64, behavior-preserving for the non-concurrent case (existing integration test for sequential upsert still holds — same return shape, same update-in-place semantics).

**Regression test:** added `should not throw on concurrent upserts for the same connection` to `downstream-token.integration.test.ts`, firing two `Promise.all` upserts for the same `connectionId` and asserting exactly one row survives with no thrown error. Before the fix this is a live risk of a thrown unique-violation from one of the two concurrent calls.

**To confirm:** `bun test apps/api/src/storage/downstream-token.integration.test.ts` (needs the repo's Postgres test harness — not runnable in my sandbox, but CI has it).

**Locally verified:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bunx oxlint` on both changed files (0 warnings/errors). Could not run the integration test itself locally (no Docker/Postgres in this environment) — full CI will validate it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes downstream token upserts race-free by replacing the select-then-insert-or-update transaction with a single atomic INSERT ... ON CONFLICT on connectionId. This removes unique-constraint errors under concurrent refreshes and cuts one round trip; sequential behavior and return shape are unchanged.

- Switches `apps/api/src/storage/downstream-token.ts` to `INSERT ... ON CONFLICT (connectionId) DO UPDATE`, returning `id` and `createdAt` from the DB and updating `updatedAt` on every upsert; aligns with patterns used in other storage modules.
- Adds a regression test ensuring concurrent upserts for the same connection do not throw and only one row exists.
- No schema or API changes; no caller updates required.

<sup>Written for commit 29ab6df54837d5283cb915bcfce4203d7efecad1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

