### PR TITLE
fix(settings): track signed_out from the mobile sidebar sign-out button

### DIFF
--- a/apps/web/src/layouts/settings-layout.tsx
+++ b/apps/web/src/layouts/settings-layout.tsx
@@ -494,6 +494,7 @@ export function SettingsSidebarMobile({ onClose }: { onClose: () => void }) {
           <button
             type="button"
             onClick={() => {
+              track("signed_out", { source: "settings_sidebar" });
               clearPersistedQueryCache();
               authClient.signOut();
             }}


### PR DESCRIPTION
The desktop settings sidebar's Sign Out button fires `track("signed_out", { source: "settings_sidebar" })` before calling `authClient.signOut()`; the mobile settings sidebar's Sign Out button (a separate JSX block in the same file) never fires that event, so mobile sign-outs from settings are silently dropped from analytics.

Why it matters: this is the same file, same feature, same event — the discrepancy means any dashboard/funnel built on `signed_out` undercounts mobile users, with no way to tell from the data itself that a whole platform is missing.

Fix: add the identical `track("signed_out", { source: "settings_sidebar" })` call to the mobile sign-out handler in `apps/web/src/layouts/settings-layout.tsx`, matching the desktop handler and the account-popover's own `signed_out` call.

To confirm: open settings on a narrow viewport (mobile sidebar), sign out, and check the `signed_out` PostHog event fires with `source: "settings_sidebar"` — same as the desktop path.

Checks run locally: `bun run fmt` (clean) and `bunx oxlint apps/web/src/layouts/settings-layout.tsx` (0 warnings/errors). No test file covers this UI event-tracking call; CI runs the rest of the suite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tracks sign-outs from the mobile settings sidebar to align analytics with desktop. Previously, mobile sign-outs did not emit `signed_out`; now they fire `track("signed_out", { source: "settings_sidebar" })` before sign-out, fixing undercounting in funnels.

**Review notes**
- Single-line addition in `apps/web/src/layouts/settings-layout.tsx` within `SettingsSidebarMobile`’s sign-out handler.
- Event payload: `signed_out` with `{ source: "settings_sidebar" }`, dispatched before clearing cache and calling `authClient.signOut()`.
- Verify by signing out via the mobile settings sidebar and confirming the `signed_out` event with the expected source.

<sup>Written for commit 10e519b0fe2897191943f19b9f169dd199e327c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

