### PR TITLE
perf(task-board): stop reviewer runs rediscovering what dispatch already knows

### DIFF
--- a/apps/api/src/tools/task-board/enqueue-reviewer.test.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.test.ts
@@ -10,6 +10,8 @@ import {
   MAX_REVIEWER_ATTEMPTS,
   REVIEWER_DISALLOWED_TOOLS,
   reviewerAttemptsExhausted,
+  pinnedRepoConnectionId,
+  priorCycleReviewAt,
   reviewerHandledThisCycle,
   spentAttemptsThisCycle,
   stalePreviewHandoffDue,
@@ -299,6 +301,84 @@ describe("reviewerAttemptsExhausted", () => {
     expect(
       reviewerAttemptsExhausted(task, "code_review", CYCLE_START, NOW),
     ).toBe(false);
+  });
+});
+
+describe("pinnedRepoConnectionId", () => {
+  const choice = {
+    choices: [
+      { connectionId: "conn_a", repo: "decocms/studio" },
+      { connectionId: "conn_b", repo: "decocms/context" },
+    ],
+  };
+
+  it("pins the id for the repo the card names", () => {
+    expect(pinnedRepoConnectionId("decocms/studio", choice)).toBe("conn_a");
+  });
+
+  it("leaves the run to discover when the card names no repo", () => {
+    expect(pinnedRepoConnectionId(null, choice)).toBeNull();
+  });
+
+  it("leaves the run to discover when the name matches nothing loadable", () => {
+    expect(pinnedRepoConnectionId("decocms/gone", choice)).toBeNull();
+  });
+
+  it("has nothing to pin when the sole repo is already cloned", () => {
+    const sole = { repo: { owner: "decocms", name: "studio" } };
+    expect(
+      pinnedRepoConnectionId(
+        "decocms/studio",
+        sole as unknown as Parameters<typeof pinnedRepoConnectionId>[1],
+      ),
+    ).toBeNull();
+    expect(pinnedRepoConnectionId("decocms/studio", null)).toBeNull();
+  });
+});
+
+describe("priorCycleReviewAt", () => {
+  it("is 0 on a first review, so the prompt stays the plain one", () => {
+    const task = taskWith([
+      thread({
+        title: "Code Reviewer: x",
+        status: "in_progress",
+        createdAt: "2026-01-01T10:01:00Z",
+      }),
+    ]);
+    expect(priorCycleReviewAt(task, "code_review", CYCLE_START)).toBe(0);
+  });
+
+  it("reports when this reviewer last ruled on an earlier cycle", () => {
+    const task = taskWith([
+      thread({
+        title: "Code Reviewer: x",
+        status: "completed",
+        createdAt: "2026-01-01T08:00:00Z",
+        lastActiveAt: "2026-01-01T08:30:00Z",
+      }),
+      thread({
+        title: "Code Reviewer: x",
+        status: "completed",
+        createdAt: "2026-01-01T09:00:00Z",
+        lastActiveAt: "2026-01-01T09:30:00Z",
+      }),
+    ]);
+    // The most recent prior verdict, not the first.
+    expect(priorCycleReviewAt(task, "code_review", CYCLE_START)).toBe(
+      new Date("2026-01-01T09:30:00Z").getTime(),
+    );
+  });
+
+  it("does not read the OTHER reviewer's prior cycle as its own", () => {
+    const task = taskWith([
+      thread({
+        title: "QA Agent: x",
+        status: "completed",
+        createdAt: "2026-01-01T09:00:00Z",
+        lastActiveAt: "2026-01-01T09:30:00Z",
+      }),
+    ]);
+    expect(priorCycleReviewAt(task, "code_review", CYCLE_START)).toBe(0);
   });
 });
 

