### PR TITLE
fix(sections-editor): don't snap a deleted array item onto a same-label sibling

### DIFF
--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts
@@ -1441,6 +1441,23 @@ describe("structural fieldKey resolution", () => {
     expect(sel?.index).toBe(1);
   });
 
+  test("resolveArrayItemSelection returns null for a deleted item instead of snapping to a same-label sibling", () => {
+    // Owner confirmed by fieldKey, but itemIndex 5 was deleted; item 0 merely shares the stale label.
+    const items = [{ name: "Duplicate" }];
+    const schema = {
+      type: "object",
+      properties: { name: { type: "string" } },
+    } as SchemaProperty;
+    const crumb: Crumb = {
+      label: "Duplicate",
+      itemIndex: 5,
+      fieldKey: "cards",
+    };
+    expect(
+      resolveArrayItemSelection("Cards", [crumb], items, schema, null, "cards"),
+    ).toBeNull();
+  });
+
   test("resolveArrayItemSelection denies a sibling whose key differs from the crumb's fieldKey", () => {
     const items = [{ name: "First" }, { name: "Second" }];
     const schema = {

--- a/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
+++ b/apps/web/src/components/sections-editor/schema-form-breadcrumb.ts
@@ -863,12 +863,12 @@ function findItemIndexForCrumb(
   ownerKey?: string,
 ): number {
   if (!isItemCrumb(crumb)) return -1;
-  // Structural ownership: the array's own key claims the item by index alone, so a churned/duplicate label can't strand it or snap it to a colliding sibling.
+  // Structural ownership: the array's own key claims the item by index alone (never by label match), so a deleted item returns -1 instead of falling through to snap onto an unrelated same-label sibling.
   if (crumb.fieldKey != null && ownerKey != null) {
     if (crumb.fieldKey !== ownerKey) return -1;
-    if (crumb.itemIndex >= 0 && crumb.itemIndex < items.length) {
-      return crumb.itemIndex;
-    }
+    return crumb.itemIndex >= 0 && crumb.itemIndex < items.length
+      ? crumb.itemIndex
+      : -1;
   }
   const labels = getArrayItemDisplayLabels(items, itemSchema);
   // Exact pin: the index addresses the item; the label confirms this array owns it.


### PR DESCRIPTION
Follows #6346's structural fieldKey ownership resolution for array-item breadcrumbs.

`findItemIndexForCrumb`'s new fieldKey fast-path confirms the crumb's owner array by exact key match, but only *returns* the index when `crumb.itemIndex` is still in bounds. When the item was deleted (index now out of range), the code fell through to the label-search fallback below — which has no idea ownership was already confirmed, and can match a different item in the *same* array that merely shares the stale crumb's label. That's precisely the "colliding label snaps to the wrong item" bug class #6346 set out to fix structurally, just re-opened for the specific out-of-bounds case.

Failure scenario: array `cards` has two items both currently or previously titled "Duplicate". User drills into item index 5 (fieldKey `cards`), then deletes it so the array shrinks. The crumb still says `{ fieldKey: "cards", itemIndex: 5, label: "Duplicate" }`. Since ownership is confirmed by fieldKey but the index no longer exists, resolution should report "no such item" (null) — instead it snapped onto the remaining item (index 0) that happens to share the label, silently opening/mutating an unrelated item.

Fix: once fieldKey ownership is confirmed, return -1 immediately when the index is out of range, instead of falling through to the label-based fallback.

Regression test added: `resolveArrayItemSelection returns null for a deleted item instead of snapping to a same-label sibling` in `schema-form-breadcrumb.test.ts`.

To verify: `bun test apps/web/src/components/sections-editor/schema-form-breadcrumb.test.ts` (94 pass, including the new case).

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/web, clean), `bunx oxlint` on both touched files (0 warnings/errors), and the targeted test file above. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops deleted array-item breadcrumbs from snapping to a same-label sibling in the Sections Editor. Previously, an out-of-range item index with a matching fieldKey fell back to label search and could open the wrong item; now it returns null and does not resolve to any item.

- Updates findItemIndexForCrumb to immediately return -1 when fieldKey confirms ownership but the index is out of range, avoiding the label-based fallback.
- Keeps existing behavior for in-bounds indices; label fallback still applies only when ownership is unknown.
- Adds a regression test that asserts deleted items resolve to null instead of snapping to a sibling.

<sup>Written for commit bada148acfe8e1638f2f9a7782fa8fb74054d9d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6352?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

