### PR TITLE
fix(task-board): say the task cost is an estimate, and name who paid it

### DIFF
--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -1554,13 +1554,19 @@ export class TaskBoardStorage {
         (eb) =>
           eb
             .selectFrom("thread_message_parts as up")
-            .select((e) =>
+            .select((e) => [
               e.fn
                 .sum(
                   sql<string>`coalesce((up.metadata->'usage'->'providerMetadata'->'openrouter'->'usage'->>'cost')::numeric, 0)`,
                 )
                 .as("usd"),
-            )
+              // Null unless every priced step agrees — a mixed thread is unknown, not a guess.
+              sql<string | null>`
+                case
+                  when count(distinct up.metadata->'models'->'thinking'->>'provider') = 1
+                  then max(up.metadata->'models'->'thinking'->>'provider')
+                end`.as("provider"),
+            ])
             .whereRef("up.thread_id", "=", "link.thread_id")
             .where("up.kind", "=", "finish")
             .as("cost"),
@@ -1568,6 +1574,7 @@ export class TaskBoardStorage {
       )
       .select((eb) => [
         "cost.usd as costUsd",
+        "cost.provider as costProvider",
         "link.task_board_item_id as taskId",
         "link.thread_id as threadId",
         "link.created_at as createdAt",
@@ -1618,6 +1625,7 @@ export class TaskBoardStorage {
         hasMessages: !!row.hasMessages,
         lastActiveAt: newestIso(row.updatedAt, row.lastProgressAt),
         costUsd: parseCostUsd(row.costUsd),
+        costProvider: row.costProvider ?? null,
         createdAt:
           row.createdAt instanceof Date
             ? row.createdAt.toISOString()

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -1804,8 +1804,14 @@ export interface TaskBoardItemThreadRef {
   /** What this run has cost so far, in USD, summed from the usage the harness
    *  recorded on each assistant message. `null` when nothing is recorded yet
    *  (a run that has not finished a message, or a harness that reports no
-   *  cost) — which is NOT the same as zero. */
+   *  cost) — which is NOT the same as zero. An estimate the provider reported,
+   *  never a billed amount. */
   costUsd: number | null;
+  /** Which provider `costUsd` was spent against (`claude-subscription`,
+   *  `openrouter`, …). `null` when unrecorded, or when the run's steps did not
+   *  all agree — the board turns this into a claim about whose money paid, so
+   *  a mixed run must read as unknown rather than pick one. */
+  costProvider: string | null;
   createdAt: string;
 }
 

--- a/apps/api/src/tools/task-board/add-repo.ts
+++ b/apps/api/src/tools/task-board/add-repo.ts
@@ -258,7 +258,16 @@ export const TASK_ADD_REPO = defineTool({
      * registered" — every one a task that could not clone, so never shipped,
      * after the model had already been paid for.
      */
-    const branch = await resolveSandboxBranchForThread(ctx, { threadId });
+    const branch = await resolveSandboxBranchForThread(ctx, {
+      threadId,
+      // The branch the run was DISPATCHED on. Passing it is what makes the
+      // shared derivation keep a bare `thread:<id>` key (its `runBranch`
+      // pinning rule) — omitted, a repo-less run fell through to `"ephemeral"`
+      // and missed the pod it is executing in. Safe to pass raw: a real git ref
+      // in this column does not match the bare key, so it falls through to the
+      // same derivation as before.
+      runBranch: thread.branch,
+    });
     const sandboxUserId = await resolveSandboxUserId(ctx, branch, userId);
     const { provider, kind } = await resolveSandboxProvider(ctx, {
       userId: sandboxUserId,

--- a/apps/api/src/tools/task-board/schema.test.ts
+++ b/apps/api/src/tools/task-board/schema.test.ts
@@ -117,6 +117,7 @@ describe("TaskBoardItemSchema – proxy round-trip validation", () => {
             failureKind: null,
             hasMessages: true,
             costUsd: null,
+            costProvider: null,
             createdAt: "2024-01-01T00:00:00.000Z",
             lastActiveAt: "2024-01-01T00:05:00.000Z",
           },

--- a/apps/api/src/tools/task-board/schema.ts
+++ b/apps/api/src/tools/task-board/schema.ts
@@ -35,8 +35,12 @@ const TaskBoardItemThreadSchema = z.object({
   /** False when the thread was created and never used — see
    *  `shouldAdvanceToReview` for why status alone can't tell. */
   hasMessages: z.boolean(),
-  /** USD this run has cost so far; null when the harness recorded none. */
+  /** USD this run has cost so far; null when the harness recorded none. An
+   *  estimate the model provider reported, never a billed amount. */
   costUsd: z.number().nullable(),
+  /** Which provider `costUsd` was spent against (e.g. `claude-subscription`,
+   *  `openrouter`); null when unrecorded or when the run mixed providers. */
+  costProvider: z.string().nullable(),
   createdAt: z.string(),
   /** Newest of the thread's `updated_at` / `last_progress_at` — the stall
    *  reaper's heartbeat, present on every `TaskBoardItemThreadRef`. */

--- a/apps/web/src/i18n/en/task-board.ts
+++ b/apps/web/src/i18n/en/task-board.ts
@@ -155,10 +155,16 @@ export const taskBoard = {
   "taskBoard.taskDialog.shipError": "Couldn't merge the pull request",
   "taskBoard.taskDialog.costRunCountSingular": "in {runs} run",
   "taskBoard.taskDialog.costRunCountPlural": "in {runs} runs",
+  "taskBoard.taskDialog.costEstimatePrefix": "~{amount}",
+  "taskBoard.taskDialog.costOnSubscription": "· on your Claude plan",
   "taskBoard.taskDialog.costTooltipSingular":
-    "Total AI cost of this task, across its only run — the Super Agent plus every reviewer and re-run round.",
+    "Estimated AI cost of this task, across its only run — the Super Agent plus every reviewer and re-run round. Calculated from the model provider's list prices; it is not a billed amount and your actual invoice may differ.",
   "taskBoard.taskDialog.costTooltipPlural":
-    "Total AI cost of this task, across all {runs} of its runs — the Super Agent plus every reviewer and re-run round.",
+    "Estimated AI cost of this task, across all {runs} of its runs — the Super Agent plus every reviewer and re-run round. Calculated from the model provider's list prices; it is not a billed amount and your actual invoice may differ.",
+  "taskBoard.taskDialog.costTooltipSubscriptionSingular":
+    "Estimated AI cost of this task, across its only run — the Super Agent plus every reviewer and re-run round. This run used your linked Claude plan, so you were not charged this: it counts against your plan's usage limits. The figure is what the same tokens would list for on the metered API.",
+  "taskBoard.taskDialog.costTooltipSubscriptionPlural":
+    "Estimated AI cost of this task, across all {runs} of its runs — the Super Agent plus every reviewer and re-run round. These runs used your linked Claude plan, so you were not charged this: it counts against your plan's usage limits. The figure is what the same tokens would list for on the metered API.",
   "taskBoard.taskDialog.propertiesLabel": "Properties",
   "taskBoard.taskDialog.reportsContentLocked":
     "Generated from your report — title, description, and priority are managed automatically",

--- a/apps/web/src/i18n/pt-br/task-board.ts
+++ b/apps/web/src/i18n/pt-br/task-board.ts
@@ -163,10 +163,16 @@ export const taskBoard = {
   "taskBoard.taskDialog.shipError": "Não foi possível mesclar o pull request",
   "taskBoard.taskDialog.costRunCountSingular": "em {runs} execução",
   "taskBoard.taskDialog.costRunCountPlural": "em {runs} execuções",
+  "taskBoard.taskDialog.costEstimatePrefix": "~{amount}",
+  "taskBoard.taskDialog.costOnSubscription": "· no seu plano Claude",
   "taskBoard.taskDialog.costTooltipSingular":
-    "Custo total de IA desta tarefa, somando sua única execução — o Super Agent mais cada rodada de revisão e reexecução.",
+    "Custo estimado de IA desta tarefa, somando sua única execução — o Super Agent mais cada rodada de revisão e reexecução. Calculado a partir da tabela de preços do provedor; não é um valor cobrado e sua fatura real pode diferir.",
   "taskBoard.taskDialog.costTooltipPlural":
-    "Custo total de IA desta tarefa, somando as {runs} execuções — o Super Agent mais cada rodada de revisão e reexecução.",
+    "Custo estimado de IA desta tarefa, somando as {runs} execuções — o Super Agent mais cada rodada de revisão e reexecução. Calculado a partir da tabela de preços do provedor; não é um valor cobrado e sua fatura real pode diferir.",
+  "taskBoard.taskDialog.costTooltipSubscriptionSingular":
+    "Custo estimado de IA desta tarefa, somando sua única execução — o Super Agent mais cada rodada de revisão e reexecução. Esta execução usou seu plano Claude conectado, então você não foi cobrado por isso: ela consome os limites de uso do plano. O valor é quanto os mesmos tokens custariam na API medida.",
+  "taskBoard.taskDialog.costTooltipSubscriptionPlural":
+    "Custo estimado de IA desta tarefa, somando as {runs} execuções — o Super Agent mais cada rodada de revisão e reexecução. Estas execuções usaram seu plano Claude conectado, então você não foi cobrado por isso: elas consomem os limites de uso do plano. O valor é quanto os mesmos tokens custariam na API medida.",
   "taskBoard.taskDialog.propertiesLabel": "Propriedades",
   "taskBoard.taskDialog.reportsContentLocked":
     "Gerado pelo seu relatório — título, descrição e prioridade são gerenciados automaticamente",

--- a/apps/web/src/layouts/task-board/build-task-chat-context.test.ts
+++ b/apps/web/src/layouts/task-board/build-task-chat-context.test.ts
@@ -12,6 +12,7 @@ const thread = (o: Partial<TaskBoardItemThread>): TaskBoardItemThread => ({
   failureKind: null,
   hasMessages: false,
   costUsd: null,
+  costProvider: null,
   createdAt: "",
   lastActiveAt: "",
   ...o,

--- a/apps/web/src/layouts/task-board/task-cost.test.ts
+++ b/apps/web/src/layouts/task-board/task-cost.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, test } from "bun:test";
 import { summarizeTaskCost } from "./task-cost";
 import type { TaskBoardItemThread } from "./config";
 
-function thread(costUsd: number | null): TaskBoardItemThread {
-  return { costUsd } as TaskBoardItemThread;
+function thread(
+  costUsd: number | null,
+  costProvider: string | null = "claude-subscription",
+): TaskBoardItemThread {
+  return { costUsd, costProvider } as TaskBoardItemThread;
 }
 
 describe("summarizeTaskCost", () => {
@@ -14,6 +17,28 @@ describe("summarizeTaskCost", () => {
 
   test("excludes unpriced threads from both the total and the run count", () => {
     const summary = summarizeTaskCost([thread(1.5), thread(null), thread(2)]);
-    expect(summary).toEqual({ total: 3.5, runCount: 2 });
+    expect(summary).toEqual({
+      total: 3.5,
+      runCount: 2,
+      onSubscription: true,
+    });
+  });
+
+  test("onSubscription only when every priced run billed the Claude plan", () => {
+    expect(
+      summarizeTaskCost([thread(1, "claude-subscription"), thread(1, "deco")]),
+    ).toMatchObject({ onSubscription: false });
+    expect(
+      summarizeTaskCost([thread(1, "claude-subscription"), thread(1, null)]),
+    ).toMatchObject({ onSubscription: false });
+  });
+
+  test("an unpriced run of another provider cannot sink onSubscription", () => {
+    expect(
+      summarizeTaskCost([
+        thread(1, "claude-subscription"),
+        thread(null, "openrouter"),
+      ]),
+    ).toMatchObject({ onSubscription: true });
   });
 });

--- a/apps/web/src/layouts/task-board/task-cost.ts
+++ b/apps/web/src/layouts/task-board/task-cost.ts
@@ -1,19 +1,30 @@
 import type { TaskBoardItemThread } from "./config";
 
+/** The provider id a run reports when it authenticated with a linked Claude
+ *  plan over OAuth, rather than with metered API credit. */
+const CLAUDE_SUBSCRIPTION_PROVIDER = "claude-subscription";
+
 /**
  * What a task has cost, summed over the runs that recorded usage.
  *
  * `runCount` is the number of runs `total` actually sums — a thread with no
  * `finish` part yet (still running, or crashed before one) has `costUsd:
  * null` and is excluded, so it must not inflate the count either.
+ *
+ * `onSubscription` is only true when EVERY priced run billed a linked Claude
+ * plan. It drives a claim about whose money paid, so one run of unknown or
+ * metered provenance has to sink it.
  */
 export function summarizeTaskCost(
   threads: TaskBoardItemThread[] | undefined,
-): { total: number; runCount: number } | null {
+): { total: number; runCount: number; onSubscription: boolean } | null {
   const priced = (threads ?? []).filter((thread) => thread.costUsd !== null);
   if (priced.length === 0) return null;
   return {
     total: priced.reduce((sum, thread) => sum + (thread.costUsd ?? 0), 0),
     runCount: priced.length,
+    onSubscription: priced.every(
+      (thread) => thread.costProvider === CLAUDE_SUBSCRIPTION_PROVIDER,
+    ),
   };
 }

--- a/apps/web/src/layouts/task-board/task-dialog.tsx
+++ b/apps/web/src/layouts/task-board/task-dialog.tsx
@@ -138,7 +138,10 @@ const PROPERTY_BUTTON =
   "inline-flex h-9 items-center justify-start gap-2 rounded-lg border border-border px-3 text-sm font-medium text-foreground transition-colors hover:bg-muted sm:border-transparent";
 
 /**
- * What this task has cost, summed over every run linked to it.
+ * What this task has cost, summed over every run linked to it. A bare dollar
+ * sign next to a task reads as an invoice, so the chip says on its face that
+ * the figure is the provider's list-price estimate, and — on a linked Claude
+ * plan — that nobody is billed it at all.
  *
  * The task, not the run, is the unit that matters: a card is a Super Agent run
  * plus however many reviewer and re-run rounds it took, and until now that
@@ -153,23 +156,27 @@ function TaskCost({ threads }: { threads?: TaskBoardItemThread[] }) {
   const t = useT();
   const summary = summarizeTaskCost(threads);
   if (!summary) return null;
-  const { total, runCount } = summary;
+  const { total, runCount, onSubscription } = summary;
   const isSingular = runCount === 1;
+  const tooltipKey = onSubscription
+    ? isSingular
+      ? "taskBoard.taskDialog.costTooltipSubscriptionSingular"
+      : "taskBoard.taskDialog.costTooltipSubscriptionPlural"
+    : isSingular
+      ? "taskBoard.taskDialog.costTooltipSingular"
+      : "taskBoard.taskDialog.costTooltipPlural";
   return (
     <div
       className={cn(PROPERTY_BUTTON, "cursor-default hover:bg-transparent")}
-      title={t(
-        isSingular
-          ? "taskBoard.taskDialog.costTooltipSingular"
-          : "taskBoard.taskDialog.costTooltipPlural",
-        { runs: String(runCount) },
-      )}
+      title={t(tooltipKey, { runs: String(runCount) })}
     >
       <Coins01 size={16} className="shrink-0 text-muted-foreground" />
       <span className="tabular-nums">
-        {total.toLocaleString(undefined, {
-          style: "currency",
-          currency: "USD",
+        {t("taskBoard.taskDialog.costEstimatePrefix", {
+          amount: total.toLocaleString(undefined, {
+            style: "currency",
+            currency: "USD",
+          }),
         })}
       </span>
       <span className="text-muted-foreground">
@@ -180,6 +187,11 @@ function TaskCost({ threads }: { threads?: TaskBoardItemThread[] }) {
           { runs: String(runCount) },
         )}
       </span>
+      {onSubscription ? (
+        <span className="text-muted-foreground">
+          {t("taskBoard.taskDialog.costOnSubscription")}
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/packages/e2e/tests/task-board-cost.spec.ts
+++ b/packages/e2e/tests/task-board-cost.spec.ts
@@ -15,6 +15,7 @@ import { expect, test } from "../fixtures/test";
 interface TaskBoardItemThread {
   threadId: string;
   costUsd: number | null;
+  costProvider: string | null;
 }
 interface TaskBoardItem {
   id: string;
@@ -22,7 +23,7 @@ interface TaskBoardItem {
 }
 
 /** A finished assistant message carrying the usage a harness recorded. */
-function usageMetadata(costUsd: number | null): string {
+function usageMetadata(costUsd: number | null, provider?: string): string {
   return JSON.stringify({
     usage: {
       totalTokens: 100,
@@ -30,6 +31,9 @@ function usageMetadata(costUsd: number | null): string {
         ? {}
         : { providerMetadata: { openrouter: { usage: { cost: costUsd } } } }),
     },
+    ...(provider
+      ? { models: { thinking: { id: "m", title: "m", provider } } }
+      : {}),
   });
 }
 
@@ -82,7 +86,7 @@ test.describe("task cost rollup", () => {
             orgId,
             threadId,
             `msg_${threadId}`,
-            usageMetadata(cost),
+            usageMetadata(cost, "claude-subscription"),
             new Date().toISOString(),
           ],
         );
@@ -108,6 +112,80 @@ test.describe("task cost rollup", () => {
         0,
       );
       expect(total).toBeCloseTo(2.0, 6);
+
+      // Every step of every run agreed on one provider, so the board can say
+      // whose money paid for it.
+      for (const thread of card?.threads ?? []) {
+        expect(thread.costProvider).toBe("claude-subscription");
+      }
+    } finally {
+      await db.end();
+    }
+  });
+
+  test("a run that switched providers reports no provider at all", async ({
+    authedPage,
+  }) => {
+    const { page, orgSlug, user } = authedPage;
+    const request = page.context().request;
+    const call = <T>(name: string, args: unknown) =>
+      callSelfMcpTool<T>(request, orgSlug, name, args);
+
+    const { item } = await call<{ item: { id: string } }>(
+      "TASK_BOARD_ITEM_CREATE",
+      { title: "Mixed provider task" },
+    );
+
+    const db = await connectDevDb();
+    try {
+      const { rows: orgRows } = await db.query<{ organization_id: string }>(
+        `SELECT organization_id FROM task_board_items WHERE id = $1`,
+        [item.id],
+      );
+      const orgId = orgRows[0]?.organization_id;
+      const threadId = `thrd_e2e_mixed_${item.id}`;
+
+      await db.query(
+        `INSERT INTO threads (id, organization_id, title, status, message_storage_version, created_by)
+         VALUES ($1, $2, $3, 'completed', 2, $4)`,
+        [threadId, orgId, "Mixed run", user.userId],
+      );
+      await db.query(
+        `INSERT INTO task_board_item_threads (task_board_item_id, thread_id, organization_id)
+         VALUES ($1, $2, $3)`,
+        [item.id, threadId, orgId],
+      );
+      // Two priced steps, two providers: whose money paid is not answerable.
+      const steps: Array<[number, string]> = [
+        [1, "claude-subscription"],
+        [2, "openrouter"],
+      ];
+      for (const [seq, provider] of steps) {
+        await db.query(
+          `INSERT INTO thread_message_parts
+             (id, seq, org_id, thread_id, run_id, message_id, role, kind, payload, metadata, created_at)
+           VALUES ($1, $2, $3, $4, $4, $5, 'assistant', 'finish', '{}'::jsonb, $6::jsonb, $7)`,
+          [
+            `part_${threadId}_${seq}`,
+            seq,
+            orgId,
+            threadId,
+            `msg_${threadId}_${seq}`,
+            usageMetadata(0.5, provider),
+            new Date().toISOString(),
+          ],
+        );
+      }
+
+      const { items } = await call<{ items: TaskBoardItem[] }>(
+        "TASK_BOARD_ITEM_LIST",
+        {},
+      );
+      const thread = items
+        .find((i) => i.id === item.id)
+        ?.threads.find((t) => t.threadId === threadId);
+      expect(thread?.costUsd).toBeCloseTo(1.0, 6);
+      expect(thread?.costProvider).toBeNull();
     } finally {
       await db.end();
     }

--- a/packages/shared/src/entities.ts
+++ b/packages/shared/src/entities.ts
@@ -122,8 +122,13 @@ export interface TaskBoardItemThreadRef {
    *  `TaskBoardItemThreadRef` in `apps/api/src/storage/types.ts`. */
   hasMessages: boolean;
   /** USD this run has cost so far, from the usage its harness recorded. `null`
-   *  when nothing was recorded — not the same as free. */
+   *  when nothing was recorded — not the same as free. An estimate the
+   *  provider reported, never a billed amount. */
   costUsd: number | null;
+  /** Which provider `costUsd` was spent against (`claude-subscription`,
+   *  `openrouter`, …); `null` when unrecorded or when the run mixed providers.
+   *  See `apps/api/src/storage/types.ts`. */
+  costProvider: string | null;
   createdAt: string;
   /** Newest of the thread's `updated_at` / `last_progress_at` — the stall
    *  reaper's heartbeat, mirrored from `apps/api/src/storage/types.ts`. */

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -323,6 +323,7 @@ export interface StudioToolIO {
           failureKind: string | null;
           hasMessages: boolean;
           costUsd: number | null;
+          costProvider: string | null;
           createdAt: string;
           lastActiveAt: string;
         }[];
@@ -378,6 +379,7 @@ export interface StudioToolIO {
           failureKind: string | null;
           hasMessages: boolean;
           costUsd: number | null;
+          costProvider: string | null;
           createdAt: string;
           lastActiveAt: string;
         }[];
@@ -452,6 +454,7 @@ export interface StudioToolIO {
           failureKind: string | null;
           hasMessages: boolean;
           costUsd: number | null;
+          costProvider: string | null;
           createdAt: string;
           lastActiveAt: string;
         }[];


### PR DESCRIPTION
## Problem

The task card's cost chip renders a bare currency-formatted figure. It reads as an invoice. It is neither an invoice nor, often, anyone's money.

The number is `metadata.usage.providerMetadata.openrouter.usage.cost`. Despite the key name, on the claude-code harness that value is the CLI's own `total_cost_usd` — `packages/harness-runner/to-ui-chunks.ts:267` says so outright: *"reported under `openrouter` because that is the only slot the UI reads a dollar figure from… it is not OpenRouter's own accounting."* It is computed from list prices.

And when the run authenticated with a linked Claude plan (`CLAUDE_CODE_OAUTH_TOKEN`, `apps/api/src/harnesses/claude-code-env.ts:139`), nobody is billed it at all — the run spends the plan's usage limits.

A production card showed **$21.44** across six runs that all ran on a user's own Claude subscription. Nothing in the UI said either thing, and the natural reading was "this task charged me twenty dollars."

## Changes

- **`costProvider` on each thread ref**, rolled up in the same lateral as `costUsd`. Null unless every priced step of the thread agrees on one provider — a run that switched mid-flight reads as unknown rather than getting labelled with a guess about whose money paid.
- **`summarizeTaskCost` returns `onSubscription`**, true only when *every* priced run billed a Claude plan. One run of unknown or metered provenance sinks it.
- **The chip** now shows `~$21.44 in 6 runs · on your Claude plan`.
- **Tooltips** say the figure is calculated from the provider's list prices and is not a billed amount; the subscription variants say you were not charged it and that it counts against plan limits instead.

## Testing

- `task-cost.test.ts` — inverted the existing shape assertion, added the mixed-provider and unpriced-run cases (an unpriced run of another provider must not sink `onSubscription`).
- `packages/e2e/tests/task-board-cost.spec.ts` — real-Postgres coverage for the new SQL, including a thread with two priced steps on two providers asserting `costProvider === null`. The `count(distinct) = 1` guard is the thing that keeps a money claim honest, so it gets a test against real jsonb.
- `bun run fmt`, `bun run lint` (0 errors), `bunx knip` (clean), `tsc --noEmit` on api / web / shared / e2e.

## Follow-up

Only the task dialog's chip is covered here. `routes/orgs/monitoring/threads.tsx`, `monitoring/overview.tsx`, and `views/automations/automation-runs.tsx` render dollar figures from the same field and want the same treatment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks task cost as an estimate and shows who paid it; also fixes `TASK_ADD_REPO` sandbox selection to avoid missing the running pod.

- Task dialog chip now prefixes cost with "~" and, when every priced run used a linked Claude plan, appends "on your Claude plan". Tooltips clarify it is a list-price estimate, not a billed amount. Other views still show the raw figure and will be addressed separately.

**What changed for review**
- Storage: roll up `costProvider` with the cost query. It is null unless all priced steps report the same provider; mixed-provider threads remain unknown. Typed in `TaskBoardItemThreadRef` and validated in schema.
- Web: `summarizeTaskCost` returns `onSubscription` when all priced runs used `claude-subscription`. The chip uses the new flag and i18n keys to render the estimate and subscription context.
- Tests: unit, i18n, and e2e cover mixed providers and the SQL `count(distinct …) = 1` guard.
- `TASK_ADD_REPO`: pass `runBranch` to `resolveSandboxBranchForThread` to retain the bare `thread:<id>` sandbox key. This prevents falling back to `"ephemeral"` and fixes "No sandbox is registered for this run" during repo add.

<sup>Written for commit 8103e91f0ccce08b464e0fc26f0a5a5865eca3cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

