### PR TITLE
fix(settings): keep heading and tab strip mounted while a tab loads

### DIFF
--- a/apps/web/src/components/settings/settings-group-page.tsx
+++ b/apps/web/src/components/settings/settings-group-page.tsx
@@ -1,0 +1,92 @@
+/**
+ * The page shell every tabbed settings screen shares.
+ *
+ * A settings group is one sidebar row fanning out into sibling routes shown as
+ * tabs (see `settings-tab-groups.ts`). Switching tabs is a route change, so the
+ * new page suspends — on its data, and the first time also on its lazy chunk.
+ * Whichever boundary catches that suspension decides how much of the screen
+ * blinks out, and TanStack wraps every route match in a `<Suspense>` whose
+ * fallback is that route's `pendingComponent`. A page that suspends without a
+ * boundary of its own therefore takes the heading and the tab strip down with
+ * it, which reads as the whole settings screen flashing on every tab click.
+ *
+ * Both halves of the fix live here:
+ *   - `SettingsGroupPage` renders the heading + tabs *above* the boundary, so a
+ *     page's own data only ever swaps the content region for a skeleton.
+ *   - `settingsGroupPendingComponent(group)` is the route-level
+ *     `pendingComponent` (wired in `router.tsx`), painting that same chrome
+ *     while the route's chunk loads.
+ *
+ * Neither hook behind the tab strip suspends (`useCapabilities` and
+ * `useOwnedSites` are plain `useQuery`), so the chrome is always safe to render
+ * outside the boundary — including from inside a Suspense fallback.
+ */
+
+import { Suspense, type ComponentProps, type ReactNode } from "react";
+import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
+import { Page } from "@/components/page";
+import { ErrorBoundary } from "@/components/error-boundary";
+import { SettingsPage } from "@/components/settings/settings-section";
+import { SettingsSubnav } from "@/components/settings/settings-subnav";
+import type { SettingsGroupKey } from "./settings-tab-groups";
+
+/** Placeholder for the content region while a tab's data or chunk loads. */
+export function SettingsContentSkeleton() {
+  return (
+    <div data-testid="settings-content-loading" className="flex flex-col gap-4">
+      <Skeleton className="h-32 w-full" />
+      <Skeleton className="h-32 w-full" />
+    </div>
+  );
+}
+
+interface SettingsGroupPageProps {
+  group: SettingsGroupKey;
+  /** Shown in place of `children` while they suspend. Chrome stays put. */
+  fallback?: ReactNode;
+  /** Shown in place of `children` when they throw. */
+  errorFallback?: ComponentProps<typeof ErrorBoundary>["fallback"];
+  /** Extra classes for the content stack (e.g. a tighter `gap-6`). */
+  className?: string;
+  children: ReactNode;
+}
+
+export function SettingsGroupPage({
+  group,
+  fallback,
+  errorFallback,
+  className,
+  children,
+}: SettingsGroupPageProps) {
+  return (
+    <Page>
+      <Page.Content>
+        <Page.Body>
+          <SettingsPage className={className}>
+            <SettingsSubnav group={group} />
+            <ErrorBoundary fallback={errorFallback}>
+              <Suspense fallback={fallback ?? <SettingsContentSkeleton />}>
+                {children}
+              </Suspense>
+            </ErrorBoundary>
+          </SettingsPage>
+        </Page.Body>
+      </Page.Content>
+    </Page>
+  );
+}
+
+/**
+ * Route `pendingComponent` for a tabbed settings route. Replaces the global
+ * `defaultPendingComponent` (a full-screen spinner) so a cold chunk load keeps
+ * the heading and tab strip on screen.
+ */
+export function settingsGroupPendingComponent(group: SettingsGroupKey) {
+  return function SettingsGroupPending() {
+    return (
+      <SettingsGroupPage group={group}>
+        <SettingsContentSkeleton />
+      </SettingsGroupPage>
+    );
+  };
+}

