### PR TITLE
fix(task-board): don't count a failed reviewer attempt as a finished review

### DIFF
--- a/apps/api/src/tools/task-board/enqueue-reviewer.test.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.test.ts
@@ -380,6 +380,19 @@ describe("priorCycleReviewAt", () => {
     ]);
     expect(priorCycleReviewAt(task, "code_review", CYCLE_START)).toBe(0);
   });
+
+  it("does not count a failed attempt as a finished review", () => {
+    const task = taskWith([
+      thread({
+        title: "Code Reviewer: x",
+        status: "failed",
+        createdAt: "2026-01-01T09:00:00Z",
+        lastActiveAt: "2026-01-01T09:05:00Z",
+      }),
+    ]);
+    // A failed run never read the PR, so this must stay a plain review.
+    expect(priorCycleReviewAt(task, "code_review", CYCLE_START)).toBe(0);
+  });
 });
 
 describe("stalePreviewHandoffDue", () => {

--- a/apps/api/src/tools/task-board/enqueue-reviewer.ts
+++ b/apps/api/src/tools/task-board/enqueue-reviewer.ts
@@ -266,6 +266,12 @@ export function pinnedRepoConnectionId(
  * this reviewer already read end to end. Told nothing, the second run repeats
  * the first almost exactly (in production, $3.39 against $3.51 for a fraction
  * of the change). Given the moment it last ruled, it can ask git what moved.
+ *
+ * Only `completed` threads count. A `failed` (or otherwise dead, see
+ * `isSpentAttempt`) prior attempt never read the PR end to end and posted no
+ * verdict — telling the next run it's a "RE-REVIEW" of a diff slice since that
+ * corpse's last heartbeat would have it skip reviewing code nobody actually
+ * reviewed.
  */
 export function priorCycleReviewAt(
   task: TaskBoardItem,
@@ -276,6 +282,7 @@ export function priorCycleReviewAt(
     .filter(
       (thr) =>
         isReviewerThreadTitle(thr.title, kind) &&
+        thr.status === "completed" &&
         new Date(thr.createdAt).getTime() < lastInReviewAt,
     )
     .map((thr) => new Date(thr.lastActiveAt).getTime())


### PR DESCRIPTION
Follows #6328 (`priorCycleReviewAt`), which added the "this is a RE-REVIEW" prompt hint telling a reviewer to only check commits since its own prior verdict.

**Bug**: `priorCycleReviewAt` matched any prior-cycle thread with the reviewer's title + a `createdAt` before the cycle started — it never checked the thread's `status`. A `failed` attempt from an earlier cycle (crashed before posting any review) still set `priorReviewAt` to that corpse's `lastActiveAt`. The next reviewer run then gets told it's a RE-REVIEW and to narrow its diff to `git log --since=<that failed run's last heartbeat>` — skipping review of everything before it, even though nothing was ever actually reviewed. The function's own doc comment says "when this reviewer last *finished* a run", but the code didn't enforce that.

**Fix**: only count threads with `status === "completed"`, matching the doc comment's intent and the existing `isSpentAttempt`/`TERMINAL_THREAD_STATUSES` distinction used elsewhere in this same file.

**Regression test**: added `"does not count a failed attempt as a finished review"` to the existing `priorCycleReviewAt` describe block in `enqueue-reviewer.test.ts` — a single `failed` thread from an earlier cycle now correctly yields `0` (plain review) instead of a nonzero re-review cutoff.

To confirm: `bun test apps/api/src/tools/task-board/enqueue-reviewer.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop counting failed reviewer attempts as finished reviews so re-reviews only trigger after a completed run. Previously, `priorCycleReviewAt` treated any prior-cycle thread as a finished review; now it only considers threads with `status === "completed"`, preventing skipped code after a crash.

- Old vs new: before, matched by title + `createdAt` only; now also requires `status: "completed"`.
- Effect: after a failed attempt, the next run does a full review instead of a narrowed diff, avoiding missed changes.
- Tests: adds a regression test in `apps/api/src/tools/task-board/enqueue-reviewer.test.ts` to assert failed attempts yield `0`.

<sup>Written for commit 5653e03cb04751e338e7c03de603fc2ca9be37e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6335?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

