### PR TITLE
fix: stop the publish and CMS gates from opening up when the dev server is down

### DIFF
--- a/apps/web/src/components/sections-editor/decofile-read-status.test.ts
+++ b/apps/web/src/components/sections-editor/decofile-read-status.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+import {
+  classifyCommittedReadStatus,
+  decofileErrorStatus,
+} from "./decofile-read-status";
+
+describe("classifyCommittedReadStatus", () => {
+  it("reads a daemon 400 as proof the file is absent", () => {
+    expect(classifyCommittedReadStatus(400)).toBe("absent");
+  });
+
+  it("reads a 404 as an unprovisioned sandbox, not an absent file", () => {
+    expect(classifyCommittedReadStatus(404)).toBe("unavailable");
+  });
+
+  it("passes 2xx through and surfaces the rest as errors", () => {
+    expect(classifyCommittedReadStatus(200)).toBe("ok");
+    expect(classifyCommittedReadStatus(204)).toBe("ok");
+    expect(classifyCommittedReadStatus(500)).toBe("error");
+    expect(classifyCommittedReadStatus(502)).toBe("error");
+  });
+});
+
+describe("decofileErrorStatus", () => {
+  it("tags 404 when the dev server answered a non-decofile 200", () => {
+    expect(decofileErrorStatus({ liveOk: true, committedAbsent: false })).toBe(
+      404,
+    );
+  });
+
+  it("tags 404 when the checkout has no decofile artifacts — dev server down", () => {
+    expect(decofileErrorStatus({ liveOk: false, committedAbsent: true })).toBe(
+      404,
+    );
+    expect(
+      decofileErrorStatus({
+        liveOk: false,
+        liveStatus: 502,
+        committedAbsent: true,
+      }),
+    ).toBe(404);
+  });
+
+  it("keeps a transient failure transient when absence is unproven", () => {
+    expect(
+      decofileErrorStatus({
+        liveOk: false,
+        liveStatus: 503,
+        committedAbsent: false,
+      }),
+    ).toBe(503);
+    expect(decofileErrorStatus({ liveOk: false, committedAbsent: false })).toBe(
+      502,
+    );
+  });
+
+  it("passes a real dev-server 404 through unchanged", () => {
+    expect(
+      decofileErrorStatus({
+        liveOk: false,
+        liveStatus: 404,
+        committedAbsent: false,
+      }),
+    ).toBe(404);
+  });
+});

--- a/apps/web/src/components/sections-editor/decofile-read-status.ts
+++ b/apps/web/src/components/sections-editor/decofile-read-status.ts
@@ -1,0 +1,49 @@
+/**
+ * Pure status arithmetic for the decofile reads. Extracted so the two decisions
+ * both Preview gates hang off are unit-testable without a stubbed `fetch`.
+ */
+
+/** What a `POST .../read` status says about the file, per the daemon contract. */
+export type CommittedReadKind =
+  /** Healthy daemon, file is not in the checkout (daemon answers 400). */
+  | "absent"
+  /** Sandbox not provisioned yet (404) — nothing proven either way. */
+  | "unavailable"
+  /** Body follows. */
+  | "ok"
+  /** Daemon reachable but broken — the caller throws and retries. */
+  | "error";
+
+export function classifyCommittedReadStatus(status: number): CommittedReadKind {
+  if (status === 400) return "absent";
+  if (status === 404) return "unavailable";
+  return status >= 200 && status < 300 ? "ok" : "error";
+}
+
+/**
+ * `.status` to tag on a failed decofile read, which
+ * `resolveBlocksTabState` reads: 404 means "this repo does not use the deco
+ * framework for sites" (a proof, and sticky per repo+branch), anything else
+ * means "the read didn't resolve" (transient).
+ *
+ * Both proofs are equivalent, and neither needs a working dev server:
+ * - `liveOk` — the dev server answered 200 with something that isn't a decofile
+ *   (a plain Vite server hands back `index.html`), so it has no decofile route.
+ * - `committedAbsent` — the checkout has neither `.deco/blocks.gen.json` nor a
+ *   `.deco/blocks/` to regenerate it from. Block sources are committed files, so
+ *   a deco site always has them once the clone lands; a repo without them has
+ *   nothing a CMS could edit.
+ *
+ * The second is what makes the gate work with the dev server down or crashed —
+ * the state where the live read can only ever yield a transient 502.
+ */
+export function decofileErrorStatus(input: {
+  /** Live `/.decofile` answered 2xx (with a non-decofile body). */
+  liveOk: boolean;
+  /** Live `/.decofile` status, when it answered at all. */
+  liveStatus?: number;
+  committedAbsent: boolean;
+}): number {
+  if (input.liveOk || input.committedAbsent) return 404;
+  return input.liveStatus ?? 502;
+}