--- a/apps/web/src/components/settings/settings-subnav.tsx
+++ b/apps/web/src/components/settings/settings-subnav.tsx
@@ -26,7 +26,7 @@ export function SettingsSubnav({ group }: { group: SettingsGroupKey }) {
   const { titleKey } = SETTINGS_TAB_GROUPS[group];
 
   return (
-    <div className="flex flex-col gap-4">
+    <div data-slot="settings-heading" className="flex flex-col gap-4">
       <Page.Title>{t(titleKey)}</Page.Title>
       {tabs.length > 1 && (
         <nav

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -9,6 +9,7 @@ import {
 } from "@tanstack/react-router";
 import { SplashScreen } from "@/components/splash-screen";
 import { ShellRouteLoading } from "@/layouts/shell-route-loading";
+import { settingsGroupPendingComponent } from "@/components/settings/settings-group-page";
 import { ChunkErrorBoundary } from "@/components/error-boundary";
 import { useT } from "@/i18n/use-t";
 import * as z from "zod";
@@ -477,6 +478,7 @@ const settingsGeneralRoute = createRoute({
 const settingsConnectRoute = createRoute({
   getParentRoute: () => settingsLayout,
   path: "/connect",
+  pendingComponent: settingsGroupPendingComponent("connect"),
   component: lazyRouteComponent(
     () => import("./routes/orgs/settings/connect.tsx"),
   ),
@@ -485,6 +487,7 @@ const settingsConnectRoute = createRoute({
 const settingsAiProvidersRoute = createRoute({
   getParentRoute: () => settingsLayout,
   path: "/ai-providers",
+  pendingComponent: settingsGroupPendingComponent("billing"),
   component: lazyRouteComponent(
     () => import("./routes/orgs/settings/ai-providers.tsx"),
   ),
@@ -505,6 +508,7 @@ const settingsBillingRoute = createRoute({
 const settingsInfraBillingRoute = createRoute({
   getParentRoute: () => settingsLayout,
   path: "/infra-billing",
+  pendingComponent: settingsGroupPendingComponent("billing"),
   component: lazyRouteComponent(
     () => import("./routes/orgs/settings/infra-billing.tsx"),
   ),
@@ -521,6 +525,7 @@ const settingsSecretsRoute = createRoute({
 const settingsApiKeysRoute = createRoute({
   getParentRoute: () => settingsLayout,
   path: "/api-keys",
+  pendingComponent: settingsGroupPendingComponent("connect"),
   component: lazyRouteComponent(
     () => import("./routes/orgs/settings/api-keys.tsx"),
   ),
@@ -529,6 +534,7 @@ const settingsApiKeysRoute = createRoute({
 const settingsBucketsRoute = createRoute({
   getParentRoute: () => settingsLayout,
   path: "/buckets",
+  pendingComponent: settingsGroupPendingComponent("storage"),
   component: lazyRouteComponent(
     () => import("./routes/orgs/settings/buckets.tsx"),
   ),
@@ -537,6 +543,7 @@ const settingsBucketsRoute = createRoute({
 const settingsSyncedReposRoute = createRoute({
   getParentRoute: () => settingsLayout,
   path: "/synced-repos",
+  pendingComponent: settingsGroupPendingComponent("storage"),
   component: lazyRouteComponent(
     () => import("./routes/orgs/settings/synced-repos.tsx"),
   ),
@@ -553,6 +560,7 @@ const settingsTasksRoute = createRoute({
 const settingsMembersRoute = createRoute({
   getParentRoute: () => settingsLayout,
   path: "/members",
+  pendingComponent: settingsGroupPendingComponent("members"),
   component: lazyRouteComponent(
     () => import("./routes/orgs/settings/members.tsx"),
   ),
@@ -561,6 +569,7 @@ const settingsMembersRoute = createRoute({
 const settingsRolesRoute = createRoute({
   getParentRoute: () => settingsLayout,
   path: "/roles",
+  pendingComponent: settingsGroupPendingComponent("members"),
   component: lazyRouteComponent(
     () => import("./routes/orgs/settings/roles.tsx"),
   ),

--- a/apps/web/src/routes/orgs/members.tsx
+++ b/apps/web/src/routes/orgs/members.tsx
@@ -1,9 +1,7 @@
 import { CollectionDisplayButton } from "@/components/collections/collection-display-button.tsx";
 import { SearchInput } from "@decocms/ui/components/search-input.tsx";
-import { Page } from "@/components/page";
 import { CollectionTableWrapper } from "@/components/collections/collection-table-wrapper.tsx";
 import { EmptyState } from "@/components/empty-state.tsx";
-import { ErrorBoundary } from "@/components/error-boundary";
 import { InviteMemberDialog } from "@/components/invite-member-dialog";
 import { JoinRequestsSection } from "@/components/settings/join-requests-section";
 import { track } from "@/lib/posthog-client";
@@ -55,7 +53,6 @@ import {
   XClose,
   Shield01,
   Key01,
-  Loading01,
 } from "@untitledui/icons";
 import {
   Select,
@@ -66,10 +63,10 @@ import {
 } from "@decocms/ui/components/select.tsx";
 import { cn } from "@decocms/ui/lib/utils.ts";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Suspense, useState } from "react";
+import { useState } from "react";
 import { toast } from "sonner";
 import { TagMultiSelect } from "@/components/tag-multi-select";
-import { SettingsSubnav } from "@/components/settings/settings-subnav";
+import { SettingsGroupPage } from "@/components/settings/settings-group-page";
 
 const BUILTIN_ROLES = ["owner", "admin", "user"];
 
@@ -770,7 +767,7 @@ function OrgMembersContent() {
   ];
 
   return (
-    <Page>
+    <>
       {/* Cancel Invitation Dialog */}
       <AlertDialog
         open={!!invitationToCancel}
@@ -833,223 +830,198 @@ function OrgMembersContent() {
         </AlertDialogContent>
       </AlertDialog>
 
-      <Page.Content>
-        <Page.Body>
-          <div className="flex flex-col gap-6">
-            <JoinRequestsSection />
-            <SettingsSubnav group="members" />
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <div className="flex items-center gap-2">
-                <SearchInput
-                  value={search}
-                  onChange={setSearch}
-                  placeholder={t("orgs.members.searchPlaceholder")}
-                  className="w-full md:w-[375px]"
-                  onKeyDown={(event) => {
-                    if (event.key === "Escape") {
-                      setSearch("");
-                      (event.target as HTMLInputElement).blur();
-                    }
-                  }}
-                />
-                <CollectionDisplayButton
-                  viewMode={viewMode}
-                  onViewModeChange={setViewMode}
-                  sortKey={sortKey}
-                  sortDirection={sortDirection}
-                  onSort={handleSort}
-                  sortOptions={[
-                    { id: "member", label: t("orgs.members.sortName") },
-                    { id: "role", label: t("orgs.members.sortRole") },
-                    { id: "joined", label: t("orgs.members.sortJoined") },
-                  ]}
-                />
-              </div>
-              {ctaButton}
-            </div>
-            {viewMode === "cards" ? (
-              <div>
-                {allRows.length === 0 ? (
-                  <EmptyState
-                    title={t("orgs.members.noMembersFound")}
-                    description={
-                      search
-                        ? t("orgs.members.noMembersMatch", { search })
-                        : t("orgs.members.inviteMembersGetStarted")
-                    }
-                  />
-                ) : (
-                  <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4">
-                    {allRows.map((row) => {
-                      if (row.type === "invitation") {
-                        // Invitation card
-                        return (
-                          <Card
-                            key={`inv-${row.data.id}`}
-                            className="transition-colors relative opacity-75"
-                          >
-                            <div className="absolute top-4 right-4 z-10">
-                              <InvitationActionsDropdown
-                                invitationId={row.data.id}
-                                onCancel={setInvitationToCancel}
-                                isCancelling={
-                                  invitationActions.cancel.isPending
-                                }
-                              />
-                            </div>
-                            <div className="flex flex-col gap-4 p-6">
-                              <Avatar
-                                fallback={getInitials(row.data.email)}
-                                shape="circle"
-                                size="lg"
-                                className="shrink-0"
-                              />
-                              <div className="flex flex-col gap-2">
-                                <h3 className="text-base font-medium text-foreground truncate">
-                                  {row.data.email}
-                                </h3>
-                                <div className="flex items-center gap-2">
-                                  <Badge
-                                    variant="outline"
-                                    className="w-fit text-warning border-warning/40"
-                                  >
-                                    {t("orgs.members.pending")}
-                                  </Badge>
-                                </div>
-                                <RoleSelector
-                                  role={row.data.role}
-                                  memberId={row.data.id}
-                                  isOwner={false}
-                                  roleColorMap={roleColorMap}
-                                  selectableRoles={selectableRoles}
-                                  onRoleChange={(invitationId, role) =>
-                                    updateInvitationRoleMutation.mutate({
-                                      invitationId,
-                                      role,
-                                      email: row.data.email,
-                                    })
-                                  }
-                                  className="w-fit"
-                                />
-                              </div>
-                            </div>
-                          </Card>
-                        );
-                      }
-                      // Member card
-                      const member = row.data;
-                      return (
-                        <Card
-                          key={member.id}
-                          className="transition-colors relative"
-                        >
-                          <div className="absolute top-4 right-4 z-10">
-                            <MemberActionsDropdown
-                              member={member}
-                              roles={roles}
-                              onChangeRole={(memberId, role) =>
-                                updateRoleMutation.mutate({ memberId, role })
-                              }
-                              onRemove={setMemberToRemove}
-                              isUpdating={updateRoleMutation.isPending}
-                            />
-                          </div>
-                          <div className="flex flex-col gap-4 p-6">
-                            <Avatar
-                              url={member.user?.image ?? undefined}
-                              fallback={getInitials(member.user?.name)}
-                              shape="circle"
-                              size="lg"
-                              className="shrink-0"
-                            />
-                            <div className="flex flex-col gap-2">
-                              <h3 className="text-base font-medium text-foreground truncate">
-                                {member.user?.name || "Unknown"}
-                              </h3>
-                              <p className="text-sm text-muted-foreground truncate">
-                                {member.user?.email}
-                              </p>
-                              <RoleSelector
-                                role={member.role}
-                                memberId={member.id}
-                                isOwner={member.role === "owner"}
-                                roleColorMap={roleColorMap}
-                                selectableRoles={selectableRoles}
-                                onRoleChange={(memberId, role) =>
-                                  updateRoleMutation.mutate({ memberId, role })
-                                }
-                                className="w-fit"
-                              />
-                              <TagMultiSelect
-                                memberId={member.id}
-                                maxDisplay={3}
-                              />
-                            </div>
-                          </div>
-                        </Card>
-                      );
-                    })}
-                  </div>
-                )}
-              </div>
-            ) : (
-              <CollectionTableWrapper
-                columns={columns}
-                data={allRows}
-                isLoading={false}
-                sortKey={sortKey}
-                sortDirection={sortDirection}
-                onSort={handleSort}
-                emptyState={
-                  search ? (
-                    <EmptyState
-                      title={t("orgs.members.noMembersFound")}
-                      description={t("orgs.members.noMembersMatch", { search })}
-                    />
-                  ) : (
-                    <EmptyState
-                      title={t("orgs.members.noMembersFound")}
-                      description={t("orgs.members.inviteMembersGetStarted")}
-                    />
-                  )
+      <JoinRequestsSection />
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <SearchInput
+              value={search}
+              onChange={setSearch}
+              placeholder={t("orgs.members.searchPlaceholder")}
+              className="w-full md:w-[375px]"
+              onKeyDown={(event) => {
+                if (event.key === "Escape") {
+                  setSearch("");
+                  (event.target as HTMLInputElement).blur();
+                }
+              }}
+            />
+            <CollectionDisplayButton
+              viewMode={viewMode}
+              onViewModeChange={setViewMode}
+              sortKey={sortKey}
+              sortDirection={sortDirection}
+              onSort={handleSort}
+              sortOptions={[
+                { id: "member", label: t("orgs.members.sortName") },
+                { id: "role", label: t("orgs.members.sortRole") },
+                { id: "joined", label: t("orgs.members.sortJoined") },
+              ]}
+            />
+          </div>
+          {ctaButton}
+        </div>
+        {viewMode === "cards" ? (
+          <div>
+            {allRows.length === 0 ? (
+              <EmptyState
+                title={t("orgs.members.noMembersFound")}
+                description={
+                  search
+                    ? t("orgs.members.noMembersMatch", { search })
+                    : t("orgs.members.inviteMembersGetStarted")
                 }
               />
+            ) : (
+              <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4">
+                {allRows.map((row) => {
+                  if (row.type === "invitation") {
+                    // Invitation card
+                    return (
+                      <Card
+                        key={`inv-${row.data.id}`}
+                        className="transition-colors relative opacity-75"
+                      >
+                        <div className="absolute top-4 right-4 z-10">
+                          <InvitationActionsDropdown
+                            invitationId={row.data.id}
+                            onCancel={setInvitationToCancel}
+                            isCancelling={invitationActions.cancel.isPending}
+                          />
+                        </div>
+                        <div className="flex flex-col gap-4 p-6">
+                          <Avatar
+                            fallback={getInitials(row.data.email)}
+                            shape="circle"
+                            size="lg"
+                            className="shrink-0"
+                          />
+                          <div className="flex flex-col gap-2">
+                            <h3 className="text-base font-medium text-foreground truncate">
+                              {row.data.email}
+                            </h3>
+                            <div className="flex items-center gap-2">
+                              <Badge
+                                variant="outline"
+                                className="w-fit text-warning border-warning/40"
+                              >
+                                {t("orgs.members.pending")}
+                              </Badge>
+                            </div>
+                            <RoleSelector
+                              role={row.data.role}
+                              memberId={row.data.id}
+                              isOwner={false}
+                              roleColorMap={roleColorMap}
+                              selectableRoles={selectableRoles}
+                              onRoleChange={(invitationId, role) =>
+                                updateInvitationRoleMutation.mutate({
+                                  invitationId,
+                                  role,
+                                  email: row.data.email,
+                                })
+                              }
+                              className="w-fit"
+                            />
+                          </div>
+                        </div>
+                      </Card>
+                    );
+                  }
+                  // Member card
+                  const member = row.data;
+                  return (
+                    <Card
+                      key={member.id}
+                      className="transition-colors relative"
+                    >
+                      <div className="absolute top-4 right-4 z-10">
+                        <MemberActionsDropdown
+                          member={member}
+                          roles={roles}
+                          onChangeRole={(memberId, role) =>
+                            updateRoleMutation.mutate({ memberId, role })
+                          }
+                          onRemove={setMemberToRemove}
+                          isUpdating={updateRoleMutation.isPending}
+                        />
+                      </div>
+                      <div className="flex flex-col gap-4 p-6">
+                        <Avatar
+                          url={member.user?.image ?? undefined}
+                          fallback={getInitials(member.user?.name)}
+                          shape="circle"
+                          size="lg"
+                          className="shrink-0"
+                        />
+                        <div className="flex flex-col gap-2">
+                          <h3 className="text-base font-medium text-foreground truncate">
+                            {member.user?.name || "Unknown"}
+                          </h3>
+                          <p className="text-sm text-muted-foreground truncate">
+                            {member.user?.email}
+                          </p>
+                          <RoleSelector
+                            role={member.role}
+                            memberId={member.id}
+                            isOwner={member.role === "owner"}
+                            roleColorMap={roleColorMap}
+                            selectableRoles={selectableRoles}
+                            onRoleChange={(memberId, role) =>
+                              updateRoleMutation.mutate({ memberId, role })
+                            }
+                            className="w-fit"
+                          />
+                          <TagMultiSelect memberId={member.id} maxDisplay={3} />
+                        </div>
+                      </div>
+                    </Card>
+                  );
+                })}
+              </div>
             )}
           </div>
-        </Page.Body>
-      </Page.Content>
-    </Page>
+        ) : (
+          <CollectionTableWrapper
+            columns={columns}
+            data={allRows}
+            isLoading={false}
+            sortKey={sortKey}
+            sortDirection={sortDirection}
+            onSort={handleSort}
+            emptyState={
+              search ? (
+                <EmptyState
+                  title={t("orgs.members.noMembersFound")}
+                  description={t("orgs.members.noMembersMatch", { search })}
+                />
+              ) : (
+                <EmptyState
+                  title={t("orgs.members.noMembersFound")}
+                  description={t("orgs.members.inviteMembersGetStarted")}
+                />
+              )
+            }
+          />
+        )}
+      </div>
+    </>
   );
 }
 
 export default function OrgMembers() {
   const t = useT();
   return (
-    <ErrorBoundary
-      fallback={
-        <Page>
-          <div className="flex items-center justify-center h-full">
-            <div className="text-sm text-muted-foreground">
-              {t("orgs.members.failedLoadMembers")}
-            </div>
-          </div>
-        </Page>
+    <SettingsGroupPage
+      group="members"
+      className="gap-6"
+      errorFallback={
+        <div className="text-sm text-muted-foreground">
+          {t("orgs.members.failedLoadMembers")}
+        </div>
       }
     >
-      <Suspense
-        fallback={
-          <Page>
-            <div className="flex items-center justify-center h-full">
-              <Loading01
-                size={32}
-                className="animate-spin text-muted-foreground"
-              />
-            </div>
-          </Page>
-        }
-      >
-        <OrgMembersContent />
-      </Suspense>
-    </ErrorBoundary>
+      <OrgMembersContent />
+    </SettingsGroupPage>
   );
 }

--- a/apps/web/src/routes/orgs/settings/roles.tsx
+++ b/apps/web/src/routes/orgs/settings/roles.tsx
@@ -50,7 +50,10 @@ import {
   type RoleEditorTarget,
 } from "@/views/settings/org-role-detail.tsx";
 import { RequirePrivileged } from "@/components/require-privileged";
-import { SettingsSubnav } from "@/components/settings/settings-subnav";
+import {
+  SettingsContentSkeleton,
+  SettingsGroupPage,
+} from "@/components/settings/settings-group-page";
 
 const BUILTIN_ROLE_KEYS = [
   { role: "owner", labelKey: "settings.roles.roleOwner" },
@@ -318,53 +321,46 @@ function RolesPageContent() {
   }
 
   return (
-    <Page>
-      <Page.Content>
-        <Page.Body>
-          <div className="flex flex-col gap-6">
-            <SettingsSubnav group="members" />
-            <div className="flex flex-wrap items-center justify-between gap-3">
-              <SearchInput
-                value={search}
-                onChange={setSearch}
-                placeholder={t("settings.roles.searchPlaceholder")}
-                className="w-full md:w-[375px]"
-                onKeyDown={(e) => {
-                  if (e.key === "Escape") {
-                    setSearch("");
-                    (e.target as HTMLInputElement).blur();
-                  }
-                }}
-              />
-              <Button onClick={() => setActiveRole("new")}>
-                <Plus size={16} />
-                {t("settings.roles.createRole")}
-              </Button>
-            </div>
-            <CollectionTableWrapper
-              columns={columns}
-              data={allRows}
-              isLoading={false}
-              onRowClick={handleRowClick}
-              emptyState={
-                search ? (
-                  <EmptyState
-                    title={t("settings.roles.noRolesFound")}
-                    description={t("settings.roles.noRolesMatchSearch", {
-                      search,
-                    })}
-                  />
-                ) : (
-                  <EmptyState
-                    title={t("settings.roles.noRoles")}
-                    description={t("settings.roles.createRoleGetStarted")}
-                  />
-                )
-              }
+    <SettingsGroupPage group="members" className="gap-6">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <SearchInput
+          value={search}
+          onChange={setSearch}
+          placeholder={t("settings.roles.searchPlaceholder")}
+          className="w-full md:w-[375px]"
+          onKeyDown={(e) => {
+            if (e.key === "Escape") {
+              setSearch("");
+              (e.target as HTMLInputElement).blur();
+            }
+          }}
+        />
+        <Button onClick={() => setActiveRole("new")}>
+          <Plus size={16} />
+          {t("settings.roles.createRole")}
+        </Button>
+      </div>
+      <CollectionTableWrapper
+        columns={columns}
+        data={allRows}
+        isLoading={false}
+        onRowClick={handleRowClick}
+        emptyState={
+          search ? (
+            <EmptyState
+              title={t("settings.roles.noRolesFound")}
+              description={t("settings.roles.noRolesMatchSearch", {
+                search,
+              })}
             />
-          </div>
-        </Page.Body>
-      </Page.Content>
+          ) : (
+            <EmptyState
+              title={t("settings.roles.noRoles")}
+              description={t("settings.roles.createRoleGetStarted")}
+            />
+          )
+        }
+      />
 
       <AlertDialog
         open={roleToDelete !== null}
@@ -396,12 +392,15 @@ function RolesPageContent() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-    </Page>
+    </SettingsGroupPage>
   );
 }
 
 function RolesPage() {
   const t = useT();
+  const { role: roleParam } = useSearch({ strict: false }) as { role?: string };
+
+  // The role editor is full-bleed with its own heading — only the list gets the group chrome.
   return (
     <ErrorBoundary
       fallback={
@@ -416,14 +415,20 @@ function RolesPage() {
     >
       <Suspense
         fallback={
-          <Page>
-            <div className="flex items-center justify-center h-full">
-              <Loading01
-                size={32}
-                className="animate-spin text-muted-foreground"
-              />
-            </div>
-          </Page>
+          roleParam ? (
+            <Page>
+              <div className="flex items-center justify-center h-full">
+                <Loading01
+                  size={32}
+                  className="animate-spin text-muted-foreground"
+                />
+              </div>
+            </Page>
+          ) : (
+            <SettingsGroupPage group="members" className="gap-6">
+              <SettingsContentSkeleton />
+            </SettingsGroupPage>
+          )
         }
       >
         <RolesPageContent />

--- a/apps/web/src/views/settings/ai-providers/index.tsx
+++ b/apps/web/src/views/settings/ai-providers/index.tsx
@@ -1,10 +1,7 @@
 import { Suspense, useState } from "react";
 import { AlertCircle } from "@untitledui/icons";
-import { Page } from "@/components/page";
 import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
-import { SettingsPage } from "@/components/settings/settings-section";
-import { SettingsSubnav } from "@/components/settings/settings-subnav";
-import { ErrorBoundary } from "@/components/error-boundary";
+import { SettingsGroupPage } from "@/components/settings/settings-group-page";
 import {
   useAiProviderKeys,
   useAiProviders,
@@ -85,25 +82,15 @@ function OrgAiProvidersContent() {
 
 export function OrgAiProvidersPage() {
   return (
-    <Page>
-      <Page.Content>
-        <Page.Body>
-          <SettingsPage>
-            <SettingsSubnav group="billing" />
-            <ErrorBoundary
-              fallback={({ error }) => (
-                <ErrorFallback
-                  error={error ?? new Error("Failed to load AI providers")}
-                />
-              )}
-            >
-              <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-                <OrgAiProvidersContent />
-              </Suspense>
-            </ErrorBoundary>
-          </SettingsPage>
-        </Page.Body>
-      </Page.Content>
-    </Page>
+    <SettingsGroupPage
+      group="billing"
+      errorFallback={({ error }) => (
+        <ErrorFallback
+          error={error ?? new Error("Failed to load AI providers")}
+        />
+      )}
+    >
+      <OrgAiProvidersContent />
+    </SettingsGroupPage>
   );
 }

--- a/apps/web/src/views/settings/api-keys.tsx
+++ b/apps/web/src/views/settings/api-keys.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useState } from "react";
+import { useState } from "react";
 import { AlertCircle, Copy01, Key01, Plus, Trash01 } from "@untitledui/icons";
 import { toast } from "sonner";
 import { Button } from "@decocms/ui/components/button.tsx";
@@ -22,10 +22,6 @@ import {
 } from "@decocms/ui/components/dialog.tsx";
 import { Input } from "@decocms/ui/components/input.tsx";
 import { Label } from "@decocms/ui/components/label.tsx";
-import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
-import { ErrorBoundary } from "@/components/error-boundary";
-import { Page } from "@/components/page";
-import { SettingsPage } from "@/components/settings/settings-section";
 import { useT } from "@/i18n/use-t.ts";
 import {
   type ApiKey,
@@ -34,7 +30,7 @@ import {
   useCreateApiKey,
   useDeleteApiKey,
 } from "@/hooks/use-api-keys";
-import { SettingsSubnav } from "@/components/settings/settings-subnav";
+import { SettingsGroupPage } from "@/components/settings/settings-group-page";
 
 function ErrorFallback({ error }: { error: Error }) {
   const t = useT();
@@ -356,25 +352,13 @@ function ApiKeysContent() {
 
 export function OrgApiKeysPage() {
   return (
-    <Page>
-      <Page.Content>
-        <Page.Body>
-          <SettingsPage>
-            <SettingsSubnav group="connect" />
-            <ErrorBoundary
-              fallback={({ error }) => (
-                <ErrorFallback
-                  error={error ?? new Error("Failed to load API keys")}
-                />
-              )}
-            >
-              <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-                <ApiKeysContent />
-              </Suspense>
-            </ErrorBoundary>
-          </SettingsPage>
-        </Page.Body>
-      </Page.Content>
-    </Page>
+    <SettingsGroupPage
+      group="connect"
+      errorFallback={({ error }) => (
+        <ErrorFallback error={error ?? new Error("Failed to load API keys")} />
+      )}
+    >
+      <ApiKeysContent />
+    </SettingsGroupPage>
   );
 }

--- a/apps/web/src/views/settings/buckets.tsx
+++ b/apps/web/src/views/settings/buckets.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useState } from "react";
+import { useState } from "react";
 import { AlertCircle, HardDrive, Plus, Trash01 } from "@untitledui/icons";
 import { toast } from "sonner";
 import { Button } from "@decocms/ui/components/button.tsx";
@@ -30,19 +30,15 @@ import {
   SelectValue,
 } from "@decocms/ui/components/select.tsx";
 import { Switch } from "@decocms/ui/components/switch.tsx";
-import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
 import { Textarea } from "@decocms/ui/components/textarea.tsx";
 import { useT } from "@/i18n/use-t.ts";
-import { ErrorBoundary } from "@/components/error-boundary";
-import { Page } from "@/components/page";
-import { SettingsPage } from "@/components/settings/settings-section";
 import {
   type FileConfigInfo,
   useCreateFileConfig,
   useDeleteFileConfig,
   useFileConfigs,
 } from "@/hooks/use-file-configs";
-import { SettingsSubnav } from "@/components/settings/settings-subnav";
+import { SettingsGroupPage } from "@/components/settings/settings-group-page";
 
 /**
  * MCP tool errors arrive as Error messages like
@@ -641,28 +637,18 @@ function FilesContent() {
 export function OrgBucketsPage() {
   const t = useT();
   return (
-    <Page>
-      <Page.Content>
-        <Page.Body>
-          <SettingsPage>
-            <SettingsSubnav group="storage" />
-            <ErrorBoundary
-              fallback={({ error }) => (
-                <ErrorFallback
-                  error={
-                    error ??
-                    new Error(t("settings.buckets.failedToLoadConfigsFallback"))
-                  }
-                />
-              )}
-            >
-              <Suspense fallback={<Skeleton className="h-32 w-full" />}>
-                <FilesContent />
-              </Suspense>
-            </ErrorBoundary>
-          </SettingsPage>
-        </Page.Body>
-      </Page.Content>
-    </Page>
+    <SettingsGroupPage
+      group="storage"
+      errorFallback={({ error }) => (
+        <ErrorFallback
+          error={
+            error ??
+            new Error(t("settings.buckets.failedToLoadConfigsFallback"))
+          }
+        />
+      )}
+    >
+      <FilesContent />
+    </SettingsGroupPage>
   );
 }

--- a/apps/web/src/views/settings/infra-billing.tsx
+++ b/apps/web/src/views/settings/infra-billing.tsx
@@ -36,18 +36,14 @@ import {
   TableHeader,
   TableRow,
 } from "@decocms/ui/components/table.tsx";
-import { Page } from "@/components/page";
-import {
-  SettingsPage,
-  SettingsSection,
-} from "@/components/settings/settings-section";
+import { SettingsSection } from "@/components/settings/settings-section";
 import { useT } from "@/i18n/use-t.ts";
 import {
   useInfraBilling,
   useInfraBillingPortal,
   useOwnedSites,
 } from "@/hooks/use-infra-billing";
-import { SettingsSubnav } from "@/components/settings/settings-subnav";
+import { SettingsGroupPage } from "@/components/settings/settings-group-page";
 
 type UsageRow = {
   date: string;
@@ -624,15 +620,8 @@ function InvoiceStatus({ status }: { status: string }) {
 
 export function OrgInfraBillingPage() {
   return (
-    <Page>
-      <Page.Content>
-        <Page.Body>
-          <SettingsPage>
-            <SettingsSubnav group="billing" />
-            <InfraBillingContent />
-          </SettingsPage>
-        </Page.Body>
-      </Page.Content>
-    </Page>
+    <SettingsGroupPage group="billing">
+      <InfraBillingContent />
+    </SettingsGroupPage>
   );
 }

--- a/apps/web/src/views/settings/org-connect.tsx
+++ b/apps/web/src/views/settings/org-connect.tsx
@@ -19,8 +19,6 @@ import {
   LinkExternal01,
   Trash01,
 } from "@untitledui/icons";
-import { Page } from "@/components/page";
-import { SettingsPage } from "@/components/settings/settings-section";
 import {
   type ConnectClient,
   InstallSnippet,
@@ -32,7 +30,7 @@ import {
   useDeleteApiKey,
 } from "@/hooks/use-api-keys";
 import { useT } from "@/i18n/use-t.ts";
-import { SettingsSubnav } from "@/components/settings/settings-subnav";
+import { SettingsGroupPage } from "@/components/settings/settings-group-page";
 
 const KEY_NAME_PREFIX = "Connect: ";
 
@@ -234,7 +232,7 @@ function ConnectKeysList() {
   );
 }
 
-export function OrgConnectPage() {
+function OrgConnectContent() {
   const t = useT();
   const { org } = useProjectContext();
   const url = mcpUrl(org.slug);
@@ -263,94 +261,94 @@ export function OrgConnectPage() {
   const oauthMetadataUrl = `${url}/.well-known/oauth-protected-resource`;
 
   return (
-    <Page>
-      <Page.Content>
-        <Page.Body>
-          <SettingsPage>
-            <SettingsSubnav group="connect" />
+    <>
+      <Card className="p-5 gap-3">
+        <div className="flex items-start gap-3">
+          <div className="size-9 rounded-lg bg-muted/60 flex items-center justify-center text-muted-foreground shrink-0">
+            <LinkExternal01 size={18} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h2 className="text-[15px] font-medium leading-tight">
+              {t("settings.connectClients.orgUnifiedMcp")}
+            </h2>
+            <p className="text-sm text-muted-foreground mt-1 leading-snug">
+              {t("settings.connectClients.orgUnifiedMcpDescription")}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2 rounded-md border border-border bg-muted/40 px-3 py-1.5">
+          <code className="text-xs flex-1 truncate">{url}</code>
+          <CopyInline text={url} />
+        </div>
+        <details className="text-xs text-muted-foreground">
+          <summary className="cursor-pointer hover:text-foreground">
+            {t("settings.connectClients.customClientHint")}
+          </summary>
+          <div className="mt-2 space-y-1">
+            <p>{t("settings.connectClients.oauthMetadataHint")}</p>
+            <div className="flex items-center gap-2 rounded-md border border-border bg-background px-2 py-1">
+              <code className="text-[11px] flex-1 truncate">
+                {oauthMetadataUrl}
+              </code>
+              <CopyInline text={oauthMetadataUrl} />
+            </div>
+          </div>
+        </details>
+      </Card>
 
-            <Card className="p-5 gap-3">
-              <div className="flex items-start gap-3">
-                <div className="size-9 rounded-lg bg-muted/60 flex items-center justify-center text-muted-foreground shrink-0">
-                  <LinkExternal01 size={18} />
-                </div>
-                <div className="min-w-0 flex-1">
-                  <h2 className="text-[15px] font-medium leading-tight">
-                    {t("settings.connectClients.orgUnifiedMcp")}
-                  </h2>
-                  <p className="text-sm text-muted-foreground mt-1 leading-snug">
-                    {t("settings.connectClients.orgUnifiedMcpDescription")}
-                  </p>
-                </div>
-              </div>
-              <div className="flex items-center gap-2 rounded-md border border-border bg-muted/40 px-3 py-1.5">
-                <code className="text-xs flex-1 truncate">{url}</code>
-                <CopyInline text={url} />
-              </div>
-              <details className="text-xs text-muted-foreground">
-                <summary className="cursor-pointer hover:text-foreground">
-                  {t("settings.connectClients.customClientHint")}
-                </summary>
-                <div className="mt-2 space-y-1">
-                  <p>{t("settings.connectClients.oauthMetadataHint")}</p>
-                  <div className="flex items-center gap-2 rounded-md border border-border bg-background px-2 py-1">
-                    <code className="text-[11px] flex-1 truncate">
-                      {oauthMetadataUrl}
-                    </code>
-                    <CopyInline text={oauthMetadataUrl} />
-                  </div>
-                </div>
-              </details>
-            </Card>
+      <Tabs defaultValue="claude-code" variant="underline">
+        <TabsList variant="underline">
+          {CLIENTS.map((c) => (
+            <TabsTrigger key={c.id} value={c.id} variant="underline">
+              {c.label}
+            </TabsTrigger>
+          ))}
+        </TabsList>
 
-            <Tabs defaultValue="claude-code" variant="underline">
-              <TabsList variant="underline">
-                {CLIENTS.map((c) => (
-                  <TabsTrigger key={c.id} value={c.id} variant="underline">
-                    {c.label}
-                  </TabsTrigger>
-                ))}
-              </TabsList>
+        {CLIENTS.map((c) => (
+          <TabsContent key={c.id} value={c.id}>
+            <ClientPanel
+              client={c.id}
+              url={url}
+              newKey={newKeys[c.id] ?? null}
+              onGenerate={() => handleGenerate(c.id)}
+              isGenerating={
+                createKey.isPending &&
+                createKey.variables?.name?.startsWith(
+                  `${KEY_NAME_PREFIX}${c.label}`,
+                ) === true
+              }
+              onClearNewKey={() =>
+                setNewKeys((prev) => {
+                  const next = { ...prev };
+                  delete next[c.id];
+                  return next;
+                })
+              }
+            />
+          </TabsContent>
+        ))}
+      </Tabs>
 
-              {CLIENTS.map((c) => (
-                <TabsContent key={c.id} value={c.id}>
-                  <ClientPanel
-                    client={c.id}
-                    url={url}
-                    newKey={newKeys[c.id] ?? null}
-                    onGenerate={() => handleGenerate(c.id)}
-                    isGenerating={
-                      createKey.isPending &&
-                      createKey.variables?.name?.startsWith(
-                        `${KEY_NAME_PREFIX}${c.label}`,
-                      ) === true
-                    }
-                    onClearNewKey={() =>
-                      setNewKeys((prev) => {
-                        const next = { ...prev };
-                        delete next[c.id];
-                        return next;
-                      })
-                    }
-                  />
-                </TabsContent>
-              ))}
-            </Tabs>
+      <section className="flex flex-col gap-3">
+        <div className="px-4">
+          <h2 className="text-[15px] font-medium leading-tight">
+            {t("settings.connectClients.activeKeys")}
+          </h2>
+          <p className="text-sm text-muted-foreground leading-snug mt-1">
+            {t("settings.connectClients.activeKeysDescription")}
+          </p>
+        </div>
+        <ConnectKeysList />
+      </section>
+    </>
+  );
+}
 
-            <section className="flex flex-col gap-3">
-              <div className="px-4">
-                <h2 className="text-[15px] font-medium leading-tight">
-                  {t("settings.connectClients.activeKeys")}
-                </h2>
-                <p className="text-sm text-muted-foreground leading-snug mt-1">
-                  {t("settings.connectClients.activeKeysDescription")}
-                </p>
-              </div>
-              <ConnectKeysList />
-            </section>
-          </SettingsPage>
-        </Page.Body>
-      </Page.Content>
-    </Page>
+export function OrgConnectPage() {
+  return (
+    <SettingsGroupPage group="connect">
+      <OrgConnectContent />
+    </SettingsGroupPage>
   );
 }

--- a/apps/web/src/views/settings/synced-repos.tsx
+++ b/apps/web/src/views/settings/synced-repos.tsx
@@ -32,8 +32,6 @@ import {
 } from "@decocms/ui/components/dialog.tsx";
 import { Input } from "@decocms/ui/components/input.tsx";
 import { Skeleton } from "@decocms/ui/components/skeleton.tsx";
-import { Page } from "@/components/page";
-import { SettingsPage } from "@/components/settings/settings-section";
 import { GitHubIcon } from "@/components/icons/github-icon";
 import {
   type GitHubImportPayload,
@@ -47,7 +45,7 @@ import {
   useOrgRepoSyncs,
 } from "@/hooks/use-org-repo-syncs";
 import { timeAgo } from "@/layouts/library/cards";
-import { SettingsSubnav } from "@/components/settings/settings-subnav";
+import { SettingsGroupPage } from "@/components/settings/settings-group-page";
 
 /** Suggest a volume name from the repo name (server re-validates). */
 function volumeNameFor(repoName: string): string {
@@ -316,15 +314,8 @@ function SyncedReposContent() {
 
 export function OrgSyncedReposPage() {
   return (
-    <Page>
-      <Page.Content>
-        <Page.Body>
-          <SettingsPage>
-            <SettingsSubnav group="storage" />
-            <SyncedReposContent />
-          </SettingsPage>
-        </Page.Body>
-      </Page.Content>
-    </Page>
+    <SettingsGroupPage group="storage">
+      <SyncedReposContent />
+    </SettingsGroupPage>
   );
 }

--- a/packages/e2e/tests/settings-navigation.spec.ts
+++ b/packages/e2e/tests/settings-navigation.spec.ts
@@ -11,6 +11,7 @@ import { expect, test } from "../fixtures/test";
 
 const SIDEBAR = '[data-slot="sidebar"]';
 const SUBNAV = '[data-slot="settings-subnav"]';
+const HEADING = '[data-slot="settings-heading"]';
 
 test.describe("settings sidebar", () => {
   test("advanced rows stay collapsed until asked for", async ({
@@ -91,5 +92,36 @@ test.describe("settings tabs", () => {
       );
       await expect(row).toHaveAttribute("data-active", "true");
     }
+  });
+
+  test("the heading and tabs stay put while the next tab loads", async ({
+    authedPage,
+  }) => {
+    const { page, orgSlug } = authedPage;
+    await page.goto(`/${orgSlug}/settings/synced-repos`);
+
+    const tabs = page.locator(SUBNAV);
+    await expect(tabs.getByRole("link", { name: "Buckets" })).toBeVisible();
+
+    // Hold the Buckets tab's fetch open so the assertions below land while it
+    // is still loading — the whole page used to blank out at this moment.
+    await page.route("**/api/*/mcp", async (route) => {
+      if (route.request().postData()?.includes("FILE_CONFIG_LIST")) {
+        await new Promise((resolve) => setTimeout(resolve, 3000));
+      }
+      await route.continue();
+    });
+
+    await tabs.getByRole("link", { name: "Buckets" }).click();
+
+    await expect(page.getByTestId("settings-content-loading")).toBeVisible();
+    await expect(page.locator(HEADING)).toContainText("Storage");
+    await expect(
+      tabs.getByRole("link", { name: "Synced repos" }),
+    ).toBeVisible();
+
+    await expect(page.getByTestId("settings-content-loading")).toHaveCount(0, {
+      timeout: 15_000,
+    });
   });
 });


### PR DESCRIPTION
## Summary

Switching tabs on a tabbed settings screen (Billing, Members, Connect, Storage) flashed a full-screen spinner over the whole page — the heading and the tab strip disappeared along with the content.

**Root cause is two boundaries, not one:**

1. TanStack wraps **every route match** in its own `<Suspense fallback={pendingComponent}>` (`Match.tsx` → `ResolvedSuspenseBoundary`), and `router.tsx` sets a global `defaultPendingComponent: SplashScreen` — a `min-h-screen` centered spinner. So *anything* that suspends inside a settings page (the lazy route chunk on the first click of a tab, or a suspense query) replaces the entire route subtree. The page-local `<Suspense>` boundaries some pages already had never got a chance for the chunk case, because the chunk suspends before the component renders at all.
2. Members and Roles put their own `<Suspense>` **above** the subnav, so `useMembers()` blanked the chrome even once the chunk was cached.

## Changes

New `apps/web/src/components/settings/settings-group-page.tsx` owns both halves:

- **`SettingsGroupPage`** — the shared shell for tabbed settings screens. Renders `Page → Page.Content → Page.Body → SettingsPage` with the heading + tab strip *above* an `ErrorBoundary`/`Suspense` pair, so page data only ever swaps the content region for a skeleton. Neither hook behind the tab strip suspends (`useCapabilities`, `useOwnedSites` are plain `useQuery`), so the chrome is safe outside the boundary — and safe to render from inside a fallback.
- **`settingsGroupPendingComponent(group)`** — route-level `pendingComponent`, wired onto all 9 tabbed routes in `router.tsx`. Overrides the global `SplashScreen` so a cold chunk load paints the same chrome + skeleton.

All 9 grouped pages now go through it: `connect`/`api-keys`, `members`/`roles`, `billing`/`ai-providers`/`infra-billing`, `buckets`/`synced-repos`. Net −87 lines (each page dropped its own `Page`/`SettingsPage`/`Suspense`/`ErrorBoundary` scaffolding).

Roles keeps a plain spinner when `?role=` is set — the role editor is a full-bleed screen with its own heading and shouldn't get the tab strip; that branch is decided from the URL, which never suspends.

Untabbed settings pages (General, Secrets, Store, Monitor, Tasks) are unchanged — no chrome to preserve.

## Affected areas

`/$org/settings/{connect,api-keys,members,roles,billing,ai-providers,infra-billing,buckets,synced-repos}`

## Behavior change worth flagging

On the Members page, `JoinRequestsSection` used to render *above* the "Members" heading; it's now the first item under the tab strip. Happy to add a slot above the subnav if the original placement was deliberate.

## Testing

- `bun run --cwd=apps/web check` — clean
- `bun run lint` — no new findings
- `bunx knip` — clean
- `bun run fmt` — clean

Not exercised in a browser: no dev server was up in this worktree and booting the stack needs an `.env` plus a seeded org. Worth a manual pass clicking through each tab group (including a hard reload so the chunks are cold) before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the settings heading and tab strip visible while a tab loads. Previously, any suspense replaced the entire page with a full-screen spinner; now only the content area shows a skeleton.

- Introduces `SettingsGroupPage` to render the heading and tab strip above an `ErrorBoundary`/`Suspense` pair so only the content region swaps during data load.
- Adds `settingsGroupPendingComponent(group)` on tabbed routes to override the global `SplashScreen`, keeping the same chrome + skeleton during cold chunk loads.
- Applies the shared shell to `connect`/`api-keys`, `members`/`roles`, `billing`/`ai-providers`/`infra-billing`, `buckets`/`synced-repos`. Untabbed settings pages are unchanged.
- Roles: when `?role=` is set, keep a centered spinner (full-bleed editor without tabs).
- Members: `JoinRequestsSection` now renders under the tab strip.
- E2E: adds a test that holds the Buckets fetch and asserts the heading and tabs remain visible; adds `data-slot="settings-heading"` and `data-testid="settings-content-loading"` for assertions.

<sup>Written for commit 9717e6e2174a0ac520242a75c04a345af26d7af8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

