### PR TITLE
fix(main-panel-tabs): stop a deep-linked Content tab from bouncing away mid-load

### DIFF
--- a/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -245,13 +245,18 @@ export function useMainPanelTabs(ctx: {
   // snapshots are read as soon as the daemon is up (before the dev server), so
   // the Content tab can show without waiting; the live route fetch stays gated
   // behind `devServerReady` and takes over once the preview warms up.
-  const { data: decofile } = useDecofile(decofileFetchParams, {
-    fetchEnabled: devServerReady,
-  });
-  const { data: meta } = useLiveMeta(decofileFetchParams, {
-    fetchEnabled: devServerReady,
-  });
+  const { data: decofile, isPending: decofileIsPending } = useDecofile(
+    decofileFetchParams,
+    { fetchEnabled: devServerReady },
+  );
+  const { data: meta, isPending: metaIsPending } = useLiveMeta(
+    decofileFetchParams,
+    { fetchEnabled: devServerReady },
+  );
   const showContentTab = hasEditableDecoContent(decofile, meta);
+  // Don't bounce a deep-linked `?main=content` away before the first load resolves.
+  const contentTabPending =
+    !!decofileFetchParams && (decofileIsPending || metaIsPending);
 
   /**
    * Assets is a per-site tab: it shows whenever an S3 bucket is associated to
@@ -292,7 +297,7 @@ export function useMainPanelTabs(ctx: {
   const activeTab =
     rawActiveTab === "git" && !gitTabVisible && !prQuery.isPending
       ? resolveDefaultTabId(layoutForDefault)
-      : rawActiveTab === "content" && !showContentTab
+      : rawActiveTab === "content" && !showContentTab && !contentTabPending
         ? resolveDefaultTabId(layoutForDefault)
         : rawActiveTab === "assets" && !showAssetsTab && !assetsTabPending
           ? resolveDefaultTabId(layoutForDefault)


### PR DESCRIPTION
Follows #6317, which fixed this exact bounce for the Assets tab but left the Content tab's identical gate unpatched.

`activeTab` bounces `?main=content` to the default tab whenever `rawActiveTab === "content" && !showContentTab`. `showContentTab` is `hasEditableDecoContent(decofile, meta)`, which returns `false` while either query is still loading (`if (!decofile) return false;` / `if (!meta) return false;`). So a deep link to `?main=content` opened before `useDecofile`/`useLiveMeta` resolve gets silently redirected away, exactly like the assets-tab bug #6317 just closed for `useFileConfigsQuery`.

Fix: gate the bounce on the same pending signal as the assets fix — track `isPending` from both queries (only when `decofileFetchParams` is non-null, i.e. only when Content could ever show) and skip the redirect while either is in flight.

To confirm: open a thread with editable deco content via a `?main=content` deep link on a cold cache and verify it lands on Content instead of bouncing to the default tab, then confirm it still bounces once loaded if the repo genuinely has no editable content.

Local checks: `bun run fmt`, `bunx oxlint apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts` (0 errors), `bunx tsc --noEmit` in `apps/web` (no errors on the touched file). No unit test added — same as #6317's precedent for this hook, which composes ~15 other hooks and isn't unit-testable in isolation; CI's e2e/web-component tiers cover the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops deep links to the Content tab from bouncing to the default tab while content data loads. Previously, `?main=content` redirected until `useDecofile`/`useLiveMeta` resolved; now it stays on Content during the first load and still redirects if no editable content exists.

- Track `isPending` from `useDecofile` and `useLiveMeta` and compute `contentTabPending` only when `decofileFetchParams` exists.
- Gate the Content redirect with `!contentTabPending` in `activeTab`, matching the prior Assets tab fix.
- Keeps existing `devServerReady` gating; no API or migration changes.

<sup>Written for commit c4cf9a0f810377e904fead2132f8673615ff2b72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

