### PR TITLE
fix(jira): surface a body-read failure instead of coercing it to an empty success

### DIFF
--- a/apps/api/src/jira/client.test.ts
+++ b/apps/api/src/jira/client.test.ts
@@ -310,4 +310,35 @@ describe("JiraClient", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  it("does not coerce a body-read failure on a 200 into an empty success", async () => {
+    let callCount = 0;
+    const originalFetch = globalThis.fetch;
+    const mockFetch = mock(async () => {
+      callCount++;
+      const response = new Response("", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+      response.text = () => Promise.reject(new Error("stream reset"));
+      return response;
+    });
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
+
+    try {
+      const client = new JiraClient(
+        "https://acme.atlassian.net",
+        "user@example.com",
+        "token",
+      );
+      await expect(client.myself()).rejects.toMatchObject({
+        cause: {
+          message: expect.stringContaining("failed to read response body"),
+        },
+      });
+      expect(callCount).toBeGreaterThan(1); // Retried as a network failure, not returned as undefined
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
 });

--- a/apps/api/src/jira/client.ts
+++ b/apps/api/src/jira/client.ts
@@ -147,7 +147,15 @@ export class JiraClient {
         },
         signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       });
-      const body = await response.text().catch(() => "");
+      let body: string;
+      try {
+        body = await response.text();
+      } catch (cause) {
+        // Distinct from a legit empty body: don't silently coerce to "".
+        throw new Error(`Jira ${path} failed to read response body`, {
+          cause,
+        });
+      }
       if (!response.ok) {
         throw new Error(
           `Jira ${path} failed (${response.status}): ${body.slice(0, 300)}`,


### PR DESCRIPTION
**Bug, found reading `apps/api/src/jira/client.ts`'s request path.**

`request()` read the response body with `await response.text().catch(() => "")`. That `.catch` was meant to keep the 204-empty-body case simple, but it also swallows a genuine stream failure (connection reset mid-read) on what looked like a 200 — the code then hits `if (body === "") return undefined as T;` and silently returns `undefined` as a *successful* result, bypassing the retry logic entirely (nothing threw) and leaving the caller to fail later with a confusing `Cannot read properties of undefined` instead of a clear Jira error.

**Failure scenario:** Jira's connection drops mid-body on an otherwise-200 response to, say, `myself()` (used to validate credentials on save) or `listBoardIssues()`. Before this fix, the call returns `undefined` as if Jira replied with nothing, the org's Jira integration setup silently "succeeds" with garbage, and the real transient failure is never retried.

**Fix:** read the body without swallowing the reject; a text()-read failure now throws its own `Error` (with the original error as `.cause`), which — having no HTTP status to match — falls into `isRetriableError`'s network-failure branch and gets retried like any other transient fetch failure, exactly as a dropped connection should be treated.

**Regression test:** `client.test.ts` — "does not coerce a body-read failure on a 200 into an empty success": mocks a 200 response whose `.text()` rejects, asserts the client retries (not returns `undefined`) and the final rejection's `.cause` names the body-read failure.

**Reviewer check:** `cd apps/api && bun test src/jira/client.test.ts`

**Locally verified:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bun test src/jira/client.test.ts` (18 pass), `bunx oxlint src/jira/client.ts src/jira/client.test.ts` (0 warnings/errors). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces response body-read failures in the Jira client so transient network errors trigger retries and clear errors. Previously a 200 whose body read failed was coerced to an empty success (undefined), bypassing retries; now the read throws with its cause, so calls like myself() and listBoardIssues() retry instead of “succeeding” with undefined.

<sup>Written for commit eaa786c874a88323d68acb63e20bed938a3db44d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6316?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

