### PR TITLE
feat(publish): load the Fast Preview publish popover in two beats

### DIFF
--- a/apps/api/src/decofile/git-compat.test.ts
+++ b/apps/api/src/decofile/git-compat.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { buildMergeTreeEntries } from "./git-compat";
+import {
+  buildMergeTreeEntries,
+  buildPublishStatus,
+  normalizeCompareStatus,
+} from "./git-compat";
 
 describe("buildMergeTreeEntries", () => {
   it("writes a rename as create-destination + delete-source", () => {
@@ -74,5 +78,103 @@ describe("buildMergeTreeEntries", () => {
     expect(entries).toEqual([
       { path: "Old.json", mode: "100644", type: "blob", sha: null },
     ]);
+  });
+});
+
+describe("normalizeCompareStatus", () => {
+  it("maps GitHub's full compare vocabulary onto the three drawable states", () => {
+    expect(normalizeCompareStatus("added")).toBe("added");
+    expect(normalizeCompareStatus("copied")).toBe("added");
+    expect(normalizeCompareStatus("removed")).toBe("removed");
+    expect(normalizeCompareStatus("renamed")).toBe("renamed");
+    expect(normalizeCompareStatus("modified")).toBe("modified");
+    expect(normalizeCompareStatus("changed")).toBe("modified");
+    expect(normalizeCompareStatus("unchanged")).toBe("modified");
+  });
+
+  it("folds an unknown status into modified rather than leaking it", () => {
+    expect(normalizeCompareStatus("something-new")).toBe("modified");
+  });
+});
+
+describe("buildPublishStatus", () => {
+  const compared = (
+    files: Array<{
+      filename: string;
+      status: string;
+      previousFilename?: string;
+    }>,
+  ) => ({
+    aheadBy: 2,
+    behindBy: 0,
+    files,
+  });
+
+  it("carries the changed-path manifest with a rename's source path", () => {
+    const status = buildPublishStatus({
+      base: "main",
+      branch: "feat",
+      headSha: "h1",
+      compared: compared([
+        { filename: ".deco/blocks/Home.json", status: "modified" },
+        {
+          filename: ".deco/blocks/Header.json",
+          status: "renamed",
+          previousFilename: ".deco/blocks/Hero.json",
+        },
+      ]),
+    });
+    expect(status.changedFiles).toEqual([
+      { path: ".deco/blocks/Home.json", status: "modified" },
+      {
+        path: ".deco/blocks/Header.json",
+        status: "renamed",
+        previousPath: ".deco/blocks/Hero.json",
+      },
+    ]);
+    expect(status.changedFilesTruncated).toBe(false);
+    expect(status.aheadOfBase).toBe(2);
+    expect(status.headSha).toBe("h1");
+  });
+
+  it("reports the PRE-cap total while capping the manifest itself", () => {
+    const files = Array.from({ length: 240 }, (_, i) => ({
+      filename: `.deco/blocks/Block${i}.json`,
+      status: "added",
+    }));
+    const status = buildPublishStatus({
+      base: "main",
+      branch: "feat",
+      headSha: "h1",
+      compared: compared(files),
+    });
+    expect(status.changedFiles).toHaveLength(200);
+    expect(status.changedFilesTotal).toBe(240);
+    expect(status.changedFilesTruncated).toBe(true);
+  });
+
+  it("reports an empty, untruncated manifest when nothing changed", () => {
+    const status = buildPublishStatus({
+      base: "main",
+      branch: "main",
+      headSha: "h1",
+      compared: { aheadBy: 0, behindBy: 0, files: [] },
+    });
+    expect(status.changedFiles).toEqual([]);
+    expect(status.changedFilesTotal).toBe(0);
+    expect(status.changedFilesTruncated).toBe(false);
+  });
+
+  it("keeps every local-work field empty — sandbox-less mode has no working tree", () => {
+    const status = buildPublishStatus({
+      base: "main",
+      branch: "feat",
+      headSha: "h1",
+      compared: compared([{ filename: "a.json", status: "added" }]),
+    });
+    expect(status.modified).toEqual([]);
+    expect(status.staged).toEqual([]);
+    expect(status.files).toEqual([]);
+    expect(status.unpushed).toBe(0);
   });
 });

--- a/apps/api/src/decofile/git-compat.ts
+++ b/apps/api/src/decofile/git-compat.ts
@@ -22,6 +22,17 @@ import { mapBounded, resolveOrCreateHead } from "./read-decofile";
 const DIFF_MAX_FILES = 200;
 const DIFF_FETCH_CONCURRENCY = 12;
 
+/** How a path changed between base and head, in the publish manifest. */
+export type CompatChangeStatus = "added" | "modified" | "removed" | "renamed";
+
+/** One changed path, without its content. See {@link CompatGitStatus.changedFiles}. */
+export interface CompatChangedFile {
+  path: string;
+  status: CompatChangeStatus;
+  /** Rename source; absent otherwise. */
+  previousPath?: string;
+}
+
 /** Mirror of the daemon's `git status` JSON (see web GitStatus). */
 export interface CompatGitStatus {
   not_added: string[];
@@ -42,20 +53,51 @@ export interface CompatGitStatus {
   behindBase: number;
   headSha: string;
   unpushed: 0;
+  /**
+   * The base…head changed-path manifest — every path {@link githubGitDiff}
+   * would return a body for, without paying for the bodies. Free: GitHub's
+   * compare response already carries `files`, and asking for it costs the SAME
+   * request the drift check already makes (identical URL, one ETag entry).
+   * Sliced to {@link DIFF_MAX_FILES} so manifest and diff agree key-for-key.
+   */
+  changedFiles: CompatChangedFile[];
+  /** Changed-path count BEFORE the cap — what "N changes" must actually say. */
+  changedFilesTotal: number;
+  /** True when the cap dropped paths, so no caller offers an all-files action. */
+  changedFilesTruncated: boolean;
 }
 
-export async function githubGitStatus(
-  client: GitDataClient,
-  branch: string,
-): Promise<CompatGitStatus> {
-  const base = await client.getDefaultBranch();
-  // Materialize thread-minted branches exactly like the decofile read does —
-  // the header polls status before the CMS ever reads content.
-  const headSha = await resolveOrCreateHead(client, branch);
-  const drift =
-    base === branch
-      ? { aheadBy: 0, behindBy: 0 }
-      : await client.compare(base, branch);
+/**
+ * GitHub's compare `status` vocabulary is wider than the three states the CMS
+ * renders. `copied`/`changed`/`unchanged` fold into the nearest state the
+ * publish surface can draw, rather than leaking an unhandled string into it.
+ */
+export function normalizeCompareStatus(raw: string): CompatChangeStatus {
+  if (raw === "added" || raw === "copied") return "added";
+  if (raw === "removed") return "removed";
+  if (raw === "renamed") return "renamed";
+  return "modified";
+}
+
+interface CompareDetail {
+  aheadBy: number;
+  behindBy: number;
+  files: Array<{ filename: string; status: string; previousFilename?: string }>;
+}
+
+/** Pure fold from a compare response to the status payload. */
+export function buildPublishStatus(args: {
+  base: string;
+  branch: string;
+  headSha: string;
+  compared: CompareDetail;
+}): CompatGitStatus {
+  const { base, branch, headSha, compared } = args;
+  const changedFiles = compared.files.slice(0, DIFF_MAX_FILES).map((f) => ({
+    path: f.filename,
+    status: normalizeCompareStatus(f.status),
+    ...(f.previousFilename ? { previousPath: f.previousFilename } : {}),
+  }));
   return {
     not_added: [],
     conflicted: [],
@@ -71,17 +113,59 @@ export async function githubGitStatus(
     tracking: `origin/${branch}`,
     detached: false,
     base,
-    aheadOfBase: drift.aheadBy,
-    behindBase: drift.behindBy,
+    aheadOfBase: compared.aheadBy,
+    behindBase: compared.behindBy,
     headSha,
     unpushed: 0,
+    changedFiles,
+    changedFilesTotal: compared.files.length,
+    changedFilesTruncated: compared.files.length > changedFiles.length,
   };
+}
+
+/** The manifest rides on the drift check: `compareDetailed` hits the URL
+ *  `compare` already hit and shares its ETag entry. */
+export async function githubGitStatus(
+  client: GitDataClient,
+  branch: string,
+): Promise<CompatGitStatus> {
+  const base = await client.getDefaultBranch();
+  // Materialize thread-minted branches exactly like the decofile read does.
+  const headSha = await resolveOrCreateHead(client, branch);
+  const compared =
+    base === branch
+      ? { aheadBy: 0, behindBy: 0, files: [] }
+      : await client.compareDetailed(base, branch);
+  return buildPublishStatus({ base, branch, headSha, compared });
 }
 
 /** Mirror of the daemon's diff JSON: full old/new contents per path. */
 export interface CompatGitDiff {
   diffs: Record<string, { from: string | null; to: string | null }>;
   mergeBaseSha: string;
+}
+
+/**
+ * Base-side blob sha per path, read off the merge-base tree.
+ *
+ * Empty for an all-additions diff: nothing has a base side, so the two calls
+ * this makes would be discarded. That is also the whole-repo recursive read,
+ * which the ETag cache excludes and which 502s as `tree listing truncated by
+ * GitHub` on large repos — so the common "created a page" publish stops
+ * paying for it, and stops failing on it.
+ */
+async function baseBlobShas(
+  client: GitDataClient,
+  mergeBaseSha: string,
+  files: Array<{ status: string }>,
+): Promise<Map<string, string>> {
+  const byPath = new Map<string, string>();
+  if (files.every((f) => f.status === "added")) return byPath;
+  const baseTreeSha = await client.getCommitTreeSha(mergeBaseSha);
+  for (const entry of await client.getTreeRecursive(baseTreeSha)) {
+    if (entry.type === "blob") byPath.set(entry.path, entry.sha);
+  }
+  return byPath;
 }
 
 /**
@@ -99,10 +183,14 @@ export async function githubGitDiff(
   const detailed = await client.compareDetailed(againstBase, branch);
   const files = detailed.files.slice(0, DIFF_MAX_FILES);
 
-  const baseTreeSha = await client.getCommitTreeSha(detailed.mergeBaseSha);
-  const baseTree = await client.getTreeRecursive(baseTreeSha);
-  const baseBlobByPath = new Map(
-    baseTree.filter((e) => e.type === "blob").map((e) => [e.path, e.sha]),
+  if (files.length === 0) {
+    return { diffs: {}, mergeBaseSha: detailed.mergeBaseSha };
+  }
+
+  const baseBlobByPath = await baseBlobShas(
+    client,
+    detailed.mergeBaseSha,
+    files,
   );
 
   const entries = await mapBounded(files, DIFF_FETCH_CONCURRENCY, async (f) => {

--- a/apps/web/src/components/sandbox/hooks/use-publish-gate.ts
+++ b/apps/web/src/components/sandbox/hooks/use-publish-gate.ts
@@ -1,6 +1,7 @@
 import {
   canPublishDirectly,
   needsSmartReviewJudgment,
+  resolvePathGate,
   smartReviewGate,
   type GitDiffResult,
   type GitStatus,
@@ -24,6 +25,13 @@ export function useResolvedPublishGate(args: {
   diff: GitDiffResult | null;
   policy: PublishPolicy;
   judgeEnabled?: boolean;
+  /**
+   * The changed-file manifest, for a surface that counts changes before it can
+   * read them. Without it a null diff falls through as allowed, so such a
+   * surface would publish ungated; with it the decision comes from
+   * {@link resolvePathGate}, which never allows on incomplete information.
+   */
+  paths?: readonly string[] | null;
 }): { gate: PublishGate; ready: boolean } {
   const {
     orgSlug,
@@ -33,6 +41,7 @@ export function useResolvedPublishGate(args: {
     diff,
     policy,
     judgeEnabled = true,
+    paths = null,
   } = args;
 
   const needsJudge = judgeEnabled && needsSmartReviewJudgment(diff, policy);
@@ -48,9 +57,10 @@ export function useResolvedPublishGate(args: {
     enabled: needsJudge,
   });
 
-  // While the diff is still loading (or the sandbox is unreachable) don't gate
-  // the button — let the click fall through to the dialog, which does its own
-  // loading + gating. Only enforce the gate once we actually have the diff.
+  // Manifest known, bodies not: decide from paths.
+  if (!diff && paths)
+    return { gate: resolvePathGate(paths, policy), ready: false };
+  // Neither known: fall through to the dialog, which loads and gates itself.
   if (!diff) return { gate: { allowed: true, reason: null }, ready: false };
   if (!needsJudge)
     return { gate: canPublishDirectly(diff, policy), ready: true };

--- a/apps/web/src/components/sections-editor/page-list.tsx
+++ b/apps/web/src/components/sections-editor/page-list.tsx
@@ -26,7 +26,8 @@ export interface AppEntry {
   resolveType: string;
 }
 
-function parsePageName(key: string): string {
+/** Display name for a page block key, when its content isn't available. */
+export function parsePageName(key: string): string {
   // "pages-home-c4bcbfb771e9" -> "home"
   // "pages-Category%20Page-69217" -> "Category Page"
   let name = key;

--- a/apps/web/src/components/thread/github/cms-header-actions.tsx
+++ b/apps/web/src/components/thread/github/cms-header-actions.tsx
@@ -62,14 +62,14 @@ import {
   type CmsAction,
 } from "./cms-panel-state.ts";
 import {
-  fetchGitStatus,
   hasPublishableLocalWork,
   normalizePublishPolicy,
   readGitHeadBranch,
   rebaseGitBranch,
   sandboxGitStatusQueryKey,
+  sandboxGitStatusQueryOptions,
 } from "./sandbox-git-api.ts";
-import { useChecks, usePrByBranch } from "./use-pr-data.ts";
+import { useChecks, useLastPublishedPr, usePrByBranch } from "./use-pr-data.ts";
 import { usePrReviews } from "./use-pr-reviews.ts";
 
 interface Props {
@@ -130,12 +130,12 @@ export function CmsHeaderActions({ virtualMcpId }: Props) {
       : null,
   );
 
-  /** Poll-free on purpose: every call forwards to GitHub; save hooks invalidate this key. */
+  /** Poll-free on purpose: every call forwards to GitHub; save hooks invalidate
+   *  this key. Shared verbatim with the publish popover, which reads the
+   *  changed-file manifest off the same entry — hence one options factory. */
   const statusQuery = useQuery({
-    queryKey: sandboxGitStatusQueryKey(org.slug, virtualMcpId, branch ?? ""),
-    queryFn: () => fetchGitStatus(org.slug, virtualMcpId, branch ?? ""),
+    ...sandboxGitStatusQueryOptions(org.slug, virtualMcpId, branch ?? ""),
     enabled: !!branch,
-    staleTime: 15_000,
   });
   const status = statusQuery.data ?? null;
   const branchMeta: BranchMeta = status
@@ -164,6 +164,17 @@ export function CmsHeaderActions({ virtualMcpId }: Props) {
     branch: githubHeadBranch,
   });
   const pr = prQuery.data ?? null;
+
+  /** Warmed here so the popover's "last published" line is ready before the
+   *  click; it is optional copy and must never gate that surface. */
+  const lastPublishedQuery = useLastPublishedPr({
+    orgId: org.id,
+    orgSlug: org.slug,
+    connectionId: githubRepo?.connectionId ?? "",
+    owner: githubRepo?.owner ?? "",
+    repo: githubRepo?.name ?? "",
+    base: baseBranch,
+  });
 
   const checksQuery = useChecks({
     orgId: org.id,
@@ -386,6 +397,7 @@ export function CmsHeaderActions({ virtualMcpId }: Props) {
           publishPolicy={normalizePublishPolicy(vm?.metadata?.publishPolicy)}
           draftPreviewUrl={draftPreview.url}
           destinationHost={draftPreview.host}
+          lastPublishedPr={lastPublishedQuery.data ?? null}
           onRequestApproval={() => openSurface("review")}
           openPullRequest={pr?.state === "open" ? pr : null}
           onPullRequestChanged={refreshPrState}

--- a/apps/web/src/components/thread/github/cms-publish-change-card.tsx
+++ b/apps/web/src/components/thread/github/cms-publish-change-card.tsx
@@ -129,6 +129,12 @@ export function PublishChangeCard({
   // Never flips once bodies land: no click target appears under a resting cursor.
   const hasBody = Object.keys(rawDiff.diffs).length > 0;
   const canExpand = bodyPending || hasBody;
+  /** Holds the height a sub-line will occupy, so the surface does not grow
+   *  under the cursor when bodies land. Only `edited` cards gain sub-lines
+   *  from bodies — a new page already counts its sections, and new or removed
+   *  blocks never have any. */
+  const reservesSubLine =
+    bodyPending && subLines.length === 0 && change.status === "edited";
 
   // Collapsed card = one big expand target; inner controls stop propagation.
   return (
@@ -229,6 +235,10 @@ export function PublishChangeCard({
               {line}
             </div>
           ))}
+        </div>
+      ) : !expanded && reservesSubLine ? (
+        <div className="mt-1 space-y-0.5 pl-[26px]">
+          <PublishGhost className="h-4 w-2/3" />
         </div>
       ) : null}
       {expanded ? (

--- a/apps/web/src/components/thread/github/cms-publish-change-card.tsx
+++ b/apps/web/src/components/thread/github/cms-publish-change-card.tsx
@@ -6,6 +6,7 @@
  */
 
 import { cn } from "@decocms/ui/lib/utils.ts";
+import { PublishCardFrame, PublishGhost } from "./cms-publish-frame.tsx";
 import {
   Tooltip,
   TooltipContent,
@@ -22,9 +23,14 @@ import {
 } from "./publish-change-summary.ts";
 import type { GitDiffResult } from "./sandbox-git-api.ts";
 
-/** Stable identity for a card across summary recomputes. */
+/**
+ * Stable identity for a card across summary recomputes. Path first: the file
+ * path is known from the manifest, while `blockKey` and `name` are derived
+ * from content that arrives later — keying on those would remount the card
+ * mid-load, collapsing an open diff and disarming a live discard confirmation.
+ */
 export function changeId(change: PublishChange): string {
-  return change.blockKey ?? change.filepaths[0] ?? change.name;
+  return change.filepaths[0] ?? change.blockKey ?? change.name;
 }
 
 function statusLabel(status: PublishChangeStatus, t: TFunction) {
@@ -84,6 +90,8 @@ interface PublishChangeCardProps {
   change: PublishChange;
   /** The whole publish diff; the card slices out its own files. */
   diff: GitDiffResult | null;
+  /** File bodies are still loading, so an empty slice is "not yet", not "none". */
+  bodyPending?: boolean;
   expanded: boolean;
   onToggleExpanded: () => void;
   /** Armed = this card shows Cancel/Discard; only one card may be armed. */
@@ -97,6 +105,7 @@ interface PublishChangeCardProps {
 export function PublishChangeCard({
   change,
   diff,
+  bodyPending = false,
   expanded,
   onToggleExpanded,
   confirming,
@@ -117,15 +126,14 @@ export function PublishChangeCard({
       }),
     ),
   };
-  const canExpand = Object.keys(rawDiff.diffs).length > 0;
+  // Never flips once bodies land: no click target appears under a resting cursor.
+  const hasBody = Object.keys(rawDiff.diffs).length > 0;
+  const canExpand = bodyPending || hasBody;
 
   // Collapsed card = one big expand target; inner controls stop propagation.
   return (
-    <div
-      className={cn(
-        "rounded-lg border bg-card px-3 py-2.5",
-        canExpand && !expanded && "cursor-pointer",
-      )}
+    <PublishCardFrame
+      className={cn(canExpand && !expanded && "cursor-pointer")}
       data-change-id={changeId(change)}
       onClick={canExpand && !expanded ? onToggleExpanded : undefined}
     >
@@ -226,10 +234,14 @@ export function PublishChangeCard({
       {expanded ? (
         <div className="-mx-3 mt-2 border-t pt-1">
           <div className="scroll-fade max-h-72 overflow-y-auto overscroll-contain [scrollbar-width:thin]">
-            <GitDiffList diff={rawDiff} hideFileRows editorHeight="220px" />
+            {hasBody ? (
+              <GitDiffList diff={rawDiff} hideFileRows editorHeight="220px" />
+            ) : (
+              <PublishGhost className="mx-3 my-2 h-40 rounded" />
+            )}
           </div>
         </div>
       ) : null}
-    </div>
+    </PublishCardFrame>
   );
 }

--- a/apps/web/src/components/thread/github/cms-publish-frame.tsx
+++ b/apps/web/src/components/thread/github/cms-publish-frame.tsx
@@ -1,0 +1,114 @@
+/**
+ * The publish surface's geometry, rendered by BOTH its loading fallback and
+ * its loaded content. Padding, dividers and the scroll region are defined once
+ * here, so a ghost and the thing it stands in for cannot drift apart — the
+ * previous hand-built skeleton had a smaller discard control and a shorter
+ * card than the cards it was standing in for.
+ *
+ * `state` is published as `data-publish-state` for tests to anchor on, since
+ * the visible copy alone cannot distinguish a ghosted card list from a real
+ * one. It is deliberately not `data-state`, which Radix already stamps on the
+ * popover content one level up.
+ */
+
+import { cn } from "@decocms/ui/lib/utils.ts";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+
+/** `loading`: no card list yet. `manifest`: cards real, bodies still landing.
+ *  `ready`: everything the surface will ever show is on screen. */
+export type PublishSurfaceState = "loading" | "manifest" | "ready";
+
+interface PublishFrameProps {
+  state: PublishSurfaceState;
+  /** Title row and its sub-line. */
+  header: ReactNode;
+  /** The change list, empty state, or error — owns its own scrolling. */
+  body: ReactNode;
+  /** Version-note block; omitted when there is nothing to publish. */
+  note?: ReactNode;
+  /** Review-gate row; omitted unless the gate has something to say. */
+  gate?: ReactNode;
+  footer: ReactNode;
+}
+
+export function PublishFrame({
+  state,
+  header,
+  body,
+  note,
+  gate,
+  footer,
+}: PublishFrameProps) {
+  return (
+    <div
+      className="flex min-h-0 flex-1 flex-col"
+      data-publish-state={state}
+      aria-busy={state !== "ready"}
+    >
+      <div className="space-y-0.5 px-4 py-3">{header}</div>
+      <div className="border-t" />
+      <div className="flex min-h-0 flex-1 flex-col">
+        {body}
+        {note ? (
+          <div className="space-y-1.5 border-t px-4 py-3">{note}</div>
+        ) : null}
+      </div>
+      {gate}
+      <div className="border-t" />
+      <div className="space-y-2 px-4 py-3">{footer}</div>
+    </div>
+  );
+}
+
+/** The scrolling change-list region — same padding and fade in both states. */
+export function PublishListRegion({ children }: { children: ReactNode }) {
+  return (
+    <div className="scroll-fade min-h-0 flex-1 space-y-3 overflow-y-auto overscroll-contain px-4 pt-3 pb-2 [scrollbar-width:thin]">
+      {children}
+    </div>
+  );
+}
+
+/** One card's outer box. The real card adds its own interaction affordances. */
+export function PublishCardFrame({
+  className,
+  children,
+  ...rest
+}: ComponentPropsWithoutRef<"div">) {
+  return (
+    <div
+      className={cn("rounded-lg border bg-card px-3 py-2.5", className)}
+      {...rest}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function PublishGhost({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn(
+        "animate-pulse rounded bg-muted motion-reduce:animate-none",
+        className,
+      )}
+    />
+  );
+}
+
+/**
+ * A card-shaped placeholder. Deliberately sub-line-free: content only ever
+ * grows downward from here, so nothing already on screen moves when it lands.
+ */
+export function PublishGhostCard() {
+  return (
+    <PublishCardFrame>
+      <div className="flex items-center gap-2.5">
+        <PublishGhost className="size-4 rounded-md" />
+        <PublishGhost className="h-3 w-24" />
+        <PublishGhost className="h-2.5 w-16" />
+        <PublishGhost className="ml-auto size-6 rounded" />
+      </div>
+    </PublishCardFrame>
+  );
+}

--- a/apps/web/src/components/thread/github/cms-publish-popover.tsx
+++ b/apps/web/src/components/thread/github/cms-publish-popover.tsx
@@ -1,6 +1,7 @@
 /**
  * Fast Preview's content-first publish surface — presentation only: reads come
  * from {@link useCmsPublishState}, writes from {@link useCmsPublishActions}.
+ * Loads in two beats — see {@link useCmsPublishState} for what each decides.
  */
 
 import { useMCPClient } from "@/sdk";
@@ -19,6 +20,7 @@ import {
   GitPullRequest,
   Globe01,
   Loading01,
+  RefreshCw01,
 } from "@untitledui/icons";
 import {
   Suspense,
@@ -27,16 +29,23 @@ import {
   useSyncExternalStore,
   type ReactNode,
 } from "react";
-import { useT } from "@/i18n/use-t.ts";
+import { ErrorBoundary } from "@/components/error-boundary.tsx";
+import { useT, type TFunction } from "@/i18n/use-t.ts";
 import { authClient } from "@/lib/auth-client.ts";
 import { coAuthorFromSessionUser } from "@/lib/co-author-identity.ts";
 import { formatTimeAgo } from "@/lib/format-time.ts";
-import { cn } from "@decocms/ui/lib/utils.ts";
 import { changeId, PublishChangeCard } from "./cms-publish-change-card.tsx";
+import {
+  PublishFrame,
+  PublishGhost,
+  PublishGhostCard,
+  PublishListRegion,
+  type PublishSurfaceState,
+} from "./cms-publish-frame.tsx";
 import { lastPublishAttribution } from "./pr-attribution.ts";
 import {
   buildAutoNote,
-  summarizePublishChanges,
+  resolveVersionNote,
   type PublishChange,
 } from "./publish-change-summary.ts";
 import type { PublishTarget } from "./publish-flow.ts";
@@ -85,6 +94,8 @@ export interface CmsPublishPopoverProps {
   /** Draft URL + destination host from useFastPreviewDraftUrl. */
   draftPreviewUrl: string | null;
   destinationHost: string | null;
+  /** The last publish, warmed by the header — never blocks this surface. */
+  lastPublishedPr?: PrSummary | null;
   /** Blocked gate: hand this surface over to review mode. */
   onRequestApproval: () => void;
   /** When set, publish updates this open PR instead of opening a new one. */
@@ -129,6 +140,7 @@ export function CmsPublishPopover(props: CmsPublishPopoverProps) {
       <PopoverContent
         align="end"
         sideOffset={8}
+        collisionPadding={12}
         // The menu that opened this returns focus to its trigger as it closes.
         onFocusOutside={(event) => event.preventDefault()}
         className="flex max-h-[min(720px,85vh)] w-[420px] flex-col gap-0 overflow-hidden p-0"
@@ -139,68 +151,149 @@ export function CmsPublishPopover(props: CmsPublishPopoverProps) {
   );
 }
 
-function Ghost({ className }: { className?: string }) {
-  return <div className={cn("animate-pulse rounded bg-muted", className)} />;
-}
-
-/** Ghost card matching the change-card anatomy, so loaded content lands in
- *  shapes that were already on screen instead of after a layout jump. */
-function GhostCard({ subline }: { subline?: boolean }) {
+function HeaderLine({
+  mode,
+  title,
+  subLine,
+  trailing,
+}: {
+  mode: CmsPublishMode;
+  title: ReactNode;
+  subLine?: ReactNode;
+  trailing?: ReactNode;
+}) {
+  const Icon = mode === "review" ? GitPullRequest : Globe01;
   return (
-    <div className="rounded-lg border bg-card px-3 py-2.5">
-      <div className="flex items-center gap-2.5">
-        <Ghost className="size-4 rounded-md" />
-        <Ghost className="h-3 w-24" />
-        <Ghost className="h-2.5 w-16" />
-        <Ghost className="ml-auto size-5 rounded-md" />
+    <>
+      <div className="flex items-center gap-2 text-sm font-medium">
+        <Icon className="size-4 shrink-0 text-muted-foreground" />
+        {title}
+        {trailing}
       </div>
-      {subline ? <Ghost className="mt-1.5 ml-[26px] h-2.5 w-56" /> : null}
-    </div>
+      {subLine ? (
+        <div className="pl-6 text-xs text-muted-foreground">{subLine}</div>
+      ) : null}
+    </>
   );
 }
 
-function CmsPublishSkeleton({ mode }: { mode: CmsPublishMode }) {
-  const t = useT();
-  const HeaderIcon = mode === "review" ? GitPullRequest : Globe01;
+/** Preview always works: its URL is a prop, settled before this surface opened. */
+function PreviewButton({
+  draftPreviewUrl,
+  t,
+}: {
+  draftPreviewUrl: string | null;
+  t: TFunction;
+}) {
   return (
-    <>
-      <div className="space-y-1.5 px-4 py-3">
-        <div className="flex items-center gap-2">
-          <HeaderIcon className="size-4 shrink-0 text-muted-foreground" />
-          <Ghost className="h-3.5 w-48" />
+    <Button
+      type="button"
+      variant="outline"
+      onClick={() => {
+        if (draftPreviewUrl) {
+          window.open(draftPreviewUrl, "_blank", "noopener,noreferrer");
+        }
+      }}
+      disabled={!draftPreviewUrl}
+    >
+      <Eye className="size-4" />
+      {t("thread.publishPopover.preview")}
+    </Button>
+  );
+}
+
+function CmsPublishSkeleton({
+  mode,
+  draftPreviewUrl,
+}: {
+  mode: CmsPublishMode;
+  draftPreviewUrl: string | null;
+}) {
+  const t = useT();
+  return (
+    <PublishFrame
+      state="loading"
+      header={
+        <HeaderLine
+          mode={mode}
+          title={<PublishGhost className="h-3.5 w-48" />}
+        />
+      }
+      body={
+        <PublishListRegion>
+          <div className="space-y-1.5">
+            <PublishGhostCard />
+            <PublishGhostCard />
+            <PublishGhostCard />
+          </div>
+        </PublishListRegion>
+      }
+      note={
+        <>
+          <PublishGhost className="h-3 w-20" />
+          <PublishGhost className="h-14 w-full rounded-lg" />
+        </>
+      }
+      footer={
+        <div className="flex gap-2">
+          <PreviewButton draftPreviewUrl={draftPreviewUrl} t={t} />
+          <Button
+            type="button"
+            variant={mode === "review" ? "default" : "brand"}
+            className="flex-1"
+            disabled
+          >
+            {mode === "review"
+              ? t("thread.publishPopover.submitForReview")
+              : t("thread.publishPopover.publish")}
+          </Button>
         </div>
-        <Ghost className="ml-6 h-2.5 w-36" />
-      </div>
-      <div className="border-t" />
-      <div className="space-y-1.5 px-4 pt-3 pb-2">
-        <Ghost className="h-2 w-12" />
-        <GhostCard subline />
-        <GhostCard />
-        <Ghost className="mt-2 h-2 w-14" />
-        <GhostCard />
-      </div>
-      <div className="space-y-1.5 border-t px-4 py-3">
-        <Ghost className="h-2.5 w-20" />
-        <Ghost className="h-14 w-full rounded-lg" />
-      </div>
-      <div className="border-t" />
-      <div className="flex gap-2 px-4 py-3 opacity-50">
-        <Button type="button" variant="outline" disabled>
-          <Eye className="size-4" />
-          {t("thread.publishPopover.preview")}
-        </Button>
-        <Button
-          type="button"
-          variant={mode === "review" ? "default" : "brand"}
-          className="flex-1"
-          disabled
-        >
-          {mode === "review"
-            ? t("thread.publishPopover.submitForReview")
-            : t("thread.publishPopover.publish")}
-        </Button>
-      </div>
-    </>
+      }
+    />
+  );
+}
+
+function CmsPublishLoadError({
+  mode,
+  draftPreviewUrl,
+  message,
+  onRetry,
+}: {
+  mode: CmsPublishMode;
+  draftPreviewUrl: string | null;
+  message: string;
+  onRetry: () => void;
+}) {
+  const t = useT();
+  return (
+    <PublishFrame
+      state="ready"
+      header={
+        <HeaderLine
+          mode={mode}
+          title={
+            <span className="truncate">
+              {t("thread.publishPopover.loadFailed")}
+            </span>
+          }
+        />
+      }
+      body={<p className="px-4 py-6 text-xs text-destructive">{message}</p>}
+      footer={
+        <div className="flex gap-2">
+          <PreviewButton draftPreviewUrl={draftPreviewUrl} t={t} />
+          <Button
+            type="button"
+            variant="outline"
+            className="flex-1"
+            onClick={onRetry}
+          >
+            <RefreshCw01 className="size-4" />
+            {t("thread.publishPopover.retry")}
+          </Button>
+        </div>
+      }
+    />
   );
 }
 
@@ -209,10 +302,29 @@ function CmsPublishBody(
     publishLockRef: React.MutableRefObject<boolean>;
   },
 ) {
+  const mode = props.mode ?? "publish";
   return (
-    <Suspense fallback={<CmsPublishSkeleton mode={props.mode ?? "publish"} />}>
-      <CmsPublishContent {...props} />
-    </Suspense>
+    <ErrorBoundary
+      fallback={({ error, resetError }) => (
+        <CmsPublishLoadError
+          mode={mode}
+          draftPreviewUrl={props.draftPreviewUrl}
+          message={error?.message ?? ""}
+          onRetry={resetError}
+        />
+      )}
+    >
+      <Suspense
+        fallback={
+          <CmsPublishSkeleton
+            mode={mode}
+            draftPreviewUrl={props.draftPreviewUrl}
+          />
+        }
+      >
+        <CmsPublishContent {...props} />
+      </Suspense>
+    </ErrorBoundary>
   );
 }
 
@@ -231,6 +343,7 @@ function CmsPublishContent({
   publishPolicy,
   draftPreviewUrl,
   destinationHost,
+  lastPublishedPr = null,
   onRequestApproval,
   openPullRequest = null,
   onPullRequestChanged,
@@ -248,31 +361,33 @@ function CmsPublishContent({
 
   const {
     status: gitStatus,
+    summary,
+    allPaths,
+    changedFilesTotal,
+    changedFilesTruncated,
+    headSha,
     diff: gitDiff,
-    lastPublishedPr,
-    loadError,
+    bodiesPending,
+    bodiesFailed,
+    cardsPending,
     refresh,
-  } = useCmsPublishState({
-    githubClient,
-    orgSlug,
-    virtualMcpId,
-    branch,
-    baseBranch,
-    owner,
-    repo,
-  });
+  } = useCmsPublishState({ orgSlug, virtualMcpId, branch, baseBranch });
 
-  const [note, setNote] = useState(() =>
-    gitDiff ? buildAutoNote(summarizePublishChanges(gitDiff)) : "",
-  );
+  /** The author's text once they type — until then the note is derived, so a
+   *  change list that lands after mount still describes itself. */
+  const [editedNote, setEditedNote] = useState<string | null>(null);
   const [discardAllConfirm, setDiscardAllConfirm] = useState(false);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   /** Only one card may arm its discard at a time — it is a one-click destroy. */
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
 
-  const summary = summarizePublishChanges(gitDiff);
+  const note = resolveVersionNote(editedNote, buildAutoNote(summary));
   const isReview = mode === "review";
-  const HeaderIcon = isReview ? GitPullRequest : Globe01;
+  const surfaceState: PublishSurfaceState = cardsPending
+    ? "loading"
+    : bodiesPending
+      ? "manifest"
+      : "ready";
 
   // Submitting for review IS the escalation the gate asks for — never judge it.
   const { gate } = useResolvedPublishGate({
@@ -281,6 +396,7 @@ function CmsPublishContent({
     branch,
     status: gitStatus,
     diff: gitDiff,
+    paths: allPaths,
     policy: publishPolicy,
     judgeEnabled: !isReview,
   });
@@ -296,6 +412,7 @@ function CmsPublishContent({
     repo,
     headBranch: readGitHeadBranch(gitStatus) ?? branch,
     coAuthor: coAuthorFromSessionUser(session?.user),
+    expectedHeadSha: headSha ?? undefined,
     existingOpenPr: commitToOpenPr
       ? { number: openPullRequest.number, htmlUrl: openPullRequest.htmlUrl }
       : undefined,
@@ -312,7 +429,7 @@ function CmsPublishContent({
     mode,
     target,
     note,
-    diff: gitDiff,
+    allPaths,
     destinationHost,
     publishLockRef,
     onOpenChange,
@@ -364,11 +481,6 @@ function CmsPublishContent({
         ? t("thread.publishPopover.publishCount", { count: summary.count })
         : t("thread.publishPopover.publish");
 
-  const openPreview = () => {
-    if (!draftPreviewUrl) return;
-    window.open(draftPreviewUrl, "_blank", "noopener,noreferrer");
-  };
-
   const renderGroup = (label: string, changes: PublishChange[]) => {
     if (changes.length === 0) return null;
     return (
@@ -383,6 +495,7 @@ function CmsPublishContent({
               key={id}
               change={change}
               diff={gitDiff}
+              bodyPending={bodiesPending}
               expanded={expandedId === id}
               onToggleExpanded={() =>
                 setExpandedId(expandedId === id ? null : id)
@@ -406,7 +519,7 @@ function CmsPublishContent({
     if (gate.pending) {
       return (
         <div className="flex items-center gap-2 border-t px-4 py-2.5 text-xs text-muted-foreground">
-          <Loading01 className="size-3.5 animate-spin" />
+          <Loading01 className="size-3.5 animate-spin motion-reduce:animate-none" />
           {t("thread.publishPopover.reviewing")}
         </div>
       );
@@ -423,157 +536,166 @@ function CmsPublishContent({
     );
   })();
 
-  return (
-    <>
-      <div className="space-y-0.5 px-4 py-3">
-        <div className="flex items-center gap-2 text-sm font-medium">
-          <HeaderIcon className="size-4 shrink-0 text-muted-foreground" />
-          <span className="truncate">{headerTitle}</span>
-          {summary.count > 1 ? (
-            discardAllConfirm ? (
-              <span className="ml-auto flex shrink-0 items-center gap-1.5 text-[11px]">
-                <span className="text-destructive">
-                  {t("thread.publishPopover.discardAllConfirm")}
-                </span>
-                <button
-                  type="button"
-                  className="text-muted-foreground hover:text-foreground"
-                  onClick={() => setDiscardAllConfirm(false)}
-                >
-                  {t("thread.publishDialog.cancel")}
-                </button>
-                <button
-                  type="button"
-                  className="font-medium text-destructive disabled:opacity-50"
-                  onClick={() => {
-                    setDiscardAllConfirm(false);
-                    void discardAll();
-                  }}
-                  disabled={isDiscarding}
-                >
-                  {t("thread.publishPopover.discard")}
-                </button>
-              </span>
-            ) : (
-              <button
-                type="button"
-                className="ml-auto shrink-0 text-[11px] text-muted-foreground transition-colors hover:text-destructive disabled:opacity-50"
-                onClick={() => setDiscardAllConfirm(true)}
-                disabled={isPublishing || isDiscarding}
-              >
-                {t("thread.publishPopover.discardAll")}
-              </button>
-            )
-          ) : null}
-        </div>
-        {subLine ? (
-          <div className="pl-6 text-xs text-muted-foreground">{subLine}</div>
-        ) : null}
-      </div>
-      <div className="border-t" />
-
-      <div className="flex min-h-0 flex-1 flex-col">
-        {loadError ? (
-          <p className="px-4 py-6 text-xs text-destructive">{loadError}</p>
-        ) : summary.count === 0 ? (
-          <div className="flex flex-col items-center gap-1 py-10 text-center">
-            <CheckCircle className="mb-1 size-5 text-success" />
-            <p className="text-sm font-medium">
-              {isReview
-                ? t("thread.publishPopover.nothingToSubmit")
-                : t("thread.publishPopover.everythingLive")}
-            </p>
-            <p className="text-xs text-muted-foreground">
-              {isReview
-                ? t("thread.publishPopover.submitEmptyHint")
-                : t("thread.publishPopover.emptyHint")}
-            </p>
-          </div>
-        ) : (
-          <>
-            <div className="scroll-fade min-h-0 flex-1 space-y-3 overflow-y-auto overscroll-contain px-4 pt-3 pb-2 [scrollbar-width:thin]">
-              {renderGroup(
-                t("thread.publishPopover.pagesGroup"),
-                summary.pages,
-              )}
-              {renderGroup(
-                t("thread.publishPopover.blocksGroup"),
-                summary.blocks,
-              )}
-              {renderGroup(
-                t("thread.publishPopover.otherGroup"),
-                summary.other,
-              )}
-            </div>
-            <div className="space-y-1.5 border-t px-4 py-3">
-              <span className="text-[13px] font-medium">
-                {isReview
-                  ? t("thread.publishPopover.reviewNote")
-                  : t("thread.publishPopover.versionNote")}
-              </span>
-              <Textarea
-                value={note}
-                onChange={(e) => setNote(e.target.value)}
-                placeholder={
-                  isReview
-                    ? t("thread.publishPopover.reviewNotePlaceholder")
-                    : t("thread.publishPopover.versionNotePlaceholder")
-                }
-                rows={2}
-                className="resize-none text-[13px]"
-                disabled={isPublishing}
-              />
-            </div>
-          </>
-        )}
-      </div>
-
-      {gateRow}
-
-      <div className="border-t" />
-      <div className="space-y-2 px-4 py-3">
-        <div className="flex gap-2">
-          <Button
+  const discardAllControl = (() => {
+    // Never offer an all-files action over a set the server truncated.
+    if (summary.count <= 1 || changedFilesTruncated) return null;
+    if (discardAllConfirm) {
+      return (
+        <span className="ml-auto flex shrink-0 items-center gap-1.5 text-[11px]">
+          <span className="text-destructive">
+            {t("thread.publishPopover.discardAllConfirm")}
+          </span>
+          <button
             type="button"
-            variant="outline"
-            onClick={openPreview}
-            disabled={!draftPreviewUrl}
+            className="text-muted-foreground hover:text-foreground"
+            onClick={() => setDiscardAllConfirm(false)}
           >
-            <Eye className="size-4" />
-            {t("thread.publishPopover.preview")}
-          </Button>
-          {!isReview && summary.count > 0 && !gate.allowed && !gate.pending ? (
-            <Button
-              type="button"
-              className="flex-1"
-              onClick={onRequestApproval}
-              disabled={isPublishing}
-            >
-              {t("thread.publishPopover.requestApproval")}
-            </Button>
-          ) : (
-            <Button
-              type="button"
-              variant={isReview ? "default" : "brand"}
-              className="flex-1"
-              onClick={() => void submit()}
-              disabled={!canSubmit}
-            >
-              {isPublishing ? (
-                <Loading01 className="size-4 animate-spin" />
-              ) : null}
-              {isPublishing
-                ? isReview
-                  ? t("thread.publishPopover.submitting")
-                  : t("thread.publishPopover.publishing")
-                : primaryLabel}
-            </Button>
-          )}
-        </div>
-        {publishError ? (
-          <p className="text-xs text-destructive">{publishError}</p>
-        ) : null}
+            {t("thread.publishDialog.cancel")}
+          </button>
+          <button
+            type="button"
+            className="font-medium text-destructive disabled:opacity-50"
+            onClick={() => {
+              setDiscardAllConfirm(false);
+              void discardAll();
+            }}
+            disabled={isDiscarding}
+          >
+            {t("thread.publishPopover.discard")}
+          </button>
+        </span>
+      );
+    }
+    return (
+      <button
+        type="button"
+        className="ml-auto shrink-0 text-[11px] text-muted-foreground transition-colors hover:text-destructive disabled:opacity-50"
+        onClick={() => setDiscardAllConfirm(true)}
+        disabled={isPublishing || isDiscarding}
+      >
+        {t("thread.publishPopover.discardAll")}
+      </button>
+    );
+  })();
+
+  const body = cardsPending ? (
+    <PublishListRegion>
+      <div className="space-y-1.5">
+        <PublishGhostCard />
+        <PublishGhostCard />
       </div>
-    </>
+    </PublishListRegion>
+  ) : summary.count === 0 ? (
+    <div className="flex flex-col items-center gap-1 py-10 text-center">
+      <CheckCircle className="mb-1 size-5 text-success" />
+      <p className="text-sm font-medium">
+        {isReview
+          ? t("thread.publishPopover.nothingToSubmit")
+          : t("thread.publishPopover.everythingLive")}
+      </p>
+      <p className="text-xs text-muted-foreground">
+        {isReview
+          ? t("thread.publishPopover.submitEmptyHint")
+          : t("thread.publishPopover.emptyHint")}
+      </p>
+    </div>
+  ) : (
+    <PublishListRegion>
+      {changedFilesTruncated ? (
+        <p className="text-[11px] text-muted-foreground">
+          {t("thread.publishPopover.showingFirst", {
+            shown: summary.count,
+            total: changedFilesTotal,
+          })}
+        </p>
+      ) : null}
+      {renderGroup(t("thread.publishPopover.pagesGroup"), summary.pages)}
+      {renderGroup(t("thread.publishPopover.blocksGroup"), summary.blocks)}
+      {renderGroup(t("thread.publishPopover.otherGroup"), summary.other)}
+      {bodiesFailed ? (
+        <p className="text-[11px] text-muted-foreground">
+          {t("thread.publishPopover.detailsUnavailable")}
+        </p>
+      ) : null}
+    </PublishListRegion>
+  );
+
+  return (
+    <PublishFrame
+      state={surfaceState}
+      header={
+        <HeaderLine
+          mode={mode}
+          title={<span className="truncate">{headerTitle}</span>}
+          subLine={subLine}
+          trailing={discardAllControl}
+        />
+      }
+      body={body}
+      note={
+        summary.count === 0 ? null : (
+          <>
+            <span className="text-[13px] font-medium">
+              {isReview
+                ? t("thread.publishPopover.reviewNote")
+                : t("thread.publishPopover.versionNote")}
+            </span>
+            <Textarea
+              value={note}
+              onChange={(e) => setEditedNote(e.target.value)}
+              placeholder={
+                isReview
+                  ? t("thread.publishPopover.reviewNotePlaceholder")
+                  : t("thread.publishPopover.versionNotePlaceholder")
+              }
+              rows={2}
+              className="resize-none text-[13px]"
+              disabled={isPublishing}
+            />
+          </>
+        )
+      }
+      gate={gateRow}
+      footer={
+        <>
+          <div className="flex gap-2">
+            <PreviewButton draftPreviewUrl={draftPreviewUrl} t={t} />
+            {!isReview &&
+            summary.count > 0 &&
+            !gate.allowed &&
+            !gate.pending ? (
+              <Button
+                type="button"
+                className="flex-1"
+                onClick={onRequestApproval}
+                disabled={isPublishing}
+              >
+                {t("thread.publishPopover.requestApproval")}
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                variant={isReview ? "default" : "brand"}
+                className="flex-1"
+                onClick={() => void submit()}
+                disabled={!canSubmit}
+              >
+                {isPublishing ? (
+                  <Loading01 className="size-4 animate-spin motion-reduce:animate-none" />
+                ) : null}
+                {isPublishing
+                  ? isReview
+                    ? t("thread.publishPopover.submitting")
+                    : t("thread.publishPopover.publishing")
+                  : primaryLabel}
+              </Button>
+            )}
+          </div>
+          {publishError ? (
+            <p className="text-xs text-destructive">{publishError}</p>
+          ) : null}
+        </>
+      }
+    />
   );
 }

--- a/apps/web/src/components/thread/github/publish-change-summary.test.ts
+++ b/apps/web/src/components/thread/github/publish-change-summary.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import {
   blockKeyFromDiffPath,
   buildAutoNote,
+  countPageSections,
   humanizeFieldName,
   resolveVersionNote,
   sectionDisplayName,
@@ -425,6 +426,16 @@ describe("summarizePublishManifest", () => {
       },
     });
     expect(bare.blocks.map(changeId)).toEqual(named.blocks.map(changeId));
+  });
+
+  it("counts a NEW page's sections from the head decofile, before bodies land", () => {
+    const summary = summarizePublishManifest({
+      files: [{ path: HOME_PATH, status: "added" }],
+      lookup: LOOKUP,
+    });
+    // Rendered as "New page with N sections" — N must not read 0 and correct
+    // itself once the body arrives.
+    expect(countPageSections(summary.pages[0]?.toJson ?? null)).toBe(2);
   });
 
   it("counts nothing when nothing changed", () => {

--- a/apps/web/src/components/thread/github/publish-change-summary.test.ts
+++ b/apps/web/src/components/thread/github/publish-change-summary.test.ts
@@ -3,10 +3,13 @@ import {
   blockKeyFromDiffPath,
   buildAutoNote,
   humanizeFieldName,
+  resolveVersionNote,
   sectionDisplayName,
   summarizePublishChanges,
+  summarizePublishManifest,
 } from "./publish-change-summary";
-import type { GitDiffResult } from "./sandbox-git-api";
+import { changeId } from "./cms-publish-change-card";
+import type { GitChangedFile, GitDiffResult } from "./sandbox-git-api";
 
 const HOME_KEY = "pages-home-c4bcbfb771e9";
 const HOME_PATH = `.deco/blocks/${encodeURIComponent(HOME_KEY)}.json`;
@@ -308,5 +311,137 @@ describe("humanizeFieldName / sectionDisplayName", () => {
       sectionDisplayName({ __resolveType: "site/sections/Hero.tsx" }, 0),
     ).toBe("Hero");
     expect(sectionDisplayName({}, 2)).toBe("Section 3");
+  });
+});
+
+describe("summarizePublishManifest", () => {
+  const HEADER_KEY = "Header";
+  const HEADER_PATH = `.deco/blocks/${HEADER_KEY}.json`;
+  const headerJson = JSON.stringify({ name: "Site header", links: ["a"] });
+
+  const FILES: GitChangedFile[] = [
+    { path: HOME_PATH, status: "modified" },
+    { path: HEADER_PATH, status: "modified" },
+    { path: "static/tailwind.css", status: "modified" },
+    { path: "README.md", status: "added" },
+  ];
+
+  const LOOKUP = {
+    [HOME_KEY]: JSON.parse(pageJson()) as Record<string, unknown>,
+    [HEADER_KEY]: JSON.parse(headerJson) as Record<string, unknown>,
+  };
+
+  const BODIES: GitDiffResult = {
+    diffs: {
+      [HOME_PATH]: { from: pageJson(), to: pageJson({ name: "Home Page" }) },
+      [HEADER_PATH]: { from: headerJson, to: headerJson },
+      "static/tailwind.css": { from: "a{}", to: "b{}" },
+      "README.md": { from: null, to: "# hi" },
+    },
+  };
+
+  it("builds the full card list from paths alone, before any body is fetched", () => {
+    const summary = summarizePublishManifest({ files: FILES, lookup: LOOKUP });
+    expect(summary.count).toBe(3);
+    expect(summary.pages.map((p) => p.name)).toEqual(["Home"]);
+    expect(summary.pages[0]?.pagePath).toBe("/");
+    expect(summary.blocks.map((b) => b.name)).toEqual(["Site header"]);
+    expect(summary.other.map((o) => o.name)).toEqual(["README.md"]);
+    expect(summary.generated).toEqual(["static/tailwind.css"]);
+  });
+
+  it("keeps identity, order, kind and status IDENTICAL once bodies land", () => {
+    const manifestOnly = summarizePublishManifest({
+      files: FILES,
+      lookup: LOOKUP,
+    });
+    const enriched = summarizePublishManifest({
+      files: FILES,
+      lookup: LOOKUP,
+      diff: BODIES,
+    });
+
+    const shape = (s: typeof manifestOnly) => ({
+      count: s.count,
+      ids: [...s.pages, ...s.blocks, ...s.other].map(changeId),
+      kinds: [...s.pages, ...s.blocks, ...s.other].map((c) => c.kind),
+      statuses: [...s.pages, ...s.blocks, ...s.other].map((c) => c.status),
+    });
+    expect(shape(enriched)).toEqual(shape(manifestOnly));
+  });
+
+  it("adds section sub-lines only once bodies land", () => {
+    const before = summarizePublishManifest({ files: FILES, lookup: LOOKUP });
+    const after = summarizePublishManifest({
+      files: FILES,
+      lookup: LOOKUP,
+      diff: BODIES,
+    });
+    expect(before.pages[0]?.sections).toEqual([]);
+    expect(after.pages[0]?.sections.length).toBeGreaterThan(0);
+  });
+
+  it("names a card from the block key when the head decofile has no entry", () => {
+    const summary = summarizePublishManifest({
+      files: [{ path: HEADER_PATH, status: "removed" }],
+      lookup: {},
+    });
+    expect(summary.blocks[0]?.name).toBe("Header");
+    expect(summary.blocks[0]?.status).toBe("removed");
+  });
+
+  it("classifies a removed page by its key convention, with no content to read", () => {
+    const summary = summarizePublishManifest({
+      files: [{ path: HOME_PATH, status: "removed" }],
+      lookup: {},
+    });
+    expect(summary.pages).toHaveLength(1);
+    expect(summary.pages[0]?.name).toBe("home");
+  });
+
+  it("does NOT re-group a card when a late body disagrees with the head shape", () => {
+    const files: GitChangedFile[] = [{ path: HOME_PATH, status: "removed" }];
+    const withBodies = summarizePublishManifest({
+      files,
+      lookup: {},
+      diff: { diffs: { [HOME_PATH]: { from: pageJson(), to: null } } },
+    });
+    expect(withBodies.pages).toHaveLength(1);
+    expect(withBodies.blocks).toHaveLength(0);
+    expect(withBodies.pages[0]?.name).toBe("Home");
+  });
+
+  it("sorts by path so a card cannot move when its name resolves", () => {
+    const files: GitChangedFile[] = [
+      { path: ".deco/blocks/Zebra.json", status: "modified" },
+      { path: ".deco/blocks/Alpha.json", status: "modified" },
+    ];
+    const bare = summarizePublishManifest({ files, lookup: {} });
+    const named = summarizePublishManifest({
+      files,
+      lookup: {
+        Zebra: { name: "AAA first now" },
+        Alpha: { name: "ZZZ last now" },
+      },
+    });
+    expect(bare.blocks.map(changeId)).toEqual(named.blocks.map(changeId));
+  });
+
+  it("counts nothing when nothing changed", () => {
+    expect(summarizePublishManifest({ files: [], lookup: {} }).count).toBe(0);
+  });
+});
+
+describe("resolveVersionNote", () => {
+  it("derives the note until the author types", () => {
+    expect(resolveVersionNote(null, "Updated Home")).toBe("Updated Home");
+  });
+
+  it("pins the author's text once typed", () => {
+    expect(resolveVersionNote("Mine", "Updated Home")).toBe("Mine");
+  });
+
+  it("keeps a deliberately cleared field empty — never refills it", () => {
+    expect(resolveVersionNote("", "Updated Home")).toBe("");
   });
 });

--- a/apps/web/src/components/thread/github/publish-change-summary.ts
+++ b/apps/web/src/components/thread/github/publish-change-summary.ts
@@ -11,8 +11,13 @@ import {
   globalSectionLabel,
   isSiteAppBlock,
   pageEntryFromBlock,
+  parsePageName,
 } from "@/components/sections-editor/page-list";
-import { isGeneratedArtifactPath, type GitDiffResult } from "./sandbox-git-api";
+import {
+  isGeneratedArtifactPath,
+  type GitChangedFile,
+  type GitDiffResult,
+} from "./sandbox-git-api";
 
 export type PublishChangeStatus = "new" | "edited" | "removed";
 
@@ -340,12 +345,27 @@ export function summarizePublishChanges(
     });
   }
 
-  const byName = (a: PublishChange, b: PublishChange) =>
-    a.name.localeCompare(b.name);
-  pages.sort(byName);
-  blocks.sort(byName);
-  other.sort(byName);
+  return collectSummary({ pages, blocks, other, generated });
+}
 
+/**
+ * Sorted by file path, not by display name: a card must not reposition when
+ * its name sharpens from the block key to the parsed title.
+ */
+function byPath(a: PublishChange, b: PublishChange): number {
+  return (a.filepaths[0] ?? "").localeCompare(b.filepaths[0] ?? "");
+}
+
+function collectSummary(buckets: {
+  pages: PublishChange[];
+  blocks: PublishChange[];
+  other: PublishChange[];
+  generated: string[];
+}): PublishChangeSummary {
+  const { pages, blocks, other, generated } = buckets;
+  pages.sort(byPath);
+  blocks.sort(byPath);
+  other.sort(byPath);
   return {
     pages,
     blocks,
@@ -353,6 +373,149 @@ export function summarizePublishChanges(
     generated,
     count: pages.length + blocks.length + other.length,
   };
+}
+
+/** Manifest statuses collapse onto the three the surface draws. */
+function manifestStatus(status: GitChangedFile["status"]): PublishChangeStatus {
+  if (status === "added") return "new";
+  if (status === "removed") return "removed";
+  return "edited";
+}
+
+/** A block-keyed path is a page when its content says so — or, with no content
+ *  to read, when it follows the `pages-<name>-<id>` key convention. */
+function looksLikePageKey(blockKey: string): boolean {
+  return blockKey.startsWith("pages-");
+}
+
+interface ManifestInput {
+  /** Changed paths and how they changed — the whole card list. */
+  files: readonly GitChangedFile[];
+  /**
+   * The branch head decofile, keyed by block key. Supplies names, page paths
+   * and classification for every path that still exists on the branch, so the
+   * list is complete before any file body has been fetched.
+   */
+  lookup?: Record<string, unknown> | null;
+  /** File bodies, once loaded. Enriches cards; never re-classifies them. */
+  diff?: GitDiffResult | null;
+}
+
+/**
+ * The publish change model built from the changed-file MANIFEST — which paths
+ * changed — with file bodies as an optional enrichment rather than a
+ * prerequisite. This is what lets the publish surface render its real list one
+ * request in, and it is the only entry point the Fast Preview popover uses.
+ *
+ * Card identity, kind, status and order come from the manifest and the head
+ * decofile alone, never from `diff`, so a body arriving later cannot remount a
+ * card, move it between groups, re-sort it, or recolor it. Bodies add only the
+ * section sub-lines and the raw JSON the expanded diff renders.
+ *
+ * One consequence worth naming: a REMOVED block is absent from the head
+ * decofile, so it classifies by key convention. A removed page not keyed
+ * `pages-*` lists under Blocks — stable and correctly named, in the wrong
+ * group. Reclassifying it once bodies land would be more accurate and worse.
+ */
+export function summarizePublishManifest(
+  input: ManifestInput,
+): PublishChangeSummary {
+  const { files, lookup, diff } = input;
+  const pages: PublishChange[] = [];
+  const blocks: PublishChange[] = [];
+  const other: PublishChange[] = [];
+  const generated: string[] = [];
+
+  for (const file of files) {
+    const path = file.path;
+    if (isGeneratedArtifactPath(path)) {
+      generated.push(path);
+      continue;
+    }
+    const status = manifestStatus(file.status);
+    const blockKey = blockKeyFromDiffPath(path);
+    if (!blockKey) {
+      other.push(otherChange(path, status));
+      continue;
+    }
+
+    const body = diff?.diffs[path];
+    const fromJson = parseBlockJson(body?.from ?? null);
+    const toJson = parseBlockJson(body?.to ?? null);
+    const headShape = readBlockShape(lookup, blockKey);
+    // Classification reads the head shape ONLY — see the doc above.
+    const nameShape = headShape ?? toJson ?? fromJson;
+
+    const headPage = headShape ? pageEntryFromBlock(blockKey, headShape) : null;
+    if (headPage ?? (!headShape && looksLikePageKey(blockKey))) {
+      const namePage = nameShape
+        ? pageEntryFromBlock(blockKey, nameShape)
+        : null;
+      pages.push({
+        kind: "page",
+        blockKey,
+        name: namePage?.name ?? parsePageName(blockKey),
+        pagePath: namePage?.path ?? null,
+        isSiteApp: false,
+        status,
+        filepaths: [path],
+        sections: status === "edited" ? diffPageSections(fromJson, toJson) : [],
+        fromJson,
+        toJson,
+      });
+      continue;
+    }
+
+    const label = globalSectionLabel(blockKey, nameShape ?? {});
+    blocks.push({
+      kind: "block",
+      blockKey,
+      name: label,
+      pagePath: null,
+      isSiteApp: isSiteAppBlock(blockKey, headShape ?? {}),
+      status,
+      filepaths: [path],
+      sections:
+        status === "edited"
+          ? [
+              {
+                name: label,
+                status: "edited" as const,
+                fields: shallowFieldDiff(fromJson, toJson, []),
+              },
+            ].filter((s) => s.fields.length > 0)
+          : [],
+      fromJson,
+      toJson,
+    });
+  }
+
+  return collectSummary({ pages, blocks, other, generated });
+}
+
+/** The head decofile's entry for a block key, when it is a plain object. */
+function readBlockShape(
+  lookup: Record<string, unknown> | null | undefined,
+  blockKey: string,
+): Record<string, unknown> | null {
+  const value = lookup?.[blockKey];
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+/**
+ * The version note to render: the author's text once they have typed anything,
+ * otherwise the note derived from the current change set.
+ *
+ * `??`, never `||` — an author who deliberately clears the field must not have
+ * it refilled underneath them.
+ */
+export function resolveVersionNote(
+  edited: string | null,
+  autoNote: string,
+): string {
+  return edited ?? autoNote;
 }
 
 function joinNames(names: string[]): string {

--- a/apps/web/src/components/thread/github/publish-change-summary.ts
+++ b/apps/web/src/components/thread/github/publish-change-summary.ts
@@ -461,7 +461,8 @@ export function summarizePublishManifest(
         filepaths: [path],
         sections: status === "edited" ? diffPageSections(fromJson, toJson) : [],
         fromJson,
-        toJson,
+        // `new` never diffs sections, so the head shape is a safe stand-in.
+        toJson: toJson ?? (status === "new" ? headShape : null),
       });
       continue;
     }

--- a/apps/web/src/components/thread/github/publish-flow.test.ts
+++ b/apps/web/src/components/thread/github/publish-flow.test.ts
@@ -97,19 +97,24 @@ describe("describePublishFailure", () => {
   it("reports no pull request when an earlier step failed", () => {
     expect(
       describePublishFailure(new PublishStepError("push denied", "push"), t),
-    ).toEqual({ message: "push denied", pullRequest: null });
+    ).toEqual({ message: "push denied", pullRequest: null, headMoved: false });
   });
 
   it("reports no pull request when the merge failed before one opened", () => {
     expect(
       describePublishFailure(new PublishStepError("merge blew up", "merge"), t),
-    ).toEqual({ message: "merge blew up", pullRequest: null });
+    ).toEqual({
+      message: "merge blew up",
+      pullRequest: null,
+      headMoved: false,
+    });
   });
 
   it("passes a plain error's message through", () => {
     expect(describePublishFailure(new Error("offline"), t)).toEqual({
       message: "offline",
       pullRequest: null,
+      headMoved: false,
     });
   });
 
@@ -117,6 +122,7 @@ describe("describePublishFailure", () => {
     expect(describePublishFailure("boom", t)).toEqual({
       message: "thread.publishDialog.failedPublish",
       pullRequest: null,
+      headMoved: false,
     });
   });
 });

--- a/apps/web/src/components/thread/github/publish-flow.ts
+++ b/apps/web/src/components/thread/github/publish-flow.ts
@@ -15,10 +15,34 @@ import {
   type CreatedPullRequest,
   type GithubMcpClient,
 } from "./github-pr-api.ts";
-import { publishGitChanges, rebaseGitBranch } from "./sandbox-git-api.ts";
+import {
+  fetchGitStatus,
+  publishGitChanges,
+  rebaseGitBranch,
+} from "./sandbox-git-api.ts";
 
 /** The steps a publish runs, in order. Submitting for review stops at `open-pr`. */
-type PublishStep = "push" | "sync" | "open-pr" | "merge";
+type PublishStep = "verify" | "push" | "sync" | "open-pr" | "merge";
+
+/**
+ * The branch moved between the moment its changes were shown and the moment
+ * publish ran — someone else's commit, the coding agent's, or the author's own
+ * autosave in another tab. Thrown before anything mutates, so the work is
+ * untouched and the surface can re-read and ask again.
+ *
+ * This cannot be a `sha` precondition on the merge instead: the sync step
+ * squash-rebases the branch onto base and force-updates the ref, so by merge
+ * time the head is one we wrote, not the one the author confirmed.
+ */
+class PublishHeadMovedError extends Error {
+  constructor(
+    readonly expectedHeadSha: string,
+    readonly actualHeadSha: string,
+  ) {
+    super("The branch changed since these changes were shown");
+    this.name = "PublishHeadMovedError";
+  }
+}
 
 /**
  * A failure attributed to the step that produced it. `pr` is set only when the
@@ -54,6 +78,12 @@ export interface PublishTarget {
   coAuthor?: CoAuthorIdentity;
   /** The branch's already-open pull request, updated instead of opening a new one. */
   existingOpenPr?: CreatedPullRequest;
+  /**
+   * The head the confirmed change list was read from. Checked against the live
+   * head before anything mutates; see {@link PublishHeadMovedError}. Omit to
+   * publish whatever the branch holds now.
+   */
+  expectedHeadSha?: string;
 }
 
 /** Pull-request title/body and the commit message, from one authored note. */
@@ -111,6 +141,26 @@ async function runStep<T>(
   }
 }
 
+/**
+ * Fail before mutating anything when the branch head is no longer the one the
+ * confirmed change list was read from. A status read that itself fails is not
+ * evidence the head moved, so it lets the publish proceed rather than blocking
+ * on an unrelated outage.
+ */
+async function assertHeadUnchanged(target: PublishTarget): Promise<void> {
+  const expected = target.expectedHeadSha;
+  if (!expected) return;
+  const status = await fetchGitStatus(
+    target.orgSlug,
+    target.virtualMcpId,
+    target.branch,
+  ).catch(() => null);
+  const actual = status?.headSha;
+  if (actual && actual !== expected) {
+    throw new PublishHeadMovedError(expected, actual);
+  }
+}
+
 function pushChanges(target: PublishTarget, message: string): Promise<void> {
   return publishGitChanges(
     target.orgSlug,
@@ -146,6 +196,7 @@ export async function runPublishFlow(
   parts: PublishMessage,
   t: TFunction,
 ): Promise<CreatedPullRequest> {
+  await assertHeadUnchanged(target);
   await runStep("push", t("thread.publishDialog.failedPushChanges"), () =>
     pushChanges(target, parts.message),
   );
@@ -192,6 +243,7 @@ export async function runSubmitForReviewFlow(
   target: PublishTarget,
   parts: PublishMessage,
 ): Promise<CreatedPullRequest> {
+  await assertHeadUnchanged(target);
   await pushChanges(target, parts.message);
   return openPullRequest(target, parts);
 }
@@ -201,6 +253,8 @@ interface PublishFailure {
   message: string;
   /** Set when the merge failed after the PR opened — the work is in that PR. */
   pullRequest: CreatedPullRequest | null;
+  /** The branch moved before anything ran: nothing changed, re-read and retry. */
+  headMoved: boolean;
 }
 
 /**
@@ -212,6 +266,13 @@ export function describePublishFailure(
   error: unknown,
   t: TFunction,
 ): PublishFailure {
+  if (error instanceof PublishHeadMovedError) {
+    return {
+      message: t("thread.publishPopover.branchMoved"),
+      pullRequest: null,
+      headMoved: true,
+    };
+  }
   if (error instanceof PublishStepError && error.step === "merge" && error.pr) {
     return {
       message: t("thread.publishDialog.mergeFailed", {
@@ -219,6 +280,7 @@ export function describePublishFailure(
         message: error.message,
       }),
       pullRequest: error.pr,
+      headMoved: false,
     };
   }
   return {
@@ -227,17 +289,18 @@ export function describePublishFailure(
         ? error.message
         : t("thread.publishDialog.failedPublish"),
     pullRequest: null,
+    headMoved: false,
   };
 }
 
 /**
  * {@link describePublishFailure} plus the toast both surfaces raise for it.
- * `pullRequestOpened` tells the caller to refresh its PR state.
+ * `pullRequestOpened` refreshes PR state; `headMoved` re-reads the change list.
  */
 export function reportPublishFailure(
   error: unknown,
   t: TFunction,
-): { message: string; pullRequestOpened: boolean } {
+): { message: string; pullRequestOpened: boolean; headMoved: boolean } {
   const failure = describePublishFailure(error, t);
   const pr = failure.pullRequest;
   if (pr) {
@@ -248,7 +311,11 @@ export function reportPublishFailure(
       },
     });
   }
-  return { message: failure.message, pullRequestOpened: pr !== null };
+  return {
+    message: failure.message,
+    pullRequestOpened: pr !== null,
+    headMoved: failure.headMoved,
+  };
 }
 
 /** Both surfaces confirm a review submission the same way: PR number + link. */

--- a/apps/web/src/components/thread/github/sandbox-git-api.test.ts
+++ b/apps/web/src/components/thread/github/sandbox-git-api.test.ts
@@ -8,9 +8,13 @@ import {
   hasPublishableLocalWork,
   hasUnpublishedWork,
   isDecoOnlyDiff,
+  isDecoOnlyPaths,
   needsSmartReviewJudgment,
   normalizePublishPolicy,
+  resolvePathGate,
   reviewDiffSignature,
+  sandboxGitStatusQueryKey,
+  sandboxGitStatusQueryOptions,
   shouldUseBaseDiff,
   smartReviewGate,
   stripGeneratedFilesFromDiff,
@@ -553,5 +557,75 @@ describe("combinePublishDiffs (full publish payload = committed ∪ working)", (
     );
     expect(gate.allowed).toBe(false);
     expect(gate.reason).toBeNull();
+  });
+});
+
+describe("isDecoOnlyPaths", () => {
+  test("accepts CMS JSON at the repo root and under a package path", () => {
+    expect(isDecoOnlyPaths([".deco/blocks/Home.json"])).toBe(true);
+    expect(isDecoOnlyPaths(["apps/site/.deco/blocks/Home.json"])).toBe(true);
+  });
+
+  test("accepts generated artifacts alongside CMS JSON", () => {
+    expect(
+      isDecoOnlyPaths([".deco/blocks/Home.json", "static/tailwind.css"]),
+    ).toBe(true);
+  });
+
+  test("rejects the list as soon as one path is code", () => {
+    expect(
+      isDecoOnlyPaths([".deco/blocks/Home.json", "site/sections/Hero.tsx"]),
+    ).toBe(false);
+  });
+
+  test("an empty list is not deco-only — nothing is known yet", () => {
+    expect(isDecoOnlyPaths([])).toBe(false);
+  });
+});
+
+describe("resolvePathGate", () => {
+  const DECO = [".deco/blocks/Home.json"];
+  const CODE = [".deco/blocks/Home.json", "site/sections/Hero.tsx"];
+
+  test("open publishes anything", () => {
+    expect(resolvePathGate(DECO, "open").allowed).toBe(true);
+    expect(resolvePathGate(CODE, "open").allowed).toBe(true);
+  });
+
+  test("deco-only publishes under every policy", () => {
+    expect(resolvePathGate(DECO, "smart").allowed).toBe(true);
+    expect(resolvePathGate(DECO, "code-review").allowed).toBe(true);
+  });
+
+  test("code under code-review is blocked outright, not pending", () => {
+    const gate = resolvePathGate(CODE, "code-review");
+    expect(gate.allowed).toBe(false);
+    expect(gate.pending).toBeUndefined();
+  });
+
+  test("code under smart is PENDING — the judge has not run yet", () => {
+    const gate = resolvePathGate(CODE, "smart");
+    expect(gate.allowed).toBe(false);
+    expect(gate.pending).toBe(true);
+  });
+
+  test("an unknown path list never resolves to allowed", () => {
+    for (const policy of ["smart", "code-review", "open"] as const) {
+      expect(resolvePathGate([], policy).allowed).toBe(false);
+    }
+  });
+});
+
+describe("sandboxGitStatusQueryOptions", () => {
+  test("shares one cache entry with sandboxGitStatusQueryKey", () => {
+    expect(sandboxGitStatusQueryOptions("org", "vm", "feat").queryKey).toEqual(
+      sandboxGitStatusQueryKey("org", "vm", "feat"),
+    );
+  });
+
+  test("carries the 5s staleness budget the header and popover both rely on", () => {
+    expect(sandboxGitStatusQueryOptions("org", "vm", "feat").staleTime).toBe(
+      5_000,
+    );
   });
 });

--- a/apps/web/src/components/thread/github/sandbox-git-api.ts
+++ b/apps/web/src/components/thread/github/sandbox-git-api.ts
@@ -24,6 +24,24 @@ export interface GitStatus {
   headSha?: string;
   /** Commits on HEAD not on origin/<branch> (from /git/status). */
   unpushed?: number;
+  /**
+   * base…head changed paths without their contents — the publish manifest.
+   * Fast Preview only: GitHub's compare response carries it for free, the
+   * sandbox daemon has no equivalent, so absent means "ask /git/diff instead".
+   */
+  changedFiles?: GitChangedFile[];
+  /** Changed-path count BEFORE the cap; `changedFiles` may be shorter. */
+  changedFilesTotal?: number;
+  /** True when the cap dropped paths — never offer an all-files action then. */
+  changedFilesTruncated?: boolean;
+}
+
+/** How a path changed between base and head. Mirrors the api's CompatChangedFile. */
+export interface GitChangedFile {
+  path: string;
+  status: "added" | "modified" | "removed" | "renamed";
+  /** Rename source; absent otherwise. */
+  previousPath?: string;
 }
 
 export interface GitDiffEntry {
@@ -262,16 +280,24 @@ function isDecoPath(path: string): boolean {
   );
 }
 
-/** Publish (squash-merge) is only allowed for CMS JSON under `.deco/` (plus generated assets). */
-export function isDecoOnlyDiff(
-  diff: GitDiffResult | null | undefined,
-): boolean {
-  if (!diff) return false;
-  const paths = Object.keys(diff.diffs);
+/**
+ * Publish (squash-merge) is only allowed for CMS JSON under `.deco/` (plus
+ * generated assets). Decided from paths alone, so the gate can be resolved
+ * from the changed-file manifest before any file body has been fetched.
+ */
+export function isDecoOnlyPaths(paths: readonly string[]): boolean {
   if (paths.length === 0) return false;
   return paths.every(
     (p) => isDecoPath(p) || isBlocksGenJsonPath(p) || isTailwindCssPath(p),
   );
+}
+
+/** {@link isDecoOnlyPaths} over a loaded diff's paths. */
+export function isDecoOnlyDiff(
+  diff: GitDiffResult | null | undefined,
+): boolean {
+  if (!diff) return false;
+  return isDecoOnlyPaths(Object.keys(diff.diffs));
 }
 
 /**
@@ -390,6 +416,32 @@ export function sandboxGitStatusQueryKey(
   branch: string,
 ) {
   return ["sandbox-git-status", orgSlug, virtualMcpId, branch] as const;
+}
+
+/**
+ * How long the changed-file manifest may be trusted before revalidating. A
+ * teammate's or the coding agent's commit can appear up to this late; the
+ * publish itself re-checks the head before it mutates anything, so the cost of
+ * being stale is a late-appearing card, never a publish of unseen work.
+ */
+const GIT_STATUS_STALE_MS = 5_000;
+
+/**
+ * The single definition of the git-status read. The Fast Preview header and the
+ * publish popover share one cache entry, so the popover opens on data the
+ * header already fetched — spread this into both rather than restating the key.
+ * Deliberately without `enabled`: `useSuspenseQuery` has no such option.
+ */
+export function sandboxGitStatusQueryOptions(
+  orgSlug: string,
+  virtualMcpId: string,
+  branch: string,
+) {
+  return {
+    queryKey: sandboxGitStatusQueryKey(orgSlug, virtualMcpId, branch),
+    queryFn: () => fetchGitStatus(orgSlug, virtualMcpId, branch),
+    staleTime: GIT_STATUS_STALE_MS,
+  };
 }
 
 export function countGitChanges(status: GitStatus | null): number {
@@ -515,6 +567,27 @@ export function canPublishDirectly(
   return isDecoOnlyDiff(diff)
     ? { allowed: true, reason: null }
     : { allowed: false, reason: null };
+}
+
+/**
+ * The gate decided from the changed-file manifest alone — what the publish
+ * surface uses while file bodies are still loading, and what it falls back to
+ * when they fail to load at all.
+ *
+ * Never resolves to `allowed` on incomplete information: an empty path list is
+ * "not known yet", and `smart` policy over code returns `pending` so the button
+ * stays disabled until the judge (which needs the bodies) has actually run.
+ */
+export function resolvePathGate(
+  paths: readonly string[],
+  policy: PublishPolicy,
+): PublishGate {
+  if (paths.length === 0) return { allowed: false, reason: null };
+  if (policy === "open") return { allowed: true, reason: null };
+  if (isDecoOnlyPaths(paths)) return { allowed: true, reason: null };
+  if (policy === "smart")
+    return { allowed: false, reason: null, pending: true };
+  return { allowed: false, reason: null };
 }
 
 /**

--- a/apps/web/src/components/thread/github/use-cms-publish-actions.ts
+++ b/apps/web/src/components/thread/github/use-cms-publish-actions.ts
@@ -18,7 +18,7 @@ import {
   runSubmitForReviewFlow,
   type PublishTarget,
 } from "./publish-flow.ts";
-import { discardGitFiles, type GitDiffResult } from "./sandbox-git-api.ts";
+import { discardGitFiles } from "./sandbox-git-api.ts";
 
 /** `publish` merges to production; `review` stops at the pull request. */
 export type CmsPublishMode = "publish" | "review";
@@ -28,7 +28,8 @@ interface CmsPublishActionsArgs {
   target: PublishTarget;
   /** The version note, authored in the popover — title on line 1, body below. */
   note: string;
-  diff: GitDiffResult | null;
+  /** Every changed path, from the manifest — what "discard all" reverts. */
+  allPaths: string[];
   /** Named in the success toast when publishing goes to a custom domain. */
   destinationHost: string | null;
   /** Held while a flow runs, so an outside click can't dismiss its progress. */
@@ -56,7 +57,7 @@ export function useCmsPublishActions(
     mode,
     target,
     note,
-    diff,
+    allPaths,
     destinationHost,
     publishLockRef,
     onOpenChange,
@@ -96,6 +97,8 @@ export function useCmsPublishActions(
       const failure = reportPublishFailure(error, t);
       setPublishError(failure.message);
       if (failure.pullRequestOpened) await onPullRequestChanged?.();
+      // Nothing was published — re-read so the list matches the new head.
+      if (failure.headMoved) await refresh();
     } finally {
       publishLockRef.current = false;
       setIsPublishing(false);
@@ -113,11 +116,11 @@ export function useCmsPublishActions(
       onOpenChange(false);
       await onPullRequestChanged?.();
     } catch (error) {
+      const failure = reportPublishFailure(error, t);
       setPublishError(
-        error instanceof Error
-          ? error.message
-          : t("thread.publishDialog.failedSubmitForReview"),
+        failure.message || t("thread.publishDialog.failedSubmitForReview"),
       );
+      if (failure.headMoved) await refresh();
     } finally {
       publishLockRef.current = false;
       setIsPublishing(false);
@@ -157,11 +160,9 @@ export function useCmsPublishActions(
         t("thread.publishPopover.discarded", { name: change.name }),
       ),
     discardAll: async () => {
-      if (!diff) return;
-      const allFiles = Object.keys(diff.diffs);
-      if (allFiles.length === 0) return;
+      if (allPaths.length === 0) return;
       await discardFiles(
-        allFiles,
+        allPaths,
         t("thread.publishDialog.allChangesDiscarded"),
       );
     },

--- a/apps/web/src/components/thread/github/use-cms-publish-state.ts
+++ b/apps/web/src/components/thread/github/use-cms-publish-state.ts
@@ -1,112 +1,152 @@
-/**
- * The publish popover's read side. Git state and the last publish are fetched
- * as one suspense load, so the surface goes straight from a single skeleton to
- * its final render instead of stacking spinners. A failed load lands in
- * `loadError` (and a null `lastPublishedPr`), rendered inline by the popover
- * rather than thrown to an error boundary.
+/** The publish popover's read side, in two lanes.
+ *
+ * The MANIFEST lane is the changed-file list, which rides free on `/git/status`
+ * and is already warm in the header — so the popover's real card list, count,
+ * gate and enabled button are decided one request in, and usually zero. It
+ * suspends; there is nothing to show without it.
+ *
+ * The BODIES lane is the file contents, which only add section sub-lines and
+ * the expanded diff. It never suspends and never blocks the button: a body
+ * arriving (or failing) changes what a card SAYS, never which cards exist.
+ *
+ * Servers that predate the manifest omit `changedFiles`, and the sandbox daemon
+ * has no equivalent — then this falls back to deriving everything from the
+ * bodies, which is what the surface did before the split.
  */
 
-import { useSuspenseQuery } from "@tanstack/react-query";
-import type { GithubMcpClient } from "./github-pr-api.ts";
+import { skipToken, useQuery, useSuspenseQuery } from "@tanstack/react-query";
+import { KEYS } from "@/lib/query-keys.ts";
 import {
-  combinePublishDiffs,
+  summarizePublishChanges,
+  summarizePublishManifest,
+  type PublishChangeSummary,
+} from "./publish-change-summary.ts";
+import {
   fetchGitDiff,
-  fetchGitStatus,
-  hasGitLocalWork,
+  sandboxGitStatusQueryOptions,
   type GitDiffResult,
   type GitStatus,
 } from "./sandbox-git-api.ts";
-import { fetchLastPublishedPr, type PrSummary } from "./use-pr-data.ts";
 
 interface CmsPublishStateArgs {
-  githubClient: GithubMcpClient;
   orgSlug: string;
   virtualMcpId: string;
   branch: string;
   baseBranch: string;
-  owner: string;
-  repo: string;
 }
 
-interface CmsPublishState {
-  status: GitStatus | null;
+export interface CmsPublishState {
+  status: GitStatus;
+  /** Cards to render — complete at the manifest beat, enriched at the bodies beat. */
+  summary: PublishChangeSummary;
+  /** Every changed path including generated artifacts: what "discard all" reverts. */
+  allPaths: string[];
+  /** Changed-path count before the server's cap; may exceed `allPaths.length`. */
+  changedFilesTotal: number;
+  /** The cap dropped paths — never offer an action over the whole set. */
+  changedFilesTruncated: boolean;
+  /** The head the card list was read from; publish asserts it before mutating. */
+  headSha: string | null;
+  /** File bodies, or null until (or unless) they load. */
   diff: GitDiffResult | null;
-  lastPublishedPr: PrSummary | null;
-  loadError: string | null;
-  /** Re-runs the load; the popover calls it after a discard. */
+  /** Bodies are still in flight — sub-lines and the expanded diff aren't ready. */
+  bodiesPending: boolean;
+  /** Bodies failed; the gate falls back to the path rule. */
+  bodiesFailed: boolean;
+  /** True while the card list itself is unknown (no manifest, bodies pending). */
+  cardsPending: boolean;
+  /** Re-reads the manifest; the popover calls it after a discard. */
   refresh: () => Promise<unknown>;
 }
 
-type LoadedPublishState = Omit<CmsPublishState, "refresh">;
-
-function cmsPublishStateQueryKey(
+function cmsPublishBodiesQueryKey(
   orgSlug: string,
   virtualMcpId: string,
   branch: string,
   baseBranch: string,
+  headSha: string | null,
 ) {
   return [
-    "cms-publish-popover-state",
+    "cms-publish-bodies",
     orgSlug,
     virtualMcpId,
     branch,
     baseBranch,
+    headSha,
   ] as const;
 }
 
-export function useCmsPublishState(args: CmsPublishStateArgs): CmsPublishState {
-  const {
-    githubClient,
-    orgSlug,
-    virtualMcpId,
-    branch,
-    baseBranch,
-    owner,
-    repo,
-  } = args;
+/** How long file bodies stay valid. They are content-addressed by `headSha`,
+ *  so a new head is a new entry rather than a stale one. */
+const BODIES_STALE_MS = 60_000;
 
-  const query = useSuspenseQuery<LoadedPublishState>({
-    queryKey: cmsPublishStateQueryKey(
+/**
+ * Read-only subscription to the decofile the CMS already loaded. It holds the
+ * head content of every block still on the branch, which is what turns a file
+ * path into "Home" before a single body has been fetched. `skipToken` makes it
+ * a reactive cache read that never issues a request of its own.
+ */
+function useDecofileHead(
+  orgSlug: string,
+  virtualMcpId: string,
+  branch: string,
+): Record<string, unknown> | undefined {
+  const { data } = useQuery({
+    queryKey: KEYS.decofile(`${orgSlug}/${virtualMcpId}/${branch}`),
+    queryFn: skipToken,
+  });
+  return data as Record<string, unknown> | undefined;
+}
+
+export function useCmsPublishState(args: CmsPublishStateArgs): CmsPublishState {
+  const { orgSlug, virtualMcpId, branch, baseBranch } = args;
+
+  const statusQuery = useSuspenseQuery(
+    sandboxGitStatusQueryOptions(orgSlug, virtualMcpId, branch),
+  );
+  const status = statusQuery.data;
+  const manifest = status.changedFiles ?? null;
+  const headSha = status.headSha ?? null;
+
+  // Sandbox-less local-work fields are always empty, so drift is the only signal.
+  const wantsBodies = manifest
+    ? manifest.length > 0
+    : (status.aheadOfBase ?? 0) > 0;
+
+  const bodiesQuery = useQuery({
+    queryKey: cmsPublishBodiesQueryKey(
       orgSlug,
       virtualMcpId,
       branch,
       baseBranch,
+      headSha,
     ),
-    queryFn: async (): Promise<LoadedPublishState> => {
-      const lastPublishedPromise = fetchLastPublishedPr(githubClient, {
-        owner,
-        repo,
-        base: baseBranch,
-      }).catch(() => null);
-      try {
-        const status = await fetchGitStatus(orgSlug, virtualMcpId, branch);
-        const baseDiff =
-          (status.aheadOfBase ?? 0) > 0
-            ? await fetchGitDiff(orgSlug, virtualMcpId, branch, {
-                base: baseBranch,
-              })
-            : null;
-        const workingDiff = hasGitLocalWork(status)
-          ? await fetchGitDiff(orgSlug, virtualMcpId, branch)
-          : null;
-        return {
-          status,
-          diff: combinePublishDiffs(baseDiff, workingDiff),
-          lastPublishedPr: await lastPublishedPromise,
-          loadError: null,
-        };
-      } catch (error) {
-        return {
-          status: null,
-          diff: null,
-          lastPublishedPr: await lastPublishedPromise,
-          loadError: error instanceof Error ? error.message : String(error),
-        };
-      }
-    },
-    staleTime: 0,
-    gcTime: 0,
+    queryFn: () =>
+      fetchGitDiff(orgSlug, virtualMcpId, branch, { base: baseBranch }),
+    enabled: wantsBodies,
+    staleTime: BODIES_STALE_MS,
   });
 
-  return { ...query.data, refresh: () => query.refetch() };
+  const decofileHead = useDecofileHead(orgSlug, virtualMcpId, branch);
+
+  const diff = bodiesQuery.data ?? null;
+  const summary = manifest
+    ? summarizePublishManifest({ files: manifest, lookup: decofileHead, diff })
+    : summarizePublishChanges(diff);
+
+  return {
+    status,
+    summary,
+    allPaths: manifest
+      ? manifest.map((file) => file.path)
+      : Object.keys(diff?.diffs ?? {}),
+    changedFilesTotal: status.changedFilesTotal ?? summary.count,
+    changedFilesTruncated: status.changedFilesTruncated ?? false,
+    headSha,
+    diff,
+    bodiesPending: wantsBodies && bodiesQuery.isPending,
+    bodiesFailed: bodiesQuery.isError,
+    cardsPending: !manifest && wantsBodies && bodiesQuery.isPending,
+    refresh: () => statusQuery.refetch(),
+  };
 }

--- a/apps/web/src/components/thread/github/use-pr-data.ts
+++ b/apps/web/src/components/thread/github/use-pr-data.ts
@@ -15,10 +15,7 @@
 
 import { useMCPClient, useMCPToolCallQuery } from "@/sdk";
 
-import {
-  extractPullRequestList,
-  type GithubMcpClient,
-} from "./github-pr-api.ts";
+import { extractPullRequestList } from "./github-pr-api.ts";
 import { assertToolOk, extractToolJson } from "./extract-tool-json.ts";
 import type { CheckRunOutput } from "./check-run-output.ts";
 
@@ -153,37 +150,56 @@ export function usePrByBranch(args: RepoArgs & { branch: string | null }) {
   });
 }
 
-/**
- * The most recent merged PR into `base` — in Fast Preview every publish is a
- * squash-merged PR, so this IS the last publish. Fetched on demand (the
- * publish popover bundles it into its one suspense load), never polled:
- * `list_pull_requests` is rate-limit-heavy (see `openPullRequestForBranch`).
- * `sort: updated` can interleave non-merged closed PRs, hence a small page
- * filtered client-side.
+/** The most recent merged PR into `base` — in Fast Preview every publish is a
+ * squash-merged PR, so this IS the last publish. Mounted by the header so the
+ * "last published" line is warm before the publish surface opens; never
+ * polled, because `list_pull_requests` is rate-limit-heavy (see
+ * `openPullRequestForBranch`). `sort: updated` can interleave non-merged
+ * closed PRs, hence a small page filtered client-side.
  */
-export async function fetchLastPublishedPr(
-  client: GithubMcpClient,
-  args: { owner: string; repo: string; base: string },
-): Promise<PrSummary | null> {
-  const result = await client.callTool({
-    name: "list_pull_requests",
-    arguments: {
+export function useLastPublishedPr(
+  args: RepoArgs & { base: string | null; enabled?: boolean },
+) {
+  const client = useMCPClient({
+    connectionId: args.connectionId,
+    orgId: args.orgId,
+    orgSlug: args.orgSlug,
+  });
+
+  return useMCPToolCallQuery<PrSummary | null>({
+    client,
+    toolName: "list_pull_requests",
+    toolArguments: {
       owner: args.owner,
       repo: args.repo,
       state: "closed",
-      base: args.base,
+      base: args.base ?? "",
       sort: "updated",
       direction: "desc",
-      perPage: 10,
+      perPage: LAST_PUBLISHED_PER_PAGE,
+    },
+    enabled:
+      (args.enabled ?? true) &&
+      !!args.base &&
+      !!args.connectionId &&
+      !!args.owner &&
+      !!args.repo,
+    staleTime: LAST_PUBLISHED_STALE,
+    select: (r) => {
+      assertToolOk(r);
+      return (
+        extractPullRequestList(r)
+          .map(mapRawPr)
+          .find((p) => p.merged) ?? null
+      );
     },
   });
-  assertToolOk(result);
-  return (
-    extractPullRequestList(result)
-      .map(mapRawPr)
-      .find((p) => p.merged) ?? null
-  );
 }
+
+/** Closed PRs read per lookup; `sort: updated` mixes in non-merged ones. */
+const LAST_PUBLISHED_PER_PAGE = 10;
+/** The last publish changes only when someone publishes — cheap to keep. */
+const LAST_PUBLISHED_STALE = 5 * 60_000;
 
 /** Max open PRs fetched for the picker; the tail beyond this is not shown. */
 const OPEN_PRS_PER_PAGE = 50;

--- a/apps/web/src/i18n/en/thread.ts
+++ b/apps/web/src/i18n/en/thread.ts
@@ -186,6 +186,14 @@ export const thread = {
   "thread.publishDialog.viewPr": "View PR",
   "thread.publishDialog.visitPreview": "Visit preview",
   "thread.publishPopover.blocksGroup": "Blocks",
+  "thread.publishPopover.branchMoved":
+    "This branch changed since these changes were shown. Close and reopen to review what will be published.",
+  "thread.publishPopover.detailsUnavailable":
+    "Details for these changes could not be loaded.",
+  "thread.publishPopover.loadFailed": "Couldn't load your changes",
+  "thread.publishPopover.retry": "Try again",
+  "thread.publishPopover.showingFirst":
+    "Showing the first {shown} of {total} changes",
   "thread.publishPopover.chipEdited": "Edited",
   "thread.publishPopover.chipNew": "New",
   "thread.publishPopover.chipRemoved": "Removed",

--- a/apps/web/src/i18n/pt-br/thread.ts
+++ b/apps/web/src/i18n/pt-br/thread.ts
@@ -195,6 +195,15 @@ export const thread = {
   "thread.publishDialog.viewPr": "Ver PR",
   "thread.publishDialog.visitPreview": "Abrir o Preview",
   "thread.publishPopover.blocksGroup": "Blocos",
+  "thread.publishPopover.branchMoved":
+    "Esta branch mudou depois que estas alterações foram exibidas. Feche e abra novamente para revisar o que será publicado.",
+  "thread.publishPopover.detailsUnavailable":
+    "Não foi possível carregar os detalhes destas alterações.",
+  "thread.publishPopover.loadFailed":
+    "Não foi possível carregar suas alterações",
+  "thread.publishPopover.retry": "Tentar novamente",
+  "thread.publishPopover.showingFirst":
+    "Mostrando as primeiras {shown} de {total} alterações",
   "thread.publishPopover.chipEdited": "Editado",
   "thread.publishPopover.chipNew": "Novo",
   "thread.publishPopover.chipRemoved": "Removido",

--- a/packages/e2e/tests/cms-publish-stages.spec.ts
+++ b/packages/e2e/tests/cms-publish-stages.spec.ts
@@ -24,6 +24,7 @@
  * purpose — this suite owns its contract (see ban-e2e-app-imports).
  */
 
+import type { Locator } from "@playwright/test";
 import {
   createFastPreviewProject,
   seedStubRepo,
@@ -41,6 +42,25 @@ const VERSION_NOTE = "Version note";
 
 /** The CTA carries its final count from the manifest beat onward. */
 const PUBLISH_ONE = "Publish 1 change";
+
+/**
+ * The settled `y` of an element, once it stops moving.
+ *
+ * The popover opens with a zoom/slide animation, so a box read the instant the
+ * manifest lands is mid-transform and sits a few px off its final position —
+ * which would otherwise be indistinguishable from the layout shift this spec
+ * exists to catch. Reading until two samples agree measures layout, not motion.
+ */
+async function settledY(locator: Locator): Promise<number> {
+  let previous = (await locator.boundingBox())?.y ?? 0;
+  for (let attempt = 0; attempt < 40; attempt++) {
+    await locator.page().waitForTimeout(50);
+    const current = (await locator.boundingBox())?.y ?? 0;
+    if (Math.abs(current - previous) < 0.5) return current;
+    previous = current;
+  }
+  return previous;
+}
 
 test.describe("fast preview publish stages", () => {
   test("the card list, count and button are live while file bodies are still loading", async ({
@@ -133,8 +153,7 @@ test.describe("fast preview publish stages", () => {
     await expect(publishCta).toBeVisible();
     await expect(publishCta).toBeEnabled();
 
-    const beforeBox = await publishCta.boundingBox();
-    expect(beforeBox).not.toBeNull();
+    const beforeY = await settledY(publishCta);
 
     // --- Beat two: the bodies --------------------------------------------
     releaseBodies();
@@ -144,10 +163,8 @@ test.describe("fast preview publish stages", () => {
 
     // Same button, same label, same place: bodies add detail, never geometry.
     await expect(publishCta).toBeEnabled();
-    const afterBox = await publishCta.boundingBox();
-    expect(afterBox).not.toBeNull();
     expect(
-      Math.abs((afterBox?.y ?? 0) - (beforeBox?.y ?? 0)),
+      Math.abs((await settledY(publishCta)) - beforeY),
       "the publish button moved when file bodies landed",
     ).toBeLessThanOrEqual(1);
   });

--- a/packages/e2e/tests/cms-publish-stages.spec.ts
+++ b/packages/e2e/tests/cms-publish-stages.spec.ts
@@ -1,0 +1,153 @@
+/**
+ * E2E: the Fast Preview publish popover loads in two beats, and the first one
+ * is already usable.
+ *
+ * The surface used to hold everything behind one skeleton until the file
+ * BODIES had been fetched — full old/new contents for every changed file, one
+ * blob request each. It now renders its real card list, count, gate and an
+ * enabled button from the changed-file MANIFEST that rides free on
+ * `/git/status`, and treats bodies as an enrichment that only fills in section
+ * sub-lines and the expanded diff.
+ *
+ * Only a browser can hold this: the two beats are distinguishable solely by
+ * what is on screen at each one, and the whole point is that the button is
+ * live before a request that has not returned yet. `/git/diff` is stalled with
+ * `page.route` so the manifest beat is a state the test can stand still in
+ * rather than a frame it has to catch.
+ *
+ * `data-publish-state` is the anchor because the visible copy cannot tell the
+ * beats apart — the CTA reads "Publish 1 change" in both.
+ *
+ * Setup mirrors `cms-publish-surface`: sandbox-less Fast Preview against the
+ * local Git Data stub, with a deliberately dead GitHub MCP connection so the
+ * header settles on its no-open-PR state. Wire-contract strings are inlined on
+ * purpose — this suite owns its contract (see ban-e2e-app-imports).
+ */
+
+import {
+  createFastPreviewProject,
+  seedStubRepo,
+  uniqueOwner,
+} from "../fixtures/fast-preview";
+import { callSelfMcpTool } from "../fixtures/mcp-tools";
+import { expect, test } from "../fixtures/test";
+
+/** Cold-Vite route compile on a loaded box; the agent shell is a lazy route. */
+const SHELL_TIMEOUT_MS = 60_000;
+
+/** UI copy — the header's split button and the popover's chrome. */
+const REVIEW_AND_PUBLISH = "Review & Publish";
+const VERSION_NOTE = "Version note";
+
+/** The CTA carries its final count from the manifest beat onward. */
+const PUBLISH_ONE = "Publish 1 change";
+
+test.describe("fast preview publish stages", () => {
+  test("the card list, count and button are live while file bodies are still loading", async ({
+    authedPage,
+  }) => {
+    // Signup + project wiring + a cold shell route compile.
+    test.slow();
+
+    const { page, orgSlug } = authedPage;
+    const api = page.context().request;
+    const owner = uniqueOwner();
+    const repo = "site";
+    const branch = "draft";
+
+    const project = await createFastPreviewProject(api, orgSlug, {
+      owner,
+      repo,
+      /** Closed port: the PR lookup must fail instantly, not dial a real host. */
+      connectionUrl: "http://127.0.0.1:1/unused",
+    });
+
+    await seedStubRepo(api, {
+      owner,
+      repo,
+      defaultBranch: "main",
+      branches: {
+        main: { files: { ".deco/blocks/Hero.json": '{"name":"Hero"}\n' } },
+        [branch]: {
+          files: { ".deco/blocks/Hero.json": '{"name":"Hero","n":2}\n' },
+        },
+      },
+    });
+
+    const thread = await callSelfMcpTool<{
+      item: { id: string; branch: string | null };
+    }>(api, orgSlug, "COLLECTION_THREADS_CREATE", {
+      data: { virtual_mcp_id: project.vmcpId, branch },
+    });
+    expect(thread.item.branch).toBe(branch);
+
+    /**
+     * Hold every body request open for the life of the test. The manifest beat
+     * is then a resting state, and `releaseBodies` is the only thing that can
+     * end it — so anything asserted before that call is provably not waiting on
+     * file contents.
+     */
+    let releaseBodies: () => void = () => {};
+    const bodiesReleased = new Promise<void>((resolve) => {
+      releaseBodies = resolve;
+    });
+    let bodyRequests = 0;
+    await page.route("**/git/diff", async (route) => {
+      bodyRequests += 1;
+      await bodiesReleased;
+      await route.continue();
+    });
+
+    await page.goto(
+      `/${orgSlug}/${thread.item.id}?virtualmcpid=${project.vmcpId}`,
+    );
+
+    const primary = page.getByRole("button", {
+      name: REVIEW_AND_PUBLISH,
+      exact: true,
+    });
+    await expect(primary).toBeVisible({ timeout: SHELL_TIMEOUT_MS });
+    await primary.click();
+
+    const surface = page.locator("[data-publish-state]");
+    const publishCta = page.getByRole("button", {
+      name: PUBLISH_ONE,
+      exact: true,
+    });
+
+    // --- Beat one: the manifest ------------------------------------------
+    await expect(surface).toHaveAttribute("data-publish-state", "manifest", {
+      timeout: 30_000,
+    });
+    expect(
+      bodyRequests,
+      "the manifest beat must be reached without a body response",
+    ).toBeGreaterThan(0);
+
+    // The real card, named — not a ghost.
+    await expect(page.getByText("Hero", { exact: true })).toBeVisible();
+    await expect(page.getByText(VERSION_NOTE, { exact: true })).toBeVisible();
+
+    // The whole point: actionable before the bodies land.
+    await expect(publishCta).toBeVisible();
+    await expect(publishCta).toBeEnabled();
+
+    const beforeBox = await publishCta.boundingBox();
+    expect(beforeBox).not.toBeNull();
+
+    // --- Beat two: the bodies --------------------------------------------
+    releaseBodies();
+    await expect(surface).toHaveAttribute("data-publish-state", "ready", {
+      timeout: 30_000,
+    });
+
+    // Same button, same label, same place: bodies add detail, never geometry.
+    await expect(publishCta).toBeEnabled();
+    const afterBox = await publishCta.boundingBox();
+    expect(afterBox).not.toBeNull();
+    expect(
+      Math.abs((afterBox?.y ?? 0) - (beforeBox?.y ?? 0)),
+      "the publish button moved when file bodies landed",
+    ).toBeLessThanOrEqual(1);
+  });
+});

--- a/packages/e2e/tests/cms-publish-stages.spec.ts
+++ b/packages/e2e/tests/cms-publish-stages.spec.ts
@@ -124,8 +124,9 @@ test.describe("fast preview publish stages", () => {
       "the manifest beat must be reached without a body response",
     ).toBeGreaterThan(0);
 
-    // The real card, named — not a ghost.
-    await expect(page.getByText("Hero", { exact: true })).toBeVisible();
+    // The real card, named — not a ghost. Scoped to the surface: the name is
+    // generic enough to collide with the page behind the popover.
+    await expect(surface.getByText("Hero", { exact: true })).toBeVisible();
     await expect(page.getByText(VERSION_NOTE, { exact: true })).toBeVisible();
 
     // The whole point: actionable before the bodies land.


### PR DESCRIPTION
## Summary

Opening the Fast Preview publish popover held the whole UI behind one suspense
load that waited on `/git/diff` — full old/new contents for every changed file,
one blob request each — before showing anything. It now renders its card list,
count, gate and an **enabled button** from the changed-file **manifest**, and
treats file bodies as an enrichment that only fills in section sub-lines and the
expanded diff.

The manifest is free. `githubGitStatus` already asked GitHub to compare base
against head and threw the `files` array away:

```
compare(base, head)          → GET /repos/:o/:r/compare/base...head   github-git-data.ts:414
compareDetailed(base, head)  → GET /repos/:o/:r/compare/base...head   github-git-data.ts:422
                                  ↑ byte-identical URL, one ETag entry
```

So `/git/status` now carries `changedFiles` at no extra GitHub traffic — and the
header already holds that cache entry warm, so a reopen paints in the first
committed frame with no ghost at all.

**Card identity, kind, status and order come from the manifest alone, never from
the bodies**, so a late body cannot remount a card, move it between groups,
re-sort it, or recolor it. `changeId` is path-first for the same reason:
`blockKey` is null before parsing and non-null after, and that flip would have
remounted every card mid-load, collapsing an open diff and disarming a live
discard confirmation.

## Also in here

Three of these are pre-existing bugs the refactor would have made worse:

- **`resolvePathGate`** decides the review gate from paths, resolving "unknown"
  to blocked-pending. `useResolvedPublishGate` returns `{allowed: true}` for a
  null diff — harmless today only because `summarizePublishChanges(null)` also
  yields count 0. Counting from the manifest while the diff was still null would
  have enabled publish with **no gate and no judge** on a `code-review` repo.
- **The version note is derived until typed** (`edited ?? autoNote`, never `||`,
  so a deliberately cleared field stays cleared). Fixes a note that described
  already-discarded changes and one that stayed empty forever after a
  failed-then-retried load — it becomes the commit/PR title either way.
- **`runPublishFlow` asserts the branch head** still matches the change list it
  showed, before it mutates anything. This cannot be a `sha` precondition on the
  merge: the sync step squash-rebases and force-updates the ref, so by merge time
  the head is one we wrote. Matters because any caching widens the window, and
  the coding agent, a teammate, and the author's own autosave all commit here.
- **`/git/diff`** returns early on an empty diff and skips the commit-tree +
  whole-repo recursive reads for an all-additions diff — which also removes the
  `tree listing truncated by GitHub` 502 that killed the whole popover on large
  repos.
- **"Discard all" is hidden when the server truncated the file set**, instead of
  silently discarding the first 200 of N.
- **The last-published-PR lookup moved into the header**, where it is warm before
  the popover opens. It was fetched on every open, uncached, and thrown away
  entirely in review mode.
- **`PublishFrame`** renders the geometry for both the ghost and the content, so
  they can't drift — the old hand-built skeleton had a `size-5` discard control
  against a real `size-6`, and one ghost sub-line against two to four real ones.
- The empty state now renders directly instead of ghosting three cards and a note
  block it immediately deletes.

## Testing

- `bun run check`, `bun run lint` (0 errors), `knip` clean, `bun run fmt`.
- **1056 unit tests pass.** New pure-logic coverage: `buildPublishStatus` /
  `normalizeCompareStatus` (incl. pre-cap total vs. capped list), `isDecoOnlyPaths`,
  `resolvePathGate` over the full 3 policies × {deco-only, code-bearing, empty}
  matrix with smart+code asserted `pending`, `resolveVersionNote` (incl. the
  cleared-field case), and the load-bearing one: the same fixture through
  `summarizePublishManifest` with and without bodies must yield identical `count`,
  identical **ordered** `changeId[]`, and identical `kind` per card.
- E2E: the pre-existing `cms-publish-surface.spec.ts` **passes against this
  refactor** locally.

⚠️ **The new `cms-publish-stages.spec.ts` has not had a green run.** Every local
attempt died in the auth fixture (401) before touching any UI — and the untouched
pre-existing spec fails identically in that environment, so it's my local setup,
not the spec. It typechecks and lints, but please treat CI as its first real run.

## Screenshots

Not included — I could not get a Fast Preview project wired up locally to
photograph the two beats. Reviewer-facing check: throttle to Slow 3G, open the
popover, and watch `document.querySelector('[data-publish-state]').dataset.publishState`
walk `loading → manifest → ready`, with the Publish button enabled and carrying
its final count from `manifest` onward, and no vertical movement when bodies land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Loads the Fast Preview publish popover in two beats to eliminate layout shifts. Previously the UI waited for `/git/diff`; now it renders real cards, count, gate, and an enabled button from `/git/status`’s changed-file manifest, fetches bodies later for detail, and reserves sub-line height so the Publish button stays put. The new E2E measures the button’s settled position to avoid animation false positives.

- Adds `changedFiles`, `changedFilesTotal`, and `changedFilesTruncated` to `/git/status`; `githubGitStatus` uses shared-ETag `compareDetailed`. Normalizes compare statuses and folds the response via `buildPublishStatus`.
- Cards derive identity, kind, status, and order from the manifest and head decofile only; bodies only add section sub-lines and the expanded diff. New pages count sections from the head decofile at the manifest beat.
- Resolves the gate from paths with `resolvePathGate` and `isDecoOnlyPaths`; `smart` over code is `pending` until the judge runs; unknown paths never resolve to allowed. `useResolvedPublishGate` uses path lists before bodies.
- Derives the version note until typed with `resolveVersionNote` (preserves an intentionally cleared field).
- Asserts the branch head before mutating (`PublishHeadMovedError`); shows a tailored “branch moved” message and re-reads on failure; merge failures still link the PR.
- Optimizes `/git/diff`: returns early on empty diffs and skips merge-base tree walks for all-additions, removing “tree listing truncated by GitHub” failures on large repos.
- Hides “Discard all” when the server truncated the set; “discard all” and gate decisions use the manifest’s paths.
- Introduces `PublishFrame` to unify geometry; adds error/retry UI; keeps Preview always enabled; reserves the sub-line row on edited cards to eliminate footer/button movement; header and popover share one cache entry and 5s staleness via `sandboxGitStatusQueryOptions`; header warms the manifest and the last published PR.
- Tests: unit coverage for manifest/status folds, path-gate decisions, summary invariants, and version-note resolution; new E2E verifies the two beats and a stable CTA position, updated to measure settled layout rather than animation.

<sup>Written for commit 4159b8b0742e67cacd190f8508c91ae2d92e6d22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

