### PR TITLE
fix(task-board): isolate a listPrs failure in the stall-recovery sweep

### DIFF
--- a/apps/api/src/tools/task-board/stall-recovery.ts
+++ b/apps/api/src/tools/task-board/stall-recovery.ts
@@ -282,9 +282,17 @@ export async function recoverStalledTasks(
     // `link.created_at desc`), so the newest *used* one is the last run to have
     // happened — an empty thread linked afterwards must not shadow it.
     // Only query PRs for a repo-backed task — that's the one gate that needs it.
-    const hasPr =
-      item.repo != null &&
-      (await ctx.storage.taskBoard.listPrs(item.id, organizationId)).length > 0;
+    let hasPr: boolean;
+    try {
+      hasPr =
+        item.repo != null &&
+        (await ctx.storage.taskBoard.listPrs(item.id, organizationId)).length >
+          0;
+    } catch (err) {
+      // Isolated like every other per-item step: a blip here must not skip the rest of the batch.
+      console.error(`[task-board] listPrs for ${item.id} failed`, err);
+      continue;
+    }
     if (!shouldAdvanceToReview(item, hasPr)) continue;
     const thread = item.threads.find((t) => t.hasMessages);
     if (!thread) continue;


### PR DESCRIPTION
**Source**: a bug found while auditing `apps/api/src/tools/task-board/stall-recovery.ts` (task-board tooling focus area) for concurrency/reliability gaps.

**Bug**: `recoverStalledTasks` runs fire-and-forget on every `TASK_BOARD_ITEM_LIST` call, iterating every task-board item in the org. Its own doc comment promises "Best-effort per task: one card's failure never stops the others" — and every step in the loop honors that with its own try/catch, EXCEPT the `listPrs` read used to compute `hasPr`. That call sat outside any try/catch, so a single DB blip (or org-fs hiccup) on one card's PR lookup throws out of the whole `for` loop, silently skipping stall recovery for every card listed after it in that batch. Under load (an org with many task-board items, one flaky read) this means most of a board-open's stall recovery just doesn't happen, with no signal beyond a console.error the loop never even reaches.

**Fix**: wrap the `listPrs`-backed `hasPr` computation in the same isolate-and-continue pattern already used above it (the `failNeverStartedThreads` step) and below it (the per-thread action step) — log and move to the next item instead of letting the loop die.

**Verify**: `cd apps/api && bunx tsc --noEmit` (clean); `bunx oxlint apps/api/src/tools/task-board/stall-recovery.ts` (0 warnings/errors); `bun test apps/api/src/tools/task-board/stall-recovery.test.ts` (23 pass — the pure-logic coverage for this file, unaffected by the change). No new integration test: reproducing the isolation gap needs a real-Postgres failure injection (this repo's testing tiers ban mocking `StudioContext`/storage in a unit test), which isn't runnable in this environment; the fix itself is a one-line structural mirror of the pattern already proven correct twice in the same loop.

**Local checks run**: `bun run fmt`, `bunx tsc --noEmit` (apps/api), `bunx oxlint` on the changed file, targeted `bun test`. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates `listPrs` failures in task-board stall recovery. Previously, an error from `listPrs` aborted `recoverStalledTasks` and skipped all later items; now we catch, log, and continue so only the failing item is skipped.

- Wraps the `listPrs`-backed `hasPr` computation in a try/catch and logs `[task-board] listPrs for <itemId> failed`, mirroring other per-item steps.
- No API or schema changes; behavior change is limited to preserving per-item best-effort processing during a PR lookup blip.

<sup>Written for commit 1e4e5ba064a387a07860493dbd0e8e2e87e03247. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6315?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

