### PR TITLE
feat(preview): scale storefront preview to fit instead of reflowing/clipping

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -1737,7 +1737,6 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
           : 1,
         1,
       );
-  const previewScalePercent = Math.round(previewScale * 100);
   const previewFrameStyle: CSSProperties = previewFluid
     ? { width: "100%", height: "100%" }
     : {
@@ -1798,14 +1797,6 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
             {t(DEVICE_LABEL_KEYS[previewDeviceSize])}
           </TooltipContent>
         </Tooltip>
-        {previewScalePercent < 100 && (
-          <>
-            <div className="mx-0.5 h-5 w-px bg-border" />
-            <span className="select-none px-1.5 text-xs tabular-nums text-muted-foreground">
-              {previewScalePercent}%
-            </span>
-          </>
-        )}
       </div>
     </div>
   ) : null;

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -1,5 +1,5 @@
 import { sleep } from "@decocms/shared/std";
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, type CSSProperties } from "react";
 import { useIsMutating } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { formatCodeTabId } from "@/layouts/main-panel-tabs/tab-id";
@@ -169,11 +169,25 @@ const DEV_SERVER_SETTLE_MS = 500;
 
 type PreviewDeviceSize = "mobile" | "tablet" | "desktop";
 
-const PREVIEW_DEVICE_WIDTHS: Record<PreviewDeviceSize, number | null> = {
-  mobile: 375,
-  tablet: 768,
-  desktop: null,
+/**
+ * Logical viewport dimensions per device, matching the legacy admin. The iframe
+ * always renders the page at this fixed logical size and is then scaled down
+ * with a CSS transform to fit the available canvas width — so widening the
+ * blocks panel shrinks a faithful proportional miniature of the full layout
+ * instead of reflowing the responsive breakpoints (desktop) or clipping the
+ * frame (mobile/tablet).
+ */
+const PREVIEW_VIEWPORTS: Record<
+  PreviewDeviceSize,
+  { width: number; height: number }
+> = {
+  mobile: { width: 412, height: 823 }, // Moto G Power
+  tablet: { width: 1024, height: 1366 }, // iPad Pro
+  desktop: { width: 1280, height: 800 }, // MacBook Pro 14
 };
+
+/** Px inset so the scaled frame's border doesn't sit flush against the canvas edge. */
+const PREVIEW_OFFSET = 1;
 
 const DEVICE_CYCLE: PreviewDeviceSize[] = ["desktop", "mobile", "tablet"];
 
@@ -278,6 +292,8 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   } | null>(null);
   const previewIframeRef = useRef<HTMLIFrameElement>(null);
   const blocksPanelRef = useRef<PanelImperativeHandle>(null);
+  // Live canvas size, used to scale the fixed-width frame to fit.
+  const [canvasSize, setCanvasSize] = useState({ width: 0, height: 0 });
   /** Origin most recently confirmed registered with the native shell via
    *  `registerPreviewOrigin` — see the effect below that sets it. `null`
    *  until the very first desktop-app production-mode registration lands. */
@@ -1706,6 +1722,34 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   ) : null;
 
   const canVisualEdit = display.mode === "sandbox";
+
+  // Desktop stays fluid until the canvas is narrower than its logical width; then (and always for mobile/tablet) the frame scales to fit.
+  const previewViewport = PREVIEW_VIEWPORTS[previewDeviceSize];
+  const previewFluid =
+    previewDeviceSize === "desktop" &&
+    (canvasSize.width === 0 ||
+      canvasSize.width >= previewViewport.width + 2 * PREVIEW_OFFSET);
+  const previewScale = previewFluid
+    ? 1
+    : Math.min(
+        canvasSize.width > 0
+          ? canvasSize.width / (previewViewport.width + 2 * PREVIEW_OFFSET)
+          : 1,
+        1,
+      );
+  const previewScalePercent = Math.round(previewScale * 100);
+  const previewFrameStyle: CSSProperties = previewFluid
+    ? { width: "100%", height: "100%" }
+    : {
+        width: `${previewViewport.width}px`,
+        height:
+          canvasSize.height > 0
+            ? `${canvasSize.height / previewScale}px`
+            : `${previewViewport.height}px`,
+        transform: `scale(${previewScale})`,
+        transformOrigin: "top center",
+      };
+
   // Device toggle works on any live iframe; visual-editor toggle is sandbox-only.
   const floatingPreviewControls = previewSurfaceActive ? (
     <div className="absolute bottom-4 left-1/2 z-20 -translate-x-1/2 scale-125">
@@ -1754,6 +1798,14 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
             {t(DEVICE_LABEL_KEYS[previewDeviceSize])}
           </TooltipContent>
         </Tooltip>
+        {previewScalePercent < 100 && (
+          <>
+            <div className="mx-0.5 h-5 w-px bg-border" />
+            <span className="select-none px-1.5 text-xs tabular-nums text-muted-foreground">
+              {previewScalePercent}%
+            </span>
+          </>
+        )}
       </div>
     </div>
   ) : null;
