### PR TITLE
feat(preview): inject the CMS hover overlay in Fast Preview

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -647,6 +647,12 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     !productionOrigin ||
     registeredPreviewOrigin === productionOrigin;
 
+  // Origin of the in-iframe editor bridge — sandbox proxy, or the site's own origin under Fast Preview.
+  const editorBridgeOrigin =
+    display.mode === "production"
+      ? productionOrigin
+      : previewOrigin(previewUrl);
+
   const iframeSrc =
     display.mode === "sandbox"
       ? withVariantMatcherOverride(
@@ -908,7 +914,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
 
   // oxlint-disable-next-line ban-use-effect/ban-use-effect — DOM event subscription
   useEffect(() => {
-    const allowedOrigin = previewOrigin(previewUrl);
+    const allowedOrigin = editorBridgeOrigin;
     if (!allowedOrigin) return;
     const handler = (e: MessageEvent) => {
       if (e.origin !== allowedOrigin) return;
@@ -926,7 +932,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     };
     window.addEventListener("message", handler);
     return () => window.removeEventListener("message", handler);
-  }, [previewUrl]);
+  }, [editorBridgeOrigin]);
 
   // Close pages dropdown on outside click
   // oxlint-disable-next-line ban-use-effect/ban-use-effect — DOM event subscription for outside-click dismiss
@@ -964,10 +970,13 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
 
   const injectCmsEditor = () => {
     const win = previewIframeRef.current?.contentWindow;
-    const origin = previewOrigin(previewUrl);
+    const origin = editorBridgeOrigin;
     if (!win || !origin) return;
+    // Sandbox speaks the daemon's `visual-editor::activate`; a Fast Preview production frame speaks the deco framework's `editor::inject`.
     win.postMessage(
-      { type: "visual-editor::activate", script: CMS_EDITOR_SCRIPT },
+      display.mode === "production"
+        ? { type: "editor::inject", args: { script: CMS_EDITOR_SCRIPT } }
+        : { type: "visual-editor::activate", script: CMS_EDITOR_SCRIPT },
       origin,
     );
     // Ordered after activate, so the script's listener is registered by the
@@ -986,7 +995,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
 
   const deactivateCmsEditor = () => {
     const win = previewIframeRef.current?.contentWindow;
-    const origin = previewOrigin(previewUrl);
+    const origin = editorBridgeOrigin;
     if (!win || !origin) return;
     win.postMessage({ type: "cms-editor::deactivate" }, origin);
   };
@@ -2029,10 +2038,17 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
                         // The page finished loading — always clear the navigation
                         // indicator first, before any of the early returns below.
                         endNavigation();
-                        // The production fallback is a view-only, cross-origin frame:
-                        // skip the sandbox-only load handling (analytics, path sync,
-                        // editor injection) — none of it applies to it.
-                        if (display.mode !== "sandbox") return;
+                        // Production (Fast Preview) frame is cross-origin: skip the sandbox-only load handling, but the site's real pages still take the CMS overlay via the framework's `editor::inject` listener.
+                        if (display.mode !== "sandbox") {
+                          if (
+                            display.mode === "production" &&
+                            !display.showWakingPill &&
+                            editingMode === "blocks"
+                          ) {
+                            injectCmsEditor();
+                          }
+                          return;
+                        }
                         // This is the VM dev-server preview (sandboxed running app),
                         // NOT an MCP app. MCP apps render via <MCPAppRenderer/>.
                         track("vm_preview_loaded", {


### PR DESCRIPTION
## Summary

With the CMS open over a **Fast Preview**, the hover-to-select section overlay (the purple section outline + label) never activated. This turns it on.

**Why it was broken:** Fast Preview renders the site's *own real pages* against an unpublished draft (not the sandbox dev server), and the editor-injection path in `preview.tsx` early-returned for any non-sandbox frame — so the overlay script was never posted to the production iframe.

**Why no framework change is needed:** the deco framework already ships an `editor::inject` message listener on every real page (the minified `LiveControls`, delivered as a `data:text/javascript,…` script — verified on `farmrio.deco.site`, deco@1.204.0). It does `eval(data.args.script)`. So we can drive the exact same overlay against the production frame; the only missing piece was Studio sending it there.

## Changes (`apps/web/.../sandbox/preview/preview.tsx`)

- **`editorBridgeOrigin`** — the origin to inject to / accept click-backs from: the sandbox proxy, or the site's own origin under Fast Preview.
- **`injectCmsEditor`** posts the framework's shape `{ type: "editor::inject", args: { script: CMS_EDITOR_SCRIPT } }` to a production frame, and the sandbox daemon's `{ type: "visual-editor::activate", script }` otherwise.
- The **message handler** (`cms-editor::section-clicked` click-back) and **`deactivateCmsEditor`** use `editorBridgeOrigin` too.
- **`onLoad`** injects the CMS overlay on a Fast Preview draft frame (production mode, draft renderable, `blocks` mode) instead of bailing.

The overlay itself (`CMS_EDITOR_SCRIPT`) is unchanged — it only needs the eval hook plus the `section[data-manifest-key]` markers, both already present on real pages.

## Testing

- `tsc --noEmit` (apps/web) ✅
- `oxlint` ✅ / `biome` fmt ✅
- **Manual (to confirm live):** open the CMS over a Fast Preview and check the hover overlay paints over sections and click-to-select works. Couldn't run the full app in this environment; the DOM contract (`data-manifest-key`) and the `editor::inject` listener are both confirmed present on the production render.

## Notes

- Supersedes the framework-side approach in deco-cx/deco#1228 (adding the listener to real draft renders) — unnecessary since prod already has it. That PR can be closed; its only extra value was origin-gating the `eval`, which is a separate hardening.
- Visual mode stays sandbox-only (it's still force-downgraded off production); this PR only enables the CMS/blocks hover overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the CMS hover-to-select overlay in Fast Preview by injecting the existing editor script into the production frame. Previously, the overlay never activated in Fast Preview (non-sandbox); now it uses the framework’s `editor::inject` on real pages. Visual mode stays sandbox-only.

- Uses a new `editorBridgeOrigin` to target postMessage and click-backs: `productionOrigin` in Fast Preview, `previewOrigin(previewUrl)` in sandbox.
- Sends `editor::inject` with `{ args: { script: CMS_EDITOR_SCRIPT } }` to production frames; keeps `visual-editor::activate` for sandbox.
- Updates message handler and deactivation to use `editorBridgeOrigin`; continues handling `cms-editor::section-clicked`.
- Injects on iframe load when mode is `production`, editing mode is `blocks`, and no waking pill is shown.
- Overlay script is unchanged and relies on the existing eval hook and `section[data-manifest-key]` markers on real pages. No migrations required.

<sup>Written for commit dd3108d35cd36f2ecbd69923e4a57e18458172d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6350?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

