### PR TITLE
fix(editor-resolve): only match code agents in choose-editor

### DIFF
--- a/apps/api/src/api/routes/editor-resolve.ts
+++ b/apps/api/src/api/routes/editor-resolve.ts
@@ -8,7 +8,7 @@
  *
  * Resolution is relative to the authenticated user: the same storefront can be
  * imported into several orgs, so we scan the orgs the caller is a member of and
- * return every project whose name (`title`) matches `site` (lowercased).
+ * return every code agent (repo-backed) whose name (`title`) matches `site`.
  * That makes access implicit (orgs the caller isn't in never appear — no leak,
  * no false 403) and lets `/choose-editor` offer a picker when the site lives in
  * more than one of the caller's orgs. Instance-level: no org in the URL path.
@@ -33,6 +33,19 @@ interface EditorMatch {
 
 interface EditorResolveResult {
   matches: EditorMatch[];
+}
+
+/**
+ * True when the agent is a code agent — it has a checked-out GitHub source
+ * (`metadata.githubRepo.url`). Mirrors `agentHasClonableSource` in
+ * `apps/web/src/lib/agent-capabilities.ts`; the metadata bag isn't centrally
+ * schematized, so this stays loosely typed.
+ */
+function hasClonableSource(metadata: unknown): boolean {
+  if (typeof metadata !== "object" || metadata === null) return false;
+  const meta = metadata as { githubRepo?: { url?: unknown } | null };
+  const url = meta.githubRepo?.url;
+  return typeof url === "string" && url.length > 0;
 }
 
 export function createEditorResolveRoutes() {
@@ -79,6 +92,8 @@ export function createEditorResolveRoutes() {
       const vms = await ctx.storage.virtualMcps.list(org.id);
       for (const vm of vms) {
         if (vm.title.toLowerCase() !== slug) continue;
+        // Match by name, but only code agents (repo-backed); skip Decopilot-only.
+        if (!hasClonableSource(vm.metadata)) continue;
         matches.push({
           orgSlug: org.slug,
           orgName: org.name ?? org.slug,

--- a/packages/e2e/tests/editor-resolve.spec.ts
+++ b/packages/e2e/tests/editor-resolve.spec.ts
@@ -42,11 +42,19 @@ async function createOrg(
   return body.slug ?? body.data?.slug ?? slug;
 }
 
+/**
+ * Create a project named `siteSlug`. By default it's a code agent (repo-backed
+ * via `metadata.githubRepo`), which is what editor-resolve returns. Pass
+ * `{ codeAgent: false }` for a Decopilot-only agent (no source) that must be
+ * excluded even when the name collides.
+ */
 async function createProjectForSite(
   ctx: APIRequestContext,
   orgSlug: string,
   siteSlug: string,
+  opts: { codeAgent?: boolean } = {},
 ): Promise<string> {
+  const codeAgent = opts.codeAgent ?? true;
   const created = await callSelfMcpTool<{ item: { id: string } }>(
     ctx,
     orgSlug,
@@ -56,7 +64,16 @@ async function createProjectForSite(
         // The project name (`title`) is what editor-resolve matches on.
         title: siteSlug,
         connections: [],
-        metadata: { instructions: null },
+        metadata: {
+          instructions: null,
+          githubRepo: codeAgent
+            ? {
+                url: `https://github.com/e2e/${siteSlug}`,
+                owner: "e2e",
+                name: siteSlug,
+              }
+            : undefined,
+        },
       },
     },
   );
@@ -82,6 +99,14 @@ test.describe("Editor resolve (choose-editor backend)", () => {
     const org2Slug = await createOrg(ownerCtx, `e2e-org2-${suffix}`);
     const project2 = await createProjectForSite(ownerCtx, org2Slug, slug);
 
+    // A Decopilot-only agent (no source) with the SAME name must be excluded.
+    const decopilotOnly = await createProjectForSite(
+      ownerCtx,
+      owner.orgSlug,
+      slug,
+      { codeAgent: false },
+    );
+
     const resolveUrl = (site: string) =>
       `/api/_editor-resolve?site=${encodeURIComponent(site)}`;
 
@@ -92,6 +117,9 @@ test.describe("Editor resolve (choose-editor backend)", () => {
     const byProject = new Map(body.matches.map((m) => [m.project.id, m]));
     expect(byProject.get(project1)?.orgSlug).toBe(owner.orgSlug);
     expect(byProject.get(project2)?.orgSlug).toBe(org2Slug);
+    // Only code agents — the Decopilot-only namesake is not a match.
+    expect(byProject.has(decopilotOnly)).toBe(false);
+    expect(body.matches.length).toBe(2);
 
     // Casing of the site name doesn't matter (slug is lowercased).
     const okUpper = await ownerCtx.get(resolveUrl(slug.toUpperCase()));


### PR DESCRIPTION
## Resumo

O atalho `/choose-editor` (fluxo do "." nas storefronts → escolher onde editar) estava casando com **qualquer** virtual MCP cujo nome batesse com o site. Por isso um agente só-Decopilot (sem source editável) aparecia como opção de editor mesmo quando só existe um code agent de verdade — como no print, onde "DecoCMS" e "decocms" apareciam lado a lado.

Agora o resolver continua casando pelo **nome** do agente (`title`), mas só retorna **code agents** — agentes com source do GitHub clonado (`metadata.githubRepo.url`, tanto imports do GitHub quanto clones de template público do Start Website). Agentes só-Decopilot com nome colidente não aparecem mais.

## Mudanças

- `apps/api/src/api/routes/editor-resolve.ts`: novo helper `hasClonableSource(metadata)` (espelha `agentHasClonableSource` de `apps/web/src/lib/agent-capabilities.ts`); filtra os matches para code agents; docstrings atualizados.
- `packages/e2e/tests/editor-resolve.spec.ts`: inverte o teste que codificava o comportamento antigo — projetos casados agora são code agents (com `metadata.githubRepo`), e adiciona asserção de que um agente só-Decopilot com o mesmo nome é **excluído**.

## Testes / áreas afetadas

- `bun run fmt`, `bun run check` (por workspace) e `bun run lint` limpos nos arquivos alterados.
- `metadata.githubRepo` faz round-trip via `COLLECTION_VIRTUAL_MCP_CREATE` → `virtualMcps.list()`, então o filtro lê dado real.

## Observação

"Code agent" aqui = **qualquer agente com repo** (GitHub import + clone de template público, os dois setam `githubRepo.url`). Se a intenção for mais restrita (só repos conectados ao GitHub), dá pra apertar pra lógica do `agentHasConnectedGithub`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limits the /choose-editor resolver to code agents so Decopilot-only agents with a matching name no longer appear as editor targets. Previously it matched any virtual MCP by title; now it still matches by title but only returns agents with `metadata.githubRepo.url`.

- Updates the resolver with a `hasClonableSource` helper and filters matches to repo-backed agents.
- Inverts and extends the e2e test to assert that same-named Decopilot-only agents are excluded.
- No API shape changes; responses may include fewer matches where non-code agents were previously included.

<sup>Written for commit acbcbd168b3664736494d2a66de717b5f4c54480. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

