### PR TITLE
fix(jira): don't retry a 2xx response with malformed JSON

### DIFF
--- a/apps/api/src/jira/client.test.ts
+++ b/apps/api/src/jira/client.test.ts
@@ -234,6 +234,31 @@ describe("JiraClient", () => {
     }
   });
 
+  it("does not retry a 200 response with a malformed JSON body", async () => {
+    let callCount = 0;
+    const originalFetch = globalThis.fetch;
+    const mockFetch = mock(async () => {
+      callCount++;
+      return new Response("not json", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    try {
+      const client = new JiraClient(
+        "https://acme.atlassian.net",
+        "user@example.com",
+        "token",
+      );
+      await expect(client.myself()).rejects.toThrow("invalid JSON");
+      expect(callCount).toBe(1); // Malformed JSON is deterministic — retrying wastes time
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("does not retry addComment on a transient error — a resubmit would duplicate the comment", async () => {
     let callCount = 0;
     const originalFetch = globalThis.fetch;

--- a/apps/api/src/jira/client.ts
+++ b/apps/api/src/jira/client.ts
@@ -73,6 +73,8 @@ function isRetriableError(error: unknown): boolean {
     // Retry 5xx and 429 (rate limit); do NOT retry 4xx (auth, not found, etc.).
     return status >= 500 || status === 429;
   }
+  // Malformed JSON is deterministic, not transient — don't retry it.
+  if (/returned invalid JSON/.test(message)) return false;
   // No status — a raw fetch/network throw. Retry with caution.
   return true;
 }
@@ -152,7 +154,15 @@ export class JiraClient {
         );
       }
       // Transition POSTs answer 204 with an empty body.
-      return (body === "" ? undefined : JSON.parse(body)) as T;
+      if (body === "") return undefined as T;
+      try {
+        return JSON.parse(body) as T;
+      } catch (cause) {
+        throw new Error(
+          `Jira ${path} returned invalid JSON: ${body.slice(0, 300)}`,
+          { cause },
+        );
+      }
     };
     if (!idempotent) return attempt();
     return retry(attempt, {


### PR DESCRIPTION
**Source:** bug found while auditing `apps/api/src/jira/client.ts` for error-handling/type-safety consistency (this lane has had a string of hardening PRs, #6274/#6278/#6284/#6293/#6298).

**Why a maintainer wants it:** `request()` parsed a 2xx body with a bare `JSON.parse(body)` — a shape mismatch (e.g. Jira answering with an HTML error page or truncated body under load) threw a raw `SyntaxError` with no path/body context, and `isRetriableError`'s catch-all ("no status match in the message → retry with caution") retried it 3x with backoff before giving up, adding ~5s of latency for a failure that will reproduce identically every attempt.

**Fix:** wrap the `JSON.parse` in a try/catch that throws a contextualized error naming the path and a body prefix (same shape as the existing `!response.ok` branch), and teach `isRetriableError` to recognize that message and return `false` — malformed JSON is a deterministic parse failure, not a transient network condition.

**Regression test:** `client.test.ts` — "does not retry a 200 response with a malformed JSON body": mocks fetch returning `200` with body `"not json"`, asserts the client throws (`invalid JSON`) and `fetch` was called exactly once.

**Reviewer check:** `bun test apps/api/src/jira/client.test.ts` (17 pass, includes the new test).

**Locally verified:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), `bun test apps/api/src/jira/client.test.ts` (17/17 pass), `bunx oxlint apps/api/src/jira/client.ts apps/api/src/jira/client.test.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop retrying 2xx Jira responses with malformed JSON and surface a contextual error instead. Previously a bare JSON.parse threw a SyntaxError, which the client treated as retriable and retried 3 times; now it throws a clear “invalid JSON” error and does not retry, reducing wasted latency.

- Wrap JSON.parse in try/catch to include the request path and a body prefix in the error message; 204 with empty body still returns undefined.
- Update isRetriableError to treat “returned invalid JSON” as non-retriable.
- Add a test asserting a single attempt on 200 with an unparseable body. No caller changes or migrations required.

<sup>Written for commit d61fa1a6d4bdc534a63d37bf05b3b653e8ab63b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6308?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

