### PR TITLE
fix(runtime): accept IPv6 loopback redirect_uri in OAuth client registration

### DIFF
--- a/packages/runtime/src/oauth.test.ts
+++ b/packages/runtime/src/oauth.test.ts
@@ -495,3 +495,33 @@ describe("OAuth stateSecret sealing", () => {
     expect(await errorOf(response)).toBe("invalid_grant");
   });
 });
+
+describe("OAuth dynamic client registration redirect_uri validation", () => {
+  const registerRequest = (redirectUris: string[]) =>
+    new Request("https://mcp.example.com/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ redirect_uris: redirectUris }),
+    });
+
+  it("accepts an IPv6 loopback redirect_uri", async () => {
+    const handlers = createOAuthHandlers(baseConfig());
+
+    const response = await handlers.handleClientRegistration(
+      registerRequest(["http://[::1]:51234/callback"]),
+    );
+
+    expect(response.status).toBe(201);
+  });
+
+  it("rejects a non-https, non-loopback redirect_uri", async () => {
+    const handlers = createOAuthHandlers(baseConfig());
+
+    const response = await handlers.handleClientRegistration(
+      registerRequest(["http://example.com/callback"]),
+    );
+
+    expect(response.status).toBe(400);
+    expect(await errorOf(response)).toBe("invalid_redirect_uri");
+  });
+});

--- a/packages/runtime/src/oauth.ts
+++ b/packages/runtime/src/oauth.ts
@@ -1,4 +1,5 @@
 import {
+  isLoopbackHost,
   redirectUriMatchesRegistered,
   satisfiesAllowedRedirectHosts,
 } from "./redirect-uri.ts";
@@ -46,9 +47,8 @@ function isValidRedirectUri(uri: string): boolean {
     const url = new URL(uri);
     return (
       url.protocol === "https:" ||
-      url.hostname === "localhost" ||
-      url.hostname.endsWith(".localhost") ||
-      url.hostname === "127.0.0.1" ||
+      // RFC 8252 §7.3: a native client's loopback redirect is exempt from https.
+      isLoopbackHost(url.hostname) ||
       // Allow custom schemes for native apps (e.g., cursor://, vscode://)
       !url.protocol.startsWith("http")
     );


### PR DESCRIPTION
Follows #6330 hardening. #6330 introduced `isLoopbackHost()` in `redirect-uri.ts`, which correctly treats `127.0.0.1`, `[::1]`/`::1`, `localhost` and `*.localhost` as loopback per RFC 8252 §7.3, and uses it in the `/authorize` redirect_uri-match path. `isValidRedirectUri()` in `oauth.ts` — used both by `/authorize` and dynamic client registration (`/register`, RFC 7591) — was never updated to match: it only special-cased `127.0.0.1`/`localhost`/`.localhost` as a non-https exception, so a native client registering an IPv6 loopback redirect (`http://[::1]:PORT/callback`) got rejected at `/register` with `400 invalid_redirect_uri`, even though the exact same URI would later pass the `/authorize` match check via `isLoopbackHost`.

**Fix**: `isValidRedirectUri()` now delegates to the shared `isLoopbackHost()` instead of re-implementing a narrower loopback check, so both validation points agree.

**Failure scenario**: a native app (e.g. one binding an ephemeral `[::1]` port instead of `127.0.0.1`) calls dynamic client registration with that redirect_uri and gets a hard `400 invalid_redirect_uri` from `/register`, even though the identical URI is accepted everywhere else loopback URIs are checked.

**Regression test**: `oauth.test.ts` — new `describe("OAuth dynamic client registration redirect_uri validation")` asserts `handleClientRegistration` accepts `http://[::1]:51234/callback` (201) and still rejects a plain non-https, non-loopback host (400 invalid_redirect_uri).

Reviewer command: `bun test packages/runtime/src/oauth.test.ts`

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (packages/runtime), `bun test packages/runtime/src/oauth.test.ts` (28 pass), `bunx oxlint packages/runtime/src/oauth.ts packages/runtime/src/oauth.test.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts IPv6 loopback redirect_uri in OAuth dynamic client registration to match RFC 8252 and `/authorize` behavior. Previously, `/register` rejected `http://[::1]:PORT/...` with 400 invalid_redirect_uri; now `isValidRedirectUri()` uses `isLoopbackHost()`, allowing loopback (including `[::1]`) over HTTP while still rejecting non-HTTPS, non-loopback hosts and allowing custom schemes.

**Review notes**
- Replace inline host checks in `isValidRedirectUri()` with `isLoopbackHost()` for consistent loopback handling.
- Tests confirm acceptance of `http://[::1]:51234/callback` and rejection of `http://example.com/callback`.
- Run: bun test packages/runtime/src/oauth.test.ts

<sup>Written for commit e2d8305af229061db2146f838e1f93b46849411c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6351?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

