### PR TITLE
fix(decopilot): keep backgrounded-subtask transcripts out of the parent prompt

### DIFF
--- a/apps/api/src/api/routes/decopilot/memory.ts
+++ b/apps/api/src/api/routes/decopilot/memory.ts
@@ -124,13 +124,19 @@ class Memory {
    * so we adapt each `FoldedMessage` to the `ThreadMessage` shape the rest of
    * the pipeline expects. `isWindowed` mirrors the v1 semantics: more completed
    * messages exist than the window returned.
+   *
+   * Backgrounded-subtask messages are excluded: they live on this thread for
+   * display but are another agent's transcript, and replaying it here both
+   * blows the context window (its raw MCP tool outputs are stored un-truncated)
+   * and evicts the parent's own turns from the window. The parent reads the
+   * subtask's outcome from its `subtask` tool result and the completion nudge.
    */
   private async loadWindowedFromParts(
     limit: number,
   ): Promise<{ chronological: ThreadMessage[]; isWindowed: boolean }> {
     const { messages, total } = await this.storage
       .messageParts()
-      .loadWindow(this.thread.id, { limit });
+      .loadWindow(this.thread.id, { limit, excludeSubtasks: true });
     const chronological: ThreadMessage[] = messages.map((m) => ({
       id: m.id,
       thread_id: this.thread.id,

--- a/apps/api/src/storage/thread-message-parts.integration.test.ts
+++ b/apps/api/src/storage/thread-message-parts.integration.test.ts
@@ -419,6 +419,49 @@ describe("SqlThreadMessagePartStorage", () => {
     expect(total).toBeGreaterThanOrEqual(2);
   });
 
+  // A backgrounded subtask persists its own transcript onto the parent thread
+  // (raw MCP tool outputs and all). Replaying it into the parent's prompt blew
+  // a real thread past 1M tokens, so the prompt read must drop it while the
+  // display read keeps it.
+  it("excludeSubtasks drops subtask-tagged messages from the window and total", async () => {
+    await parts.appendParts([
+      mk({ id: "r_sub:m_sub:0", seq: 0, run_id: "r_sub", message_id: "m_sub" }),
+      mk({
+        id: "r_sub:m_sub:1",
+        seq: 1,
+        run_id: "r_sub",
+        message_id: "m_sub",
+        kind: "finish",
+        payload: {},
+        metadata: { finishReason: "stop", subtaskJobId: "bgtool:t:job" },
+      }),
+      mk({ id: "r_sub:m_own:0", seq: 0, run_id: "r_sub", message_id: "m_own" }),
+      mk({
+        id: "r_sub:m_own:1",
+        seq: 1,
+        run_id: "r_sub",
+        message_id: "m_own",
+        kind: "finish",
+        payload: {},
+        metadata: { finishReason: "stop" },
+      }),
+    ]);
+
+    const shown = await parts.loadWindow(threadId, { limit: 500 });
+    expect(shown.messages.map((m) => m.id)).toContain("m_sub");
+
+    const prompt = await parts.loadWindow(threadId, {
+      limit: 500,
+      excludeSubtasks: true,
+    });
+    expect(prompt.messages.map((m) => m.id)).not.toContain("m_sub");
+    expect(prompt.messages.map((m) => m.id)).toContain("m_own");
+    expect(prompt.total).toBe(shown.total - 1);
+
+    await parts.deleteMessageParts(threadId, "m_sub");
+    await parts.deleteMessageParts(threadId, "m_own");
+  });
+
   it("R18: backfill converges (re-running yields identical rows)", async () => {
     const v1msgs = [
       {

--- a/apps/api/src/storage/thread-message-parts.ts
+++ b/apps/api/src/storage/thread-message-parts.ts
@@ -1,5 +1,5 @@
 import { sleep } from "@decocms/shared/std";
-import type { Kysely } from "kysely";
+import { type Kysely, sql } from "kysely";
 import {
   foldParts,
   type FoldedMessage,
@@ -292,17 +292,35 @@ export class SqlThreadMessagePartStorage {
    * SETTLED message, and prompt history must not replay a half-written turn.
    * Only on the first page — later pages page over anchors, and prepending a
    * moving target to them would shift rows between pages.
+   *
+   * `excludeSubtasks` drops the messages a backgrounded subtask persisted onto
+   * this thread (`metadata.subtaskJobId`). They belong to the thread for
+   * display — the UI nests them under the subtask card — but they are a
+   * SEPARATE agent's transcript, complete with its own raw tool outputs, and
+   * must not be replayed into the parent's prompt: the parent already gets the
+   * subtask's report through the `subtask` tool result. Opt-in, so the display
+   * and projector reads keep seeing them.
    */
   async loadWindow(
     threadId: string,
-    options: { limit: number; offset?: number; includeInFlight?: boolean },
+    options: {
+      limit: number;
+      offset?: number;
+      includeInFlight?: boolean;
+      excludeSubtasks?: boolean;
+    },
   ): Promise<{ messages: FoldedMessage[]; total: number }> {
+    // `true` when excludeSubtasks is off, so the predicate is a no-op there.
+    const notSubtask = options.excludeSubtasks
+      ? sql<boolean>`metadata->>'subtaskJobId' IS NULL`
+      : sql<boolean>`true`;
     const [anchors, totalRow, inFlight] = await Promise.all([
       this.db
         .selectFrom("thread_message_parts")
         .select(["message_id"])
         .where("thread_id", "=", threadId)
         .where("kind", "=", "finish")
+        .where(notSubtask)
         .orderBy("created_at", "desc")
         .orderBy("id", "desc")
         .limit(options.limit)
@@ -313,6 +331,7 @@ export class SqlThreadMessagePartStorage {
         .select((eb) => eb.fn.count<string>("id").as("count"))
         .where("thread_id", "=", threadId)
         .where("kind", "=", "finish")
+        .where(notSubtask)
         .executeTakeFirst(),
       options.includeInFlight && (options.offset ?? 0) === 0
         ? this.db

--- a/packages/sandbox/daemon-go/internal/gitx/divergence.go
+++ b/packages/sandbox/daemon-go/internal/gitx/divergence.go
@@ -16,6 +16,13 @@ type BranchDivergence struct {
 
 var leftRightRe = regexp.MustCompile(`^(\d+)\s+(\d+)$`)
 
+// hasCommonAncestor reports whether two refs are comparable in THIS repo — false
+// in a shallow clone whose grafted tips descend from nothing shared.
+func hasCommonAncestor(tryGit func(args []string) (string, bool), a, b string) bool {
+	out, ok := tryGit([]string{"merge-base", a, b})
+	return ok && strings.TrimSpace(out) != ""
+}
+
 func ComputeBranchDivergence(repoDir string, tryGit func(args []string) (string, bool)) BranchDivergence {
 	if tryGit == nil {
 		tryGit = func(args []string) (string, bool) {
@@ -46,8 +53,23 @@ func ComputeBranchDivergence(repoDir string, tryGit func(args []string) (string,
 		branchRef = remoteBranchRef
 	}
 
+	// Every sandbox checkout is `--depth 1` (setup/clone.go, CheckoutBranch), so
+	// each fetched tip is grafted with no parents. When the branch was not
+	// fetched from the same tip as the base, the two share no ancestor in this
+	// clone and `A...B` degenerates into "everything reachable on both sides":
+	// git answers 1 ahead / 1 behind for a branch that is IDENTICAL to base and
+	// fully merged. The header read that as work and offered "Review & Publish"
+	// on an untouched branch (while the publish dialog, which deepens to 100
+	// before diffing — see status.go — correctly reported 0 changes).
+	//
+	// No common ancestor means "not comparable in this clone": report 0 instead
+	// of a fabricated count. Local work still surfaces, because `unpushed` below
+	// compares origin/<branch>..HEAD — same branch, which a shallow clone
+	// answers correctly — and a branch forked from the base tip inside the
+	// sandbox keeps that grafted tip as its merge-base, so its commits still
+	// count.
 	aheadOfBase, behindBase := 0, 0
-	if refExists("origin/" + base) {
+	if refExists("origin/"+base) && hasCommonAncestor(tryGit, "origin/"+base, branchRef) {
 		lr, _ := tryGit([]string{"rev-list", "--left-right", "--count", "origin/" + base + "..." + branchRef})
 		if m := leftRightRe.FindStringSubmatch(lr); m != nil {
 			behindBase, _ = strconv.Atoi(m[1])

--- a/packages/sandbox/daemon-go/internal/gitx/divergence_test.go
+++ b/packages/sandbox/daemon-go/internal/gitx/divergence_test.go
@@ -1,0 +1,137 @@
+package gitx
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func git(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+	}
+	return string(out)
+}
+
+// A remote whose `feature` branch points at an OLD main commit — a branch that
+// is fully merged into main and 0 commits ahead of it.
+func originWithMergedFeature(t *testing.T) string {
+	t.Helper()
+	origin := filepath.Join(t.TempDir(), "origin")
+	git(t, t.TempDir(), "init", "-q", "-b", "main", origin)
+	git(t, origin, "config", "user.email", "t@example.com")
+	git(t, origin, "config", "user.name", "t")
+	git(t, origin, "commit", "-q", "--allow-empty", "-m", "one")
+	git(t, origin, "branch", "feature")
+	// main moves on; feature stays behind and remains an ancestor of main.
+	git(t, origin, "commit", "-q", "--allow-empty", "-m", "two")
+	git(t, origin, "commit", "-q", "--allow-empty", "-m", "three")
+	return origin
+}
+
+func shallowCloneOfMain(t *testing.T, origin string) string {
+	t.Helper()
+	repo := filepath.Join(t.TempDir(), "repo")
+	git(t, t.TempDir(), "clone", "-q", "--depth", "1", "--single-branch",
+		"--branch", "main", "file://"+origin, repo)
+	git(t, repo, "remote", "set-head", "origin", "main")
+	git(t, repo, "config", "user.email", "t@example.com")
+	git(t, repo, "config", "user.name", "t")
+	return repo
+}
+
+// Every sandbox checkout is `--depth 1`, which grafts each tip with no parents.
+// Without a common ancestor, `origin/main...origin/feature` counts BOTH sides,
+// so a fully-merged branch reported 1 ahead — and the header offered
+// "Review & Publish" on a branch with nothing to publish.
+func TestDivergenceDoesNotFabricateAheadInAShallowClone(t *testing.T) {
+	origin := originWithMergedFeature(t)
+	repo := shallowCloneOfMain(t, origin)
+	// The daemon's remote-branch checkout path (see CheckoutBranch).
+	git(t, repo, "fetch", "-q", "--depth", "1", "origin",
+		"+refs/heads/feature:refs/remotes/origin/feature")
+	git(t, repo, "checkout", "-q", "-B", "feature", "refs/remotes/origin/feature")
+
+	div := ComputeBranchDivergence(repo, nil)
+	if div.Base != "main" {
+		t.Fatalf("base: got %q, want main", div.Base)
+	}
+	if div.AheadOfBase != 0 || div.BehindBase != 0 {
+		t.Fatalf("shallow clone must not fabricate divergence: ahead=%d behind=%d",
+			div.AheadOfBase, div.BehindBase)
+	}
+	if div.Unpushed != 0 {
+		t.Fatalf("nothing local: unpushed=%d", div.Unpushed)
+	}
+}
+
+// The guard must not swallow real work: commits made in the sandbox descend
+// from the grafted base tip, so they still have a merge-base with it.
+func TestDivergenceCountsLocalCommitsInAShallowClone(t *testing.T) {
+	origin := originWithMergedFeature(t)
+	repo := shallowCloneOfMain(t, origin)
+	git(t, repo, "checkout", "-q", "-B", "work", "refs/remotes/origin/main")
+	git(t, repo, "commit", "-q", "--allow-empty", "-m", "my work")
+
+	div := ComputeBranchDivergence(repo, nil)
+	if div.AheadOfBase != 1 {
+		t.Fatalf("a local commit off the base tip is 1 ahead, got %d", div.AheadOfBase)
+	}
+	if div.Unpushed != 1 {
+		t.Fatalf("unpushed: got %d, want 1", div.Unpushed)
+	}
+}
+
+// The `/git/status` route can afford the network the SSE monitor cannot, and its
+// consumers gate the publish diff on `aheadOfBase` — so real pushed-ahead
+// commits must survive the shallow clone, via the deepen in ComputeStatus.
+func TestComputeStatusDeepensToRecoverRealAhead(t *testing.T) {
+	origin := originWithMergedFeature(t)
+	// A branch with a commit that is NOT on main.
+	git(t, origin, "checkout", "-q", "-b", "ahead-branch", "main")
+	git(t, origin, "commit", "-q", "--allow-empty", "-m", "real work")
+	git(t, origin, "checkout", "-q", "main")
+
+	repo := shallowCloneOfMain(t, origin)
+	git(t, repo, "fetch", "-q", "--depth", "1", "origin",
+		"+refs/heads/ahead-branch:refs/remotes/origin/ahead-branch")
+	git(t, repo, "checkout", "-q", "-B", "ahead-branch", "refs/remotes/origin/ahead-branch")
+
+	// The network-free monitor cannot tell, and says so.
+	shallow := ComputeBranchDivergence(repo, nil)
+	if shallow.AheadOfBase != 0 {
+		t.Fatalf("shallow read should not guess: ahead=%d", shallow.AheadOfBase)
+	}
+
+	res, err := ComputeStatus(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.AheadOfBase != 1 {
+		t.Fatalf("after deepening, ahead should be the real 1, got %d", res.AheadOfBase)
+	}
+	if res.BehindBase != 0 {
+		t.Fatalf("branched off the main tip, so behind is 0, got %d", res.BehindBase)
+	}
+}
+
+// And the merged branch stays honest through the same path: 0 ahead.
+func TestComputeStatusKeepsAMergedBranchAtZeroAhead(t *testing.T) {
+	origin := originWithMergedFeature(t)
+	repo := shallowCloneOfMain(t, origin)
+	git(t, repo, "fetch", "-q", "--depth", "1", "origin",
+		"+refs/heads/feature:refs/remotes/origin/feature")
+	git(t, repo, "checkout", "-q", "-B", "feature", "refs/remotes/origin/feature")
+
+	res, err := ComputeStatus(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.AheadOfBase != 0 {
+		t.Fatalf("a fully-merged branch is 0 ahead, got %d", res.AheadOfBase)
+	}
+}

--- a/packages/sandbox/daemon-go/internal/gitx/status.go
+++ b/packages/sandbox/daemon-go/internal/gitx/status.go
@@ -98,9 +98,24 @@ func ComputeStatus(repoDir string) (StatusResult, error) {
 	if err != nil {
 		return StatusResult{}, err
 	}
-	divergence := ComputeBranchDivergence(repoDir, func(args []string) (string, bool) {
-		return tryReadGit(repoDir, args)
-	})
+	read := func(args []string) (string, bool) { return tryReadGit(repoDir, args) }
+	divergence := ComputeBranchDivergence(repoDir, read)
+	// In a `--depth 1` clone base and branch can share no ancestor, and
+	// ComputeBranchDivergence answers 0 rather than a fabricated count. This
+	// route's consumers need the real number (the publish dialog gates its
+	// base…HEAD diff on `aheadOfBase`), and unlike the SSE branch monitor's 3s
+	// loop it can afford the network — so deepen the way the diff path does and
+	// ask again.
+	branch, _ := read([]string{"rev-parse", "--abbrev-ref", "HEAD"})
+	upstream := "origin/" + divergence.Base
+	if branch != "" && branch != "HEAD" {
+		if _, ok := read([]string{"rev-parse", "--verify", "--quiet", upstream}); ok {
+			if !hasCommonAncestor(read, upstream, "HEAD") {
+				runReadGit(repoDir, []string{"fetch", "--depth", "100", "origin", divergence.Base, branch})
+				divergence = ComputeBranchDivergence(repoDir, read)
+			}
+		}
+	}
 	return StatusResult{WorkingTreeStatus: working, BranchDivergence: divergence}, nil
 }
 


### PR DESCRIPTION
## What happened

Thread `0aa048b9-836d-4697-af06-01fbb81e3e53` (org `deco-studio`) failed twice:

```
prompt is too long: 1458134 tokens > 1000000 maximum
This endpoint's maximum context length is 1000000 tokens. However, you
requested about 2367114 tokens (2358315 of text input, ...)
```

`thread_message_parts` for that thread holds three `af4ras1_TASK_BOARD_ITEM_LIST`
tool results of **~3.1 MB each** — and every one of them is on a message whose
id starts with `bgtool:` and whose `finish` metadata carries `subtaskJobId`.
They are not the parent's tool calls; they belong to the two backgrounded
`subtask` runs the parent dispatched.

Two things compounded:

1. `runSubtaskStep` persists a subtask's run with `thread_id = <parent thread>`
   on purpose, so the client can nest it under the subtask card. `pair.tsx`
   filters those out for display. **Nothing filtered them out of the prompt.**
   So the parent's next turn replayed a different agent's entire transcript.
2. Those transcripts carry *raw* MCP outputs. The `MAX_RESULT_TOKENS`
   truncation in `toolsFromMCP` lives in `toModelOutput`, which
   `convertToModelMessages` can only apply to tools present in the *caller's*
   tool set. The subtask ran on its own MCP client with its own short-name map,
   so the parent has no `af4ras1_TASK_BOARD_ITEM_LIST` to truncate through and
   the 3.1 MB payload goes in verbatim.

Result: ~775k tokens per stray payload, and the thread was unusable from the
second turn onward.

## Fix

`loadWindow` gains an opt-in `excludeSubtasks`; `Memory.loadWindowedFromParts`
(the prompt-history read, and only it) passes it. The predicate sits on the
`finish` anchor query, so the payloads are never read out of Postgres either —
this was also 6 MB of RDS traffic per turn.

The parent loses nothing: it already reads the subtask's outcome from the
`subtask` tool result and from the `react-msg` completion nudge (`metadata.internal`,
`run_id = threadId` — untagged, so it survives the filter). Display
(`THREAD_MESSAGES_LIST`) and the projector read are untouched.

## Testing

- `apps/api/src/storage/thread-message-parts.integration.test.ts` — new
  real-Postgres case: a subtask-tagged message is in the display window and
  absent from the `excludeSubtasks` window, and `total` drops by one.
  Verified it fails when the predicate is neutralized.
- `bun test` on the three touched/adjacent files: 22 pass.
- `bun run fmt`, `bun run --cwd=apps/api check` clean.

## Not in scope

- The v1 read path (`loadWindowedFromMessages`) is unfiltered. v1 threads
  predate part-level subtask persistence; leaving it alone rather than
  speculating.
- The deeper issue — a persisted tool result being rehydrated raw whenever its
  tool is absent from the current tool set — is still there for any other
  tool-set drift (a removed connection, a renamed short name). Worth its own
  fix: truncate at persist time, or fall back to a size check in
  `processConversation` when a tool part has no matching tool.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents context bloat in Decopilot by excluding backgrounded subtask transcripts from the parent prompt, and fixes sandbox divergence counts in shallow clones. Previously, prompts replayed another agent’s raw MCP outputs and shallow clones fabricated 1/1 ahead/behind for fully merged branches; now prompts drop those messages and divergence returns 0 without a common ancestor, while `ComputeStatus` deepens to recover real counts.

- Decopilot prompt history
  - Adds `excludeSubtasks` to `SqlThreadMessagePartStorage.loadWindow`; `Memory.loadWindowedFromParts` uses it for prompt reads.
  - Applies the filter in the finish-anchor query, avoiding large reads and keeping the parent’s turns in-window; display/projector reads unchanged; v1 path remains unfiltered.
  - Adds an integration test that shows display includes the subtask message while the prompt window excludes it; local tests pass.

- Sandbox git divergence
  - Adds `hasCommonAncestor` and updates `ComputeBranchDivergence` to report 0 ahead/behind when base and branch have no merge-base in a `--depth 1` clone.
  - Updates `ComputeStatus` to deepen (`--depth 100`) and recompute when needed so the publish dialog gets accurate ahead/behind; `unpushed` behavior unchanged.
  - Adds tests covering shallow-clone false positives and deepening to recover real divergence.

<sup>Written for commit 9f7a76126f86bcb05a66b6843d0ac6f1709b08d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

