### PR TITLE
fix(github): degrade a malformed 2xx branch-search body instead of a raw SyntaxError

### DIFF
--- a/apps/api/src/tools/github/search-branches.test.ts
+++ b/apps/api/src/tools/github/search-branches.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { isGithubConnection } from "@/oauth/github-mint";
-import { parseBranchSearchResponse } from "./search-branches";
+import { parseBranchSearchResponse, parseJsonBody } from "./search-branches";
 
 const REPO = "acme/site";
 
@@ -130,5 +130,20 @@ describe("isGithubConnection", () => {
   it("rejects a connection with no slug", () => {
     expect(isGithubConnection({})).toBe(false);
     expect(isGithubConnection({ slug: null })).toBe(false);
+  });
+});
+
+describe("parseJsonBody", () => {
+  it("parses a well-formed JSON body", async () => {
+    const body = { data: { repository: null } };
+    const res = new Response(JSON.stringify(body));
+    expect(await parseJsonBody(res, REPO)).toEqual(body);
+  });
+
+  it("throws a named error instead of a raw SyntaxError on a malformed 2xx body", async () => {
+    const res = new Response("<html>upstream error</html>");
+    await expect(parseJsonBody(res, REPO)).rejects.toThrow(
+      /acme\/site returned invalid JSON: <html>upstream error<\/html>/,
+    );
   });
 });

--- a/apps/api/src/tools/github/search-branches.ts
+++ b/apps/api/src/tools/github/search-branches.ts
@@ -65,6 +65,28 @@ const branchSearchOutput = z.object({
 
 export type BranchSearchResult = z.infer<typeof branchSearchOutput>;
 
+/**
+ * A 2xx response body isn't guaranteed to be JSON (a proxy/outage page can
+ * still answer 200), and `res.json()` throwing a raw `SyntaxError` on that
+ * would surface as an opaque "Unexpected token" instead of naming what
+ * failed. Same gap the Jira client closed for its own 2xx-but-malformed
+ * case (#6308).
+ */
+export async function parseJsonBody(
+  res: Response,
+  repoLabel: string,
+): Promise<BranchSearchResponse> {
+  const text = await res.text();
+  try {
+    return JSON.parse(text) as BranchSearchResponse;
+  } catch (cause) {
+    throw new Error(
+      `GitHub GraphQL branch search for ${repoLabel} returned invalid JSON: ${text.slice(0, 300)}`,
+      { cause },
+    );
+  }
+}
+
 interface BranchSearchResponse {
   data?: {
     repository?: {
@@ -219,9 +241,10 @@ export const GITHUB_SEARCH_BRANCHES = defineTool({
     }
 
     // GraphQL reports failures as 200 + `errors`, so an ok status isn't enough.
+    const repoLabel = `${input.owner}/${input.repo}`;
     return parseBranchSearchResponse(
-      (await res.json()) as BranchSearchResponse,
-      `${input.owner}/${input.repo}`,
+      await parseJsonBody(res, repoLabel),
+      repoLabel,
     );
   },
 });


### PR DESCRIPTION
Follows #6308's fix in the Jira client — same bug class, different endpoint.

`GITHUB_SEARCH_BRANCHES` (apps/api/src/tools/github/search-branches.ts) calls `res.json()` unconditionally once `res.ok` is true. GitHub's GraphQL endpoint can still answer 200 with a non-JSON body (an outage page, a misbehaving proxy in the path), and `res.json()` throwing on that surfaces as an opaque `SyntaxError: Unexpected token ...` instead of a message that names what failed — the exact gap #6308 closed for the Jira client's own 2xx-but-malformed case.

**Fix**: `parseJsonBody` reads the response as text first and wraps `JSON.parse`, throwing a named error (`GitHub GraphQL branch search for <repo> returned invalid JSON: <snippet>`) instead of letting the raw `SyntaxError` propagate.

**Regression test**: `search-branches.test.ts` now covers `parseJsonBody` directly — a well-formed body parses through unchanged, and a malformed 2xx body (`<html>...</html>`) throws the named error rather than a bare `SyntaxError`.

**To verify**: `bun test apps/api/src/tools/github/search-branches.test.ts`

**Checks run locally**: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test file (12 pass), `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Handle 2xx-but-non‑JSON responses from GitHub branch search by emitting a named, actionable error instead of a raw SyntaxError. Previously `GITHUB_SEARCH_BRANCHES` called `res.json()` on any ok response; now we read the body as text, attempt `JSON.parse`, and throw “GitHub GraphQL branch search for <owner>/<repo> returned invalid JSON: <snippet>” on failure.

**Review notes**
- Replace `res.json()` with `parseJsonBody(res, repoLabel)` in `apps/api/src/tools/github/search-branches.ts`; behavior on valid JSON is unchanged.
- Add tests in `apps/api/src/tools/github/search-branches.test.ts` for well-formed JSON and malformed 2xx HTML.
- No API or caller changes; only error messaging changes in malformed 2xx cases.

<sup>Written for commit 419f18a1b800348bd3365f0a5939516d6432ce92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

