### PR TITLE
fix(github): bound the installations-list fetch with a 15s timeout

### DIFF
--- a/apps/api/src/tools/github/list-user-orgs.ts
+++ b/apps/api/src/tools/github/list-user-orgs.ts
@@ -10,6 +10,8 @@ import { getRepoScope } from "@decocms/shared/github-repo-scope";
 import { DownstreamTokenStorage } from "../../storage/downstream-token";
 
 const GITHUB_API = "https://api.github.com";
+/** Matches the Git Data client's per-attempt timeout in `decofile/github-git-data.ts`. */
+const GITHUB_TIMEOUT_MS = 15_000;
 
 export const GITHUB_LIST_USER_ORGS = defineTool({
   name: "GITHUB_LIST_USER_ORGS",
@@ -103,6 +105,7 @@ export const GITHUB_LIST_USER_ORGS = defineTool({
             Accept: "application/vnd.github+json",
             "X-GitHub-Api-Version": "2022-11-28",
           },
+          signal: AbortSignal.timeout(GITHUB_TIMEOUT_MS),
         },
       );
 


### PR DESCRIPTION
GITHUB_LIST_USER_ORGS's pagination loop (`apps/api/src/tools/github/list-user-orgs.ts`) calls `fetch(.../user/installations, ...)` with no `AbortSignal.timeout`, unlike its sibling `apps/api/src/tools/github/search-branches.ts` and `apps/api/src/decofile/github-git-data.ts`, which both bound their GitHub calls at 15s for exactly this reason (see the `GITHUB_TIMEOUT_MS`/`DEFAULT_TIMEOUT_MS` constants there). A slow or hung GitHub response leaves this request (and the `while (true)` pagination loop around it, which can run multiple pages) blocked indefinitely instead of failing fast.

This follows the same bounded-external-call pattern already applied across the repo (see the 'Resource/DoS bounds' lane: browserless/gemini/health-check/OIDC calls all got timeouts). Fix: add the same `GITHUB_TIMEOUT_MS = 15_000` constant and pass `signal: AbortSignal.timeout(GITHUB_TIMEOUT_MS)` on the fetch, matching `search-branches.ts`'s existing constant name/value exactly.

Behavior-preserving on the happy path — only bounds worst-case latency on a hanging connection to GitHub.

To confirm: `cd apps/api && bunx tsc --noEmit` (green, no new type errors) and `bunx oxlint apps/api/src/tools/github/list-user-orgs.ts` (0 warnings/errors). No existing test covers this fetch's network behavior (it isn't exported/testable in isolation, same as before my change), so I didn't add one — a timeout add to an untested fetch call isn't a new logic branch that needs its own trust-boundary test. Ran `bun run fmt` locally. Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the `GITHUB_LIST_USER_ORGS` `GET /user/installations` fetch with a 15s timeout to prevent indefinite hangs during pagination. Previously this call had no timeout; now each page uses `AbortSignal.timeout(15_000)`, matching other GitHub calls. Success-path behavior is unchanged; slow or hung responses now fail after 15s.

**Review notes**
- Adds `GITHUB_TIMEOUT_MS = 15_000` and passes `signal` to the fetch in `apps/api/src/tools/github/list-user-orgs.ts`.
- Aligns with the existing 15s bounds in `apps/api/src/tools/github/search-branches.ts` and `apps/api/src/decofile/github-git-data.ts`.
- Callers may now receive an `AbortError` on slow GitHub responses. No config or migration required.

<sup>Written for commit 4ed854ea599c4618cf1d9eb4abd218d0d6625062. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