--- a/apps/web/src/components/sections-editor/read-committed-file.ts
+++ b/apps/web/src/components/sections-editor/read-committed-file.ts
@@ -1,4 +1,5 @@
 import { stripLineNumbers } from "@/components/sandbox/preview/file-explorer/utils";
+import { classifyCommittedReadStatus } from "./decofile-read-status";
 
 interface RepoFileParams {
   orgSlug: string;
@@ -7,19 +8,28 @@ interface RepoFileParams {
 }
 
 /**
+ * Outcome of a committed-snapshot read. `absent` and `unavailable` both mean
+ * "no data", but only `absent` proves the file isn't in the checkout — which is
+ * how the Preview gates tell a non-deco repo from a sandbox that isn't up yet.
+ */
+export type CommittedRead<T> =
+  | { kind: "data"; data: T }
+  | { kind: "absent" }
+  | { kind: "unavailable" };
+
+/**
  * Read a JSON file committed to the repo working tree via the sandbox daemon's
  * file-read proxy. Unlike `/.decofile` and `/live/_meta` (served by the dev
  * server), this works as soon as the daemon is up — before the dev script boots
  * or even when it has crashed — so the CMS can be read (and, since block writes
  * go straight to the FS, edited) without a working preview.
  *
- * Returns `null` when the file is absent (daemon 400) or unparseable; throws on
- * transient daemon-unreachable errors so the caller's query retries.
+ * Throws on transient daemon-unreachable errors so the caller's query retries.
  */
 export async function readCommittedJson<T>(
   params: RepoFileParams,
   path: string,
-): Promise<T | null> {
+): Promise<CommittedRead<T>> {
   const url = `/api/${params.orgSlug}/sandbox/${encodeURIComponent(
     params.virtualMcpId,
   )}/${encodeURIComponent(params.branch)}/read`;
@@ -29,28 +39,35 @@ export async function readCommittedJson<T>(
     body: JSON.stringify({ path, full: true }),
   });
   // 400 = file not found: the repo simply doesn't commit this artifact, so
-  // there is no committed source to fall back to. Don't retry.
+  // there is no committed source to fall back to. Don't retry — and report it
+  // as `absent`, which is a proof callers act on (see `decofileErrorStatus`).
   //
   // 404 = the sandbox isn't provisioned yet (proxy/runner "sandbox not found";
   // a healthy daemon returns 400, never 404, for an absent file). This is a
-  // transient startup state, not a hard error — return null so the caller falls
-  // through to its next source / 502-wait and the sandbox lifecycle re-triggers
-  // the read once the daemon is up, instead of throwing a non-502 error that
-  // gets retried in a tight loop (and, in useLiveMeta, skips the production
-  // fallback).
-  if (res.status === 400 || res.status === 404) return null;
-  if (!res.ok) {
+  // transient startup state, not a hard error — report `unavailable` so the
+  // caller falls through to its next source / 502-wait and the sandbox
+  // lifecycle re-triggers the read once the daemon is up, instead of throwing a
+  // non-502 error that gets retried in a tight loop (and, in useLiveMeta, skips
+  // the production fallback).
+  const kind = classifyCommittedReadStatus(res.status);
+  if (kind === "absent") return { kind: "absent" };
+  if (kind === "unavailable") return { kind: "unavailable" };
+  if (kind === "error") {
     const err = new Error(`Failed to read ${path}: ${res.status}`);
     (err as { status?: number }).status = res.status;
     throw err;
   }
   // The daemon returns line-number-prefixed content ("1\t...\n2\t..."), even
-  // with `full: true`, so strip it before parsing.
+  // with `full: true`, so strip it before parsing. An unparseable body proves
+  // nothing about the framework — a corrupt artifact is not an absent one.
   const data = (await res.json()) as { content?: string };
-  if (typeof data.content !== "string") return null;
+  if (typeof data.content !== "string") return { kind: "unavailable" };
   try {
-    return JSON.parse(stripLineNumbers(data.content)) as T;
+    return {
+      kind: "data",
+      data: JSON.parse(stripLineNumbers(data.content)) as T,
+    };
   } catch {
-    return null;
+    return { kind: "unavailable" };
   }
 }

--- a/apps/web/src/components/sections-editor/use-decofile.ts
+++ b/apps/web/src/components/sections-editor/use-decofile.ts
@@ -7,6 +7,7 @@ import { parseDecofileBody } from "./decofile-body";
 import { fetchDecofile } from "./decofile-api";
 import { buildDecofileFetchUrl } from "./preview-fetch-url";
 import { readCommittedJson } from "./read-committed-file";
+import { decofileErrorStatus } from "./decofile-read-status";
 import { usePackagePath } from "./use-package-path";
 
 interface UseDecofileParams {
@@ -71,25 +72,32 @@ export function useDecofile(
         // Dev server reported ready but the route failed (e.g. dev script
         // crashed): fall back to the committed snapshot so editing still works.
         const committed = await readCommitted();
-        if (committed) return committed;
+        if (committed.kind === "data") return committed.data;
         const err = new Error(
           `Failed to fetch decofile: ${res?.status ?? "network error"}`,
         );
-        // A 200 that isn't a decofile means this dev server has no decofile
-        // route at all — the repo doesn't use the deco framework for sites. Tag
-        // it 404 (same as a missing route) so `resolveBlocksTabState` classifies
-        // it as framework-missing rather than a transient read error.
-        (err as { status?: number }).status = res?.ok
-          ? 404
-          : (res?.status ?? 502);
+        // 404 tags a proven "this repo has no decofile at all" — see
+        // `decofileErrorStatus` for the two proofs — which
+        // `resolveBlocksTabState` reads as framework-missing rather than a
+        // transient read error.
+        (err as { status?: number }).status = decofileErrorStatus({
+          liveOk: !!res?.ok,
+          liveStatus: res?.status,
+          committedAbsent: committed.kind === "absent",
+        });
         throw err;
       }
       const committed = await readCommitted();
-      if (committed) return committed;
+      if (committed.kind === "data") return committed.data;
       const err = new Error(
         "decofile unavailable (preview down, no committed snapshot)",
       );
-      (err as { status?: number }).status = 502;
+      // Same proof, without a dev server to ask: no decofile artifacts in the
+      // checkout means this isn't a deco site. Anything else is transient.
+      (err as { status?: number }).status = decofileErrorStatus({
+        liveOk: false,
+        committedAbsent: committed.kind === "absent",
+      });
       throw err;
     },
     enabled: !!params,

--- a/apps/web/src/components/sections-editor/use-live-meta.ts
+++ b/apps/web/src/components/sections-editor/use-live-meta.ts
@@ -90,7 +90,18 @@ export function useLiveMeta(
       const fetchMeta = async (baseUrl: string): Promise<LiveMeta | null> => {
         const url = new URL("/live/_meta", baseUrl).href;
         const res = await fetch(url, { cache: "no-store" }).catch(() => null);
-        return res?.ok ? ((await res.json()) as LiveMeta) : null;
+        if (!res?.ok) return null;
+        // A repo that doesn't use the deco framework for sites still answers
+        // this route: a plain Vite/SPA dev server hands back `index.html` with
+        // a 200. `res.json()` on that throws a SyntaxError that escapes the
+        // whole queryFn — skipping the remaining sources and surfacing an
+        // untagged error the Preview gates can only read as "transient". Treat
+        // an unparseable 200 as no answer instead, same as `parseDecofileBody`.
+        try {
+          return (await res.json()) as LiveMeta;
+        } catch {
+          return null;
+        }
       };
       const readCommitted = () =>
         readCommittedJson<LiveMeta>(
@@ -110,10 +121,12 @@ export function useLiveMeta(
         fastPreviewActive,
       });
       for (const source of sources) {
-        const meta =
-          source.kind === "committed"
-            ? await readCommitted()
-            : await fetchMeta(source.baseUrl);
+        if (source.kind === "committed") {
+          const committed = await readCommitted();
+          if (committed.kind === "data") return committed.data;
+          continue;
+        }
+        const meta = await fetchMeta(source.baseUrl);
         if (meta) return meta;
       }
       const err = new Error(

--- a/apps/web/src/layouts/main-panel-tabs/blocks-tab-state.test.ts
+++ b/apps/web/src/layouts/main-panel-tabs/blocks-tab-state.test.ts
@@ -218,6 +218,19 @@ describe("resolveBlocksTabState", () => {
     ).toEqual({ kind: "error", source: "data" });
   });
 
+  // `framework-missing` is sticky, so a wrong call mid-checkout would outlive
+  // the checkout: the tree is between two branches there.
+  test("a 404 while checking out is not proof — stays loading", () => {
+    expect(
+      resolveBlocksTabState(
+        input({
+          lifecyclePhase: "checking-out",
+          decofile: { status: "error", hasData: false, errorStatus: 404 },
+        }),
+      ),
+    ).toEqual({ kind: "loading" });
+  });
+
   test("a proven-404 repo stays framework-missing through a transient refetch failure", () => {
     for (const errorStatus of [500, 502, undefined]) {
       expect(

--- a/apps/web/src/layouts/main-panel-tabs/blocks-tab-state.ts
+++ b/apps/web/src/layouts/main-panel-tabs/blocks-tab-state.ts
@@ -143,6 +143,18 @@ export function resolveBlocksTabState(
     return { kind: "error", source: "sandbox" };
   if (phaseClass === "booting") return { kind: "loading" };
 
+  const readFailed =
+    (input.decofile.status === "error" && !input.decofile.hasData) ||
+    (input.meta.status === "error" && !input.meta.hasData);
+
+  // Mid-checkout the working tree is between two branches, so an absent
+  // `.deco/*` says nothing about the branch being switched TO — and
+  // `framework-missing` is sticky per repo+branch, so a wrong call here would
+  // outlive the checkout that caused it.
+  if (readFailed && input.lifecyclePhase === "checking-out") {
+    return { kind: "loading" };
+  }
+
   const blocksFrameworkMissing = [input.decofile, input.meta].some(
     (query) =>
       query.status === "error" && !query.hasData && query.errorStatus === 404,
@@ -151,14 +163,10 @@ export function resolveBlocksTabState(
     return { kind: "empty", reason: "framework-missing" };
   }
 
-  const initialDataFailed =
-    (input.decofile.status === "error" && !input.decofile.hasData) ||
-    (input.meta.status === "error" && !input.meta.hasData);
-  if (initialDataFailed) {
-    // While booting, the committed snapshot may not be written yet, and an
-    // absent file surfaces as a synthetic 502 from the read fallback (see
-    // `use-decofile`), NOT a 404 — so it can't be classified as "framework
-    // missing" above. Treat it as loading instead of a hard data error: the
+  if (readFailed) {
+    // Not a 404, so absence is unproven (see `decofileErrorStatus` for what
+    // does prove it): the read reached neither the dev server nor the daemon.
+    // Treat it as loading instead of a hard data error: the
     // `→running` lifecycle transition re-invalidates both queries and resolves
     // content/empty authoritatively. Only surface the error once the dev
     // server has settled (running/crashed), where the failure is real.

--- a/packages/sandbox/daemon-e2e/daemon.decofile.e2e.test.ts
+++ b/packages/sandbox/daemon-e2e/daemon.decofile.e2e.test.ts
@@ -48,9 +48,19 @@ afterEach(async () => {
 }, HOOK_TIMEOUT_MS);
 
 describe("GET /_sandbox/decofile", () => {
-  test("404s when there are no blocks to merge", async () => {
+  test("404s when there is no blocks dir at all", async () => {
     const res = await fetch(url(d!, "/_sandbox/decofile"));
     expect(res.status).toBe(404);
+  });
+
+  // Emptiness is not absence: the dir exists, so this IS a deco site that just
+  // has no pages yet. Studio hides its CMS affordances on the 404 above, so
+  // answering it here would strand a fresh site with no way to create a page.
+  test("serves an empty decofile for an empty blocks dir", async () => {
+    await mkdir(blocksDir(d!), { recursive: true });
+    const res = await fetch(url(d!, "/_sandbox/decofile"));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({});
   });
 
   test("serves the merged blocks with a content ETag", async () => {

--- a/packages/sandbox/daemon-go/internal/decofile/merge.go
+++ b/packages/sandbox/daemon-go/internal/decofile/merge.go
@@ -67,8 +67,13 @@ func generateFromBlocks(blocksDir string) (string, bool) {
 			names = append(names, e.Name())
 		}
 	}
+	// A blocks dir with no blocks in it is an EMPTY decofile, not a missing one:
+	// the dir exists, so this repo does use the deco framework — it just has no
+	// pages yet. Answering ok=false here made the read fall through to "file not
+	// found", which Studio reads as "not a deco repo" and hides the CMS
+	// affordances with, including the "Create page" that would fix it.
 	if len(names) == 0 {
-		return "", false
+		return "{}", true
 	}
 	sort.Strings(names)
 

--- a/packages/sandbox/daemon-go/internal/decofile/merge_test.go
+++ b/packages/sandbox/daemon-go/internal/decofile/merge_test.go
@@ -24,9 +24,13 @@ func TestGenerateFromBlocks(t *testing.T) {
 		}
 	})
 
-	t.Run("empty dir → ok=false", func(t *testing.T) {
-		if _, ok := generateFromBlocks(t.TempDir()); ok {
-			t.Fatal("expected ok=false for a dir with no .json files")
+	// The dir's existence is what says "deco site"; its emptiness only says
+	// "no pages yet". Absence has to stay distinguishable from emptiness — the
+	// CMS gates hide on the former and must not on the latter.
+	t.Run("empty dir → an empty decofile", func(t *testing.T) {
+		merged, ok := generateFromBlocks(t.TempDir())
+		if !ok || merged != "{}" {
+			t.Fatalf("expected ok=true and {}, got %q ok=%v", merged, ok)
 		}
 	})
 

--- a/packages/sandbox/daemon-go/internal/gitx/branchstatus.go
+++ b/packages/sandbox/daemon-go/internal/gitx/branchstatus.go
@@ -50,26 +50,33 @@ func (m *BranchStatusMonitor) GetLast() events.BranchMeta {
 	return m.last
 }
 
+// ArmBaseline snapshots what is dirty right now as "not the user's work": a
+// checkout is littered with generated artifacts (lockfiles, `*.gen.*`, build
+// output the repo doesn't gitignore) before anyone edits anything, and counting
+// those as changes made a pristine branch look publishable.
+//
+// First arm wins — a later call is a no-op. The arm points are boot outcomes
+// (see the callers), and a dev server that dies and comes back re-enters them;
+// re-baselining there would swallow every edit made in between, which is
+// exactly the data loss the hash comparison exists to prevent.
 func (m *BranchStatusMonitor) ArmBaseline() {
-	paths := m.readDirtyPaths()
 	m.mu.Lock()
-	m.baseline = map[string]string{}
-	m.hasBaseline = true
-	for p := range paths {
-		m.baseline[p] = m.hashWorktreeFile(p)
-	}
-	m.mu.Unlock()
-	m.Refresh()
-}
-
-func (m *BranchStatusMonitor) ClearBaseline() {
-	m.mu.Lock()
-	if !m.hasBaseline {
+	if m.hasBaseline {
 		m.mu.Unlock()
 		return
 	}
-	m.baseline = nil
-	m.hasBaseline = false
+	// Claimed before the scan so a concurrent arm can't double-scan. Until the
+	// map lands, `compute` sees an empty baseline and reports dirty — the same
+	// answer it gave a moment earlier, un-armed.
+	m.hasBaseline = true
+	m.mu.Unlock()
+	paths := m.readDirtyPaths()
+	baseline := make(map[string]string, len(paths))
+	for p := range paths {
+		baseline[p] = m.hashWorktreeFile(p)
+	}
+	m.mu.Lock()
+	m.baseline = baseline
 	m.mu.Unlock()
 	m.Refresh()
 }

--- a/packages/sandbox/daemon-go/internal/gitx/branchstatus_test.go
+++ b/packages/sandbox/daemon-go/internal/gitx/branchstatus_test.go
@@ -1,0 +1,75 @@
+package gitx
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type nopBroadcaster struct{}
+
+func (nopBroadcaster) Emit(string, any) {}
+
+func write(t *testing.T, repo, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(repo, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func dirty(t *testing.T, m *BranchStatusMonitor) bool {
+	t.Helper()
+	meta := m.compute()
+	if meta == nil || meta.Ready == nil {
+		t.Fatal("expected a ready BranchMeta")
+	}
+	return meta.Ready.WorkingTreeDirty
+}
+
+// The header reads WorkingTreeDirty as "the user has work to publish", so boot
+// artifacts must not count — and a baseline that is never armed (dev server
+// never came up) or dropped (it crashed) is what made them count.
+func TestBaselineSeparatesBootDirtFromUserWork(t *testing.T) {
+	repo := initRepoOnBranch(t, "feature")
+	m := NewBranchStatusMonitor(repo, nopBroadcaster{}, nil)
+
+	write(t, repo, "boot.gen.json", "{}\n")
+	if !dirty(t, m) {
+		t.Fatal("un-armed: any dirt reads as dirty")
+	}
+
+	m.ArmBaseline()
+	if dirty(t, m) {
+		t.Fatal("armed: boot dirt must not read as the user's work")
+	}
+
+	write(t, repo, "user.txt", "edit\n")
+	if !dirty(t, m) {
+		t.Fatal("a file written after arming is the user's work")
+	}
+
+	// Re-entering a boot outcome (crash → restart → crash) must not re-baseline
+	// over that edit.
+	m.ArmBaseline()
+	if !dirty(t, m) {
+		t.Fatal("first arm wins: a later arm must not swallow the edit")
+	}
+}
+
+// The baseline pins content, not just paths: editing a file that was dirty at
+// boot is still the user's work.
+func TestBaselineDetectsEditToBaselinedPath(t *testing.T) {
+	repo := initRepoOnBranch(t, "feature")
+	m := NewBranchStatusMonitor(repo, nopBroadcaster{}, nil)
+
+	write(t, repo, "boot.gen.json", "{}\n")
+	m.ArmBaseline()
+	if dirty(t, m) {
+		t.Fatal("armed: boot dirt must not read as the user's work")
+	}
+
+	write(t, repo, "boot.gen.json", `{"edited":true}`)
+	if !dirty(t, m) {
+		t.Fatal("a changed baselined file is the user's work")
+	}
+}

--- a/packages/sandbox/daemon-go/main.go
+++ b/packages/sandbox/daemon-go/main.go
@@ -275,7 +275,11 @@ func (d *daemon) onProbeChange(s probe.State) {
 			d.baselineTimer = nil
 		}
 		d.mu.Unlock()
-		d.branchStatus.ClearBaseline()
+		// The `crashed` transition arms the baseline (see OnTransition) if the
+		// pending timer never got to. It is deliberately NOT cleared here: a
+		// dead dev server says nothing about which paths are the user's work,
+		// and dropping the baseline reported a pristine branch as dirty — which
+		// the header reads as "Review & Publish".
 	}
 }
 
@@ -817,6 +821,18 @@ func main() {
 			d.readyOnce.Do(func() {
 				telemetry.RecordReady(context.Background(), time.Since(processStartedAt).Milliseconds())
 			})
+		}
+		// Boot outcomes where no dev server is coming (or the one we had died):
+		// nothing else will write to the checkout on its own, so this is the last
+		// honest moment to record what boot left dirty. The `running` path arms on
+		// a 3s delay instead (see onProbeChange); whichever fires first wins.
+		// Without these, a repo whose dev server never came up had no baseline at
+		// all, so every generated artifact read as the user's work.
+		// Off the probe/transition thread: arming shells out to git, and this hook
+		// runs on the health-probe path.
+		switch next.Phase {
+		case events.PhaseInstallFailed, events.PhaseStartFailed, events.PhaseCrashed:
+			go d.branchStatus.ArmBaseline()
 		}
 		// Working tree just landed (see events.IsWorkingTreeReadyPhase). Announce
 		// the initial draft version here too, not only from emitFileChanged: a


### PR DESCRIPTION
Follow-up to #6314 and #6312/#6321, which fixed the same two symptoms on the path where the dev server is **up**. Both bugs survive on the path where it is **down** — which is the state in the report (blank preview, CMS button, page selector degraded to the raw preview host, brand "Review & Publish" on an untouched branch).

## What the merged PRs missed

**"Review & Publish" on a branch with no changes** — #6314 gated the header on `installing`/`starting` and deliberately let the failure phases fall through. But the false positive isn't the phase, it's `workingTreeDirty`. The daemon keeps a dirty-baseline so boot artifacts (lockfiles, `*.gen.*`, build output the repo doesn't gitignore) don't count as the user's work — and it is armed **3s after the probe reports the dev server online**, then **cleared the moment it goes offline**. A dev server that never came up, or crashed, therefore has no baseline at all, so every artifact boot left behind reads as work to publish. `start-failed` and `crashed` fall through to the git/PR copy, so it renders as a brand "Review & Publish".

**CMS button + page selector on a non-deco repo** — `showCmsControls` hides only on `framework-missing`, and the only thing that could prove it was a 404 from the live `/.decofile` route. With the dev server down the read falls back to the committed snapshot, and its absence was reported as a transient 502 → state `error` → "absence unproven, keep the controls". The sticky bit from #6321 can't help: it makes a proof stick, it can't create one. Two more gaps on the same path: `/live/_meta` on a plain Vite dev server answers 200 with `index.html` and `res.json()` threw a SyntaxError out of the whole queryFn (untagged error, remaining meta sources skipped); and the daemon conflated an absent `.deco/blocks` dir with an empty one.

## The fix

Both gates now answer from the checkout, which is readable whether or not anything is serving.

- `ArmBaseline` fires on the boot outcomes too (`install-failed`, `start-failed`, `crashed`) and is never cleared — a dead dev server says nothing about which paths are the user's work. First arm wins, because a crash/restart cycle re-enters those phases and re-baselining there would swallow every edit made in between.
- The committed read distinguishes "the daemon says this file is not in the checkout" (400) from "the sandbox isn't up yet" (404); the decofile read tags the former **404**, the proof `resolveBlocksTabState` already knows how to make sticky. Block sources are committed files, so a deco site always has them once the clone lands.
- Absence ≠ emptiness: a `.deco/blocks` dir with no blocks in it now serves an empty decofile instead of "not found", so a fresh site isn't classified as "not a deco repo" and stranded without the "Create page" that would fix it.
- A 404 mid-checkout isn't proof (the tree is between two branches) and the classification is sticky, so it stays `loading`.
- An unparseable 200 from `/live/_meta` is no answer, same as `parseDecofileBody`.

## Known ceiling (not in this PR)

The baseline pins content hashes, so an artifact **regenerated with different bytes** after arming still reads as dirty. Distinguishing that from a real edit needs the daemon to report dirty *paths* rather than a boolean, which is a bigger change than this.

## Testing

- `go test ./...` in `daemon-go` — new `branchstatus_test.go` covers un-armed vs armed, work after arming, first-arm-wins over a later edit, and an edit to a baselined path.
- `bun test` — new `decofile-read-status.test.ts` (the two absence proofs, and that a transient failure stays transient); new `blocks-tab-state` case for the mid-checkout 404.
- New `daemon.decofile.e2e.test.ts` case: empty blocks dir → `200 {}`; missing blocks dir still 404.
- `bun run fmt`, `bun run lint`, `knip` clean. The pre-existing `mustache`-not-installed failures in `apps/web` are unrelated (identical count on `main`).

Not verified end-to-end in a real sandbox — the dev-server-down path needs a cluster sandbox to reproduce.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops false “Review & Publish” and CMS controls when the dev server is down. Previously we only armed the dirty-baseline after “running” and cleared it on crash, and we only proved a non-deco repo via a live 404; now we baseline on boot failures and prove absence from the checkout.

- Baseline: `BranchStatusMonitor.ArmBaseline` is first-arm-wins and never cleared; it now arms on `install-failed`, `start-failed`, and `crashed`. Boot artifacts no longer set `workingTreeDirty` when the dev server never came up.
- Proof from checkout: committed reads now distinguish 400 “absent” vs 404 “unavailable”. `readCommittedJson` returns typed outcomes, and `decofileErrorStatus` maps either a live non-deco 200 or a committed-absent decofile to 404 so the CMS gate hides even with preview down. Mid-checkout 404s stay “loading” and `framework-missing` remains sticky.
- Resilience: treat an unparseable 200 from `/live/_meta` as “no answer” instead of throwing, matching `/.decofile` handling.
- Deco blocks: an empty `.deco/blocks` dir now returns `{}` (200); only a missing dir 404s, so fresh sites keep the “Create page” entry point.
- Tests cover baseline arming, committed-read classification, sticky framework-missing, empty blocks behavior, and e2e decofile responses.

<sup>Written for commit 3cf33e40dc5d05986dda704c137c00b4df47ff80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

