### PR TITLE
fix(sections-editor): claim @titleBy array items by target-section schema

### DIFF
--- a/apps/web/src/components/sections-editor/fields/object-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/object-field.tsx
@@ -68,6 +68,7 @@ export function ObjectField({
     objValue,
     breadcrumbPath,
     decofile,
+    meta,
   );
   const isOpen = open || breadcrumbInside;
   const contentId = `${path}-fields`;

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import type { SchemaProperty } from "./resolve-schema";
+import type { LiveMeta, SchemaProperty } from "./resolve-schema";
 import {
   breadcrumbPathForActiveField,
   breadcrumbsForHeaderClick,
@@ -691,6 +691,112 @@ describe("resolveActiveFieldKey", () => {
         ["Beach Short"],
       ),
     ).toBeNull();
+  });
+
+  test("narrows to the sibling section whose SCHEMA owns a @titleBy-labelled array item", () => {
+    // casaevideo NotFoundChallenge: drilling a URL-labelled coupon in `children` (MountedPDP.pdpCupons, @titleBy couponCode) must not drift to `fallback` (NotFound.categories) — the value scan can't see the title/titleBy, so ownership falls back to the target schema.
+    const mountedPdpSchema: Record<string, unknown> = {
+      type: "object",
+      properties: {
+        pdpCupons: {
+          type: "array",
+          title: "Cupons da PDP",
+          items: {
+            type: "object",
+            titleBy: "couponCode",
+            properties: {
+              couponCode: { type: "string" },
+              discountTitle: { type: "string" },
+            },
+          },
+        },
+      },
+    };
+    const notFoundSchema: Record<string, unknown> = {
+      type: "object",
+      properties: {
+        categories: {
+          type: "array",
+          title: "Categories",
+          items: {
+            type: "object",
+            properties: {
+              label: { type: "string" },
+              link: { type: "string" },
+            },
+          },
+        },
+      },
+    };
+    const meta: LiveMeta = {
+      manifest: {
+        blocks: {
+          sections: {
+            "site/sections/Product/MountedPDP.tsx": mountedPdpSchema,
+            "site/sections/Product/NotFound.tsx": notFoundSchema,
+          },
+        },
+      },
+      schema: {},
+    };
+    const properties = {
+      children: {
+        title: "On Product Found",
+        type: "block-ref",
+        anyOfRefs: [
+          {
+            resolveType: "site/sections/Product/MountedPDP.tsx",
+            title: "MountedPDP",
+          },
+        ],
+      },
+      fallback: {
+        title: "On Product Not Found",
+        type: "block-ref",
+        anyOfRefs: [
+          {
+            resolveType: "site/sections/Product/NotFound.tsx",
+            title: "NotFound",
+          },
+        ],
+      },
+    } satisfies Record<string, SchemaProperty>;
+    const couponUrl =
+      "https://www.casaevideo.com.br/3393?map=productClusterIds&order=OrderByTopSaleDESC";
+    const objValue = {
+      children: {
+        __resolveType: "site/sections/Product/MountedPDP.tsx",
+        pdpCupons: [{ couponCode: couponUrl, discountTitle: "10% OFF" }],
+      },
+      fallback: {
+        __resolveType: "site/sections/Product/NotFound.tsx",
+        categories: [
+          { label: "Telefones e Celulares", link: "/telefones-e-celulares" },
+          { label: "Ar e ventilação", link: "/" },
+        ],
+      },
+    };
+    const crumb: Crumb = {
+      label: couponUrl,
+      itemIndex: 0,
+      arrayLabel: "Cupons da PDP",
+    };
+    expect(
+      resolveActiveFieldKey(
+        Object.keys(properties),
+        properties,
+        objValue,
+        [crumb],
+        undefined,
+        meta,
+      ),
+    ).toBe("children");
+    // Without the schema (no meta) it can't disambiguate, but must NOT wrongly pick `fallback`.
+    expect(
+      resolveActiveFieldKey(Object.keys(properties), properties, objValue, [
+        crumb,
+      ]),
+    ).not.toBe("fallback");
   });
 
   test("narrows to a PLP loader whose selectedFacets[] item is labelled by key", () => {

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -3,7 +3,11 @@ import {
   getArrayItemLabel,
 } from "./array-item-display";
 import { isPageMultivariateSectionArrayField } from "./page-variants";
-import type { SchemaProperty } from "./resolve-schema";
+import {
+  resolveSchema,
+  type LiveMeta,
+  type SchemaProperty,
+} from "./resolve-schema";
 import { unwrapBlockReference } from "./unwrap-section";
 
 /**
@@ -475,6 +479,58 @@ function valueOwnsItemCrumb(
   return false;
 }
 
+/**
+ * Whether a block-ref field's target SCHEMA declares a drill-down array whose
+ * display title (or key) matches `arrayLabel`.
+ *
+ * A drilled array item carries its array's SCHEMA `@title` as the crumb's
+ * `arrayLabel` (e.g. "Cupons da PDP" for `pdpCupons: CupomPDPProps[]`). The
+ * value-only owner scan ({@link valueOwnsItemCrumb}) can't see that title — it
+ * humanizes the KEY (`pdpCupons` → "Pdp Cupons") — and can't recompute a
+ * `@titleBy` item label (`couponCode`) without the item schema, so a section whose
+ * array is titled and whose items are `@titleBy`-labelled goes unclaimed and
+ * resolution drifts to a sibling block-ref (the "drilling a coupon opens the
+ * fallback's categories" bug). Resolving the target schema restores the match by
+ * the array's real title, mirroring the top-level `arrayLabel` disambiguation in
+ * {@link resolveActiveFieldKeyInScope}. Depth-bounded for nested config objects.
+ */
+function blockRefSchemaOwnsArrayLabel(
+  data: unknown,
+  arrayLabel: string,
+  meta: LiveMeta | undefined,
+  depth = 0,
+): boolean {
+  if (!meta || depth > 4 || data == null || typeof data !== "object") {
+    return false;
+  }
+  const resolveType = (data as Record<string, unknown>).__resolveType;
+  if (typeof resolveType !== "string" || !resolveType) return false;
+  const props = resolveSchema(resolveType, meta)?.properties;
+  if (!props) return false;
+  const keys = Object.keys(props);
+  for (const key of keys) {
+    const child = props[key];
+    if (!child) continue;
+    if (isArrayDrillDownField(child)) {
+      const title = siblingFieldLabel(key, keys, props);
+      if (labelsMatch(title, arrayLabel) || labelsMatch(key, arrayLabel)) {
+        return true;
+      }
+    }
+    // Follow inner block refs so a Lazy-wrapped section's array is still found.
+    const childValue = (data as Record<string, unknown>)[key];
+    if (
+      childValue != null &&
+      typeof childValue === "object" &&
+      !Array.isArray(childValue) &&
+      blockRefSchemaOwnsArrayLabel(childValue, arrayLabel, meta, depth + 1)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /** Resolve which property at this level should be shown for the breadcrumb trail. */
 function resolveActiveFieldKeyInScope(
   keys: string[],
@@ -482,6 +538,7 @@ function resolveActiveFieldKeyInScope(
   objValue: Record<string, unknown>,
   breadcrumbPath: Crumb[],
   decofile?: Record<string, unknown>,
+  meta?: LiveMeta,
 ): string | null {
   if (breadcrumbPath.length === 0) return null;
   const head = crumbLabel(breadcrumbPath[0]!);
@@ -561,6 +618,7 @@ function resolveActiveFieldKeyInScope(
           childObj,
           breadcrumbPath.slice(1),
           decofile,
+          meta,
         ) != null;
       if (matchedStrong) {
         if (strongMatch === null) strongMatch = key;
@@ -576,6 +634,7 @@ function resolveActiveFieldKeyInScope(
         childObj,
         breadcrumbPath,
         decofile,
+        meta,
       ) != null;
     if (matchedLoose) {
       if (looseMatch === null) looseMatch = key;
@@ -614,6 +673,7 @@ function resolveActiveFieldKeyInScope(
         childObj,
         breadcrumbPath,
         decofile,
+        meta,
       );
       if (direct) return key;
 
@@ -624,6 +684,7 @@ function resolveActiveFieldKeyInScope(
           childObj,
           breadcrumbPath.slice(1),
           decofile,
+          meta,
         );
         if (viaLabel) return key;
       }
@@ -666,7 +727,11 @@ function resolveActiveFieldKeyInScope(
       const data = saved?.data ?? rawVal;
       if (
         valueOwnsItemCrumb(data, head) ||
-        foldedArrayLabels.some((al) => valueOwnsItemCrumb(data, al))
+        foldedArrayLabels.some(
+          (al) =>
+            valueOwnsItemCrumb(data, al) ||
+            blockRefSchemaOwnsArrayLabel(data, al, meta),
+        )
       ) {
         valueOwners.push(key);
       }
@@ -705,6 +770,7 @@ export function resolveActiveFieldKey(
   objValue: Record<string, unknown>,
   breadcrumbPath: Crumb[],
   decofile?: Record<string, unknown>,
+  meta?: LiveMeta,
 ): string | null {
   return resolveActiveFieldKeyInScope(
     keys,
@@ -712,6 +778,7 @@ export function resolveActiveFieldKey(
     objValue,
     breadcrumbPath,
     decofile,
+    meta,
   );
 }
 
@@ -723,6 +790,7 @@ export function isBreadcrumbInsideObject(
   objValue: Record<string, unknown>,
   breadcrumbPath: Crumb[],
   decofile?: Record<string, unknown>,
+  meta?: LiveMeta,
 ): boolean {
   if (breadcrumbPath.length === 0 || !schema.properties) return false;
 
@@ -734,6 +802,7 @@ export function isBreadcrumbInsideObject(
       objValue,
       breadcrumbPath,
       decofile,
+      meta,
     )
   ) {
     return true;
@@ -750,6 +819,7 @@ export function isBreadcrumbInsideObject(
       objValue,
       breadcrumbPath.slice(1),
       decofile,
+      meta,
     ) !== null
   );
 }

--- a/apps/web/src/components/sections-editor/schema-form.tsx
+++ b/apps/web/src/components/sections-editor/schema-form.tsx
@@ -570,6 +570,7 @@ export function SchemaForm({
           objValue,
           breadcrumbPath,
           decofile,
+          meta,
         )
       : null;
   const activeSchema = activeKey ? properties[activeKey] : null;


### PR DESCRIPTION
## Problem

In the CMS Content editor, drilling into an array item labelled by `@titleBy` — e.g. a coupon in `pdpCupons: CupomPDPProps[]` (`@titleBy couponCode`) — that lives inside a **sibling block-ref section** landed on a completely unrelated screen.

Reproduced on **casaevideo-tanstack**: the `NotFoundChallenge` section has `children` → `MountedPDP` (owns `pdpCupons`, titled "Cupons da PDP") and `fallback` → `NotFound` (has a `categories` array). Clicking a coupon whose `couponCode` is a URL opened the **fallback's `categories` list** instead of the coupon's fields.

<img width="500" alt="Cupons da PDP item" src="—" />

## Root cause

Block-ref ownership resolution (`valueOwnsItemCrumb` in `schema-form-breadcrumb.ts`) scans the block-ref's raw **data** with no item schema. So it:
- can't recompute a `@titleBy` item label (`couponCode` isn't in the hardcoded `["name","label","title","alt","text","href","id","key"]` label list), and
- only humanizes the array **key** (`pdpCupons` → "Pdp Cupons"), never matching the array's real `@title` ("Cupons da PDP") that rides on the drilled crumb as `arrayLabel`.

So `children` (the real owner) failed the ownership check and resolution drifted to `fallback`. The old comment even claimed this blind spot "degrade[s] to 'all siblings shown', never a wrong narrow" — but it produced a wrong narrow.

## Fix

Add `blockRefSchemaOwnsArrayLabel`: resolve the block-ref's target section schema and match its drill-down arrays by real `@title`/key against the crumb's folded `arrayLabel`, mirroring the top-level arrayLabel disambiguation. `meta` is threaded through `resolveActiveFieldKey` / `isBreadcrumbInsideObject` as an **optional** param, so existing callers/tests without `meta` keep the prior value-scan behaviour.

## Testing

- New regression test in `schema-form-breadcrumb.test.ts` reproducing the casaevideo NotFoundChallenge case (fails without the fix — with `meta`, `children` is only ownable via the schema-based check).
- `bun test apps/web/src/components/sections-editor/` → 686 pass.
- `bun run fmt`, `bun run lint` (clean for touched files), and apps/web typecheck pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes drill-down ownership for array items labeled via `@titleBy` inside sibling block-ref sections. Previously, clicking such an item could open a different sibling section; now we use the target section schema to match the array by its real `@title` or key and select the correct owner.

- Adds `blockRefSchemaOwnsArrayLabel` and threads optional `meta` through `resolveActiveFieldKey` and `isBreadcrumbInsideObject`; `schema-form.tsx` and `object-field.tsx` now pass `meta`. Callers without `meta` keep prior behavior.
- Adds a regression test reproducing the NotFoundChallenge case. To enable schema-based matching elsewhere, pass `meta` when resolving active fields.

<sup>Written for commit 3f09bbd76ceae6e1a74b7acba8ea8692c38517e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