--- a/apps/api/src/tools/task-board/enqueue-reviewer.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.ts
@@ -4,6 +4,7 @@ import type { TaskBoardItem } from "@/storage/types";
 import {
   enabledReviewerKinds,
   isReviewerThreadTitle,
+  PR_DIFF_RECIPE,
   REVIEWER_LABEL,
   reviewCycleStart,
   SHALLOW_CHECKOUT_NOTE,
@@ -12,7 +13,10 @@ import {
 import { recordTaskActivity } from "./activity";
 import { emitTaskBoardUpdated, handTaskToHuman } from "./run-reactions";
 import { enqueueAgentRunForTask } from "./enqueue-task-run";
-import { resolveTaskRepoChoice } from "./claude-code-task-run";
+import {
+  resolveTaskRepoChoice,
+  type TaskRepoChoice,
+} from "./claude-code-task-run";
 import { isThreadRunStale } from "@/tools/thread/helpers";
 import { mintReviewToken } from "./review-token";
 import { orgFlagEnabled } from "@decocms/shared/organization/schema";
@@ -235,6 +239,50 @@ export function spentAttemptsThisCycle(
   ).length;
 }
 
+/**
+ * The connectionId for the repository a card already names, when the org has
+ * several and the run would otherwise have to go looking.
+ *
+ * Every reviewer in a multi-repo org opened by calling `TASK_ADD_REPO` with no
+ * arguments — the discovery form, which answers with the org's whole catalog —
+ * and only then called it again with the id. A card that names its repo makes
+ * that round trip pure waste. Null when the card names no repo, when the sole
+ * repo is already cloned (nothing to pick), or when the name matches nothing
+ * loadable: each leaves the run to discover it as before.
+ */
+export function pinnedRepoConnectionId(
+  taskRepo: string | null,
+  choice: TaskRepoChoice,
+): string | null {
+  if (!taskRepo || !choice || !("choices" in choice)) return null;
+  return choice.choices.find((c) => c.repo === taskRepo)?.connectionId ?? null;
+}
+
+/**
+ * When this reviewer last finished a run on an EARLIER review cycle, in ms —
+ * else 0.
+ *
+ * A re-review is not a review: the Super Agent pushed more commits onto a PR
+ * this reviewer already read end to end. Told nothing, the second run repeats
+ * the first almost exactly (in production, $3.39 against $3.51 for a fraction
+ * of the change). Given the moment it last ruled, it can ask git what moved.
+ */
+export function priorCycleReviewAt(
+  task: TaskBoardItem,
+  kind: ReviewerKind,
+  lastInReviewAt: number,
+): number {
+  const times = task.threads
+    .filter(
+      (thr) =>
+        isReviewerThreadTitle(thr.title, kind) &&
+        new Date(thr.createdAt).getTime() < lastInReviewAt,
+    )
+    .map((thr) => new Date(thr.lastActiveAt).getTime())
+    .filter((ms) => Number.isFinite(ms));
+  return times.length === 0 ? 0 : Math.max(...times);
+}
+
 /** A reviewer attempt that produced no verdict and never will: it failed, or it
  *  is non-terminal with a heartbeat past the stall window. */
 function isSpentAttempt(
@@ -417,6 +465,8 @@ async function enqueueReviewerForTask(
   const choice = await resolveTaskRepoChoice(ctx, organizationId);
   const repo = choice && "repo" in choice ? choice.repo : null;
   const sandboxed = choice !== null;
+  const priorReviewAt = priorCycleReviewAt(task, kind, cycleAt.getTime());
+  const pinnedConnectionId = pinnedRepoConnectionId(task.repo, choice);
   // Over the sandbox's MCP client the task-run tools are namespaced; hosted
   // Decopilot calls them bare. Naming them wrong is not cosmetic — it is what
   // the model retries `enable_tool` against before giving up.
@@ -429,6 +479,9 @@ async function enqueueReviewerForTask(
   const commentTool = sandboxed
     ? "mcp__studio__TASK_BOARD_COMMENT_CREATE"
     : "TASK_BOARD_COMMENT_CREATE";
+  const commentListTool = sandboxed
+    ? "mcp__studio__TASK_BOARD_COMMENT_LIST"
+    : "TASK_BOARD_COMMENT_LIST";
 
   // Who this run IS. On the sandboxed path this becomes the harness's system
   // instructions (`agent.instructions`), replacing the org agent's own — those
@@ -462,8 +515,18 @@ async function enqueueReviewerForTask(
     repo
       ? `- The repository ${repo.owner}/${repo.name} is already cloned at your working directory and \`git\` and \`gh\` are authenticated — check the PR's branch out there to inspect / exercise the change. ${SHALLOW_CHECKOUT_NOTE}`
       : sandboxed
-        ? `- Your working directory is EMPTY. Call \`mcp__studio__TASK_ADD_REPO\` with the connectionId of the PR's repository FIRST; it clones the repository and waits for the checkout, and \`git\` and \`gh\` are authenticated once it returns.`
+        ? `- Your working directory is EMPTY. Call \`mcp__studio__TASK_ADD_REPO\` ${
+            pinnedConnectionId
+              ? `with connectionId \`${pinnedConnectionId}\` (${task.repo}) FIRST — do NOT call it with no arguments, that only lists the org's repositories and costs you a turn.`
+              : `with the connectionId of the PR's repository FIRST;`
+          } it clones the repository and waits for the checkout, and \`git\` and \`gh\` are authenticated once it returns. ${SHALLOW_CHECKOUT_NOTE}`
         : "- Load the PR's repository to inspect / exercise the change.",
+    `- ${PR_DIFF_RECIPE}`,
+    ...(priorReviewAt > 0
+      ? [
+          `- This is a RE-REVIEW. You already reviewed an earlier version of this pull request and asked for changes; the Super Agent has pushed more commits since. Read your own previous notes with \`${commentListTool}\`, then review WHAT MOVED SINCE — \`gh pr diff <number>\` still shows the whole PR, so narrow it with \`git log --since='${new Date(priorReviewAt).toISOString()}' --oneline\` and diff only those commits. Confirm your earlier notes were addressed and check the new commits for their own problems. Do NOT re-read the parts of the PR you already cleared.`,
+        ]
+      : []),
     ...(kind === "qa"
       ? [
           `- Exercise the change on the PR's deploy \`previewUrl\` (from \`${prsGetTool}\`), deep-linked to the page/route the task affects (not root). If you cannot render or exercise it, do NOT approve — \`request_changes\` with what's blocking.`,

--- a/packages/shared/src/task-board.ts
+++ b/packages/shared/src/task-board.ts
@@ -76,6 +76,26 @@ export const SHALLOW_CHECKOUT_NOTE =
   "`git fetch --deepen=100`. Same for `git log main..HEAD` and anything else " +
   "that needs shared history.";
 
+/**
+ * How a reviewer should read the change it is reviewing.
+ *
+ * Left to itself a reviewer improvises: fetch the PR ref, find the merge base,
+ * `--stat`, then `git diff` sliced by directory because it cannot tell how big
+ * the diff is. One production Code Reviewer run spent six turns and 46KB doing
+ * that, across three overlapping slices of ONE diff — and a tool result is not
+ * paid for once, it rides in the prompt of every turn after it.
+ *
+ * `gh pr diff` is served by the API, so it needs neither a fetch nor a merge
+ * base and is immune to the shallow checkout that causes the improvising.
+ */
+export const PR_DIFF_RECIPE =
+  "Read the diff with `gh pr diff <number>`. It comes from the API, so it " +
+  "needs no fetch, no merge base, and is unaffected by the shallow checkout. " +
+  "Read it ONCE — `gh pr diff <number> --name-only` first if you need to size " +
+  "it, then pull the hunks you need per FILE. Do NOT re-run the diff sliced " +
+  "by directory: each slice re-reads bytes you already have into every " +
+  "remaining turn's context, and it is the largest avoidable cost in a review.";
+
 export const REVIEWER_KINDS: ReviewerKind[] = ["qa", "code_review"];
 
 /** Human label for a reviewer — also the prefix of its run thread's title


### PR DESCRIPTION
Follow-up to #6327, which made the cost figure honest. This makes it smaller.

## What the $21.44 card actually spent

Measured from `thread_message_parts` on `board_kc0B9` — six runs, 25.6M input tokens, 98% cache reads. Tool-call histogram per run:

| Run | Cost | Tool calls | Notes |
|---|---|---|---|
| Super Agent #1 | $9.16 | Bash ×103, Edit ×21, Read ×11 | real work on a cross-cutting feature |
| QA Agent #1 | $3.51 | Bash ×45, Read ×1 (114KB) | |
| Code Reviewer #1 | $1.19 | Bash ×16 | |
| Super Agent #2 | $2.02 | Bash ×37, Edit ×12, Read ×12 | |
| QA Agent #2 | $3.39 | Bash ×37, Write ×5 | re-review, cost ~= the first |
| Code Reviewer #2 | $2.17 | Bash ×46 | re-review, cost ~2× the first |

Three of those costs are the dispatcher's fault, not the model's.

## 1. Every reviewer probed `TASK_ADD_REPO` bare

4 of 4 reviewer threads opened with `TASK_ADD_REPO {}` — the discovery form — got back the org's whole repository catalog, then immediately called it again with the right connectionId. The prompt says "call it with the connectionId of the PR's repository FIRST"; the model probes anyway, because the bare form is a real affordance.

The card already carries `repo: "decocms/studio"`, and `resolveTaskRepoChoice` already returns `{connectionId, repo}` for every loadable repo. Match them at dispatch and pin the id in the prompt. One turn per reviewer run.

## 2. The clone path never got the shallow-checkout warning

`SHALLOW_CHECKOUT_NOTE` was emitted only on the already-cloned branch, never on the `TASK_ADD_REPO` branch — which is the branch every reviewer in a multi-repo org takes. So they rediscovered `--depth 1` the hard way. Code Reviewer #2, verbatim:

```
seq 5   git fetch origin pull/6319/head:pr6319 && git log -3 && git diff --stat $(git merge-base …)
seq 6   git log --oneline $(git merge-base pr6319 origin/main)..pr6319
seq 7   git diff --stat c87d6f688..pr6319
seq 9   git diff c87d6f688..pr6319 -- packages/shared apps/api/src/storage …   19,521 B
seq 10  git diff c87d6f688..pr6319 -- apps/api/src/tools apps/web/src/layouts  13,660 B
seq 14  git diff c87d6f688..pr6319 -- apps/web/src/components/settings …       13,384 B
```

Six turns and 46KB across three overlapping slices of one diff, sliced by directory because it could not tell how big the diff was — and seq 14 comes *after* it had started exploring, so the rediscovery is interleaved.

Fixed two ways: emit the note on this path too, and add `PR_DIFF_RECIPE` pointing at `gh pr diff`, which is served by the API and so needs neither a fetch nor a merge base — immune to the shallow checkout that causes the improvising in the first place.

**Why this is the big one:** a tool result is not paid for once. It sits in the prompt of every turn after it. 46KB ≈ 12k tokens, landing around turn 10 of ~50, rides ~40 more turns ≈ 480k of that run's 1.57M input tokens. Two of the three slices are redundant, so ~20% of that run. (Estimate, stated as one.)

## 3. A re-review re-read the whole PR

QA #2 cost $3.39 against QA #1's $3.51, for a fraction of the change; Code Reviewer #2 cost *more* than #1. The cycle-2 prompt is byte-identical to cycle 1 — nothing tells the run it has seen this PR before.

`priorCycleReviewAt` reads it off `task.threads` (no new query): the newest `lastActiveAt` among this reviewer's threads from before the current cycle. When non-zero the prompt says so and hands over the timestamp, so the run can `git log --since=…` instead of reading the PR again.

## Risk

Prompt text and two pure derivations. No behavior gates, no schema change, no migration — nothing to roll back but words.

## Testing

`enqueue-reviewer.test.ts`, +7 cases on the two functions with a branch:
- `pinnedRepoConnectionId` — pins on match; null when the card names no repo, when the name matches nothing loadable, and when the sole repo is already cloned (nothing to pick). Each null leaves the run to discover as before.
- `priorCycleReviewAt` — 0 on a first review; the *most recent* prior verdict when there are several; and does not read the other reviewer's prior cycle as its own.

29 pass in that file. `bun run fmt`, `bun run lint` (0 errors), `bunx knip` clean, `tsc --noEmit` on api + shared + web. The 43 failures in `apps/api/src/tools/task-board/` are the DB-backed integration tests and fail identically on `main`.

## Not addressed

- **Super Agent #1's 103 Bash calls / 12.4M tokens.** That is a genuinely cross-cutting feature (settings UI + backend config + three toggle semantics) and a careful human would also read a lot of files. The prompt-level levers are weaker and riskier here; it wants its own measurement before anyone touches it.
- **Repeated `TASK_BOARD_ITEM_PRS_GET`** (×4, 26KB in Super Agent #1) looked like duplication. Two of the three responses are byte-identical, but it is a legitimate poll waiting for CI checks to go green, not a bug. Left alone.
- **Super Agent #2 called `TASK_ADD_REPO` twice mid-run** (seq 2 and seq 33, different results) — that is the known load_repo same-run issue, out of scope here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduces reviewer token spend by reusing dispatch knowledge. Old: reviewers listed repos via bare TASK_ADD_REPO, improvised diffs under shallow checkouts, and re-read unchanged PRs on re-review; New: the prompt pins the repo connectionId, always warns about shallow checkouts, recommends `gh pr diff`, and passes the prior review timestamp.

- Key changes
  - Repo pinning: `pinnedRepoConnectionId` maps `task.repo` to the connectionId and injects it into the prompt, avoiding the initial bare `TASK_ADD_REPO` turn.
  - Diff recipe and shallow checkout: always emit `SHALLOW_CHECKOUT_NOTE` on the clone path and add `PR_DIFF_RECIPE` to read diffs via `gh pr diff <number>` (API-backed, no fetch/merge-base), preventing directory-sliced re-diffs.
  - Re-review awareness: `priorCycleReviewAt` finds the reviewer’s last verdict time from earlier cycles and includes it in the prompt, so runs diff only what changed since then; exposes `TASK_BOARD_COMMENT_LIST` to revisit prior notes.
  - Scope: prompt text and two pure derivations only; no schema changes, flags, or migrations. Unit tests cover both functions.

<sup>Written for commit b7061b296d9a8e9945f0e19500da418fd529cb44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6328?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

