### PR TITLE
fix(github-mint): grant deployments:read so QA can read PR preview URLs

### DIFF
--- a/apps/api/src/oauth/github-mint.ts
+++ b/apps/api/src/oauth/github-mint.ts
@@ -20,8 +20,9 @@ import {
 } from "@/oauth/token-refresh";
 import {
   getRepoScope,
-  mintRepoTokenWithChecksFallback,
+  mintRepoTokenWithFallback,
   type RepoScopeRecipe,
+  withOptionalReadPermissions,
 } from "@decocms/shared/github-repo-scope";
 import { DownstreamTokenStorage } from "@/storage/downstream-token";
 import type { ConnectionEntity } from "@/tools/connection/schema";
@@ -74,11 +75,8 @@ async function mintRepoToken(
       content?: Array<{ type?: string; text?: string }>;
     };
 
-    // Self-heal legacy connections on their ~1h re-mint: request checks:read on
-    // top of the stored recipe so the token gains check-run access without a
-    // re-install, falling back to the checks-less recipe when checks isn't
-    // available yet. (Re-probes each cycle — see the helper's note.)
-    const { result: res } = await mintRepoTokenWithChecksFallback<MintResult>(
+    // Self-heal legacy recipes: re-add the optional reads each re-mint, shedding whichever the installation hasn't granted yet (see the helper's note).
+    const { result: res } = await mintRepoTokenWithFallback<MintResult>(
       (permissions) =>
         client.callTool({
           name: "MINT_REPO_TOKEN",
@@ -89,7 +87,7 @@ async function mintRepoToken(
             permissions,
           },
         }) as Promise<MintResult>,
-      recipe.permissions,
+      withOptionalReadPermissions(recipe.permissions),
     );
 
     const token = res.structuredContent?.token;

--- a/apps/web/src/lib/provision-repo-scoped-github-connection.ts
+++ b/apps/web/src/lib/provision-repo-scoped-github-connection.ts
@@ -3,7 +3,7 @@ import {
   findReusableRepoConnection,
   GITHUB_SCOPED_PERMISSIONS,
   isOrgSharedConnection,
-  mintRepoTokenWithChecksFallback,
+  mintRepoTokenWithFallback,
 } from "@decocms/shared/github-repo-scope";
 
 type McpCallTool = (req: {
@@ -150,12 +150,9 @@ export async function provisionRepoScopedGithubConnection(params: {
     };
     content?: Array<{ type?: string; text?: string }>;
   };
-  // Request checks:read for the PR Checks tab, falling back to a checks-less
-  // token when the deployed github-mcp/installation doesn't grant it yet — so
-  // importing the repo keeps working. The stored recipe records whichever set
-  // was granted.
+  // Request the full scoped set, shedding whichever optional read the github-mcp allowlist/installation doesn't grant yet; the stored recipe records the granted set.
   const { result: mintRes, grantedPermissions } =
-    await mintRepoTokenWithChecksFallback<MintResult>(
+    await mintRepoTokenWithFallback<MintResult>(
       (permissions) =>
         githubCallTool({
           name: "MINT_REPO_TOKEN",

--- a/packages/shared/src/github-repo-scope.test.ts
+++ b/packages/shared/src/github-repo-scope.test.ts
@@ -4,12 +4,13 @@ import {
   getOrgGithubConnections,
   getRepoScope,
   GITHUB_SCOPED_PERMISSIONS,
-  isChecksPermissionRejected,
   isOrgSharedConnection,
+  isPermissionRejected,
   listRepoScopeLabels,
-  mintRepoTokenWithChecksFallback,
-  permissionsWithoutChecks,
+  mintRepoTokenWithFallback,
+  OPTIONAL_MINT_PERMISSIONS,
   type RepoScopeRecipe,
+  withOptionalReadPermissions,
 } from "./github-repo-scope";
 
 describe("GITHUB_SCOPED_PERMISSIONS", () => {
@@ -20,6 +21,11 @@ describe("GITHUB_SCOPED_PERMISSIONS", () => {
     expect(GITHUB_SCOPED_PERMISSIONS.checks).toBe("read");
   });
 
+  it("includes deployments:read so the PR panel can read the preview URL", () => {
+    // FastStore WebOps posts the preview only as a Deployment; without it GET_PREVIEW_DEPLOYMENT 403s and previewUrl stays null.
+    expect(GITHUB_SCOPED_PERMISSIONS.deployments).toBe("read");
+  });
+
   it("keeps the write scopes the PR/sandbox flows depend on", () => {
     expect(GITHUB_SCOPED_PERMISSIONS).toMatchObject({
       contents: "write",
@@ -28,57 +34,68 @@ describe("GITHUB_SCOPED_PERMISSIONS", () => {
       issues: "write",
     });
   });
+
+  it("marks every optional permission as one it actually requests", () => {
+    // OPTIONAL_MINT_PERMISSIONS says which requested perms are droppable — never one the scoped set doesn't request.
+    for (const permission of OPTIONAL_MINT_PERMISSIONS) {
+      expect(GITHUB_SCOPED_PERMISSIONS[permission]).toBe("read");
+    }
+  });
 });
 
-describe("isChecksPermissionRejected", () => {
-  it("matches the github-mcp allowlist rejection", () => {
+describe("isPermissionRejected", () => {
+  it("matches the github-mcp allowlist rejection for an optional permission", () => {
     expect(
-      isChecksPermissionRejected(
+      isPermissionRejected(
         'Permission "checks" is not allowed. This tool only mints repo-scoped ' +
           "code access (contents, metadata, pull_requests, issues).",
       ),
     ).toBe(true);
+    expect(
+      isPermissionRejected('Permission "deployments" is not allowed.'),
+    ).toBe(true);
   });
 
-  it("matches the GitHub 422 raised when the installation lacks Checks", () => {
+  it("matches the generic GitHub 422 (which doesn't name the permission)", () => {
     expect(
-      isChecksPermissionRejected(
+      isPermissionRejected(
         "Repository is not in this installation, or the requested permissions " +
           "exceed what the GitHub App was granted.",
       ),
     ).toBe(true);
   });
 
-  it("does not match unrelated errors or empty input", () => {
-    expect(
-      isChecksPermissionRejected('Permission "issues" is not allowed.'),
-    ).toBe(false);
-    expect(isChecksPermissionRejected("Repository is not accessible.")).toBe(
+  it("does NOT match an allowlist rejection for a REQUIRED permission", () => {
+    // A required perm being rejected is a real misconfiguration — surface it, don't downgrade.
+    expect(isPermissionRejected('Permission "issues" is not allowed.')).toBe(
       false,
     );
-    expect(isChecksPermissionRejected(null)).toBe(false);
-    expect(isChecksPermissionRejected(undefined)).toBe(false);
+  });
+
+  it("does not match unrelated errors or empty input", () => {
+    expect(isPermissionRejected("Repository is not accessible.")).toBe(false);
+    expect(isPermissionRejected(null)).toBe(false);
+    expect(isPermissionRejected(undefined)).toBe(false);
   });
 });
 
-describe("permissionsWithoutChecks", () => {
-  it("drops only the checks key and leaves the rest intact", () => {
-    expect(permissionsWithoutChecks(GITHUB_SCOPED_PERMISSIONS)).toEqual({
+describe("withOptionalReadPermissions", () => {
+  it("adds every optional read on top of the base set", () => {
+    expect(withOptionalReadPermissions({ contents: "write" })).toEqual({
       contents: "write",
-      metadata: "read",
-      pull_requests: "write",
-      issues: "write",
+      deployments: "read",
+      checks: "read",
     });
   });
 
-  it("is a no-op when checks is absent", () => {
-    expect(permissionsWithoutChecks({ contents: "write" })).toEqual({
-      contents: "write",
-    });
+  it("does not mutate its input", () => {
+    const base = { contents: "write" };
+    withOptionalReadPermissions(base);
+    expect(base).toEqual({ contents: "write" });
   });
 });
 
-describe("mintRepoTokenWithChecksFallback", () => {
+describe("mintRepoTokenWithFallback", () => {
   type MintResult = {
     isError?: boolean;
     content?: Array<{ type?: string; text?: string }>;
@@ -86,46 +103,91 @@ describe("mintRepoTokenWithChecksFallback", () => {
   };
   const ok: MintResult = { structuredContent: { token: "ghs_x" } };
   const base = { contents: "write", metadata: "read" };
+  const desired = withOptionalReadPermissions(base);
+  const rejected = (text: string): MintResult => ({
+    isError: true,
+    content: [{ type: "text", text }],
+  });
 
-  it("requests checks:read and returns it as granted on success", async () => {
+  it("returns the full desired set as granted on first-try success", async () => {
     const calls: Record<string, string>[] = [];
-    const { result, grantedPermissions } =
-      await mintRepoTokenWithChecksFallback((permissions) => {
+    const { result, grantedPermissions } = await mintRepoTokenWithFallback(
+      (permissions) => {
         calls.push(permissions);
         return Promise.resolve(ok);
-      }, base);
-    expect(calls).toEqual([{ ...base, checks: "read" }]);
+      },
+      desired,
+    );
+    expect(calls).toEqual([desired]);
+    expect(grantedPermissions).toEqual(desired);
+    expect(result).toBe(ok);
+  });
+
+  it("sheds only deployments when checks is granted but deployments isn't", async () => {
+    const calls: Record<string, string>[] = [];
+    const { result, grantedPermissions } = await mintRepoTokenWithFallback(
+      (permissions) => {
+        calls.push(permissions);
+        // Generic 422 on the full set, then success once deployments is gone.
+        return Promise.resolve(
+          "deployments" in permissions
+            ? rejected("the requested permissions exceed what the GitHub App")
+            : ok,
+        );
+      },
+      desired,
+    );
+    expect(calls).toEqual([desired, { ...base, checks: "read" }]);
     expect(grantedPermissions).toEqual({ ...base, checks: "read" });
     expect(result).toBe(ok);
   });
 
-  it("retries without checks when the mint is rejected for checks", async () => {
+  it("sheds both optionals when the installation grants neither", async () => {
     const calls: Record<string, string>[] = [];
-    const rejected: MintResult = {
-      isError: true,
-      content: [{ type: "text", text: 'Permission "checks" is not allowed.' }],
-    };
-    const { result, grantedPermissions } =
-      await mintRepoTokenWithChecksFallback((permissions) => {
+    const { result, grantedPermissions } = await mintRepoTokenWithFallback(
+      (permissions) => {
         calls.push(permissions);
-        return Promise.resolve(calls.length === 1 ? rejected : ok);
-      }, base);
-    expect(calls).toEqual([{ ...base, checks: "read" }, base]);
+        const stillOptional =
+          "deployments" in permissions || "checks" in permissions;
+        return Promise.resolve(
+          stillOptional
+            ? rejected("the requested permissions exceed what the GitHub App")
+            : ok,
+        );
+      },
+      desired,
+    );
+    expect(calls).toEqual([desired, { ...base, checks: "read" }, base]);
     expect(grantedPermissions).toEqual(base);
     expect(result).toBe(ok);
   });
 
-  it("does NOT retry on an unrelated error (surfaces it once)", async () => {
+  it("does NOT drop optionals on an unrelated error (surfaces it once)", async () => {
     const calls: Record<string, string>[] = [];
-    const err: MintResult = {
-      isError: true,
-      content: [{ type: "text", text: "GitHub is temporarily unavailable." }],
-    };
-    const { result } = await mintRepoTokenWithChecksFallback((permissions) => {
+    const err = rejected("GitHub is temporarily unavailable.");
+    const { result } = await mintRepoTokenWithFallback((permissions) => {
       calls.push(permissions);
       return Promise.resolve(err);
-    }, base);
+    }, desired);
     expect(calls).toHaveLength(1);
+    expect(result).toBe(err);
+  });
+
+  it("surfaces a rejection for a required permission after optionals are gone", async () => {
+    const calls: Record<string, string>[] = [];
+    const err = rejected(
+      "the requested permissions exceed what the GitHub App",
+    );
+    const { result, grantedPermissions } = await mintRepoTokenWithFallback(
+      (permissions) => {
+        calls.push(permissions);
+        return Promise.resolve(err);
+      },
+      desired,
+    );
+    // Full -> drop deployments -> drop checks -> base (still rejected) -> surface.
+    expect(calls).toEqual([desired, { ...base, checks: "read" }, base]);
+    expect(grantedPermissions).toEqual(base);
     expect(result).toBe(err);
   });
 });

--- a/packages/shared/src/github-repo-scope.ts
+++ b/packages/shared/src/github-repo-scope.ts
@@ -20,9 +20,16 @@
  * Least-privilege permission set minted for an imported agent's repo token.
  *
  * `checks: read` lets the PR panel's Checks tab read CI check runs
- * (`GET /commits/{sha}/check-runs`); without it the GitHub App installation
- * token gets `403 Resource not accessible by integration`. The backing GitHub
- * App must also grant Checks (read) or the mint fails with 422.
+ * (`GET /commits/{sha}/check-runs`); `deployments: read` lets it read a PR's
+ * preview URL from the GitHub Deployments API (`GET /repos/{o}/{r}/deployments`
+ * + `/statuses`, via `GET_PREVIEW_DEPLOYMENT`) — the ONLY place a VTEX FastStore
+ * WebOps preview is published (not a commit-status target_url, not a bot
+ * comment). Without each, the GitHub App installation token gets `403 Resource
+ * not accessible by integration` on that endpoint. The backing GitHub App must
+ * also grant them (and github-mcp's mint allowlist must permit them) or the mint
+ * is rejected — see OPTIONAL_MINT_PERMISSIONS / mintRepoTokenWithFallback, which
+ * sheds them one at a time so an installation that grants neither still mints a
+ * working code token.
  */
 export const GITHUB_SCOPED_PERMISSIONS: Record<string, string> = {
   contents: "write",
@@ -30,35 +37,47 @@ export const GITHUB_SCOPED_PERMISSIONS: Record<string, string> = {
   pull_requests: "write",
   issues: "write",
   checks: "read",
+  deployments: "read",
 };
 
 /**
- * Detects a mint failure caused specifically by requesting `checks`, so callers
- * can retry without it. Two distinct upstreams produce this:
- *   1. github-mcp's own allowlist predating `checks` — it hard-rejects with
- *      `Permission "checks" is not allowed` (deploy-window skew).
- *   2. GitHub itself, when the App installation hasn't granted Checks — the
- *      mint 422s, surfaced as `...the requested permissions exceed what the
- *      GitHub App was granted`.
- * Either way the safe move is a checks-less retry; if the real problem were
- * unrelated (e.g. repo not in the installation), that retry fails identically.
+ * The read permissions an installation (or github-mcp's mint allowlist) may not
+ * grant yet, ordered MOST-DROPPABLE FIRST. `mintRepoTokenWithFallback` sheds
+ * them one at a time on a permission rejection, so an installation that has the
+ * long-standing `checks` but not the newer `deployments` keeps checks. Anything
+ * NOT listed here is required and never dropped — a rejection for one of those
+ * surfaces instead of being silently downgraded.
+ *
+ * Every entry must also appear in GITHUB_SCOPED_PERMISSIONS (asserted in the
+ * unit test): this list marks which of the requested permissions are droppable,
+ * it does not add new ones.
  */
-export function isChecksPermissionRejected(
+export const OPTIONAL_MINT_PERMISSIONS = ["deployments", "checks"] as const;
+
+/**
+ * Detects a mint rejection caused specifically by requesting a permission the
+ * installation/allowlist doesn't grant, so callers can retry without it. Two
+ * distinct upstreams produce this:
+ *   1. github-mcp's own allowlist predating a permission — it hard-rejects with
+ *      `Permission "<name>" is not allowed` (deploy-window skew).
+ *   2. GitHub itself, when the App installation hasn't granted it — the mint
+ *      422s, surfaced as `...the requested permissions exceed what the GitHub
+ *      App was granted`.
+ * The allowlist form matches ONLY for an OPTIONAL permission (a required one
+ * being rejected is a real misconfiguration, not something to silently drop);
+ * the generic 422 doesn't name the offending permission, so the ladder degrades
+ * by dropping optionals in order until the mint succeeds.
+ */
+export function isPermissionRejected(
   message: string | null | undefined,
 ): boolean {
   if (!message) return false;
+  const optional = OPTIONAL_MINT_PERMISSIONS.join("|");
   return (
-    /permission\s+"?checks"?\s+is not allowed/i.test(message) ||
-    /permissions exceed what the github app/i.test(message)
+    new RegExp(`permission\\s+"?(?:${optional})"?\\s+is not allowed`, "i").test(
+      message,
+    ) || /permissions exceed what the github app/i.test(message)
   );
-}
-
-/** A copy of a permission map with the `checks` key removed. */
-export function permissionsWithoutChecks(
-  permissions: Record<string, string>,
-): Record<string, string> {
-  const { checks: _checks, ...rest } = permissions;
-  return rest;
 }
 
 /** Minimal shape of a github-mcp MINT_REPO_TOKEN result the fallback inspects. */
@@ -68,40 +87,59 @@ export interface MintToolResultLike {
 }
 
 /**
- * Mint a repo token requesting `checks:read` on top of `basePermissions`, and
- * transparently retry WITHOUT `checks` when the mint is rejected specifically
- * for it (github-mcp allowlist skew, or an installation that hasn't granted
- * Checks → 422). Single-sources the retry decision shared by the web provision
- * flow and the server re-mint path.
+ * `base` plus every OPTIONAL_MINT_PERMISSIONS key at `read`. Used by the timer
+ * re-mint path to request the current optionals on top of a stored recipe, so a
+ * legacy connection self-heals into `checks`/`deployments` on its next ~1h
+ * re-mint without a re-import.
+ */
+export function withOptionalReadPermissions(
+  base: Record<string, string>,
+): Record<string, string> {
+  const out = { ...base };
+  for (const permission of OPTIONAL_MINT_PERMISSIONS) {
+    out[permission] = "read";
+  }
+  return out;
+}
+
+/**
+ * Mint a repo token requesting `desiredPermissions`, transparently shedding one
+ * OPTIONAL_MINT_PERMISSIONS entry at a time (in list order) whenever the mint is
+ * rejected specifically for exceeding what the installation/allowlist grants —
+ * so importing/refreshing keeps working on an installation that hasn't been
+ * re-approved for the newer reads. Base (required) permissions are never
+ * dropped, so a rejection for one of those (or any unrelated error) surfaces
+ * once the optionals are gone. Single-sources the retry ladder shared by the
+ * web provision flow and the server re-mint path.
  *
  * `callTool` performs the actual MINT_REPO_TOKEN call with a given permission
- * map; the returned `grantedPermissions` is whichever set was ultimately
- * requested (with or without `checks`) so callers can persist the truth.
+ * map; the returned `grantedPermissions` is whichever set ultimately succeeded
+ * (or was last attempted) so callers can persist the truth.
  *
- * Note: callers that re-mint on a timer (github-mint) always re-add `checks`
- * here, so a connection whose installation will never grant Checks pays a
- * second mint each cycle. That's the deliberate cost of picking up a
- * later-granted Checks without a re-import; provision persists the granted set
- * and does not re-probe.
+ * Note: callers that re-mint on a timer (github-mint) always re-add the
+ * optionals via withOptionalReadPermissions, so a connection whose installation
+ * will never grant them pays extra mints each cycle. That's the deliberate cost
+ * of picking up a later-granted permission without a re-import; provision
+ * persists the granted set and does not re-probe.
  */
-export async function mintRepoTokenWithChecksFallback<
-  R extends MintToolResultLike,
->(
+export async function mintRepoTokenWithFallback<R extends MintToolResultLike>(
   callTool: (permissions: Record<string, string>) => Promise<R>,
-  basePermissions: Record<string, string>,
+  desiredPermissions: Record<string, string>,
 ): Promise<{ result: R; grantedPermissions: Record<string, string> }> {
-  const desiredPermissions = { ...basePermissions, checks: "read" };
-  const result = await callTool(desiredPermissions);
-  if (
-    result.isError &&
-    isChecksPermissionRejected(
-      result.content?.find((c) => c.type === "text")?.text,
-    )
-  ) {
-    const grantedPermissions = permissionsWithoutChecks(basePermissions);
-    return { result: await callTool(grantedPermissions), grantedPermissions };
+  let permissions: Record<string, string> = { ...desiredPermissions };
+  for (;;) {
+    const result = await callTool(permissions);
+    if (!result.isError) {
+      return { result, grantedPermissions: permissions };
+    }
+    const text = result.content?.find((c) => c.type === "text")?.text;
+    const droppable = OPTIONAL_MINT_PERMISSIONS.find((p) => p in permissions);
+    if (!droppable || !isPermissionRejected(text)) {
+      return { result, grantedPermissions: permissions };
+    }
+    const { [droppable]: _dropped, ...rest } = permissions;
+    permissions = rest;
   }
-  return { result, grantedPermissions: desiredPermissions };
 }
 
 /** The repo grant metadata stored at `connection.metadata.repoScope`. */


### PR DESCRIPTION
## Problema

O QA agent aprovou a [faststoretorra#204](https://github.com/agencia-e-plus/faststoretorra/pull/204) reportando `previewUrl: null` — "check FastStore WebOps verde, mas a API de deployments retorna 403 para este token" — e teve que subir a aplicação no sandbox (`bun run dev`) para exercer a mudança, em vez de usar o preview da PR.

**Causa raiz.** `TASK_BOARD_ITEM_PRS_GET` resolve o `previewUrl` de 4 fontes (`apps/api/src/tools/task-board/prs-get.ts`). Para **VTEX FastStore WebOps** o preview é publicado **só** como um GitHub Deployment — não como `target_url` de commit-status nem comentário de bot — então a única fonte que o encontra é o último recurso `GET_PREVIEW_DEPLOYMENT` (Deployments API). Conexões repo-scoped mintam seu installation token a partir de `GITHUB_SCOPED_PERMISSIONS`, que **nunca pedia `deployments`** → a chamada retorna `403 Resource not accessible by integration` e `previewUrl` volta `null`.

Companheiro do [decocms/mcps#535](https://github.com/decocms/mcps/pull/535) (que adicionou a tool `GET_PREVIEW_DEPLOYMENT`): a tool lê com o token do caller, e faltava conceder `deployments:read` a esse token.

## Correção

- Adiciona `deployments: "read"` a `GITHUB_SCOPED_PERMISSIONS`.
- Generaliza o fallback checks-only (`mintRepoTokenWithChecksFallback`) num **ladder agnóstico de permissão** (`mintRepoTokenWithFallback` + `OPTIONAL_MINT_PERMISSIONS`), que descarta um read opcional por vez (`deployments`, depois `checks`) quando o mint é rejeitado especificamente por exceder o que a instalação/allowlist concede:
  - instalação com `checks` mas sem o mais novo `deployments` → **mantém checks**;
  - instalação sem nenhum dos dois → ainda minta um token de código funcional;
  - portanto **não dá 422-break** em import/refresh de orgs que ainda não reaprovaram o upgrade de permissão.
- `withOptionalReadPermissions` self-heala recipes legadas no re-mint (~1h).

## Depende de (fora deste repo)

Só tem efeito pleno quando: (1) o GitHub App do deco **declarar** `deployments:read`, (2) cada org **reaprovar** a instalação, e (3) o allowlist do `MINT_REPO_TOKEN` (github-mcp) **permitir** `deployments`. Até lá o ladder degrada graciosamente (comportamento idêntico ao de hoje).

## Testes

- `packages/shared/src/github-repo-scope.test.ts` — reescritos para o ladder: sucesso first-try, drop só de deployments (mantém checks), drop de ambos, erro não relacionado não descarta optionals, rejeição de permissão required só surfa depois que os optionals acabam. `bun test` verde (42 pass).
- `bun run check` (shared/api/web), `bun run lint` (0 erros), `bun run fmt`, `knip` — todos limpos para os símbolos alterados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grant `deployments:read` to repo-scoped tokens and add a permission-agnostic mint fallback so the PR panel can read PR preview URLs via GitHub Deployments. Previously we did not request deployments and `GET_PREVIEW_DEPLOYMENT` 403’d, leaving `previewUrl` null; now we request it and shed optional reads (deployments, then checks) only when the installation or allowlist rejects them.

- Review notes
  - Adds `deployments: "read"` to `GITHUB_SCOPED_PERMISSIONS`; keeps existing write scopes.
  - Replaces `mintRepoTokenWithChecksFallback` with `mintRepoTokenWithFallback`, driven by `OPTIONAL_MINT_PERMISSIONS` and `withOptionalReadPermissions`.
  - Updates `apps/api/src/oauth/github-mint.ts` and `apps/web/src/lib/provision-repo-scoped-github-connection.ts` to use the new ladder; tokens self-heal optionals on re-mint.
  - Extends tests in `packages/shared/src/github-repo-scope.test.ts` to cover deployments, ladder behavior, and non-downgrade errors.

- Rollout
  - Update the GitHub App to declare `deployments:read`, have orgs re-approve the installation, and permit `deployments` in the `MINT_REPO_TOKEN` allowlist.
  - No breaking changes before re-approval: the ladder downgrades gracefully and preserves `checks` when available.

<sup>Written for commit 328c3c0fd60c4d01a1b8cccf599686156b6fcf57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6333?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

