### PR TITLE
fix(task-board): honor the human-rejected-Done override in the sweeper's auto-merge retry

### DIFF
--- a/apps/api/src/tools/task-board/merge-pr.ts
+++ b/apps/api/src/tools/task-board/merge-pr.ts
@@ -433,6 +433,10 @@ export async function retryAutoMergeIfApproved(
   if (item.status !== "in_review") return false;
   const settings = await ctx.storage.organizationSettings.get(orgId);
   if (settings?.flags?.auto_merge !== true) return false;
+  // Same human-override guard `review-decision.ts` and `prs-get` honor.
+  if (await ctx.storage.taskBoard.hasHumanRejectedDone(item.id, orgId)) {
+    return false;
+  }
   if (!(await allEnabledReviewersVerifiedApproved(ctx, orgId, item.id))) {
     await handUnverifiedApprovalToHuman(ctx, item);
     return false;

--- a/apps/api/src/tools/task-board/retry-auto-merge-human-override.integration.test.ts
+++ b/apps/api/src/tools/task-board/retry-auto-merge-human-override.integration.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Real-Postgres coverage for the sweeper's own auto-merge retry honoring the
+ * human-override guard `hasHumanRejectedDone` added (#6231) to the two other
+ * auto-completing paths (`prs-get`'s reconcile, `review-decision`'s inline
+ * merge) but not to this one — so a card a member dragged out of Done could
+ * still be silently re-merged and re-closed on the sweeper's next visit.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { sql } from "kysely";
+import type { StudioContext } from "../../core/studio-context";
+import type { StudioDatabase } from "../../database";
+import {
+  closeTestPgDatabase,
+  connectTestPgDatabase,
+  resetTestPgDatabase,
+} from "../../database/test-db-pg";
+import { OrganizationSettingsStorage } from "../../storage/organization-settings";
+import { TaskBoardStorage } from "../../storage/task-board";
+import { retryAutoMergeIfApproved } from "./merge-pr";
+
+const ORG = "org_retryautomerge_1";
+const USER = "user_ram1";
+
+describe("retryAutoMergeIfApproved", () => {
+  let database: StudioDatabase;
+  let taskBoard: TaskBoardStorage;
+  let organizationSettings: OrganizationSettingsStorage;
+  let ctx: StudioContext;
+
+  /** A card In Review, every enabled reviewer verifiably approved, no PR linked. */
+  const approvedCard = async () => {
+    const item = await taskBoard.create({
+      organizationId: ORG,
+      title: "ship me",
+      by: USER,
+      status: "in_review",
+    });
+    for (const reviewer of ["qa", "code_review"]) {
+      await taskBoard.recordActivity({
+        taskBoardItemId: item.id,
+        action: "review_approved",
+        actorId: null,
+        data: { reviewer, verified: true },
+      });
+    }
+    return { ...item, status: "in_review" as const };
+  };
+
+  beforeAll(async () => {
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    const now = new Date().toISOString();
+    await database.db
+      .insertInto("organization")
+      .values({
+        id: ORG,
+        name: ORG,
+        slug: "org-retryautomerge-1",
+        createdAt: now,
+      })
+      .execute();
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES (${USER}, ${"ram1@retryautomerge.test"}, false, ${USER}, ${now}, ${now})
+    `.execute(database.db);
+    taskBoard = new TaskBoardStorage(database.db);
+    organizationSettings = new OrganizationSettingsStorage(database.db);
+    await organizationSettings.upsert(ORG, {
+      flags: {
+        auto_merge: true,
+        qa_agent_enabled: true,
+        code_reviewer_enabled: true,
+      },
+    });
+    ctx = {
+      storage: { taskBoard, organizationSettings },
+    } as unknown as StudioContext;
+  });
+
+  afterAll(async () => {
+    await closeTestPgDatabase(database);
+  });
+
+  // A missing merge attempt with no PR linked always logs `no_pr` — its absence proves the short-circuit.
+  it("does not attempt a merge once a member has dragged the card out of Done", async () => {
+    const item = await approvedCard();
+    await taskBoard.recordActivity({
+      taskBoardItemId: item.id,
+      action: "status_changed",
+      actorId: USER,
+      data: { from: "done", to: "in_review" },
+    });
+
+    expect(await retryAutoMergeIfApproved(ctx, item)).toBe(false);
+
+    const activity = await taskBoard.listActivity(item.id, ORG);
+    expect(activity.some((a) => a.action === "merge_failed")).toBe(false);
+  });
+
+  it("still attempts a merge for an untouched approved card", async () => {
+    const item = await approvedCard();
+
+    expect(await retryAutoMergeIfApproved(ctx, item)).toBe(false);
+
+    const activity = await taskBoard.listActivity(item.id, ORG);
+    expect(activity.some((a) => a.action === "merge_failed")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

#6231 added `TaskBoardStorage.hasHumanRejectedDone` — a sticky guard that stops a task board card from being auto-completed to Done again once a member has explicitly dragged it OUT of Done. It wired the guard into the two paths that auto-complete a card: `TASK_BOARD_ITEM_PRS_GET`'s merge-reconcile-on-read, and `TASK_BOARD_REVIEW_DECISION`'s inline auto-merge on approval.

It missed a third path: `retryAutoMergeIfApproved` in `merge-pr.ts`, called by the 60s review-sweeper (`review-sweeper.ts:498`) to resume an auto-merge that failed inline. That function re-checks org auto-merge + verified reviewer approvals, but never consults `hasHumanRejectedDone` — so once a human rejects a Done card back to In Review and the still-valid reviewer approvals from the prior cycle remain, the sweeper's background retry can silently re-merge the PR and re-close the card to Done, exactly the bug #6231 fixed, just reached from a path nobody visits on demand (it runs on an unattended timer, with no card open and no reviewer decision firing).

## Fix

Add the same `hasHumanRejectedDone` check to `retryAutoMergeIfApproved`, right after the `auto_merge` flag check and before the merge is attempted — mirroring exactly how `review-decision.ts` guards its own auto-merge call.

## Testing

- Added `retry-auto-merge-human-override.integration.test.ts` (real-Postgres, same pattern as the existing `human-rejected-done.integration.test.ts` and `rerun-merge-pending.integration.test.ts`): a card with every reviewer verifiably approved and a human-authored `done → in_review` move no longer even attempts a merge (asserted by the absence of a `merge_failed` activity entry, which a real no-PR merge attempt always logs); an untouched approved card still attempts it as before.
- This needs the `storage-integration` CI workflow (real Postgres) to run — this laptop has no Docker/Postgres, so I could not execute it locally; verified locally instead with `bunx tsc --noEmit` (apps/api, clean) and `bunx oxlint` on both changed files (0 warnings/errors), plus `bun run fmt`.
- Reviewer: `bun test apps/api/src/tools/task-board/retry-auto-merge-human-override.integration.test.ts` against a local Postgres (see the file header of any sibling `*.integration.test.ts` for setup) confirms the fix; full CI validates the rest.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honors the human-rejected Done override in the review sweeper’s auto-merge retry to prevent re-closing cards a member moved out of Done. Previously the sweeper ignored the override and could re-merge; now `retryAutoMergeIfApproved` checks `hasHumanRejectedDone` and bails before approvals/merge.

- Mirrors the existing guard used in `review-decision.ts` and `prs-get`.
- Adds real-Postgres integration test `retry-auto-merge-human-override.integration.test.ts` (skipped retries do not log `merge_failed`; untouched approved cards still attempt merge).
- No schema/config changes; impact is limited to the background sweeper retry path.

<sup>Written for commit 42cf9d80fa74b93ff62de125c90f267eb051f2a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6309?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

