### PR TITLE
fix(sandbox): stop a shallow clone faking a commit ahead of base

### DIFF
--- a/packages/sandbox/daemon-go/internal/gitx/divergence.go
+++ b/packages/sandbox/daemon-go/internal/gitx/divergence.go
@@ -16,6 +16,13 @@ type BranchDivergence struct {
 
 var leftRightRe = regexp.MustCompile(`^(\d+)\s+(\d+)$`)
 
+// hasCommonAncestor reports whether two refs are comparable in THIS repo — false
+// in a shallow clone whose grafted tips descend from nothing shared.
+func hasCommonAncestor(tryGit func(args []string) (string, bool), a, b string) bool {
+	out, ok := tryGit([]string{"merge-base", a, b})
+	return ok && strings.TrimSpace(out) != ""
+}
+
 func ComputeBranchDivergence(repoDir string, tryGit func(args []string) (string, bool)) BranchDivergence {
 	if tryGit == nil {
 		tryGit = func(args []string) (string, bool) {
@@ -46,8 +53,23 @@ func ComputeBranchDivergence(repoDir string, tryGit func(args []string) (string,
 		branchRef = remoteBranchRef
 	}
 
+	// Every sandbox checkout is `--depth 1` (setup/clone.go, CheckoutBranch), so
+	// each fetched tip is grafted with no parents. When the branch was not
+	// fetched from the same tip as the base, the two share no ancestor in this
+	// clone and `A...B` degenerates into "everything reachable on both sides":
+	// git answers 1 ahead / 1 behind for a branch that is IDENTICAL to base and
+	// fully merged. The header read that as work and offered "Review & Publish"
+	// on an untouched branch (while the publish dialog, which deepens to 100
+	// before diffing — see status.go — correctly reported 0 changes).
+	//
+	// No common ancestor means "not comparable in this clone": report 0 instead
+	// of a fabricated count. Local work still surfaces, because `unpushed` below
+	// compares origin/<branch>..HEAD — same branch, which a shallow clone
+	// answers correctly — and a branch forked from the base tip inside the
+	// sandbox keeps that grafted tip as its merge-base, so its commits still
+	// count.
 	aheadOfBase, behindBase := 0, 0
-	if refExists("origin/" + base) {
+	if refExists("origin/"+base) && hasCommonAncestor(tryGit, "origin/"+base, branchRef) {
 		lr, _ := tryGit([]string{"rev-list", "--left-right", "--count", "origin/" + base + "..." + branchRef})
 		if m := leftRightRe.FindStringSubmatch(lr); m != nil {
 			behindBase, _ = strconv.Atoi(m[1])

--- a/packages/sandbox/daemon-go/internal/gitx/divergence_test.go
+++ b/packages/sandbox/daemon-go/internal/gitx/divergence_test.go
@@ -1,0 +1,137 @@
+package gitx
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func git(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+	}
+	return string(out)
+}
+
+// A remote whose `feature` branch points at an OLD main commit — a branch that
+// is fully merged into main and 0 commits ahead of it.
+func originWithMergedFeature(t *testing.T) string {
+	t.Helper()
+	origin := filepath.Join(t.TempDir(), "origin")
+	git(t, t.TempDir(), "init", "-q", "-b", "main", origin)
+	git(t, origin, "config", "user.email", "t@example.com")
+	git(t, origin, "config", "user.name", "t")
+	git(t, origin, "commit", "-q", "--allow-empty", "-m", "one")
+	git(t, origin, "branch", "feature")
+	// main moves on; feature stays behind and remains an ancestor of main.
+	git(t, origin, "commit", "-q", "--allow-empty", "-m", "two")
+	git(t, origin, "commit", "-q", "--allow-empty", "-m", "three")
+	return origin
+}
+
+func shallowCloneOfMain(t *testing.T, origin string) string {
+	t.Helper()
+	repo := filepath.Join(t.TempDir(), "repo")
+	git(t, t.TempDir(), "clone", "-q", "--depth", "1", "--single-branch",
+		"--branch", "main", "file://"+origin, repo)
+	git(t, repo, "remote", "set-head", "origin", "main")
+	git(t, repo, "config", "user.email", "t@example.com")
+	git(t, repo, "config", "user.name", "t")
+	return repo
+}
+
+// Every sandbox checkout is `--depth 1`, which grafts each tip with no parents.
+// Without a common ancestor, `origin/main...origin/feature` counts BOTH sides,
+// so a fully-merged branch reported 1 ahead — and the header offered
+// "Review & Publish" on a branch with nothing to publish.
+func TestDivergenceDoesNotFabricateAheadInAShallowClone(t *testing.T) {
+	origin := originWithMergedFeature(t)
+	repo := shallowCloneOfMain(t, origin)
+	// The daemon's remote-branch checkout path (see CheckoutBranch).
+	git(t, repo, "fetch", "-q", "--depth", "1", "origin",
+		"+refs/heads/feature:refs/remotes/origin/feature")
+	git(t, repo, "checkout", "-q", "-B", "feature", "refs/remotes/origin/feature")
+
+	div := ComputeBranchDivergence(repo, nil)
+	if div.Base != "main" {
+		t.Fatalf("base: got %q, want main", div.Base)
+	}
+	if div.AheadOfBase != 0 || div.BehindBase != 0 {
+		t.Fatalf("shallow clone must not fabricate divergence: ahead=%d behind=%d",
+			div.AheadOfBase, div.BehindBase)
+	}
+	if div.Unpushed != 0 {
+		t.Fatalf("nothing local: unpushed=%d", div.Unpushed)
+	}
+}
+
+// The guard must not swallow real work: commits made in the sandbox descend
+// from the grafted base tip, so they still have a merge-base with it.
+func TestDivergenceCountsLocalCommitsInAShallowClone(t *testing.T) {
+	origin := originWithMergedFeature(t)
+	repo := shallowCloneOfMain(t, origin)
+	git(t, repo, "checkout", "-q", "-B", "work", "refs/remotes/origin/main")
+	git(t, repo, "commit", "-q", "--allow-empty", "-m", "my work")
+
+	div := ComputeBranchDivergence(repo, nil)
+	if div.AheadOfBase != 1 {
+		t.Fatalf("a local commit off the base tip is 1 ahead, got %d", div.AheadOfBase)
+	}
+	if div.Unpushed != 1 {
+		t.Fatalf("unpushed: got %d, want 1", div.Unpushed)
+	}
+}
+
+// The `/git/status` route can afford the network the SSE monitor cannot, and its
+// consumers gate the publish diff on `aheadOfBase` — so real pushed-ahead
+// commits must survive the shallow clone, via the deepen in ComputeStatus.
+func TestComputeStatusDeepensToRecoverRealAhead(t *testing.T) {
+	origin := originWithMergedFeature(t)
+	// A branch with a commit that is NOT on main.
+	git(t, origin, "checkout", "-q", "-b", "ahead-branch", "main")
+	git(t, origin, "commit", "-q", "--allow-empty", "-m", "real work")
+	git(t, origin, "checkout", "-q", "main")
+
+	repo := shallowCloneOfMain(t, origin)
+	git(t, repo, "fetch", "-q", "--depth", "1", "origin",
+		"+refs/heads/ahead-branch:refs/remotes/origin/ahead-branch")
+	git(t, repo, "checkout", "-q", "-B", "ahead-branch", "refs/remotes/origin/ahead-branch")
+
+	// The network-free monitor cannot tell, and says so.
+	shallow := ComputeBranchDivergence(repo, nil)
+	if shallow.AheadOfBase != 0 {
+		t.Fatalf("shallow read should not guess: ahead=%d", shallow.AheadOfBase)
+	}
+
+	res, err := ComputeStatus(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.AheadOfBase != 1 {
+		t.Fatalf("after deepening, ahead should be the real 1, got %d", res.AheadOfBase)
+	}
+	if res.BehindBase != 0 {
+		t.Fatalf("branched off the main tip, so behind is 0, got %d", res.BehindBase)
+	}
+}
+
+// And the merged branch stays honest through the same path: 0 ahead.
+func TestComputeStatusKeepsAMergedBranchAtZeroAhead(t *testing.T) {
+	origin := originWithMergedFeature(t)
+	repo := shallowCloneOfMain(t, origin)
+	git(t, repo, "fetch", "-q", "--depth", "1", "origin",
+		"+refs/heads/feature:refs/remotes/origin/feature")
+	git(t, repo, "checkout", "-q", "-B", "feature", "refs/remotes/origin/feature")
+
+	res, err := ComputeStatus(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.AheadOfBase != 0 {
+		t.Fatalf("a fully-merged branch is 0 ahead, got %d", res.AheadOfBase)
+	}
+}

--- a/packages/sandbox/daemon-go/internal/gitx/status.go
+++ b/packages/sandbox/daemon-go/internal/gitx/status.go
@@ -98,9 +98,24 @@ func ComputeStatus(repoDir string) (StatusResult, error) {
 	if err != nil {
 		return StatusResult{}, err
 	}
-	divergence := ComputeBranchDivergence(repoDir, func(args []string) (string, bool) {
-		return tryReadGit(repoDir, args)
-	})
+	read := func(args []string) (string, bool) { return tryReadGit(repoDir, args) }
+	divergence := ComputeBranchDivergence(repoDir, read)
+	// In a `--depth 1` clone base and branch can share no ancestor, and
+	// ComputeBranchDivergence answers 0 rather than a fabricated count. This
+	// route's consumers need the real number (the publish dialog gates its
+	// base…HEAD diff on `aheadOfBase`), and unlike the SSE branch monitor's 3s
+	// loop it can afford the network — so deepen the way the diff path does and
+	// ask again.
+	branch, _ := read([]string{"rev-parse", "--abbrev-ref", "HEAD"})
+	upstream := "origin/" + divergence.Base
+	if branch != "" && branch != "HEAD" {
+		if _, ok := read([]string{"rev-parse", "--verify", "--quiet", upstream}); ok {
+			if !hasCommonAncestor(read, upstream, "HEAD") {
+				runReadGit(repoDir, []string{"fetch", "--depth", "100", "origin", divergence.Base, branch})
+				divergence = ComputeBranchDivergence(repoDir, read)
+			}
+		}
+	}
 	return StatusResult{WorkingTreeStatus: working, BranchDivergence: divergence}, nil
 }
 


### PR DESCRIPTION
The real cause of "Review & Publish on a branch with 0 changes" — and it is neither the working tree nor the dev server, which is why #6332 didn't move it.

## Reproduced

Every sandbox checkout fetches with `--depth 1` (`setup/clone.go`, `CheckoutBranch`), so each fetched tip is grafted with no parents. Run the daemon's own checkout sequence against this repo and the branch from the report:

```
git clone --depth 1 --single-branch --branch main <repo> repo
git fetch --depth 1 origin '+refs/heads/pedro-je4bq0tm:refs/remotes/origin/pedro-je4bq0tm'
git checkout -B pedro-je4bq0tm refs/remotes/origin/pedro-je4bq0tm

git rev-list --left-right --count origin/main...origin/pedro-je4bq0tm
→ 1	1
git status --porcelain | wc -l
→ 0
```

`origin/pedro-je4bq0tm` is **0 ahead / 99 behind** `origin/main` in reality — it is an ancestor of main. With no common ancestor in the clone, `A...B` stops being a divergence count and becomes the symmetric difference of two unrelated histories, so git answers 1 ahead / 1 behind.

`aheadOfBase > 0` with no PR is `panel-state.ts`'s "Review & Publish" (`panel-state.ts:357`), so the branch offered publishing with nothing to publish. The publish dialog then computed the truth and said "0 changes to publish" — that disagreement is the tell, and it's what the screenshot shows: the *header* believes there's a commit, the *diff* knows there isn't.

The diff path already knew about this: `status.go` guards on `merge-base` and deepens to `--depth 100` before diffing. The divergence path never got that treatment.

Confirmed in prod first: the pod for that handle (`studio-sandbox-prod-vbmj4`, image `studio-sandbox-go:1.55.13` — i.e. with #6332 in it) had a **completely clean** working tree, which rules out the dirty-baseline path.

## The fix

- No common ancestor means "not comparable in this clone" → report 0 rather than a fabricated count. Local work still surfaces: `unpushed` compares `origin/<branch>..HEAD` (same branch, which a shallow clone answers correctly), and a branch forked from the base tip inside the sandbox keeps that grafted tip as its merge-base, so its commits still count.
- `/git/status` needs the real number — the publish dialog gates its base…HEAD diff on `aheadOfBase`, and before this PR it was accidentally relying on the fabricated ≥1 — and unlike the branch monitor's 3s poll it can afford the network, so it deepens the same way the diff path does and asks again.

Bogus `behindBase` (and the phantom "Get latest" it puts in the menu) goes away with the same guard.

## Testing

`go test ./internal/gitx/` — four new tests over real shallow clones (`file://` remote):

- a fully-merged branch fetched `--depth 1` reports 0 ahead / 0 behind (fails on `main`: `ahead=1 behind=1`)
- a commit made inside the sandbox still counts as 1 ahead / 1 unpushed
- `ComputeStatus` deepens and recovers a genuinely pushed-ahead commit as 1
- and keeps a merged branch at 0 through the same path

Full daemon suite green; `bun run fmt`/`lint` clean. No web changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop shallow clones from faking “1 ahead / 1 behind,” which caused “Review & Publish” to appear on branches with no changes. Previously a shallow checkout without a merge-base misreported divergence; now we detect that case and return 0, and the status path deepens the clone to recover real counts.

- In `packages/sandbox/daemon-go/internal/gitx/divergence.go`, detect no common ancestor and report 0 ahead/behind instead of using `rev-list ... A...B` on unrelated tips.
- In `packages/sandbox/daemon-go/internal/gitx/status.go`, `/git/status` deepens with `fetch --depth 100` when needed and recomputes divergence so the publish dialog sees the real `aheadOfBase`.
- Local work still surfaces: `unpushed` and ahead count for commits off the base tip remain correct.
- Removes phantom `behindBase` and the spurious “Get latest” menu entry.
- Adds targeted tests in `packages/sandbox/daemon-go/internal/gitx/divergence_test.go` to cover shallow clones, local commits, deepening, and merged branches.

<sup>Written for commit c70b9ff6c63948f3edd264d0fc75f778f1b6b387. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6339?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

