### PR TITLE
fix(github): surface retry-after guidance on a rate-limited branch search

### DIFF
--- a/apps/api/src/tools/github/search-branches.test.ts
+++ b/apps/api/src/tools/github/search-branches.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "bun:test";
 import { isGithubConnection } from "@/oauth/github-mint";
-import { parseBranchSearchResponse, parseJsonBody } from "./search-branches";
+import {
+  branchSearchErrorMessage,
+  parseBranchSearchResponse,
+  parseJsonBody,
+} from "./search-branches";
 
 const REPO = "acme/site";
 
@@ -130,6 +134,32 @@ describe("isGithubConnection", () => {
   it("rejects a connection with no slug", () => {
     expect(isGithubConnection({})).toBe(false);
     expect(isGithubConnection({ slug: null })).toBe(false);
+  });
+});
+
+describe("branchSearchErrorMessage", () => {
+  it("surfaces retry-after guidance on a 403 rate limit", () => {
+    expect(branchSearchErrorMessage(403, "42")).toBe(
+      "GitHub GraphQL branch search rate-limited, retry after 42s",
+    );
+  });
+
+  it("surfaces retry-after guidance on a 429", () => {
+    expect(branchSearchErrorMessage(429, "5")).toBe(
+      "GitHub GraphQL branch search rate-limited, retry after 5s",
+    );
+  });
+
+  it("falls back to a generic status message without a retry-after header", () => {
+    expect(branchSearchErrorMessage(403, null)).toBe(
+      "GitHub GraphQL branch search failed: 403",
+    );
+  });
+
+  it("falls back to a generic status message for an unrelated failure", () => {
+    expect(branchSearchErrorMessage(500, null)).toBe(
+      "GitHub GraphQL branch search failed: 500",
+    );
   });
 });
 

--- a/apps/api/src/tools/github/search-branches.ts
+++ b/apps/api/src/tools/github/search-branches.ts
@@ -87,6 +87,21 @@ export async function parseJsonBody(
   }
 }
 
+/**
+ * A secondary-rate-limit or abuse-detection response (403/429 + `Retry-After`)
+ * looks identical to a real permissions/server failure once reduced to a bare
+ * status code, so callers can't tell "wait and retry" from "this is broken".
+ */
+export function branchSearchErrorMessage(
+  status: number,
+  retryAfterHeader: string | null,
+): string {
+  if ((status === 403 || status === 429) && retryAfterHeader) {
+    return `GitHub GraphQL branch search rate-limited, retry after ${retryAfterHeader}s`;
+  }
+  return `GitHub GraphQL branch search failed: ${status}`;
+}
+
 interface BranchSearchResponse {
   data?: {
     repository?: {
@@ -237,7 +252,9 @@ export const GITHUB_SEARCH_BRANCHES = defineTool({
     }
 
     if (!res.ok) {
-      throw new Error(`GitHub GraphQL branch search failed: ${res.status}`);
+      throw new Error(
+        branchSearchErrorMessage(res.status, res.headers.get("retry-after")),
+      );
     }
 
     // GraphQL reports failures as 200 + `errors`, so an ok status isn't enough.


### PR DESCRIPTION
**Source**: bug found while auditing GITHUB_SEARCH_BRANCHES (`apps/api/src/tools/github/search-branches.ts`), which was already hardened twice this week (#6295 drained a discarded 401 body, #6313 degraded a malformed 2xx body). The remaining gap: any non-401 failure — including GitHub's secondary rate limit / abuse detection (403/429 + `Retry-After` header) — collapsed to a bare `GitHub GraphQL branch search failed: <status>`, indistinguishable from a real permissions or server error.

**Payoff**: a caller (or a human debugging a flaky branch picker) can now tell "GitHub is rate-limiting us, back off" from "this connection/repo is actually broken" without digging into raw HTTP status codes.

**Fix**: extracted `branchSearchErrorMessage(status, retryAfterHeader)` as a pure function. When the status is 403 or 429 and GitHub sent a `Retry-After` header, the message now includes the wait time; otherwise it falls back to the original generic message. No retry logic added (out of scope, and this repo's `@decocms/shared/std` `retry()` is the sanctioned home for that if ever needed) — this is purely a clearer error surface at the trust boundary of an external API response.

**Verify**: `bun test apps/api/src/tools/github/search-branches.test.ts` — 4 new cases cover 403+retry-after, 429+retry-after, 403 without the header, and an unrelated 500.

**Checks run locally**: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies branch search errors when GitHub rate-limits requests. Previously 403/429 responses were reported as a generic “failed: <status>”; now, when `Retry-After` is present, we surface “rate-limited, retry after Ns” so callers can back off instead of misdiagnosing permissions or server errors.

- **Review notes**
  - Extracts `branchSearchErrorMessage(status, retryAfterHeader)` and uses it in `GITHUB_SEARCH_BRANCHES`; no retry logic added and no other behavior changes.
  - Adds tests for 403/429 with `Retry-After`, 403 without it, and unrelated 500.

<sup>Written for commit 934a61264a3a02629a0ea90affb6af419cb8234b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

