### PR TITLE
fix(ui): select a Combobox option by its own value, not a label reverse-lookup

### DIFF
--- a/packages/ui/src/components/combobox.tsx
+++ b/packages/ui/src/components/combobox.tsx
@@ -89,13 +89,9 @@ export function Combobox({
                   <CommandItem
                     key={option.value}
                     value={option.label}
-                    onSelect={(currentLabel) => {
-                      const currentValue = options.find(
-                        (option) => option.label === currentLabel,
-                      )?.value;
-                      onChange(
-                        currentValue === value ? "" : (currentValue ?? ""),
-                      );
+                    // Closes over this option's own value — no reverse lookup by label.
+                    onSelect={() => {
+                      onChange(option.value === value ? "" : option.value);
                       setOpen(false);
                     }}
                   >


### PR DESCRIPTION
Follows #6284 (the Jira board picker, the shared `Combobox`'s only current consumer) — reading that change to satisfy this tick's "reactive" JIRA-lane task surfaced a latent bug in the component itself, one directory over from `apps/api/src/jira`.

**The bug:** `Combobox`'s `onSelect` handler receives cmdk's `currentLabel` (the string each `CommandItem` was registered under, i.e. `option.label`) and re-derives the picked value with `options.find((option) => option.label === currentLabel)?.value` — a reverse lookup by label. If two options ever share a label, this silently resolves to the FIRST one in the array, selecting the wrong item regardless of which row the user actually clicked.

**Why it matters now:** `jira-board-labels.ts`'s own doc comment calls out exactly this shape — "one Jira site can hold several boards with the same name in different projects — three '03. Tarefas' is a real shape" — and works around it by forcing every label to end with `#{board.id}` specifically so the reverse lookup stays unambiguous. That's a real, working mitigation for the one call site today, but it means the *shared* component's correctness currently depends on every future caller remembering to uniqueify its labels too, silently, with no enforcement.

**The fix:** each `CommandItem` is created inside a `.map((option) => ...)` — it already has its own `option` in closure. Use it directly instead of re-deriving it from the label. Net -4 lines, and the picked value now always matches the clicked row, independent of label uniqueness.

Behavior for the current consumer (`jira.tsx`) is unchanged (labels there are already unique), verified by reading through: `option.value === value` mirrors the prior `currentValue === value` check exactly, just sourced correctly.

How to verify: `bunx tsc --noEmit` in `packages/ui` (no new errors; pre-existing unrelated `.stories.tsx` TS4023 errors are untouched by this diff) and `bunx oxlint packages/ui/src/components/combobox.tsx apps/web/src/views/settings/jira.tsx` (0 warnings/errors). No component test exists for `Combobox` and this repo's test tier rules bar adding a DOM/mock-based one; full CI (including any relevant e2e) validates the rest.

Local checks run: `bun run fmt`, `bunx tsc --noEmit` (packages/ui), `bunx oxlint` (both touched files).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Selects a Combobox option by its own value instead of reverse lookup by label. Previously selection used the label to find a value, which could pick the wrong item when labels duplicated; now it closes over the option value so selection always matches the clicked row. No API changes; current Jira board picker behavior is unchanged.

- Review notes
  - Change limited to `packages/ui/src/components/combobox.tsx`; removes label-based lookup and calls onChange with the option value.
  - Keeps toggle-to-clear behavior when re-selecting the current value; no consumer migration or label uniqueness requirement.

<sup>Written for commit ae0a7fd1f5fcc90f88b3d904abbad0a57f9057d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

