### PR TITLE
refactor(sections-editor): resolve array-item ownership by fieldKey, not label

### DIFF
--- a/apps/web/src/components/sections-editor/fields/array-field.tsx
+++ b/apps/web/src/components/sections-editor/fields/array-field.tsx
@@ -157,6 +157,7 @@ export function ArrayField({
     items,
     itemSchema,
     openIndex,
+    arrayFieldKey,
   );
   const selectedIndex = selection?.index ?? null;
 

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -1235,7 +1235,14 @@ describe("buildArrayDrillDownBreadcrumb", () => {
       buildArrayDrillDownBreadcrumb([], "Products", "items", 0, {
         arrayKey: "items",
       }),
-    ).toEqual([{ label: "items", itemIndex: 0, arrayLabel: "Products" }]);
+    ).toEqual([
+      {
+        label: "items",
+        itemIndex: 0,
+        arrayLabel: "Products",
+        fieldKey: "items",
+      },
+    ]);
   });
 
   test("carries the array label on the item crumb when a sibling drill-down field exists", () => {
@@ -1255,7 +1262,7 @@ describe("buildArrayDrillDownBreadcrumb", () => {
         arrayKey: "images",
         hasSiblingDrillDownFields: false,
       }),
-    ).toEqual([{ label: "Item 1", itemIndex: 0 }]);
+    ).toEqual([{ label: "Item 1", itemIndex: 0, fieldKey: "images" }]);
   });
 
   test("never yields a standalone array-list navigation stop", () => {
@@ -1279,7 +1286,12 @@ describe("buildArrayDrillDownBreadcrumb", () => {
         itemLabelFromSchema: true,
       }),
     ).toEqual([
-      { label: "cat > 1", itemIndex: 0, arrayLabel: "Selected Facets" },
+      {
+        label: "cat > 1",
+        itemIndex: 0,
+        arrayLabel: "Selected Facets",
+        fieldKey: "selectedFacets",
+      },
     ]);
   });
 
@@ -1332,7 +1344,7 @@ describe("sibling array disambiguation (regression)", () => {
       hasSiblingDrillDownFields: true,
     });
     expect(trail).toEqual([
-      { label: "Item 1", itemIndex: 0, arrayLabel: "Logos" },
+      { label: "Item 1", itemIndex: 0, arrayLabel: "Logos", fieldKey: "logos" },
     ]);
     expect(
       resolveActiveFieldKey(
@@ -1352,7 +1364,9 @@ describe("sibling array disambiguation (regression)", () => {
       arrayKey: "cards",
       hasSiblingDrillDownFields: false,
     });
-    expect(trail).toEqual([{ label: "Men's", itemIndex: 0 }]);
+    expect(trail).toEqual([
+      { label: "Men's", itemIndex: 0, fieldKey: "cards" },
+    ]);
     expect(
       resolveActiveFieldKey(
         ["cards"],
@@ -1361,6 +1375,83 @@ describe("sibling array disambiguation (regression)", () => {
         trail,
       ),
     ).toBe("cards");
+  });
+});
+
+describe("structural fieldKey resolution", () => {
+  const itemSchema = {
+    type: "object",
+    properties: { src: { type: "string" } },
+  } as SchemaProperty;
+  // Two sibling arrays sharing the SAME title AND identical item labels: neither the array label nor the item label can disambiguate — only the recorded fieldKey can.
+  const properties = {
+    a: { title: "Items", type: "array", items: itemSchema },
+    b: { title: "Items", type: "array", items: itemSchema },
+  } as Record<string, SchemaProperty>;
+  const objValue = { a: [{ src: "x" }], b: [{ src: "x" }] };
+
+  test("resolves the drilled array by fieldKey when title AND item label both collide", () => {
+    const trail = buildArrayDrillDownBreadcrumb([], "Items", "Item 1", 0, {
+      arrayKey: "b",
+      hasSiblingDrillDownFields: true,
+    });
+    expect(
+      resolveActiveFieldKey(
+        Object.keys(properties),
+        properties,
+        objValue,
+        trail,
+      ),
+    ).toBe("b");
+  });
+
+  test("a legacy crumb without fieldKey can't disambiguate and picks the first sibling", () => {
+    const legacyTrail: Crumb[] = [
+      { label: "Item 1", itemIndex: 0, arrayLabel: "Items" },
+    ];
+    expect(
+      resolveActiveFieldKey(
+        Object.keys(properties),
+        properties,
+        objValue,
+        legacyTrail,
+      ),
+    ).toBe("a");
+  });
+
+  test("resolveArrayItemSelection pins by index via fieldKey despite a churned label", () => {
+    const items = [{ name: "First" }, { name: "Second" }];
+    const schema = {
+      type: "object",
+      properties: { name: { type: "string" } },
+    } as SchemaProperty;
+    const crumb: Crumb = {
+      label: "STALE — being typed",
+      itemIndex: 1,
+      fieldKey: "cards",
+    };
+    const sel = resolveArrayItemSelection(
+      "Cards",
+      [crumb],
+      items,
+      schema,
+      null,
+      "cards",
+    );
+    expect(sel?.index).toBe(1);
+  });
+
+  test("resolveArrayItemSelection denies a sibling whose key differs from the crumb's fieldKey", () => {
+    const items = [{ name: "First" }, { name: "Second" }];
+    const schema = {
+      type: "object",
+      properties: { name: { type: "string" } },
+    } as SchemaProperty;
+    // Index 1 is in range and the label matches, but the crumb belongs to `cards`, not this array.
+    const crumb: Crumb = { label: "Second", itemIndex: 1, fieldKey: "cards" };
+    expect(
+      resolveArrayItemSelection("Other", [crumb], items, schema, null, "other"),
+    ).toBeNull();
   });
 });
 

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -24,9 +24,15 @@ import { unwrapBlockReference } from "./unwrap-section";
  * "array list only" navigation stop the user would have to click back through —
  * the array's list is already shown inline in its parent form.
  */
