### PR TITLE
fix(main-panel-tabs): stop a deep-linked assets tab from bouncing away mid-load

### DIFF
--- a/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -264,6 +264,8 @@ export function useMainPanelTabs(ctx: {
     fileConfigsQuery.data?.configs ?? [],
     siteName,
   );
+  // Don't bounce a deep-linked `?main=assets` away before the first config load resolves.
+  const assetsTabPending = fileConfigsQuery.isPending;
 
   const { activeTab: rawActiveTab, mainOpen: rawMainOpen } =
     resolveActiveTabAndOpen({
@@ -292,7 +294,7 @@ export function useMainPanelTabs(ctx: {
       ? resolveDefaultTabId(layoutForDefault)
       : rawActiveTab === "content" && !showContentTab
         ? resolveDefaultTabId(layoutForDefault)
-        : rawActiveTab === "assets" && !showAssetsTab
+        : rawActiveTab === "assets" && !showAssetsTab && !assetsTabPending
           ? resolveDefaultTabId(layoutForDefault)
           : rawActiveTab;
   const mainOpen =


### PR DESCRIPTION
**Bug**: `use-main-panel-tabs.ts` redirects `?main=assets` to the default tab whenever `showAssetsTab` is false — but `showAssetsTab` is derived straight from `fileConfigsQuery.data`, with no check for the query still being in flight. On a fresh page load (no cache yet) `fileConfigsQuery.data` is `undefined` for a beat, so `showAssetsTab` reads `false` and the redirect fires before the bucket match ever gets a chance to resolve true — a user opening a bookmarked/shared `?main=assets` link, or refreshing on that tab, gets silently bounced to whatever the default tab is.

The git tab already guards against this exact race with `prQuery.isPending` (see `gitTabVisible`); the assets tab was missing the equivalent guard.

**Fix**: hold the assets tab selected while `fileConfigsQuery.isPending`. `AssetsTab` already renders inside its own `<Suspense>` boundary in `index.tsx`, so keeping the tab selected during load just shows that fallback instead of redirecting away.

**How I verified**: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts` (0 warnings/errors). No existing test file covers this hook (it composes ~15 other hooks — a real unit test would need heavy mocking, which the repo's testing philosophy reserves for e2e). Full CI validates the rest.

A reviewer can confirm by reading the `assetsTabPending` guard next to the existing `gitTabVisible`/`prQuery.isPending` pattern a few lines above it — same shape, same race.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents deep-linked Assets tab (?main=assets) from redirecting to the default tab while configs load. Previously it redirected because showAssetsTab read false before fileConfigsQuery resolved; now it holds the Assets tab selected during the pending state and shows its Suspense fallback.

- Added assetsTabPending = fileConfigsQuery.isPending and gated the assets redirect on !assetsTabPending.
- Mirrors the existing git tab guard (prQuery.isPending).
- Change is isolated to apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts; no migrations or API changes.

<sup>Written for commit 21205c8141254d93012d2a6b2794fff5b67a8f2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

