### PR TITLE
refactor(i18n): remove dead settings.subnav.planUsage key

### DIFF
--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -15,7 +15,6 @@ export const settings = {
   "settings.nav.advanced": "Advanced",
   "settings.subnav.ariaLabel": "Settings sections",
   "settings.subnav.clients": "Clients",
-  "settings.subnav.planUsage": "Plan & usage",
   "settings.subnav.infrastructure": "Infrastructure",
   "settings.nav.tasks": "Board",
   "settings.jira.sectionTitle": "Jira integration",

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -17,7 +17,6 @@ export const settings = {
   "settings.nav.advanced": "Avançado",
   "settings.subnav.ariaLabel": "Seções de configurações",
   "settings.subnav.clients": "Clientes",
-  "settings.subnav.planUsage": "Plano e uso",
   "settings.subnav.infrastructure": "Infraestrutura",
   "settings.nav.tasks": "Quadro",
   "settings.jira.sectionTitle": "Integração com o Jira",


### PR DESCRIPTION
Follows #6329, which merged the standalone "Plan & usage" settings tab into the AI Providers page and deleted the `plan` tab entry from `SETTINGS_TAB_GROUPS` (`settings-tab-groups.ts`). That was the only consumer of the `settings.subnav.planUsage` translation key, which #6329 left behind in both `en/settings.ts` and `pt-br/settings.ts`.

A dead i18n key is harmless at runtime but it's dead weight a translator or future reader has no way to know is unused — `en/index.ts` derives `TranslationKey` from these dictionaries, so it stays "valid" forever even with zero call sites.

**Change**: delete the `settings.subnav.planUsage` entry from both `apps/web/src/i18n/en/settings.ts` and `apps/web/src/i18n/pt-br/settings.ts`. -2 / +0.

Confirmed dead: `grep -rn "planUsage" apps/web/src` returns zero hits after the change (and zero non-dictionary hits before it).

A reviewer can confirm with the same grep, plus `cd apps/web && bunx tsc --noEmit` (the `en`/`pt-br` dictionaries must stay in `satisfies Record<keyof typeof enDomain, string>` lockstep, so a stray reference would fail to compile).

Locally ran: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the dead i18n key `settings.subnav.planUsage` from the en and pt-br settings dictionaries after the "Plan & usage" tab merged into the AI Providers page. No runtime behavior changes; this reduces unused translation surface for translators.

- Deleted from `apps/web/src/i18n/en/settings.ts` and `apps/web/src/i18n/pt-br/settings.ts` (−2 lines).
- Verify with: grep for `planUsage` shows no call sites; `cd apps/web && bunx tsc --noEmit` stays clean.

<sup>Written for commit c223be5bda10da92eb9a7b79594ea906bbeefb5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

