### PR TITLE
fix(runtime)!: enforce registered redirect_uri on /authorize

### DIFF
--- a/packages/runtime/src/oauth.test.ts
+++ b/packages/runtime/src/oauth.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "bun:test";
 import { createOAuthHandlers, OAuthInvalidGrantError } from "./oauth.ts";
-import type { OAuthConfig } from "./tools.ts";
+import type { OAuthClient, OAuthConfig } from "./tools.ts";
 
 const baseConfig = (
   refreshToken?: OAuthConfig["refreshToken"],
@@ -95,35 +95,403 @@ describe("OAuth /token refresh handler", () => {
   });
 });
 
-describe("OAuth /authorize handler", () => {
+const REGISTERED = "https://client.example.com/callback";
+
+const withPersistence = (
+  clients: OAuthClient[],
+  extra: Partial<OAuthConfig> = {},
+): OAuthConfig => ({
+  ...baseConfig(),
+  persistence: {
+    getClient: async (clientId) =>
+      clients.find((client) => client.client_id === clientId) ?? null,
+    saveClient: async () => {},
+  },
+  ...extra,
+});
+
+const registeredClient = (redirectUris: string[]): OAuthClient => ({
+  client_id: "client-1",
+  redirect_uris: redirectUris,
+});
+
+const authorizeRequest = (params: Record<string, string>) =>
+  new Request(
+    `https://mcp.example.com/authorize?${new URLSearchParams({
+      response_type: "code",
+      ...params,
+    }).toString()}`,
+  );
+
+const errorOf = async (response: Response) =>
+  ((await response.json()) as { error: string }).error;
+
+describe("OAuth /authorize redirect_uri validation", () => {
   it("rejects a redirect_uri with a non-https, non-local scheme", async () => {
-    const handlers = createOAuthHandlers(baseConfig());
+    const handlers = createOAuthHandlers(
+      withPersistence([registeredClient([REGISTERED])]),
+    );
 
     const response = await handlers.handleAuthorize(
-      new Request(
-        "https://mcp.example.com/authorize?response_type=code&redirect_uri=" +
-          encodeURIComponent("http://attacker.example.com/callback"),
-      ),
+      authorizeRequest({
+        client_id: "client-1",
+        redirect_uri: "http://attacker.example.com/callback",
+      }),
     );
 
     expect(response.status).toBe(400);
-    const body = (await response.json()) as { error: string };
-    expect(body.error).toBe("invalid_request");
+    expect(await errorOf(response)).toBe("invalid_request");
   });
 
-  it("accepts an https redirect_uri and redirects to the upstream authorization URL", async () => {
-    const handlers = createOAuthHandlers(baseConfig());
+  it("rejects an https redirect_uri the client never registered", async () => {
+    const handlers = createOAuthHandlers(
+      withPersistence([registeredClient([REGISTERED])]),
+    );
 
     const response = await handlers.handleAuthorize(
-      new Request(
-        "https://mcp.example.com/authorize?response_type=code&redirect_uri=" +
-          encodeURIComponent("https://client.example.com/callback"),
-      ),
+      authorizeRequest({
+        client_id: "client-1",
+        redirect_uri: "https://studio.evil.com/oauth/callback",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await errorOf(response)).toBe("invalid_request");
+    expect(response.headers.get("location")).toBeNull();
+  });
+
+  it("rejects a request without client_id", async () => {
+    const handlers = createOAuthHandlers(
+      withPersistence([registeredClient([REGISTERED])]),
+    );
+
+    const response = await handlers.handleAuthorize(
+      authorizeRequest({ redirect_uri: REGISTERED }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await errorOf(response)).toBe("invalid_request");
+  });
+
+  it("rejects an unknown client_id", async () => {
+    const handlers = createOAuthHandlers(
+      withPersistence([registeredClient([REGISTERED])]),
+    );
+
+    const response = await handlers.handleAuthorize(
+      authorizeRequest({ client_id: "nope", redirect_uri: REGISTERED }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await errorOf(response)).toBe("invalid_client");
+  });
+
+  it("rejects a registered URI that differs only by a trailing slash", async () => {
+    const handlers = createOAuthHandlers(
+      withPersistence([registeredClient([REGISTERED])]),
+    );
+
+    const response = await handlers.handleAuthorize(
+      authorizeRequest({
+        client_id: "client-1",
+        redirect_uri: `${REGISTERED}/`,
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await errorOf(response)).toBe("invalid_request");
+  });
+
+  it("rejects a registered URI that differs only by an extra query param", async () => {
+    const handlers = createOAuthHandlers(
+      withPersistence([registeredClient([REGISTERED])]),
+    );
+
+    const response = await handlers.handleAuthorize(
+      authorizeRequest({
+        client_id: "client-1",
+        redirect_uri: `${REGISTERED}?next=https://evil.example.com`,
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await errorOf(response)).toBe("invalid_request");
+  });
+
+  it("accepts an exactly matching registered redirect_uri", async () => {
+    const handlers = createOAuthHandlers(
+      withPersistence([registeredClient([REGISTERED])]),
+    );
+
+    const response = await handlers.handleAuthorize(
+      authorizeRequest({ client_id: "client-1", redirect_uri: REGISTERED }),
     );
 
     expect(response.status).toBe(302);
     expect(response.headers.get("location")).toBe(
       "https://upstream.example.com/authorize",
     );
+  });
+
+  it("allows a native client's loopback redirect on a different port", async () => {
+    const handlers = createOAuthHandlers(
+      withPersistence([registeredClient(["http://127.0.0.1:8080/callback"])]),
+    );
+
+    const response = await handlers.handleAuthorize(
+      authorizeRequest({
+        client_id: "client-1",
+        redirect_uri: "http://127.0.0.1:51234/callback",
+      }),
+    );
+
+    expect(response.status).toBe(302);
+  });
+
+  it("does not extend the loopback port relaxation to the path", async () => {
+    const handlers = createOAuthHandlers(
+      withPersistence([registeredClient(["http://127.0.0.1:8080/callback"])]),
+    );
+
+    const response = await handlers.handleAuthorize(
+      authorizeRequest({
+        client_id: "client-1",
+        redirect_uri: "http://127.0.0.1:8080/other",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it("rejects every redirect_uri when the server has no client store and no host allowlist", async () => {
+    const handlers = createOAuthHandlers(baseConfig());
+
+    const response = await handlers.handleAuthorize(
+      authorizeRequest({
+        client_id: "client-1",
+        redirect_uri: "https://client.example.com/callback",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await errorOf(response)).toBe("invalid_client");
+    expect(response.headers.get("location")).toBeNull();
+  });
+});
+
+describe("OAuth /authorize allowedRedirectHosts", () => {
+  const allowlisted = (redirectUri: string) =>
+    createOAuthHandlers({
+      ...baseConfig(),
+      allowedRedirectHosts: ["decocms.com"],
+    }).handleAuthorize(
+      authorizeRequest({ client_id: "client-1", redirect_uri: redirectUri }),
+    );
+
+  it("accepts a subdomain of an allowed host", async () => {
+    const response = await allowlisted(
+      "https://github-mcp.decocms.com/oauth/callback",
+    );
+    expect(response.status).toBe(302);
+  });
+
+  it("accepts the allowed host itself", async () => {
+    const response = await allowlisted("https://decocms.com/oauth/callback");
+    expect(response.status).toBe(302);
+  });
+
+  it("rejects a host that only ends with the allowed string", async () => {
+    const response = await allowlisted("https://evildecocms.com/callback");
+    expect(response.status).toBe(400);
+    expect(await errorOf(response)).toBe("invalid_request");
+  });
+
+  it("rejects a host that only starts with the allowed string", async () => {
+    const response = await allowlisted("https://decocms.com.attacker.io/cb");
+    expect(response.status).toBe(400);
+    expect(await errorOf(response)).toBe("invalid_request");
+  });
+
+  it("rejects http on an allowed host", async () => {
+    const response = await allowlisted("http://decocms.com/callback");
+    expect(response.status).toBe(400);
+  });
+
+  it("still requires the client's registered URI when persistence is configured", async () => {
+    const handlers = createOAuthHandlers(
+      withPersistence(
+        [registeredClient(["https://app.decocms.com/callback"])],
+        {
+          allowedRedirectHosts: ["decocms.com"],
+        },
+      ),
+    );
+
+    const response = await handlers.handleAuthorize(
+      authorizeRequest({
+        client_id: "client-1",
+        redirect_uri: "https://other.decocms.com/callback",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await errorOf(response)).toBe("invalid_request");
+  });
+});
+
+describe("OAuth /oauth/callback redirect_uri validation", () => {
+  const forgedState = (redirectUri: string) =>
+    btoa(JSON.stringify({ redirectUri, clientId: "client-1" }))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+
+  const callback = (config: OAuthConfig, state: string) =>
+    createOAuthHandlers(config).handleOAuthCallback(
+      new Request(
+        `https://mcp.example.com/oauth/callback?code=upstream-code&state=${state}`,
+      ),
+    );
+
+  it("does not redirect to a redirect_uri smuggled in through a forged state", async () => {
+    const response = await callback(
+      withPersistence([registeredClient([REGISTERED])]),
+      forgedState("https://studio.evil.com/oauth/callback"),
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("location")).toBeNull();
+  });
+
+  it("does not redirect to a forged state on the upstream error path", async () => {
+    const handlers = createOAuthHandlers(
+      withPersistence([registeredClient([REGISTERED])]),
+    );
+
+    const response = await handlers.handleOAuthCallback(
+      new Request(
+        `https://mcp.example.com/oauth/callback?error=access_denied&state=${forgedState(
+          "https://studio.evil.com/oauth/callback",
+        )}`,
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("location")).toBeNull();
+  });
+
+  it("redirects to the client's registered redirect_uri with our code", async () => {
+    const response = await callback(
+      withPersistence([registeredClient([REGISTERED])]),
+      forgedState(REGISTERED),
+    );
+
+    expect(response.status).toBe(302);
+    const location = new URL(response.headers.get("location") ?? "");
+    expect(location.origin + location.pathname).toBe(REGISTERED);
+    expect(location.searchParams.get("code")).toBeTruthy();
+  });
+});
+
+describe("OAuth stateSecret sealing", () => {
+  const sealingConfig = () =>
+    withPersistence([registeredClient([REGISTERED])], {
+      stateSecret: "a-high-entropy-secret",
+      exchangeCode: async () => ({
+        access_token: "upstream-token",
+        token_type: "Bearer",
+      }),
+    });
+
+  it("does not leak the redirect_uri in the state it sends upstream", async () => {
+    let upstreamCallback = "";
+    const handlers = createOAuthHandlers({
+      ...sealingConfig(),
+      authorizationUrl: (callbackUrl) => {
+        upstreamCallback = callbackUrl;
+        return "https://upstream.example.com/authorize";
+      },
+    });
+
+    await handlers.handleAuthorize(
+      authorizeRequest({ client_id: "client-1", redirect_uri: REGISTERED }),
+    );
+
+    const state = new URL(upstreamCallback).searchParams.get("state") ?? "";
+    expect(state).toStartWith("v1.");
+    expect(state).not.toContain(btoa("client.example.com").replace(/=+$/, ""));
+  });
+
+  it("rejects a plaintext state once a stateSecret is configured", async () => {
+    const handlers = createOAuthHandlers(sealingConfig());
+
+    const response = await handlers.handleOAuthCallback(
+      new Request(
+        `https://mcp.example.com/oauth/callback?code=c&state=${btoa(
+          JSON.stringify({ redirectUri: REGISTERED, clientId: "client-1" }),
+        )
+          .replace(/\+/g, "-")
+          .replace(/\//g, "_")
+          .replace(/=+$/, "")}`,
+      ),
+    );
+
+    expect(response.status).toBe(400);
+    expect(response.headers.get("location")).toBeNull();
+  });
+
+  it("round-trips a sealed code without exposing the upstream token", async () => {
+    const handlers = createOAuthHandlers(sealingConfig());
+
+    let upstreamCallback = "";
+    const authorizeHandlers = createOAuthHandlers({
+      ...sealingConfig(),
+      stateSecret: "a-high-entropy-secret",
+      authorizationUrl: (callbackUrl) => {
+        upstreamCallback = callbackUrl;
+        return "https://upstream.example.com/authorize";
+      },
+    });
+    await authorizeHandlers.handleAuthorize(
+      authorizeRequest({ client_id: "client-1", redirect_uri: REGISTERED }),
+    );
+    const state = new URL(upstreamCallback).searchParams.get("state") ?? "";
+
+    const callbackResponse = await handlers.handleOAuthCallback(
+      new Request(
+        `https://mcp.example.com/oauth/callback?code=upstream-code&state=${encodeURIComponent(
+          state,
+        )}`,
+      ),
+    );
+    const ourCode =
+      new URL(callbackResponse.headers.get("location") ?? "").searchParams.get(
+        "code",
+      ) ?? "";
+
+    expect(ourCode).toStartWith("v1.");
+    expect(ourCode).not.toContain("upstream-token");
+
+    const tokenResponse = await handlers.handleToken(
+      buildTokenRequest({ grant_type: "authorization_code", code: ourCode }),
+    );
+    expect(tokenResponse.status).toBe(200);
+    expect(
+      ((await tokenResponse.json()) as { access_token: string }).access_token,
+    ).toBe("upstream-token");
+  });
+
+  it("rejects a tampered sealed code", async () => {
+    const handlers = createOAuthHandlers(sealingConfig());
+
+    const response = await handlers.handleToken(
+      buildTokenRequest({
+        grant_type: "authorization_code",
+        code: "v1.QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVo",
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await errorOf(response)).toBe("invalid_grant");
   });
 });

--- a/packages/runtime/src/oauth.ts
+++ b/packages/runtime/src/oauth.ts
@@ -1,3 +1,7 @@
+import {
+  redirectUriMatchesRegistered,
+  satisfiesAllowedRedirectHosts,
+} from "./redirect-uri.ts";
 import type { OAuthClient, OAuthConfig, OAuthParams } from "./tools.ts";
 
 /**
@@ -53,14 +57,22 @@ function isValidRedirectUri(uri: string): boolean {
   }
 }
 
+function toBase64Url(binary: string): string {
+  return btoa(binary)
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function fromBase64Url(encoded: string): string {
+  return atob(encoded.replace(/-/g, "+").replace(/_/g, "/"));
+}
+
 /**
  * Encode data as base64url JSON
  */
 function encodeState<T>(data: T): string {
-  return btoa(JSON.stringify(data))
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/, "");
+  return toBase64Url(JSON.stringify(data));
 }
 
 /**
@@ -68,15 +80,93 @@ function encodeState<T>(data: T): string {
  */
 function decodeState<T>(encoded: string): T | null {
   try {
-    const base64 = encoded.replace(/-/g, "+").replace(/_/g, "/");
-    return JSON.parse(atob(base64)) as T;
+    return JSON.parse(fromBase64Url(encoded)) as T;
   } catch {
     return null;
   }
 }
 
+/** Marks a payload as AES-GCM sealed, so an unsealed one can never be mistaken for it. */
+const SEALED_PREFIX = "v1.";
+const GCM_IV_BYTES = 12;
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return toBase64Url(binary);
+}
+
+function base64UrlToBytes(encoded: string) {
+  const binary = fromBase64Url(encoded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+/**
+ * Seal and unseal the `state` and `code` this server round-trips through the
+ * browser. A `stateSecret` turns both into AES-GCM ciphertext, which keeps the
+ * upstream access token out of the code and makes the state tamper-evident.
+ * Without one they stay plain base64url JSON.
+ */
+function createSealer(secret: string | undefined) {
+  const keyPromise = secret
+    ? crypto.subtle
+        .digest("SHA-256", new TextEncoder().encode(secret))
+        .then((raw) =>
+          crypto.subtle.importKey("raw", raw, { name: "AES-GCM" }, false, [
+            "encrypt",
+            "decrypt",
+          ]),
+        )
+    : null;
+
+  const seal = async <T>(data: T): Promise<string> => {
+    if (!keyPromise) {
+      return encodeState(data);
+    }
+    const iv = crypto.getRandomValues(new Uint8Array(GCM_IV_BYTES));
+    const ciphertext = await crypto.subtle.encrypt(
+      { name: "AES-GCM", iv },
+      await keyPromise,
+      new TextEncoder().encode(JSON.stringify(data)),
+    );
+    const sealed = new Uint8Array(GCM_IV_BYTES + ciphertext.byteLength);
+    sealed.set(iv);
+    sealed.set(new Uint8Array(ciphertext), GCM_IV_BYTES);
+    return SEALED_PREFIX + bytesToBase64Url(sealed);
+  };
+
+  const unseal = async <T>(value: string): Promise<T | null> => {
+    if (!keyPromise) {
+      return value.startsWith(SEALED_PREFIX) ? null : decodeState<T>(value);
+    }
+    if (!value.startsWith(SEALED_PREFIX)) {
+      return null;
+    }
+    try {
+      const sealed = base64UrlToBytes(value.slice(SEALED_PREFIX.length));
+      const plaintext = await crypto.subtle.decrypt(
+        { name: "AES-GCM", iv: sealed.subarray(0, GCM_IV_BYTES) },
+        await keyPromise,
+        sealed.subarray(GCM_IV_BYTES),
+      );
+      return JSON.parse(new TextDecoder().decode(plaintext)) as T;
+    } catch {
+      return null;
+    }
+  };
+
+  return { seal, unseal };
+}
+
 interface PendingAuthState {
   redirectUri: string;
+  clientId?: string;
   clientState?: string;
   codeChallenge?: string;
   codeChallengeMethod?: string;
@@ -112,6 +202,79 @@ const forceHttps = (url: URL) => {
  * Per MCP Authorization spec: https://modelcontextprotocol.io/specification/draft/basic/authorization
  */
 export function createOAuthHandlers(oauth: OAuthConfig) {
+  const { seal, unseal } = createSealer(oauth.stateSecret);
+  const allowedRedirectHosts = oauth.allowedRedirectHosts?.filter(
+    (host) => host.trim().length > 0,
+  );
+
+  /**
+   * Decide whether a `redirect_uri` may receive an authorization code. Returns
+   * `null` when allowed, otherwise the error to render. RFC 6749 §4.1.2.1
+   * forbids redirecting to the URI under scrutiny. Both configured checks must
+   * pass, and with neither configured this fails closed.
+   */
+  const checkRedirectUri = async (
+    clientId: string | null | undefined,
+    redirectUri: string,
+  ): Promise<{ error: string; error_description: string } | null> => {
+    if (!isValidRedirectUri(redirectUri)) {
+      return {
+        error: "invalid_request",
+        error_description: `Invalid redirect_uri: ${redirectUri}`,
+      };
+    }
+
+    if (!clientId) {
+      return {
+        error: "invalid_request",
+        error_description: "client_id required",
+      };
+    }
+
+    if (
+      allowedRedirectHosts?.length &&
+      !satisfiesAllowedRedirectHosts(redirectUri, allowedRedirectHosts)
+    ) {
+      return {
+        error: "invalid_request",
+        error_description: `redirect_uri host is not allowed: ${redirectUri}`,
+      };
+    }
+
+    if (oauth.persistence) {
+      const client = await oauth.persistence.getClient(clientId);
+      if (!client) {
+        return {
+          error: "invalid_client",
+          error_description: "Unknown client_id",
+        };
+      }
+      const registered = client.redirect_uris ?? [];
+      if (
+        !registered.some((uri) =>
+          redirectUriMatchesRegistered(redirectUri, uri),
+        )
+      ) {
+        return {
+          error: "invalid_request",
+          error_description:
+            "redirect_uri does not exactly match a registered redirect URI for this client",
+        };
+      }
+      return null;
+    }
+
+    if (!allowedRedirectHosts?.length) {
+      return {
+        error: "invalid_client",
+        error_description:
+          "This server cannot validate redirect URIs: configure oauth.persistence (to resolve registered clients) or oauth.allowedRedirectHosts",
+      };
+    }
+
+    return null;
+  };
+
   /**
    * Build OAuth 2.0 Protected Resource Metadata (RFC9728)
    * Points to THIS server as the authorization server
@@ -156,9 +319,10 @@ export function createOAuthHandlers(oauth: OAuthConfig) {
    * Handle authorization request - redirects to external OAuth provider
    * Stateless: encodes all needed info in the state parameter
    */
-  const handleAuthorize = (req: Request): Response => {
+  const handleAuthorize = async (req: Request): Promise<Response> => {
     const url = forceHttps(new URL(req.url));
     const redirectUri = url.searchParams.get("redirect_uri");
+    const clientId = url.searchParams.get("client_id");
     const responseType = url.searchParams.get("response_type");
     const clientState = url.searchParams.get("state");
     const codeChallenge = url.searchParams.get("code_challenge");
@@ -175,14 +339,9 @@ export function createOAuthHandlers(oauth: OAuthConfig) {
       );
     }
 
-    if (!isValidRedirectUri(redirectUri)) {
-      return Response.json(
-        {
-          error: "invalid_request",
-          error_description: `Invalid redirect_uri: ${redirectUri}`,
-        },
-        { status: 400 },
-      );
+    const rejection = await checkRedirectUri(clientId, redirectUri);
+    if (rejection) {
+      return Response.json(rejection, { status: 400 });
     }
 
     if (responseType !== "code") {
@@ -203,12 +362,13 @@ export function createOAuthHandlers(oauth: OAuthConfig) {
     // Encode pending auth state (including the clean callback URL)
     const pendingState: PendingAuthState = {
       redirectUri,
+      clientId: clientId ?? undefined,
       clientState: clientState ?? undefined,
       codeChallenge: codeChallenge ?? undefined,
       codeChallengeMethod: codeChallengeMethod ?? undefined,
       oauthCallbackUri,
     };
-    const encodedState = encodeState(pendingState);
+    const encodedState = await seal(pendingState);
 
     // Add state to callback URL
     callbackUrl.searchParams.set("state", encodedState);
@@ -232,8 +392,19 @@ export function createOAuthHandlers(oauth: OAuthConfig) {
 
     // Decode state
     const pending = encodedState
-      ? decodeState<PendingAuthState>(encodedState)
+      ? await unseal<PendingAuthState>(encodedState)
       : null;
+
+    // Every redirect below hands a live credential to `pending.redirectUri`.
+    if (pending?.redirectUri) {
+      const rejection = await checkRedirectUri(
+        pending.clientId,
+        pending.redirectUri,
+      );
+      if (rejection) {
+        return Response.json(rejection, { status: 400 });
+      }
+    }
 
     if (error) {
       const errorDescription =
@@ -286,7 +457,7 @@ export function createOAuthHandlers(oauth: OAuthConfig) {
         codeChallenge: pending.codeChallenge,
         codeChallengeMethod: pending.codeChallengeMethod,
       };
-      const ourCode = encodeState(codePayload);
+      const ourCode = await seal(codePayload);
 
       // Redirect back to client with our code
       const redirectUrl = forceHttps(new URL(pending.redirectUri));
@@ -442,7 +613,7 @@ export function createOAuthHandlers(oauth: OAuthConfig) {
       }
 
       // Decode the code to get the token
-      const payload = decodeState<CodePayload>(code);
+      const payload = await unseal<CodePayload>(code);
       if (!payload || !payload.accessToken) {
         return Response.json(
           {

--- a/packages/runtime/src/redirect-uri.test.ts
+++ b/packages/runtime/src/redirect-uri.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "bun:test";
+import {
+  hostMatchesSuffix,
+  isLoopbackHost,
+  redirectUriMatchesRegistered,
+  satisfiesAllowedRedirectHosts,
+} from "./redirect-uri.ts";
+
+describe("isLoopbackHost", () => {
+  it("accepts loopback literals and reserved localhost names", () => {
+    for (const host of [
+      "127.0.0.1",
+      "[::1]",
+      "::1",
+      "localhost",
+      "app.localhost",
+    ]) {
+      expect(isLoopbackHost(host)).toBe(true);
+    }
+  });
+
+  it("rejects hosts that merely look local", () => {
+    for (const host of [
+      "localhost.evil.com",
+      "127.0.0.1.evil.com",
+      "notlocalhost",
+    ]) {
+      expect(isLoopbackHost(host)).toBe(false);
+    }
+  });
+});
+
+describe("redirectUriMatchesRegistered", () => {
+  const registered = "https://client.example.com/callback";
+
+  it("matches an identical URI", () => {
+    expect(redirectUriMatchesRegistered(registered, registered)).toBe(true);
+  });
+
+  it("rejects prefix, suffix, path and query variations", () => {
+    for (const requested of [
+      "https://client.example.com/callback/",
+      "https://client.example.com/callback?next=1",
+      "https://client.example.com/callback/../evil",
+      "https://client.example.com.evil.io/callback",
+      "https://evil.io/https://client.example.com/callback",
+      "http://client.example.com/callback",
+    ]) {
+      expect(redirectUriMatchesRegistered(requested, registered)).toBe(false);
+    }
+  });
+
+  it("allows only the port to vary on loopback URIs", () => {
+    const loopback = "http://127.0.0.1:8080/callback";
+    expect(
+      redirectUriMatchesRegistered("http://127.0.0.1:51234/callback", loopback),
+    ).toBe(true);
+    expect(
+      redirectUriMatchesRegistered("http://127.0.0.1:51234/other", loopback),
+    ).toBe(false);
+    expect(
+      redirectUriMatchesRegistered("http://[::1]:51234/callback", loopback),
+    ).toBe(false);
+    expect(
+      redirectUriMatchesRegistered("https://127.0.0.1/callback", loopback),
+    ).toBe(false);
+  });
+
+  it("does not relax the port for non-loopback hosts", () => {
+    expect(
+      redirectUriMatchesRegistered(
+        "https://client.example.com:8443/callback",
+        registered,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects unparseable URIs", () => {
+    expect(redirectUriMatchesRegistered("not a url", registered)).toBe(false);
+  });
+});
+
+describe("hostMatchesSuffix", () => {
+  it("matches on a label boundary only", () => {
+    expect(hostMatchesSuffix("decocms.com", "decocms.com")).toBe(true);
+    expect(hostMatchesSuffix("github-mcp.decocms.com", "decocms.com")).toBe(
+      true,
+    );
+    expect(hostMatchesSuffix("evildecocms.com", "decocms.com")).toBe(false);
+    expect(hostMatchesSuffix("decocms.com.attacker.io", "decocms.com")).toBe(
+      false,
+    );
+  });
+
+  it("ignores case, surrounding whitespace and a leading dot", () => {
+    expect(hostMatchesSuffix("API.DecoCMS.com", " .decocms.com ")).toBe(true);
+  });
+
+  it("never matches an empty suffix", () => {
+    expect(hostMatchesSuffix("decocms.com", "   ")).toBe(false);
+  });
+});
+
+describe("satisfiesAllowedRedirectHosts", () => {
+  const allowed = ["decocms.com"];
+
+  it("accepts https on an allowed host", () => {
+    expect(
+      satisfiesAllowedRedirectHosts(
+        "https://github-mcp.decocms.com/oauth/callback",
+        allowed,
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts http only for loopback", () => {
+    expect(
+      satisfiesAllowedRedirectHosts("http://127.0.0.1:5173/cb", allowed),
+    ).toBe(true);
+    expect(
+      satisfiesAllowedRedirectHosts("http://decocms.com/cb", allowed),
+    ).toBe(false);
+  });
+
+  it("rejects custom schemes, which have no host to check", () => {
+    expect(
+      satisfiesAllowedRedirectHosts("cursor://decocms.com/cb", allowed),
+    ).toBe(false);
+  });
+
+  it("rejects an empty allowlist and unparseable URIs", () => {
+    expect(satisfiesAllowedRedirectHosts("https://decocms.com/cb", [])).toBe(
+      false,
+    );
+    expect(satisfiesAllowedRedirectHosts("not a url", allowed)).toBe(false);
+  });
+});

--- a/packages/runtime/src/redirect-uri.ts
+++ b/packages/runtime/src/redirect-uri.ts
@@ -1,0 +1,106 @@
+/**
+ * Redirect URI policy for the OAuth authorization endpoint.
+ *
+ * The endpoint hands out an authorization code that, in this runtime, encodes
+ * the upstream provider token. A redirect target the server cannot tie back to
+ * a registered client is an open redirect carrying a live credential, so these
+ * rules stay literal.
+ */
+
+/**
+ * Hosts that always resolve to the machine running the user agent, so a
+ * redirect there never leaves the client. Covers the RFC 8252 §7.3 loopback IP
+ * literals and the `localhost` names RFC 6761 reserves for the same purpose.
+ */
+export function isLoopbackHost(hostname: string): boolean {
+  const host = hostname.toLowerCase();
+  return (
+    host === "127.0.0.1" ||
+    host === "[::1]" ||
+    host === "::1" ||
+    host === "localhost" ||
+    host.endsWith(".localhost")
+  );
+}
+
+/**
+ * Compare a requested `redirect_uri` against one the client registered.
+ *
+ * Exact string comparison per RFC 6749 §3.1.2.2. No prefix, substring or
+ * "same host" relaxation. RFC 8252 §7.3 is the one exception: a native client
+ * binds an ephemeral loopback port it cannot know at registration time, so the
+ * port alone may differ for loopback URIs.
+ */
+export function redirectUriMatchesRegistered(
+  requested: string,
+  registered: string,
+): boolean {
+  if (requested === registered) {
+    return true;
+  }
+
+  let requestedUrl: URL;
+  let registeredUrl: URL;
+  try {
+    requestedUrl = new URL(requested);
+    registeredUrl = new URL(registered);
+  } catch {
+    return false;
+  }
+
+  if (
+    !isLoopbackHost(requestedUrl.hostname) ||
+    !isLoopbackHost(registeredUrl.hostname)
+  ) {
+    return false;
+  }
+
+  return (
+    requestedUrl.protocol === registeredUrl.protocol &&
+    requestedUrl.hostname.toLowerCase() ===
+      registeredUrl.hostname.toLowerCase() &&
+    requestedUrl.pathname === registeredUrl.pathname &&
+    requestedUrl.search === registeredUrl.search &&
+    requestedUrl.hash === registeredUrl.hash
+  );
+}
+
+/**
+ * Match a host against an allowlist suffix on a label boundary, so
+ * `decocms.com` covers `github-mcp.decocms.com` but neither `evildecocms.com`
+ * nor `decocms.com.attacker.io`.
+ */
+export function hostMatchesSuffix(hostname: string, suffix: string): boolean {
+  const host = hostname.toLowerCase();
+  const allowed = suffix.trim().toLowerCase().replace(/^\.+/, "");
+  if (!allowed) {
+    return false;
+  }
+  return host === allowed || host.endsWith(`.${allowed}`);
+}
+
+/**
+ * Server-level allowlist check. `https` URIs must land on an allowed host.
+ * `http` is accepted only for loopback, where there is no network to
+ * intercept. Every other scheme, including the custom schemes native clients
+ * register, has no host to check and is rejected.
+ */
+export function satisfiesAllowedRedirectHosts(
+  uri: string,
+  allowedHosts: readonly string[],
+): boolean {
+  let url: URL;
+  try {
+    url = new URL(uri);
+  } catch {
+    return false;
+  }
+
+  if (url.protocol === "http:") {
+    return isLoopbackHost(url.hostname);
+  }
+  if (url.protocol !== "https:") {
+    return false;
+  }
+  return allowedHosts.some((suffix) => hostMatchesSuffix(url.hostname, suffix));
+}

--- a/packages/runtime/src/tools.ts
+++ b/packages/runtime/src/tools.ts
@@ -527,14 +527,15 @@ export interface OAuthConfig {
    * Called when the client requests a new access token with grant_type=refresh_token
    */
   refreshToken?: (refreshToken: string) => Promise<OAuthTokenResponse>;
-  /**
-   * Optional: persistence for dynamic client registration (RFC7591)
-   * If not provided, clients are accepted without validation
-   */
+  /** Client store (RFC7591) `/authorize` matches `redirect_uri` against. Set this or `allowedRedirectHosts`, else `/authorize` rejects everything. */
   persistence?: {
     getClient: (clientId: string) => Promise<OAuthClient | null>;
     saveClient: (client: OAuthClient) => Promise<void>;
   };
+  /** Label-boundary host allowlist for `redirect_uri`, enforced on top of the client's registered URIs. */
+  allowedRedirectHosts?: string[];
+  /** AES-GCM key material for `state` and `code`; unset leaves both plaintext, exposing the upstream token in the code. Share one value across instances. */
+  stateSecret?: string;
 }
 
 export interface CreateMCPServerOptions<


### PR DESCRIPTION
## What is this contribution about?

The OAuth authorization endpoint in `@decocms/runtime` accepted any `redirect_uri` that parsed as https, without comparing it to the requesting client.

Registered redirect URIs were write-only. `handleClientRegistration` persisted them through `saveClient`, but `getClient` had no callers anywhere in the package, so what a client declared at registration never constrained anything. The request's `client_id` was read and then discarded. That is an open redirect on the authorization endpoint, and this runtime encodes the upstream provider token into the authorization code, so the consequence is worse than a normal code leak. PKCE does not help, because whoever builds the `/authorize` URL also chooses the challenge.

The fix adds one gate, `checkRedirectUri`, called from both `/authorize` and `/oauth/callback`:

- `client_id` is required, resolved through `persistence.getClient`, and `redirect_uri` must match one of that client's registered URIs by exact string comparison (RFC 6749 3.1.2.2). The only relaxation is a variable port on loopback URIs for native clients (RFC 8252 7.3).
- A new optional `allowedRedirectHosts` applies in addition, matched on a label boundary so a suffix cannot be spoofed by a longer host. `http` is accepted only for loopback. This is what a stateless deployment uses, where there is no client store to resolve.
- With neither configured, the gate rejects everything. The previous effective policy, any https URL, is not a policy.
- Rejections render a 400 instead of redirecting to the URI under scrutiny (RFC 6749 4.1.2.1).

The callback runs the same gate on the redirect URI it decodes from the `state`, before any of its three redirect paths. `state` was unsigned and upstream providers permit extra query params on their registered callback, so a state this server never issued could otherwise reach `/oauth/callback` and steer a real token off-origin. Fixing `/authorize` alone would not have closed that.

Also adds an optional `stateSecret`. When set, the `state` and the authorization code are AES-GCM sealed. The code previously carried the upstream access and refresh tokens as plain base64url JSON, so a leaked code was a leaked token rather than something PKCE and the token endpoint could still contain.

## How did you verify your code works?

40 tests pass across `packages/runtime/src/oauth.test.ts` and the new `packages/runtime/src/redirect-uri.test.ts`.

New coverage in `oauth.test.ts`: unregistered `redirect_uri` rejected with no upstream redirect; missing `client_id` rejected; unknown `client_id` rejected as `invalid_client`; registered URI differing only by a trailing slash or an extra query param rejected; exact match accepted; loopback port relaxation accepted while a differing path is not; every `redirect_uri` rejected when neither policy is configured; the `allowedRedirectHosts` suffix cases including the two near-miss hosts and `http` on an allowed host; a forged `state` at `/oauth/callback` returning 400 with no `location` header on both the success and the upstream-error path; and the `stateSecret` round trip, including that the sealed code does not contain the upstream token and that a plaintext state is refused once a secret is configured.

`redirect-uri.test.ts` covers the matchers directly, including path traversal and embedded-URL shapes.

I inverted the existing test that asserted the old behaviour (`accepts an https redirect_uri and redirects to the upstream authorization URL`) rather than appending a new one, since it encoded exactly this bug.

`bun run --cwd packages/runtime check`, `bun run fmt:check`, `bun run lint` and `knip` are clean. Note that `bun test packages/runtime` has a pre-existing failure in `triggers.test.ts` when the whole package runs at once; it fails identically on a stashed tree and passes when that file runs alone.

## How to Test

1. `bun test packages/runtime/src/oauth.test.ts packages/runtime/src/redirect-uri.test.ts`
2. Configure a server with `oauth.persistence`, register a client through `/register`, then call `/authorize` with a `redirect_uri` that is not the registered one.
3. Expected: 400 with `invalid_request` and no `location` header, instead of a 302 to the upstream provider.

## Migration Notes

This is a breaking change for consumers of `@decocms/runtime`, which is why the title carries `!`. It bumps only `packages/runtime/package.json`; the Studio app release line is untouched (`scripts/release-changes.ts` returns `packageManifests: ["packages/runtime/package.json"]` for this diff).

Nothing in this repo configures `oauth`, so there is no internal impact. Every downstream consumer is pinned to runtime 1.x, so nothing picks this up automatically.

Consumers need, in the same deploy that takes the new version:

- Stateless servers must set `oauth.allowedRedirectHosts`, or `/authorize` rejects every request by design.
- Servers with `persistence` need no config, but should audit stored `redirect_uris` first, since matching is now exact and anything registered with a trailing slash or stray query param will start failing.
- In-flight authorizations do not survive the upgrade. A `state` issued by the previous version carries no `client_id`, so the new callback gate rejects it. Users retry and it works.
- `stateSecret` is opt-in and should be a separate, later deploy. Mid-rollout, an instance holding the secret cannot unseal a state written by one without it.

Follow-up in `decocms/mcps`: pass the existing `ALLOWED_REDIRECT_HOST_SUFFIXES` into the runtime config and delete `github/server/lib/redirect-allowlist.ts`, whose `assertAllowedRedirectUri()` currently only ever sees the server's own origin and so cannot reject anything.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [ ] Documentation is updated (if needed)
- [ ] No breaking changes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes an open redirect in `@decocms/runtime` OAuth by enforcing exact `redirect_uri` validation. Previously `/authorize` accepted any https URL; now it requires `client_id` and only redirects to a URI registered for that client, preventing token leakage.

- Implements `checkRedirectUri` used in both `/authorize` and `/oauth/callback`.
- Exact match against the client’s registered URIs (RFC 6749 §3.1.2.2); only relaxation is varying the port on loopback URIs for native apps (RFC 8252 §7.3).
- Adds optional `allowedRedirectHosts` as an additional allowlist (label-boundary match). `http` is only allowed for loopback. With neither `persistence` nor `allowedRedirectHosts`, all requests are rejected. Rejections return 400 instead of redirecting (RFC 6749 §4.1.2.1).
- Validates the decoded `redirect_uri` at `/oauth/callback` to block forged `state` from steering tokens off-origin.
- Adds optional `stateSecret` to AES-GCM seal `state` and our authorization `code`, removing upstream tokens from plaintext codes and making state tamper-evident.

**Migration**
- Breaking: `/authorize` now requires `client_id` and a validated `redirect_uri`.
- Stateless servers must set `oauth.allowedRedirectHosts`, or every request is rejected.
- Servers with `persistence` should audit stored `redirect_uris` for exact matches; trailing slashes or extra query params will now fail.
- In-flight authorizations from the old version will fail; users must retry.
- `stateSecret` is optional; roll out separately. Mixed instances (with/without it) cannot read each other’s `state`.

<sup>Written for commit 29443cec0b8da6c48328e023c0d972d1e55af9e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