@@ -1866,11 +1918,26 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
               className="min-w-0 overflow-hidden"
             >
               <div
+                ref={(node) => {
+                  if (!node) return;
+                  const measure = () =>
+                    setCanvasSize((prev) =>
+                      prev.width === node.clientWidth &&
+                      prev.height === node.clientHeight
+                        ? prev
+                        : {
+                            width: node.clientWidth,
+                            height: node.clientHeight,
+                          },
+                    );
+                  measure();
+                  const observer = new ResizeObserver(measure);
+                  observer.observe(node);
+                  return () => observer.disconnect();
+                }}
                 className={cn(
-                  "h-full relative overflow-hidden",
-                  previewDeviceSize !== "desktop" &&
-                    previewSurfaceActive &&
-                    "flex justify-center bg-muted/30",
+                  "h-full relative overflow-hidden flex justify-center",
+                  previewSurfaceActive && !previewFluid && "bg-muted/30",
                 )}
               >
                 {/* Asymptotic "commit ramp" progress: brand lime fill over a
@@ -1948,16 +2015,11 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                 {previewSurfaceActive && iframeSrc && (
                   <div
                     className={cn(
-                      "h-full transition-[width] duration-250 [transition-timing-function:var(--ease-in-out-cubic)]",
-                      previewDeviceSize !== "desktop" &&
-                        "w-full max-w-full border-x border-border bg-background shadow-sm",
+                      "shrink-0",
+                      !previewFluid &&
+                        "border-x border-border bg-background shadow-sm",
                     )}
-                    style={{
-                      width:
-                        previewDeviceSize === "desktop"
-                          ? "100%"
-                          : `${PREVIEW_DEVICE_WIDTHS[previewDeviceSize]}px`,
-                    }}
+                    style={previewFrameStyle}
                   >
                     <iframe
                       // Key on the iframe base: remount when the base URL changes


### PR DESCRIPTION
## Summary

Widening the blocks/content editor panel used to break the storefront preview: the desktop iframe was fluid (`width: 100%`), so a narrower canvas reflowed the responsive breakpoints, and mobile/tablet used fixed widths that just clipped. The legacy admin scaled the whole preview down to fit ("Fit (35%)") and kept the proportion — this ports that behavior.

The iframe now always renders the page at a **fixed logical viewport** and is scaled down with a CSS `transform` to fit the available canvas width, so dragging the divider produces a faithful proportional miniature of the full layout instead of a reflowed/clipped one.

Logical viewports match the old admin:
- **Desktop** 1280×800 · **Tablet** 1024×1366 · **Mobile** 412×823

## Behavior

- **Desktop** stays fluid at full width while the canvas is ≥ 1280px; once narrower (e.g. after widening the cadastro panel) it renders at 1280 and scales down — no more reflow/breakage.
- **Mobile/Tablet** always render at their fixed logical width and scale down to fit instead of clipping.
- `scale = min(canvasWidth / (logicalWidth + 2), 1)` — never upscales past 100%.
- A small **"NN%"** zoom readout shows in the floating controls when scaled (mirrors the admin's "(35%)").

## Implementation notes

- Canvas size measured via a `ResizeObserver` attached through a ref-callback with cleanup (React 19 pattern — no `useEffect`).
- `transform-origin: top center`, so the scaled frame stays top-aligned and horizontally centered in the canvas.
- Visual-editor and CMS highlight overlays live **inside** the iframe document, so the wrapper `transform: scale` is transparent to them — no misalignment.

## Testing

- `bun run check` (type-check) ✅
- `bun run lint` ✅ (no new issues in the changed file)
- `bun run fmt` ✅
- No tests depended on the previous device widths (375/768).

Not yet validated in the live editor — visual confirmation needs the full sandbox/storefront stack running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scales the storefront preview iframe to fit the canvas instead of reflowing desktop breakpoints or clipping mobile/tablet, matching the legacy admin’s Fit mode. The iframe renders at a fixed logical viewport and is CSS-scaled so the preview stays proportional as panels resize.

- Device viewports: desktop 1280×800, tablet 1024×1366, mobile 412×823.
- Behavior: desktop is fluid while the canvas ≥1280px; otherwise scales. Mobile/tablet always scale to fit. Never upscales.
- Scaling: scale = min(canvasWidth / (logicalWidth + 2px), 1) — 1px inset on each side; transform-origin top-center to keep the frame anchored and centered.
- Implementation: canvas measured via ResizeObserver in a ref callback; wrapper transform keeps in-iframe overlays/highlights aligned.
- UI: remove the zoom percentage readout.

<sup>Written for commit d6ca577cd7b189a3179312bcd71ec359c668f39f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

