### PR TITLE
fix(main-panel-tabs): fall back instead of crashing on an unknown system tab id

### DIFF
--- a/apps/web/src/layouts/main-panel-tabs/resolve-tab-icon.test.ts
+++ b/apps/web/src/layouts/main-panel-tabs/resolve-tab-icon.test.ts
@@ -41,6 +41,16 @@ describe("resolveTabIcon", () => {
     ).toEqual({ kind: "component", Component: LayoutAlt04 });
   });
 
+  test("system tab with an id absent from SYSTEM_TAB_ICONS → fallback", () => {
+    expect(
+      resolveTabIcon({
+        tabId: "not-a-real-system-tab",
+        kind: "system",
+        connections: conns,
+      }),
+    ).toEqual({ kind: "fallback" });
+  });
+
   test("agent ext-app with connection icon URL → url kind", () => {
     expect(
       resolveTabIcon({

--- a/apps/web/src/layouts/main-panel-tabs/resolve-tab-icon.ts
+++ b/apps/web/src/layouts/main-panel-tabs/resolve-tab-icon.ts
@@ -44,6 +44,10 @@ export const SYSTEM_TAB_ICONS: Record<SystemTabId, IconComponent> = {
   files: Folder,
 };
 
+function isSystemTabId(tabId: string): tabId is SystemTabId {
+  return tabId in SYSTEM_TAB_ICONS;
+}
+
 type ConnectionLike = { id: string; icon: string | null };
 
 /**
@@ -78,8 +82,9 @@ export function resolveTabIcon(args: {
   connections: ConnectionLike[];
 }): TabIcon {
   if (args.kind === "system") {
-    const Component = SYSTEM_TAB_ICONS[args.tabId as SystemTabId];
-    return { kind: "component", Component };
+    // Unknown system tab id → fall back instead of an undefined Component.
+    if (!isSystemTabId(args.tabId)) return { kind: "fallback" };
+    return { kind: "component", Component: SYSTEM_TAB_ICONS[args.tabId] };
   }
 
   const fromExplicit = toTabIcon(args.iconUrl);


### PR DESCRIPTION
`resolveTabIcon` indexed `SYSTEM_TAB_ICONS` with `args.tabId as SystemTabId` — an unchecked cast from a plain `string`. Any future `kind: "system"` tab id pushed without a matching `SYSTEM_TAB_ICONS` entry (the two call sites in `use-main-panel-tabs.ts` build these ids dynamically off `systemTabs`/`leadingSystemTabs` arrays, not a literal-checked union) would silently resolve `Component: undefined`, which crashes at render ("Element type is invalid") when `MainPanelTabsBar` renders `<Component />` for that tab. This narrows the cast into an `in`-based type guard (`isSystemTabId`) so an id outside the known set now falls back to `{ kind: "fallback" }` instead of reaching render with an undefined component — a rename or a new tab id added later without wiring its icon becomes a visible fallback glyph, not a crash.

All current call sites already only pass known ids (verified via `grep -rn resolveTabIcon`), so this is a safety net for the next change to this file, not a fix for an active production crash.

Added a regression test: `resolveTabIcon({ tabId: "not-a-real-system-tab", kind: "system", ... })` now returns `{ kind: "fallback" }` instead of `{ kind: "component", Component: undefined }`.

Reviewer check: `bun test apps/web/src/layouts/main-panel-tabs/resolve-tab-icon.test.ts`

Locally verified: `bun run fmt`, `bunx tsc --noEmit` (apps/web), the targeted test file above, and `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Falls back to a generic icon when a system tab id is missing from `SYSTEM_TAB_ICONS`, preventing a render crash. Previously, unknown ids yielded `{ kind: "component", Component: undefined }` and crashed; now `resolveTabIcon` returns `{ kind: "fallback" }`.

- Replaces the unchecked cast with an `isSystemTabId` guard; unknown ids return fallback, known ids return the mapped component.
- Adds a regression test for an unknown system id → fallback.
- No behavior change for known ids; current call sites pass only known ids. This is a safety net for future tab additions or renames.

<sup>Written for commit 31748996e0236fae66fa23db318923492d6bdcee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6345?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