-export type Crumb =
-  | string
-  | { label: string; itemIndex: number; arrayLabel?: string };
+interface ItemCrumb {
+  label: string;
+  itemIndex: number;
+  arrayLabel?: string;
+  /** The array's own property key, recorded at drill-in for exact ownership resolution (no label guessing). */
+  fieldKey?: string;
+}
+
+export type Crumb = string | ItemCrumb;
 
 /** The human-visible text of a crumb (the label part of an item crumb). */
 export function crumbLabel(crumb: Crumb): string {
@@ -34,15 +40,18 @@ export function crumbLabel(crumb: Crumb): string {
 }
 
 /** Whether a crumb addresses an array item (carries an `itemIndex`). */
-function isItemCrumb(
-  crumb: Crumb,
-): crumb is { label: string; itemIndex: number; arrayLabel?: string } {
+function isItemCrumb(crumb: Crumb): crumb is ItemCrumb {
   return typeof crumb === "object";
 }
 
 /** The disambiguating array label riding on an item crumb, if any. */
 function crumbArrayLabel(crumb: Crumb): string | undefined {
   return isItemCrumb(crumb) ? crumb.arrayLabel : undefined;
+}
+
+/** The array's own property key recorded on an item crumb at drill-in, if any. */
+function crumbFieldKey(crumb: Crumb): string | undefined {
+  return isItemCrumb(crumb) ? crumb.fieldKey : undefined;
 }
 
 /**
@@ -176,13 +185,12 @@ export function buildArrayDrillDownBreadcrumb(
   ) {
     return breadcrumbPath;
   }
-  const itemCrumb = arrayCrumbNeededForDisambiguation(
-    arrayLabel,
-    itemLabel,
-    opts,
-  )
-    ? { label: itemLabel, itemIndex, arrayLabel }
-    : { label: itemLabel, itemIndex };
+  const itemCrumb: ItemCrumb = { label: itemLabel, itemIndex };
+  if (arrayCrumbNeededForDisambiguation(arrayLabel, itemLabel, opts)) {
+    itemCrumb.arrayLabel = arrayLabel;
+  }
+  // Record the array's own key so resolution can match by key, not by label.
+  if (opts?.arrayKey) itemCrumb.fieldKey = opts.arrayKey;
   return [...breadcrumbPath, itemCrumb];
 }
 
@@ -543,6 +551,14 @@ function resolveActiveFieldKeyInScope(
   if (breadcrumbPath.length === 0) return null;
   const head = crumbLabel(breadcrumbPath[0]!);
 
+  // Structural fast-path: an item crumb records the array's own key at drill-in, so a drill-down field it names resolves by exact key match — no label/title/arrayLabel guessing. Label matching below stays the fallback for older/context crumbs.
+  for (const key of keys) {
+    const schema = properties[key];
+    if (!schema || !isArrayDrillDownField(schema, objValue[key])) continue;
+    if (breadcrumbPath.some((crumb) => crumbFieldKey(crumb) === key))
+      return key;
+  }
+
   for (const key of keys) {
     const schema = properties[key];
     if (!schema || !isArrayDrillDownField(schema, objValue[key])) continue;
@@ -844,8 +860,16 @@ function findItemIndexForCrumb(
   itemSchema: SchemaProperty | undefined,
   crumb: Crumb,
   preferredIndex?: number | null,
+  ownerKey?: string,
 ): number {
   if (!isItemCrumb(crumb)) return -1;
+  // Structural ownership: the array's own key claims the item by index alone, so a churned/duplicate label can't strand it or snap it to a colliding sibling.
+  if (crumb.fieldKey != null && ownerKey != null) {
+    if (crumb.fieldKey !== ownerKey) return -1;
+    if (crumb.itemIndex >= 0 && crumb.itemIndex < items.length) {
+      return crumb.itemIndex;
+    }
+  }
   const labels = getArrayItemDisplayLabels(items, itemSchema);
   // Exact pin: the index addresses the item; the label confirms this array owns it.
   if (
@@ -905,6 +929,7 @@ export function resolveArrayItemSelection(
   items: unknown[],
   itemSchema: SchemaProperty | undefined,
   preferredIndex?: number | null,
+  ownerKey?: string,
 ): { index: number; innerPath: Crumb[]; crumbIndex: number } | null {
   if (breadcrumbPath.length === 0) return null;
 
@@ -915,6 +940,7 @@ export function resolveArrayItemSelection(
       itemSchema,
       crumb,
       preferredIndex,
+      ownerKey,
     );
     if (index >= 0) {
       return { index, innerPath: breadcrumbPath.slice(pi + 1), crumbIndex: pi };
@@ -931,6 +957,7 @@ export function resolveArrayItemSelection(
       itemSchema,
       itemCrumb,
       preferredIndex,
+      ownerKey,
     );
     if (index >= 0) {
       return {


### PR DESCRIPTION
## Why do these breadcrumb bugs keep coming back?

Auditing the history, there are **~20 PRs** patching `sections-editor` breadcrumb/ownership over a few months (#6255, #6250, #5885, #5862, #5359, #5426, #4662, #4482, #4479, #4065, …, most recently #6337). It's not bad luck — it's one structural flaw wearing new clothes.

The breadcrumb is a trail of **display labels**, and the resolver reverse-engineers *"which field/section owns this item"* by matching those labels against schema + data. That inverse problem is lossy and breaks on three recurring axes:

1. **A new label source** — every way an item can get a name is a new way the match fails: `__resolveType` (#6250), inline-union (#5359), `@titleBy` (#6337). There's always a next one.
2. **Label collisions** — same-titled siblings ($ref the same interface), duplicated items, "Item N" fallbacks.
3. **Missing/stale labels** — the resolver often scans raw data without the schema, and labels churn while you type.

The entire disambiguation machinery (`arrayLabel` folding, `siblingFieldLabel`, strong/loose match, ancestor crumbs, and the schema-resolution heuristic I added in #6337) exists only to patch this guessing.

## This PR — first structural step (strangler-fig)

Make the crumb carry the **structural key**, not just a label, and have the resolver **prefer a direct key lookup** — keeping all label matching as a fallback so nothing regresses.

- `Crumb` item crumbs gain an optional `fieldKey`, set at drill-in from the `arrayKey` the producer (`ArrayField`) already has.
- `resolveActiveFieldKey`: a drill-down field named by a crumb's `fieldKey` wins by **exact key match** before any label/title/arrayLabel guessing.
- `findItemIndexForCrumb` / `resolveArrayItemSelection`: when the crumb and the array both know the key, ownership is decided by key and the item is pinned **by index alone** — a churned/duplicate label can no longer strand it or snap it to a colliding sibling (the "editing a duplicate's title jumps to the original" family).

Because it's additive, crumbs minted before this and context/string crumbs behave exactly as before.

## What it fixes now vs. later

- **Now (this PR):** array/item ownership — the largest recurring cluster — becomes deterministic. New regression tests cover cases label matching *can't* resolve (two sibling arrays with identical `@title` **and** identical item labels; a churned label pinned by index; a wrong-owner crumb denied).
- **Follow-up (Phase 2):** widen ancestor/section **string** crumbs to carry `fieldKey` too. That makes block-ref *section* ownership deterministic and lets us delete the schema-resolution heuristic from #6337. Left out here to keep the type change (string → object) reviewable on its own.

## Testing

- `bun test apps/web/src/components/sections-editor/` → **697 pass**.
- 4 new tests in `schema-form-breadcrumb.test.ts`; existing crumb-shape assertions updated to include `fieldKey` (the intended shape change).
- apps/web typecheck, `bun run fmt`, `bun run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make array-item ownership deterministic in the sections editor by recording and resolving on the structural field key, not display labels. Previously the resolver matched labels to guess the owning array; now item crumbs include a `fieldKey` and resolution prefers an exact key match, with label matching kept as a fallback for legacy crumbs.

- `Crumb` item crumbs gain optional `fieldKey`, set by `buildArrayDrillDownBreadcrumb` from the array’s `arrayKey` (plumbed from `ArrayField`).
- `resolveActiveFieldKey` fast-paths to a direct key match when any crumb names the array’s key; otherwise falls back to existing label/title logic.
- `findItemIndexForCrumb` and `resolveArrayItemSelection` now accept the array’s owner key; when it matches the crumb’s `fieldKey`, selection pins by index alone and rejects mismatched siblings.
- Backward compatible: old crumbs and context/string crumbs still resolve via labels; no UI or usage changes required.
- Tests updated and added to cover identical array/item labels and churned labels; only expected crumb-shape assertions changed to include `fieldKey`.

<sup>Written for commit b3405b9d486337c2bf8aed78806adfe0f963762b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6346?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

