### PR TITLE
fix(jira): render mentions as display names instead of raw account ids

### DIFF
--- a/apps/api/src/jira/client.test.ts
+++ b/apps/api/src/jira/client.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it, mock } from "bun:test";
 import {
+  collectMentionAccountIds,
   jiraBodyToText,
   assertBoardId,
   normalizeSiteUrl,
   textToAdf,
   JiraClient,
+  JiraUserDirectory,
 } from "./client";
 
 describe("normalizeSiteUrl", () => {
@@ -88,6 +90,174 @@ describe("jiraBodyToText", () => {
   it("returns empty on null and non-body values", () => {
     expect(jiraBodyToText(null)).toBe("");
     expect(jiraBodyToText(42)).toBe("");
+  });
+});
+
+describe("jiraBodyToText mentions", () => {
+  const mention = (attrs: Record<string, unknown>) => ({
+    type: "doc",
+    content: [{ type: "paragraph", content: [{ type: "mention", attrs }] }],
+  });
+
+  it("uses the name ADF already carries, stripping its @", () => {
+    expect(
+      jiraBodyToText(mention({ id: "557058:abc-123", text: "@Ana Souza" })),
+    ).toBe("@Ana Souza");
+  });
+
+  it("falls back to the resolved name when ADF carries none", () => {
+    expect(
+      jiraBodyToText(
+        mention({ id: "557058:abc-123" }),
+        new Map([["557058:abc-123", "Ana Souza"]]),
+      ),
+    ).toBe("@Ana Souza");
+  });
+
+  it("renders an unresolvable mention as @unknown", () => {
+    expect(jiraBodyToText(mention({ id: "557058:abc-123" }))).toBe("@unknown");
+    expect(jiraBodyToText(mention({ text: "  @  " }))).toBe("@unknown");
+  });
+
+  it("collects only the account ids that need a lookup", () => {
+    expect(
+      collectMentionAccountIds({
+        type: "doc",
+        content: [
+          {
+            type: "paragraph",
+            content: [
+              { type: "mention", attrs: { id: "a", text: "@Ana" } },
+              { type: "text", text: " e " },
+              { type: "mention", attrs: { id: "b" } },
+              { type: "mention", attrs: { id: "b" } },
+            ],
+          },
+        ],
+      }),
+    ).toEqual(["b"]);
+  });
+
+  it("collects account ids from wiki-markup bodies too", () => {
+    expect(
+      collectMentionAccountIds("cc [~accountid:557058:abc-123] e [~jsmith]"),
+    ).toEqual(["557058:abc-123"]);
+  });
+
+  it("collects nothing from bodies without mentions", () => {
+    expect(collectMentionAccountIds(null)).toEqual([]);
+    expect(collectMentionAccountIds("plain text")).toEqual([]);
+  });
+});
+
+describe("JiraUserDirectory", () => {
+  const client = () =>
+    new JiraClient("https://acme.atlassian.net", "e@acme.com", "tok");
+
+  async function withFetch<T>(
+    handler: (url: string) => Response,
+    body: (calls: string[]) => Promise<T>,
+  ): Promise<T> {
+    const originalFetch = globalThis.fetch;
+    const calls: string[] = [];
+    globalThis.fetch = mock(async (input: unknown) => {
+      calls.push(String(input));
+      return handler(String(input));
+    }) as unknown as typeof fetch;
+    try {
+      return await body(calls);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  }
+
+  const json = (value: unknown) =>
+    new Response(JSON.stringify(value), { status: 200 });
+
+  it("costs no request when nothing needs resolving", async () => {
+    await withFetch(
+      () => json({}),
+      async (calls) => {
+        const names = await new JiraUserDirectory(client()).resolve([]);
+        expect(calls).toHaveLength(0);
+        expect(names.size).toBe(0);
+      },
+    );
+  });
+
+  it("resolves repeated ids from cache — one request per run", async () => {
+    await withFetch(
+      () =>
+        json({
+          values: [
+            { accountId: "a", displayName: "Ana Souza" },
+            { accountId: "b", displayName: "Bruno Lima" },
+          ],
+        }),
+      async (calls) => {
+        const directory = new JiraUserDirectory(client());
+        for (let i = 0; i < 50; i++) await directory.resolve(["a", "b"]);
+        expect(calls).toHaveLength(1);
+        expect(await directory.resolve(["a"])).toEqual(
+          new Map([["a", "Ana Souza"]]),
+        );
+      },
+    );
+  });
+
+  it("latches off after a 403 so a missing permission costs one request", async () => {
+    await withFetch(
+      () => new Response("Forbidden", { status: 403 }),
+      async (calls) => {
+        const directory = new JiraUserDirectory(client());
+        for (let i = 0; i < 20; i++) {
+          expect((await directory.resolve([`user-${i}`])).size).toBe(0);
+        }
+        expect(calls).toHaveLength(1);
+      },
+    );
+  });
+
+  it("keeps ids Jira declines to disclose out of the map", async () => {
+    await withFetch(
+      () =>
+        json({ values: [{ accountId: "a", displayName: "Ana" }], total: 1 }),
+      async (calls) => {
+        const names = await new JiraUserDirectory(client()).resolve([
+          "a",
+          "b",
+          "c",
+        ]);
+        expect(names).toEqual(new Map([["a", "Ana"]]));
+        expect(calls).toHaveLength(1);
+      },
+    );
+  });
+
+  it("pages until a page comes back empty, not on `isLast`", async () => {
+    let served = 0;
+    await withFetch(
+      () =>
+        json(
+          served < 3
+            ? {
+                values: [
+                  { accountId: `u${served}`, displayName: `U${served++}` },
+                ],
+              }
+            : { values: [] },
+        ),
+      async (calls) => {
+        const names = await new JiraUserDirectory(client()).resolve([
+          "u0",
+          "u1",
+          "u2",
+          "u3",
+        ]);
+        expect(names.size).toBe(3);
+        expect(calls).toHaveLength(4);
+      },
+    );
   });
 });
 

--- a/apps/api/src/jira/client.ts
+++ b/apps/api/src/jira/client.ts
@@ -8,9 +8,18 @@
  */
 
 import { retry } from "@decocms/shared/std";
-import { wikiToMarkdown } from "./wiki-markdown";
+import {
+  collectWikiMentionAccountIds,
+  escapeMentionName,
+  UNKNOWN_MENTION,
+  wikiToMarkdown,
+} from "./wiki-markdown";
 
 const REQUEST_TIMEOUT_MS = 15_000;
+
+/** Account ids per `/user/bulk` request. Jira caps the repeated `accountId`
+ *  param at 200; stay well under and let the chunker loop. */
+const USER_LOOKUP_CHUNK = 100;
 
 export interface JiraBoard {
   id: number;
@@ -188,6 +197,42 @@ export class JiraClient {
     return this.request("/rest/api/3/myself");
   }
 
+  /**
+   * Display names for up to `USER_LOOKUP_CHUNK` account ids per query — the
+   * mention resolver. `/user/bulk` needs the "Browse users and groups" global
+   * permission and answers 403 without it; it also omits ids it won't disclose
+   * rather than erroring, so the result can be shorter than the input. Paged
+   * because Jira clamps `maxResults` to its own ceiling, silently.
+   */
+  async listUsersByAccountId(
+    accountIds: string[],
+  ): Promise<Array<{ accountId: string; displayName: string }>> {
+    if (accountIds.length === 0) return [];
+    const users: Array<{ accountId: string; displayName: string }> = [];
+    let startAt = 0;
+    for (;;) {
+      const query = new URLSearchParams({
+        startAt: String(startAt),
+        maxResults: String(accountIds.length),
+      });
+      for (const accountId of accountIds) query.append("accountId", accountId);
+      const page = await this.request<{
+        values?: Array<{ accountId: string; displayName: string }>;
+        total?: number;
+      }>(`/rest/api/3/user/bulk?${query}`);
+      const values = page.values ?? [];
+      users.push(...values);
+      // `total` is the disclosed count, which is <= the ids asked for; an empty
+      // page is the fallback signal if Jira omits it. `isLast` is not used —
+      // it is optional in the response and absent means "stop" if trusted.
+      const total =
+        typeof page.total === "number" ? page.total : accountIds.length;
+      if (values.length === 0 || users.length >= total) break;
+      startAt += values.length;
+    }
+    return users;
+  }
+
   /** Boards visible to the credentials — the sync-target picker. */
   async listBoards(): Promise<JiraBoard[]> {
     const boards: JiraBoard[] = [];
@@ -358,22 +403,134 @@ export function textToAdf(text: string): unknown {
   };
 }
 
+interface MentionAttrs {
+  id?: unknown;
+  text?: unknown;
+}
+
+/** The display name ADF usually ships inside the mention itself (`"@Jane Doe"`),
+ *  normalized without its `@`. Absent on mentions written through the API, and
+ *  on some older bodies — those need the account-id lookup. */
+function mentionLabel(attrs: MentionAttrs | undefined): string | null {
+  const text = typeof attrs?.text === "string" ? attrs.text.trim() : "";
+  const label = text.startsWith("@") ? text.slice(1).trim() : text;
+  return label === "" ? null : label;
+}
+
+function mentionText(
+  attrs: MentionAttrs | undefined,
+  names: ReadonlyMap<string, string>,
+): string {
+  const label = mentionLabel(attrs);
+  if (label) return `@${escapeMentionName(label)}`;
+  const id = typeof attrs?.id === "string" ? attrs.id : "";
+  const name = id ? names.get(id) : undefined;
+  return name ? `@${escapeMentionName(name)}` : UNKNOWN_MENTION;
+}
+
+/** Account ids in a body that a name lookup has to resolve, so a run can batch
+ *  them into one request instead of rendering opaque ids. Mentions that already
+ *  carry their name (the common ADF case) contribute nothing. */
+export function collectMentionAccountIds(body: unknown): string[] {
+  const ids = new Set<string>();
+  collectMentions(body, ids);
+  return [...ids];
+}
+
+function collectMentions(body: unknown, ids: Set<string>): void {
+  if (typeof body === "string") {
+    for (const id of collectWikiMentionAccountIds(body)) ids.add(id);
+    return;
+  }
+  if (!body || typeof body !== "object") return;
+  const node = body as {
+    type?: string;
+    attrs?: MentionAttrs;
+    content?: unknown[];
+  };
+  if (node.type === "mention") {
+    const id = typeof node.attrs?.id === "string" ? node.attrs.id : "";
+    if (id && !mentionLabel(node.attrs)) ids.add(id);
+    return;
+  }
+  for (const child of Array.isArray(node.content) ? node.content : []) {
+    collectMentions(child, ids);
+  }
+}
+
 /** Jira rich body → text the cards can render. The Agile API returns
  *  v2-style STRING bodies (wiki markup — converted to markdown); REST v3
  *  returns an ADF tree, which is flattened: text nodes concatenated,
  *  doc-level blocks separated by blank lines. ADF marks, tables, and media
  *  are dropped — the card links back to the issue for full fidelity. */
-export function jiraBodyToText(adf: unknown): string {
-  if (typeof adf === "string") return wikiToMarkdown(adf);
+export function jiraBodyToText(
+  adf: unknown,
+  names: ReadonlyMap<string, string> = new Map(),
+): string {
+  if (typeof adf === "string") return wikiToMarkdown(adf, names);
   if (!adf || typeof adf !== "object") return "";
-  const node = adf as { type?: string; text?: string; content?: unknown[] };
+  const node = adf as {
+    type?: string;
+    text?: string;
+    attrs?: MentionAttrs;
+    content?: unknown[];
+  };
   if (node.type === "text") return node.text ?? "";
   if (node.type === "hardBreak") return "\n";
-  const inner = (Array.isArray(node.content) ? node.content : []).map(
-    jiraBodyToText,
+  if (node.type === "mention") return mentionText(node.attrs, names);
+  const inner = (Array.isArray(node.content) ? node.content : []).map((child) =>
+    jiraBodyToText(child, names),
   );
   if (node.type === "doc") {
     return inner.filter((text) => text.trim() !== "").join("\n\n");
   }
   return inner.join("");
+}
+
+/**
+ * Account id → display name, resolved once per sync run.
+ *
+ * Unresolved ids are cached as such: a deleted account, or a credential
+ * without the "Browse users and groups" global permission, must not re-cost a
+ * request for every issue that mentions it. A lookup failure degrades the text
+ * to `@unknown` — it never fails the sync, which would strand every other
+ * field over a cosmetic detail.
+ */
+export class JiraUserDirectory {
+  private readonly names = new Map<string, string | null>();
+  private lookupsDisabled = false;
+
+  constructor(private readonly client: JiraClient) {}
+
+  async resolve(accountIds: string[]): Promise<ReadonlyMap<string, string>> {
+    const missing = this.lookupsDisabled
+      ? []
+      : [...new Set(accountIds.filter((id) => !this.names.has(id)))];
+    for (let at = 0; at < missing.length; at += USER_LOOKUP_CHUNK) {
+      const chunk = missing.slice(at, at + USER_LOOKUP_CHUNK);
+      // Seeded before the call so ids Jira silently omits aren't re-requested.
+      for (const id of chunk) this.names.set(id, null);
+      try {
+        for (const user of await this.client.listUsersByAccountId(chunk)) {
+          if (user.displayName)
+            this.names.set(user.accountId, user.displayName);
+        }
+      } catch (err) {
+        // Latched, not retried per id: a credential without the permission
+        // would otherwise cost one failing round-trip per mentioned account.
+        this.lookupsDisabled = true;
+        console.warn(
+          "[jira] user lookup failed, mentions render as @unknown for this run:",
+          err instanceof Error ? err.message : err,
+        );
+        break;
+      }
+    }
+    const resolved = new Map<string, string>();
+    for (const id of accountIds) {
+      const name = this.names.get(id);
+      if (name) resolved.set(id, name);
+    }
+    return resolved;
+  }
 }

--- a/apps/api/src/jira/client.ts
+++ b/apps/api/src/jira/client.ts
@@ -17,9 +17,12 @@ import {
 
 const REQUEST_TIMEOUT_MS = 15_000;
 
-/** Account ids per `/user/bulk` request. Jira caps the repeated `accountId`
- *  param at 200; stay well under and let the chunker loop. */
-const USER_LOOKUP_CHUNK = 100;
+/** Account ids per `/user/bulk` request. Jira allows 200, but each id spends
+ *  ~56 URL bytes, so 200 would build a ~11KB request line — past the 4KB cap
+ *  common in proxies, and a 414 is a 4xx: not retried, latching every mention
+ *  to `@unknown`. 50 keeps the URL under ~3KB and costs ~1 extra request per
+ *  50 distinct people in a page. */
+const USER_LOOKUP_CHUNK = 50;
 
 export interface JiraBoard {
   id: number;

--- a/apps/api/src/jira/sync.ts
+++ b/apps/api/src/jira/sync.ts
@@ -21,7 +21,13 @@ import type {
 } from "@/storage/types";
 import { reactToSuperAgentDelegation } from "@/tools/task-board/enqueue-super-agent";
 import { emitTaskBoardUpdated } from "@/tools/task-board/run-reactions";
-import { jiraBodyToText, JiraClient, type JiraIssue } from "./client";
+import {
+  collectMentionAccountIds,
+  jiraBodyToText,
+  JiraClient,
+  JiraUserDirectory,
+  type JiraIssue,
+} from "./client";
 
 /** `created_by`/`updated_by` on synced cards. Deliberately NOT "system" —
  *  that marks reports-owned cards and locks their title/description. */
@@ -101,8 +107,14 @@ function isCardIssue(issue: JiraIssue): boolean {
   return typeof level !== "number" || level === 0;
 }
 
-function cardDescription(siteUrl: string, issue: JiraIssue): string {
-  const text = jiraBodyToText(issue.fields.description);
+async function cardDescription(
+  siteUrl: string,
+  issue: JiraIssue,
+  users: JiraUserDirectory,
+): Promise<string> {
+  const body = issue.fields.description;
+  const names = await users.resolve(collectMentionAccountIds(body));
+  const text = jiraBodyToText(body, names);
   return `${siteUrl}/browse/${issue.key}\n\n${text}`
     .trim()
     .slice(0, MAX_DESCRIPTION_CHARS);
@@ -169,6 +181,7 @@ async function pullComments(
   issue: JiraIssue,
   itemId: string,
   integrationAccountId: string,
+  users: JiraUserDirectory,
 ): Promise<void> {
   const orgId = integration.organizationId;
   const embedded = issue.fields.comment;
@@ -181,10 +194,21 @@ async function pullComments(
     orgId,
     comments.map((comment) => comment.id),
   );
-  for (const comment of comments) {
-    if (known.has(comment.id)) continue;
-    if (comment.author?.accountId === integrationAccountId) continue;
-    const text = jiraBodyToText(comment.body).slice(0, MAX_DESCRIPTION_CHARS);
+  const pending = comments.filter(
+    (comment) =>
+      !known.has(comment.id) &&
+      comment.author?.accountId !== integrationAccountId,
+  );
+  if (pending.length === 0) return;
+  // One lookup for the whole batch, not one per comment.
+  const names = await users.resolve(
+    pending.flatMap((comment) => collectMentionAccountIds(comment.body)),
+  );
+  for (const comment of pending) {
+    const text = jiraBodyToText(comment.body, names).slice(
+      0,
+      MAX_DESCRIPTION_CHARS,
+    );
     const created = await ctx.storage.taskBoard.createComment({
       taskBoardItemId: itemId,
       organizationId: orgId,
@@ -236,6 +260,7 @@ async function runSync(
   );
   // The integration account's own comments are echoes of our pushes.
   const { accountId: integrationAccountId } = await client.myself();
+  const users = new JiraUserDirectory(client);
   // Backlog-tab issues have normal statuses but are not visible board cards.
   const backlogIds = await client.listBacklogIssueIds(boardId);
   const jql = buildJql(integration);
@@ -258,6 +283,16 @@ async function runSync(
     const links = await ctx.storage.jiraIntegrations.getLinksByIssueIds(
       orgId,
       page.issues.map((issue) => issue.id),
+    );
+    // One name lookup for the page, so the per-issue resolves below are cache
+    // hits rather than up to MAX_ISSUES_PER_RUN sequential single-id requests.
+    await users.resolve(
+      page.issues.flatMap((issue) => [
+        ...collectMentionAccountIds(issue.fields.description),
+        ...(issue.fields.comment?.comments ?? []).flatMap((comment) =>
+          collectMentionAccountIds(comment.body),
+        ),
+      ]),
     );
 
     for (const issue of page.issues) {
@@ -286,7 +321,7 @@ async function runSync(
       const jiraStatusName = issue.fields.status.name;
       const fields = {
         title: issue.fields.summary,
-        description: cardDescription(integration.siteUrl, issue),
+        description: await cardDescription(integration.siteUrl, issue, users),
         priority: mapPriority(issue),
       };
 
@@ -321,6 +356,7 @@ async function runSync(
           issue,
           link.itemId,
           integrationAccountId,
+          users,
         );
         // Last, because this is what marks the issue "fully processed": moving
         // it before `pullComments` means a failed comment fetch is never
@@ -371,6 +407,7 @@ async function runSync(
           issue,
           item.id,
           integrationAccountId,
+          users,
         );
         await ctx.storage.jiraIntegrations.touchLink(item.id, {
           jiraUpdatedAt: issueUpdated,

--- a/apps/api/src/jira/wiki-markdown.test.ts
+++ b/apps/api/src/jira/wiki-markdown.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { wikiToMarkdown } from "./wiki-markdown";
+import { collectWikiMentionAccountIds, wikiToMarkdown } from "./wiki-markdown";
 
 describe("wikiToMarkdown", () => {
   it("converts bold and strips color, keeping literal brackets", () => {
@@ -51,6 +51,78 @@ describe("wikiToMarkdown", () => {
   it("converts tables with inline marks in cells", () => {
     expect(wikiToMarkdown("||Nome||*Nota*||\n|a|b|")).toBe(
       "| Nome | **Nota** |\n| --- | --- |\n| a | b |",
+    );
+  });
+
+  it("resolves accountid mentions to display names", () => {
+    expect(
+      wikiToMarkdown(
+        "[~accountid:557058:abc-123] revisa com [~accountid:712020:def-456]",
+        new Map([
+          ["557058:abc-123", "Ana Souza"],
+          ["712020:def-456", "Bruno Lima"],
+        ]),
+      ),
+    ).toBe("@Ana Souza revisa com @Bruno Lima");
+  });
+
+  it("renders unknown account ids as @unknown, never the raw id", () => {
+    expect(wikiToMarkdown("cc [~accountid:557058:abc-123]")).toBe(
+      "cc @unknown",
+    );
+  });
+
+  it("leaves non-accountid bracket-tilde text alone", () => {
+    expect(wikiToMarkdown("lookup[~key], arr[~1], [~], regex [^a-z]")).toBe(
+      "lookup[~key], arr[~1], [~], regex [^a-z]",
+    );
+  });
+
+  it("leaves mentions inside code blocks byte-exact", () => {
+    expect(
+      wikiToMarkdown(
+        "{code}\n[~accountid:557058:abc-123]\n{code}",
+        new Map([["557058:abc-123", "Ana Souza"]]),
+      ),
+    ).toBe("```\n[~accountid:557058:abc-123]\n```");
+  });
+
+  it("does not mistake a link for a mention", () => {
+    expect(wikiToMarkdown("[~x|https://example.com/a]")).toBe(
+      "[~x](https://example.com/a)",
+    );
+  });
+
+  it("neutralizes wiki and markdown markup inside a display name", () => {
+    expect(
+      wikiToMarkdown(
+        "cc [~accountid:a] ok",
+        new Map([["a", "Ana _Nick_ Souza"]]),
+      ),
+    ).toBe("cc @Ana \\_Nick\\_ Souza ok");
+    expect(
+      wikiToMarkdown("cc [~accountid:a]", new Map([["a", "Ana *Nick*"]])),
+    ).toBe("cc @Ana \\*Nick\\*");
+  });
+
+  it("keeps a pipe in a display name from splitting a table cell", () => {
+    expect(
+      wikiToMarkdown("|[~accountid:c]|done|", new Map([["c", "Cid | Team"]])),
+    ).toBe("| @Cid \\| Team | done |");
+  });
+
+  it("does not collect account ids it will never render", () => {
+    expect(
+      collectWikiMentionAccountIds(
+        "{code}\n[~accountid:X:1]\n{code}\ncc [~accountid:Y:2]",
+      ),
+    ).toEqual(["Y:2"]);
+  });
+
+  it("strips a source sentinel so it cannot forge a mention reference", () => {
+    const nul = String.fromCharCode(0);
+    expect(wikiToMarkdown(`a${nul}0${nul}b [~accountid:x]`)).toBe(
+      "a0b @unknown",
     );
   });
 

--- a/apps/api/src/jira/wiki-markdown.ts
+++ b/apps/api/src/jira/wiki-markdown.ts
@@ -10,21 +10,27 @@
  * showing a stray `*`.
  */
 
-export function wikiToMarkdown(wiki: string): string {
-  return splitBlocks(wiki)
+export function wikiToMarkdown(
+  wiki: string,
+  names: ReadonlyMap<string, string> = new Map(),
+): string {
+  const resolved: string[] = [];
+  const stash = (text: string) => stashMentions(text, names, resolved);
+  const converted = splitBlocks(wiki)
     .map((block) => {
       if (block.type === "code") {
         return `\`\`\`${block.lang}\n${trimEdgeNewlines(block.content)}\n\`\`\``;
       }
       if (block.type === "quote") {
-        return convertLines(trimEdgeNewlines(block.content))
+        return convertLines(stash(trimEdgeNewlines(block.content)))
           .split("\n")
           .map((line) => `> ${line}`)
           .join("\n");
       }
-      return convertLines(block.content);
+      return convertLines(stash(block.content));
     })
     .join("");
+  return restoreMentions(converted, resolved);
 }
 
 type Block =
@@ -259,4 +265,68 @@ function emphasis(
     };
   }
   return null;
+}
+
+/** What a mention renders as when the account id can't be resolved to a name:
+ *  a deleted account, or a credential without "Browse users and groups". Still
+ *  better than leaking the raw opaque id into a card. */
+export const UNKNOWN_MENTION = "@unknown";
+
+/** A Cloud mention: `[~accountid:557058:1a2b…]`. The `accountid:` prefix is
+ *  load-bearing — matching bare `[~token]` too would rewrite prose describing
+ *  code (`lookup[~key]`, `arr[~1]`), and Cloud has no other mention form. */
+const WIKI_MENTION = /\[~accountid:([^\]\s|]+)\]/g;
+
+/** Markdown metacharacters in a DISPLAY NAME, which is tenant-controlled text:
+ *  an unescaped `Ana _Nick_ Souza` renders as italics, and a `|` splits a table
+ *  cell. Escaped for the markdown the card renders; the wiki parser never sees
+ *  the name at all (see `stashMentions`). */
+export function escapeMentionName(name: string): string {
+  return name.replace(/([\\`*_[\]|~])/g, "\\$1");
+}
+
+/** Account ids referenced by wiki mentions outside code blocks — what a name
+ *  lookup needs. Skips `{code}`/`{noformat}` so it can't request a name the
+ *  renderer will then discard. */
+export function collectWikiMentionAccountIds(wiki: string): string[] {
+  const ids: string[] = [];
+  for (const block of splitBlocks(wiki)) {
+    if (block.type === "code") continue;
+    for (const [, id] of block.content.matchAll(WIKI_MENTION)) {
+      if (id) ids.push(id);
+    }
+  }
+  return ids;
+}
+
+/** NUL can't occur in Jira text (Postgres can't even store it) and carries no
+ *  markup, so it survives the parser as inert content. */
+const SENTINEL = "\u0000";
+const SENTINEL_REF = new RegExp(`${SENTINEL}(\\d+)${SENTINEL}`, "g");
+
+/** Swap each mention for an inert sentinel BEFORE parsing, per non-code block:
+ *  the resolved name never reaches the inline scanner, so a name can't open
+ *  emphasis or split a table cell, and code stays byte-exact. */
+function stashMentions(
+  wiki: string,
+  names: ReadonlyMap<string, string>,
+  resolved: string[],
+): string {
+  // Dropped first so the sentinel namespace is ours alone and source text
+  // can't forge a reference. Postgres rejects NUL, so this text is unstorable.
+  return wiki
+    .replaceAll(SENTINEL, "")
+    .replace(WIKI_MENTION, (_whole, id: string) => {
+      const name = names.get(id);
+      const index = resolved.length;
+      resolved.push(name ? `@${escapeMentionName(name)}` : UNKNOWN_MENTION);
+      return `${SENTINEL}${index}${SENTINEL}`;
+    });
+}
+
+function restoreMentions(markdown: string, resolved: string[]): string {
+  return markdown.replace(
+    SENTINEL_REF,
+    (_whole, index: string) => resolved[Number(index)] ?? UNKNOWN_MENTION,
+  );
 }


### PR DESCRIPTION
## Problem

Jira mentions arrive in two body formats and the sync handled neither, so synced cards showed opaque account ids — or lost the mention entirely.

- **Wiki markup** (`description`, from the Agile API): `[~accountid:557058:…]`. The inline scanner in `wikiToMarkdown` checks whether a `[…]` body is a URL, decides it isn't, and emits it literally.
- **ADF** (comments, via REST v3): a `{ type: "mention", attrs }` node matched no branch in `jiraBodyToText`, so it fell to the "join my children" case and, having no children, rendered as `""` — mentions were **silently deleted**, not mangled.

## Change

Mentions render as `@Display Name` on both paths, resolved as cheaply as possible:

1. ADF usually ships the name inside the mention (`attrs.text`) — used directly, **zero requests**.
2. When it doesn't, and for all wiki mentions, ids are batch-resolved via `GET /rest/api/3/user/bulk`, **prefetched once per issue page** so the per-issue conversions are cache hits.
3. `JiraUserDirectory` caches per run **including misses**, and **latches off after a failure** — a credential without *Browse users and groups* costs one request per run, not one per mentioned account.
4. A failed lookup degrades to `@unknown` and warns; it never fails the sync.

## Two things worth reviewing closely

**The wiki path no longer splices names into the string it parses.** Each mention becomes an inert sentinel *before* parsing and is substituted back after, because a display name is tenant-controlled text: spliced raw, `Ana _Nick_ Souza` rendered as italics and a name containing `|` added a table cell, shifting every later column. Names are also backslash-escaped for the markdown the card renders. `{code}`/`{noformat}` stay byte-exact, and the id collector now skips them too so it can't request a name the renderer will discard.

**The `accountid:` prefix is required.** Supporting bare `[~token]` for legacy Server/DC mentions over-matched prose describing code — `lookup[~key]` → `lookup@key`, `arr[~1]` → `arr@1`, silent corruption of text that previously rendered fine. `normalizeSiteUrl` already restricts this integration to `*.atlassian.net`, and Cloud has had no other mention form since the 2019 GDPR migration, so the legacy branch bought nothing.

`/user/bulk` paging deliberately ignores `isLast` (optional in the response — absent would read as "stop" and silently resolve only the first page) and uses `total`, falling back to an empty page.

## Testing

`bun test apps/api/src/jira/` — **47 pass, 0 fail** (23 new). Covers both mention formats, name-escaping, table cells, code-block exactness, the sentinel-forgery case, and — via the `globalThis.fetch` harness already established in `client.test.ts` — request counts, negative caching, the 403 latch, undisclosed ids, and paging.

Also verified with a throwaway differential against `HEAD`'s converter over a 20-input corpus: **zero output changes** on any input without a literal `[~accountid:`. That harness is what caught the `lookup[~key]` over-match, after a first version whose oracle reused the implementation's own regex and so labelled every over-match "expected."

`tsc --noEmit` clean, `bun run lint` 0 errors, `knip` clean.

## Notes for the reviewer

- **Nothing here has run against a live Jira.** `/user/bulk`'s response shape and `maxResults` ceiling come from Atlassian's docs, not a call I made — the paging loop is defensive precisely because I couldn't confirm the ceiling. First real sync against a board with mentions is the actual proof.
- **Existing cards won't heal on their own.** A description is only rewritten once the issue's `updated` passes the link watermark, so already-synced cards keep their raw ids until someone touches the issue in Jira. A backfill over `task_board_item_jira_links` would be a separate change.
- A tenant whose credential lacks *Browse users and groups* gets one warn line per sync tick, not surfaced in `last_sync_error`. Deliberate — logging beats failing a sync over a display name — but worth knowing before it's filed as noise.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renders Jira mentions as @Display Name in synced descriptions and comments. Previously wiki “[~accountid:…]” showed raw account ids and ADF mention nodes were dropped; now both render “@Name”, degrading to “@unknown” without failing syncs.

- Key changes:
  - ADF mentions use `attrs.text` when present; otherwise resolve names via `/rest/api/3/user/bulk` in chunks of 50 to keep URLs under proxy limits. Results cache per run (including misses) and latch off after any failure (e.g., 403) to avoid repeated requests.
  - Wiki mentions swap to inert sentinels before parsing, then restore as escaped “@Name”; `{code}`/`{noformat}` blocks remain byte-exact. Only Cloud-form `[~accountid:…]` matches; id collection skips code blocks.
  - Sync prefetches names once per issue page and for each comment batch; `jiraBodyToText` accepts a names map. Unknown or undisclosed ids render as “@unknown”.

- Rollout notes:
  - No migration. Existing cards update when the Jira issue changes.
  - Requires Jira “Browse users and groups”; without it, mentions render as “@unknown” and log one warning per run.
  - Cloud-only by design; Server/DC-style `[~token]` is not matched.

<sup>Written for commit a61369013442049284e62cfc69fbb8b349cf291c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

