### PR TITLE
feat(web): announce Linux desktop beta

### DIFF
--- a/apps/web/src/lib/release-feed.ts
+++ b/apps/web/src/lib/release-feed.ts
@@ -37,6 +37,32 @@ export interface Release {
  */
 const ALL_RELEASES: Release[] = [
   {
+    id: "native-app-linux-beta",
+    date: "2026-08-20",
+    eyebrow: "Now Available",
+    title: "Studio for Linux is now in beta",
+    bullets: [
+      {
+        icon: Monitor01,
+        title: "Native Linux desktop app",
+        body: "Studio now ships as an AppImage for 64-bit x86 Linux, bringing the local desktop workflow to Linux.",
+      },
+      {
+        icon: CheckCircle,
+        title: "Verified, no-root install",
+        body: "The installer verifies the download, installs Studio to ~/.local/bin, and adds it to your application launcher without sudo.",
+      },
+      {
+        icon: Zap,
+        title: "Beta today, broader support next",
+        body: "We're validating more distributions and desktop environments. Arm builds are not available yet, and your feedback will shape general availability.",
+      },
+    ],
+    cta: { label: "Install Studio", action: "download-app" },
+    learnMoreHref:
+      "https://github.com/decocms/studio/releases/tag/native-v4.242.0",
+  },
+  {
     id: "native-app-macos",
     date: "2026-07-30",
     eyebrow: "Now Available",


### PR DESCRIPTION
## Summary

- add a Linux desktop beta notice as the newest in-product release announcement
- describe the x86_64 AppImage, verified user-level installer, and current beta/Arm limitations
- use the existing download-app action so installed desktop users do not see an install prompt
- link the immutable first Linux release for details

## Testing

- bun run fmt
- bun run lint
- bun run check

## Screenshots

Not captured. This is a data-only addition rendered by the existing release announcement card.

Related to #6281

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Announces the Studio for Linux beta in the in-product release feed so users discover the new native desktop app. Previously there was no Linux announcement; now the latest floating card promotes the x86_64 AppImage and verified, no-root installer, with Arm not yet supported.

- Adds a new `ALL_RELEASES` entry (`id: "native-app-linux-beta"`) with CTA using the existing `download-app` action to avoid reinstall prompts for users who already installed the desktop app.
- Links “Learn more” to the pinned release tag `native-v4.242.0`. No component or layout changes; this is a data-only addition.

<sup>Written for commit 89e5c4c4a9878d0f5150d27ac4048f4b4e0c07d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

