### PR TITLE
fix(preview): ask for the published render while the preview boots

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -86,7 +86,9 @@ import { decoBlockFileViewPath } from "@/components/sections-editor/deco-block-k
 import { findLivePageResolveType } from "@/components/sections-editor/section-catalog";
 import {
   buildGlobalSectionPreviewUrl,
+  DRAFT_OFF,
   resolveSectionPreviewBase,
+  withDraftPointer,
 } from "@/components/sections-editor/section-preview-url";
 import { useFastPreviewDraftUrl } from "@/components/sections-editor/use-fast-preview-draft-url";
 import { decofileWriteMutationKey } from "@/components/sections-editor/decofile-api";
@@ -625,9 +627,13 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
         ? // Fast Preview's draft route honours the variant matcher override like the sandbox dev server, so append it here too.
           withVariantMatcherOverride(
             withDeviceHint(
-              directPreviewUrl ??
-                draftPreviewUrl ??
-                new URL(resolvedPath, display.iframeBase!).href,
+              // Waking pill up ⇒ no draft is renderable yet, so ask for published.
+              withDraftPointer(
+                directPreviewUrl ??
+                  draftPreviewUrl ??
+                  new URL(resolvedPath, display.iframeBase!).href,
+                display.showWakingPill ? DRAFT_OFF : null,
+              ),
               previewDeviceSize,
             ),
             workspace.state.variantOverride ?? [],

--- a/apps/web/src/components/sections-editor/section-preview-url.test.ts
+++ b/apps/web/src/components/sections-editor/section-preview-url.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   buildFastPreviewDraftUrl,
+  DRAFT_OFF,
   resolveSectionPreviewBase,
   withDraftPointer,
 } from "./section-preview-url";
@@ -192,5 +193,28 @@ describe("resolveSectionPreviewBase", () => {
         fastPreviewActive: false,
       }),
     ).toBeNull();
+  });
+});
+
+describe("DRAFT_OFF", () => {
+  const PAGE = "https://www.example.com/blog/news/post";
+
+  it("asks the site for its published render — what the boot fallback stamps", () => {
+    const url = new URL(withDraftPointer(PAGE, DRAFT_OFF));
+    expect(url.pathname).toBe("/blog/news/post");
+    expect(url.searchParams.get("__draft")).toBe("off");
+  });
+
+  it("replaces a pointer already on the url — the trailing draft is what it kills", () => {
+    const url = new URL(
+      withDraftPointer(
+        withDraftPointer(
+          PAGE,
+          "api.deco.cx/api/acme/decofile/vm-1/main?token=t@abc",
+        ),
+        DRAFT_OFF,
+      ),
+    );
+    expect(url.searchParams.getAll("__draft")).toEqual(["off"]);
   });
 });

--- a/apps/web/src/components/sections-editor/section-preview-url.ts
+++ b/apps/web/src/components/sections-editor/section-preview-url.ts
@@ -65,10 +65,14 @@ export function buildDraftPointer(input: {
   return `${pointer}@${input.version}`;
 }
 
+/** `__draft` value asking for the PUBLISHED render — external contract: the site runtime honours it, Studio never reads it back. */
+export const DRAFT_OFF = "off";
+
 /**
- * Stamp a draft pointer onto an already-built site URL. Callers that compute
- * their own path (blog post/category links) build the URL first and decorate
- * here; a null pointer (Fast Preview off, or no grant yet) leaves it alone.
+ * Stamp a draft pointer — or {@link DRAFT_OFF} — onto an already-built site
+ * URL. Callers that compute their own path (blog post/category links) build the
+ * URL first and decorate here; a null pointer (Fast Preview off, or no grant
+ * yet) leaves it alone.
  */
 export function withDraftPointer(
   url: string,


### PR DESCRIPTION
## Summary

While the sandbox is still starting, the preview canvas holds the site's **published** page behind the "Starting your preview" pill. That URL carried no `__draft` param at all — which is not the same as asking for published content. The site could still render a draft, so the boot fallback painted a **trailing preview** instead of the live page.

This stamps `?__draft=off` on the iframe src for exactly that phase.

## How it's scoped

The gate is `display.showWakingPill`, which `resolvePreviewDisplay` sets **only** on the fallback branch (`preview-display.ts:133-140`) and explicitly sets `false` on the Fast-Preview-ready branch — so `__draft=off` can never collide with a real draft pointer. The sandbox dev-server arm is untouched (no `__draft` concept there). Every other writer of the frame's URL (`handleRefresh`, the re-navigation effect, `preview-iframe-recovery`) reads `iframeSrc`, so they inherit it for free.

No new helper: `withDraftPointer` already stamps whatever value it is handed, so this adds an exported `DRAFT_OFF` sentinel and passes it through.

```ts
withDraftPointer(
  directPreviewUrl ?? draftPreviewUrl ?? new URL(resolvedPath, display.iframeBase!).href,
  display.showWakingPill ? DRAFT_OFF : null,
)
```

## Testing

- `bun test apps/web/src/components/sandbox/preview apps/web/src/components/sections-editor` — 880 pass / 0 fail
- `bun run --cwd=apps/web check` — clean
- `bun run lint` — 0 errors · `bun run fmt:check` — clean · `knip` — nothing on the touched files
- Two unit tests added: the sentinel's wire form, and that it **replaces** a pointer already on the URL (the trailing-draft guarantee).

No e2e spec: the non-FP boot fallback is unreachable in e2e (no sandbox provider ⇒ `previewState.kind === "errored"` ⇒ no iframe), and the FP pill window is a decofile-round-trip race that would only be reachable by deliberately breaking the read.

## Reviewer notes

- **`off` is an out-of-repo contract.** Nothing in this repo reads `__draft` back — only the deco runtime does, and its documented grammar is `<authority><path>?token=…@<version>`. Worth loading `<previewServerUrl>/?__draft=off` against a real site once before merge: if the runtime *errors* rather than falling through to published, this would turn the default boot surface into an error page.
- **Out of scope, pre-existing:** "Copy current URL" will now include `?__draft=off` during boot — `handleCopyUrl` falls back to `iframeSrc` when the cross-origin `location.href` read throws. It already leaks `deviceHint` and matcher overrides the same way; the real fix is pointing that fallback at `openInNewTabUrl`. "Open in new tab" rebuilds cleanly and is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures the preview boot fallback always shows the published page. Previously the iframe had no `__draft` param and could render a trailing draft; now it stamps `?__draft=off` while the "Starting your preview" pill is shown.

- Gate: only when `display.showWakingPill` is true; never after Fast Preview is ready.
- Implementation: `withDraftPointer(..., DRAFT_OFF)`; sandbox dev-server path is unchanged.
- Propagation: anything that reads `iframeSrc` inherits the param; it cannot collide with real draft pointers.
- Tests: cover the `DRAFT_OFF` wire form and that it replaces any existing `__draft` pointer.
- Reviewer check: the site runtime must treat `__draft=off` as published; verify once against a real site.
- Known side effect: during boot, "Copy current URL" may include `?__draft=off`; "Open in new tab" is unaffected.

<sup>Written for commit 660570c3691104625420b8b887d2d8c748291727. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6302?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

