### PR TITLE
fix(native): bypass updater throttle for new platforms

### DIFF
--- a/apps/native/scripts/ci/native-update-channel.mjs
+++ b/apps/native/scripts/ci/native-update-channel.mjs
@@ -73,17 +73,29 @@ export function shouldPromote({
       reason: `channel already at newer ${currentManifest.version}`,
     };
   }
-  if (cmp === 0 && !force) {
-    // Same version: idempotent skip. A forced dispatch still re-promotes so
-    // a corrupt-but-parseable manifest of the current version can be healed.
+
+  if (force) {
+    return { promote: true, reason: "forced by workflow_dispatch" };
+  }
+
+  const currentPlatforms = new Set(platformKeysOf(currentManifest));
+  const missingRequiredPlatforms = Object.keys(PLATFORM_ASSETS).filter(
+    (key) => !currentPlatforms.has(key),
+  );
+  if (missingRequiredPlatforms.length > 0) {
+    return {
+      promote: true,
+      reason: `channel missing required platform(s): ${missingRequiredPlatforms.join(", ")}`,
+    };
+  }
+
+  if (cmp === 0) {
+    // Same version with complete platform coverage is an idempotent skip.
+    // An incomplete manifest is repaired by the coverage check above.
     return {
       promote: false,
       reason: `channel already at ${currentManifest.version}`,
     };
-  }
-
-  if (force) {
-    return { promote: true, reason: "forced by workflow_dispatch" };
   }
 
   const pubDateMs = Date.parse(currentManifest.pub_date ?? "");
@@ -204,11 +216,13 @@ function platformKeysOf(manifest) {
  * Coverage-regression guard, run against the CURRENTLY-PUBLISHED manifest
  * before uploading a new one.
  *
- * `shouldPromote` compares only `version`, so a repair dispatch from a ref
- * predating a platform key — or a revert — can legitimately decide to promote
- * a narrower manifest over a wider one. Nothing downstream would notice: the
- * dropped platform's clients simply poll a manifest without their key and see
- * "no update" forever, with no failed job and no dangling URL to grep for.
+ * `shouldPromote` detects when the published manifest is missing a platform
+ * required by the current ref, but it cannot detect the inverse: a repair
+ * dispatch from a ref predating a platform key — or a revert — can legitimately
+ * decide to promote a narrower manifest over a wider one. Nothing downstream
+ * would notice: the dropped platform's clients simply poll a manifest without
+ * their key and see "no update" forever, with no failed job and no dangling URL
+ * to grep for.
  *
  * Fail-open on an absent/unreadable current manifest, matching `shouldPromote`
  * — there is nothing to regress from. Fail CLOSED on an empty next manifest:

--- a/apps/native/scripts/ci/native-update-channel.test.ts
+++ b/apps/native/scripts/ci/native-update-channel.test.ts
@@ -13,9 +13,17 @@ import {
 const NOW = Date.parse("2026-07-30T12:00:00Z");
 const iso = (msAgo: number) => new Date(NOW - msAgo).toISOString();
 
-const manifest = (version: string, pubDate?: string) => ({
+const manifest = (
+  version: string,
+  pubDate?: string,
+  platforms: Record<string, object> = {
+    "darwin-aarch64": {},
+    "linux-x86_64": {},
+  },
+) => ({
   version,
   ...(pubDate !== undefined ? { pub_date: pubDate } : {}),
+  platforms,
 });
 
 describe("parseSemver / compareSemver", () => {
@@ -49,7 +57,9 @@ describe("shouldPromote", () => {
   });
 
   test("never regresses: skips when channel is newer, even forced", () => {
-    const current = manifest("9.0.0", iso(THROTTLE_MS * 2));
+    const current = manifest("9.0.0", iso(THROTTLE_MS * 2), {
+      "darwin-aarch64": {},
+    });
     expect(shouldPromote({ ...base, currentManifest: current }).promote).toBe(
       false,
     );
@@ -78,6 +88,26 @@ describe("shouldPromote", () => {
     ).toBe(true);
   });
 
+  test("missing required platform bypasses the throttle", () => {
+    const current = manifest("4.150.13", iso(60_000), {
+      "darwin-aarch64": {},
+    });
+    expect(shouldPromote({ ...base, currentManifest: current })).toEqual({
+      promote: true,
+      reason: "channel missing required platform(s): linux-x86_64",
+    });
+  });
+
+  test("missing required platform repairs the current version", () => {
+    const current = manifest("4.151.0", iso(60_000), {
+      "darwin-aarch64": {},
+    });
+    expect(shouldPromote({ ...base, currentManifest: current })).toEqual({
+      promote: true,
+      reason: "channel missing required platform(s): linux-x86_64",
+    });
+  });
+
   test("fail-open: missing, unparseable, or FUTURE pub_date promotes", () => {
     for (const bad of [
       manifest("4.150.13"),
@@ -90,7 +120,7 @@ describe("shouldPromote", () => {
     }
   });
 
-  test("throttles a fresh manifest, promotes a stale one", () => {
+  test("throttles a fresh complete manifest, promotes a stale one", () => {
     const fresh = manifest("4.150.13", iso(THROTTLE_MS - 60_000));
     const stale = manifest("4.150.13", iso(THROTTLE_MS + 60_000));
     expect(shouldPromote({ ...base, currentManifest: fresh }).promote).toBe(


### PR DESCRIPTION
## Summary

- promote the native rolling channel immediately when its published manifest is missing a required platform
- repair incomplete same-version manifests while preserving no-downgrade and complete-manifest throttling
- cover missing-platform, same-version repair, complete-manifest throttle, and newer-version safety

## Testing

- bun run fmt
- bun test apps/native/scripts/ci/native-update-channel.test.ts (26 passed)

Closes #6288

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bypasses the native updater’s rolling throttle when the published manifest is missing a required platform, and repairs incomplete same-version manifests. Previously, the channel could be throttled or skip re-promotion; now it promotes immediately to add missing platforms while still preventing downgrades and honoring the throttle for complete manifests. Aligns with #6288.

- `shouldPromote` now:
  - Promotes if `force` is set (checked earlier), unless it would downgrade.
  - Promotes when the current manifest lacks any required platform(s), including for the same version.
  - Skips equal-version promotions only when platform coverage is complete; keeps newer-version guard and complete-manifest throttle.
- Tests add platform-aware fixtures and cover missing-platform bypass, same-version repair, complete-manifest throttling, and newer-version safety.

<sup>Written for commit e168f12e9d8b2bec1fad0108fdc70611fb1c2b3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

