### PR TITLE
fix(web): render project icons via AgentAvatar in choose-editor picker

### DIFF
--- a/apps/web/src/routes/choose-editor.tsx
+++ b/apps/web/src/routes/choose-editor.tsx
@@ -18,6 +18,7 @@ import { Navigate, useNavigate, useSearch } from "@tanstack/react-router";
 import { useQuery } from "@tanstack/react-query";
 import { Loading01 } from "@untitledui/icons";
 import { Button } from "@decocms/ui/components/button.tsx";
+import { AgentAvatar } from "@/components/agent-icon";
 import RequiredAuthLayout from "@/layouts/required-auth-layout";
 import { KEYS } from "@/lib/query-keys";
 import { useT } from "@/i18n/use-t.ts";
@@ -193,15 +194,11 @@ function EditorChooser({
             })}
             className="flex w-full items-center gap-3 rounded-lg border border-border bg-card p-3 text-left transition-colors hover:bg-accent"
           >
-            {match.project.icon ? (
-              <img
-                src={match.project.icon}
-                alt=""
-                className="size-8 shrink-0 rounded-md object-cover"
-              />
-            ) : (
-              <div className="size-8 shrink-0 rounded-md bg-muted" />
-            )}
+            <AgentAvatar
+              icon={match.project.icon}
+              name={match.project.title}
+              size="sm"
+            />
             <div className="flex min-w-0 flex-col">
               <span className="truncate text-sm font-medium text-foreground">
                 {match.project.title}


### PR DESCRIPTION
## Summary

The `/choose-editor` multi-workspace picker rendered each project's icon as a raw `<img src={match.project.icon}>`. But project icons aren't plain URLs — they're stored in the app's internal format (e.g. `icon://Briefcase01?color=yellow`). Feeding that string to `<img src>` produces a broken-image placeholder, which is what users saw.

Fix: render the icon through the shared `AgentAvatar` component (`@/components/agent-icon`) — the same component every other surface uses. It parses the `icon://Name?color=` format (and real image URLs, with a deterministic fallback for null).

## Affected areas

Only the multi-match case of `/choose-editor` (when a site lives in more than one of the caller's orgs). The single-match case redirects immediately without rendering an icon, so it was never affected.

## Testing

- `bun run fmt` ✅
- `bun run --cwd=apps/web check` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes project icons in the /choose-editor multi-workspace picker. Old behavior rendered `match.project.icon` directly in an <img>, which showed broken placeholders because values are `icon://Name?color=`; new behavior uses `AgentAvatar` from `@/components/agent-icon` to parse that format (and real URLs) with a deterministic fallback, matching the rest of the app.

- Scope: only affects the multi-match render path; the single-match redirect path is unchanged.
- Code touchpoints: replaces the raw <img> and empty-box fallback with `AgentAvatar` (`icon`, `name`, `size="sm"`).
- Verify: visual size/alignment of the avatar in the list matches the prior 32px layout.

<sup>Written for commit eb522ee8998e5f79c72a93791b6fc1f41a4d8696. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6323?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

