### PR TITLE
feat(navigation): start new orgs on the first-class navigation

### DIFF
--- a/apps/api/src/auth/index.ts
+++ b/apps/api/src/auth/index.ts
@@ -41,7 +41,7 @@ import { createEmailOtpConfig } from "./email-otp";
 import { createEmailSender, findEmailProvider } from "./email-providers";
 import { emailButton, emailParagraph, emailTemplate } from "./email-template";
 import { createMagicLinkConfig } from "./magic-link";
-import { seedOrgDb } from "./org";
+import { seedOrgDb, seedOrgDefaultFlags } from "./org";
 import { hoistOrgLogo } from "./hoist-org-logo";
 import { identifyAuthenticatedUser } from "./posthog-identify";
 import { ADMIN_ROLES } from "@decocms/shared/auth/roles";
@@ -240,6 +240,8 @@ const plugins = [
   organization({
     organizationCreation: {
       afterCreate: async (data) => {
+        // Before seedOrgDb: the client reads settings as soon as the org exists.
+        await seedOrgDefaultFlags(data.organization.id);
         await seedOrgDb(data.organization.id, data.member.userId);
       },
     },

--- a/apps/api/src/auth/org.ts
+++ b/apps/api/src/auth/org.ts
@@ -1,3 +1,4 @@
+import { NEW_ORG_DEFAULT_FLAGS } from "@decocms/shared/organization/schema";
 import {
   getWellKnownCommunityRegistryConnection,
   getWellKnownRegistryConnection,
@@ -9,6 +10,7 @@ import { getDb } from "@/database";
 import { CredentialVault } from "@/encryption/credential-vault";
 import { AIProviderKeyStorage } from "@/storage/ai-provider-keys";
 import { ConnectionStorage } from "@/storage/connection";
+import { OrganizationSettingsStorage } from "@/storage/organization-settings";
 import { Permission } from "@/storage/types";
 import { fetchToolsFromMCP } from "@/tools/connection/fetch-tools";
 import {
@@ -80,6 +82,20 @@ function getDefaultOrgMcps(organizationId: string): MCPCreationSpec[] {
       data: getWellKnownRegistryConnection(organizationId),
     },
   ];
+}
+
+/**
+ * Seed NEW_ORG_DEFAULT_FLAGS into a brand-new org's `organization_settings`.
+ * Kept out of `seedOrgDb`, whose single catch would swallow this write and mint
+ * an org on the old defaults under a misleading connection-error log.
+ */
+export async function seedOrgDefaultFlags(organizationId: string) {
+  try {
+    const storage = new OrganizationSettingsStorage(getDb().db);
+    await storage.upsert(organizationId, { flags: NEW_ORG_DEFAULT_FLAGS });
+  } catch (err) {
+    console.error("Failed to seed default organization flags:", err);
+  }
 }
 
 /**

--- a/apps/web/src/hooks/use-organization-settings.ts
+++ b/apps/web/src/hooks/use-organization-settings.ts
@@ -249,12 +249,9 @@ export function useReportsOnly(): boolean {
  * destinations (Reports / Library / Tasks) instead of chat threads, and the
  * thread list moves into a menu at the top of the chat panel.
  *
- * Defaults ON for reports-only orgs — their sidebar has no agent navigation to
- * lose, so the destination list is strictly what they need. An explicit
- * `nav_v2: false` still wins, which is why this reads the raw tri-state value
- * rather than going through `useOrgFlag`/`DEFAULT_ON_FLAGS`: that mechanism
- * only expresses a flag defaulting on for every org, not one flag's default
- * depending on another flag's value.
+ * Unset means an org created before NEW_ORG_DEFAULT_FLAGS seeded this on; those
+ * fall back to reports-only. Raw tri-state read, not `useOrgFlag`, so an explicit
+ * `false` wins and one flag's default can depend on another's.
  */
 export function useNavV2(): boolean {
   const { data } = useOrganizationSettings(

--- a/apps/web/src/i18n/en/settings.ts
+++ b/apps/web/src/i18n/en/settings.ts
@@ -453,7 +453,7 @@ export const settings = {
   "settings.navigation.updateError": "Couldn't update navigation settings",
   "settings.navigation.navV2Title": "First-class navigation",
   "settings.navigation.navV2Description":
-    "The sidebar lists destinations (Reports, Library, Tasks) instead of chats, and the chat list moves to the top of the chat panel. On by default for report organizations.",
+    "The sidebar lists destinations (Reports, Library, Tasks) instead of chats, and the chat list moves to the top of the chat panel. On by default for new organizations and report organizations.",
   "settings.orgGeneral.organization": "Organization",
   "settings.mainAgent.title": "Main agent",
   "settings.mainAgent.description":

--- a/apps/web/src/i18n/pt-br/settings.ts
+++ b/apps/web/src/i18n/pt-br/settings.ts
@@ -469,7 +469,7 @@ export const settings = {
     "Não foi possível atualizar as configurações de navegação",
   "settings.navigation.navV2Title": "Navegação de primeira classe",
   "settings.navigation.navV2Description":
-    "A barra lateral lista destinos (Relatórios, Biblioteca, Tarefas) em vez de chats, e a lista de chats vai para o topo do painel de chat. Ativada por padrão em organizações de relatório.",
+    "A barra lateral lista destinos (Relatórios, Biblioteca, Tarefas) em vez de chats, e a lista de chats vai para o topo do painel de chat. Ativada por padrão em organizações novas e em organizações de relatório.",
   "settings.orgGeneral.organization": "Organiza\u00e7\u00e3o",
   "settings.mainAgent.title": "Agente principal",
   "settings.mainAgent.description":

--- a/packages/e2e/fixtures/mcp-tools.ts
+++ b/packages/e2e/fixtures/mcp-tools.ts
@@ -130,3 +130,39 @@ export async function createHttpConnection(
   }
   return response.item;
 }
+
+/** Resolve the org id for a slug via Better Auth's organization list. */
+export async function findOrgId(
+  request: APIRequestContext,
+  orgSlug: string,
+): Promise<string> {
+  const res = await request.get("/api/auth/organization/list");
+  if (!res.ok()) throw new Error(`organization/list → HTTP ${res.status()}`);
+  const body = (await res.json()) as
+    | Array<{ id: string; slug: string }>
+    | { data?: Array<{ id: string; slug: string }> };
+  const orgs = Array.isArray(body) ? body : (body.data ?? []);
+  const org = orgs.find((o) => o.slug === orgSlug);
+  if (!org) throw new Error(`org ${orgSlug} not found in organization/list`);
+  return org.id;
+}
+
+/**
+ * Shallow-merge org boolean flags through ORGANIZATION_SETTINGS_UPDATE,
+ * resolving the org id for you. Keys passed win (explicit `false` persists);
+ * omitted keys keep their stored value.
+ *
+ * Wire contract: flag names are inlined by callers on purpose — this suite owns
+ * its contract (see ban-e2e-app-imports).
+ */
+export async function setOrgFlags(
+  request: APIRequestContext,
+  orgSlug: string,
+  flags: Record<string, boolean>,
+): Promise<void> {
+  const organizationId = await findOrgId(request, orgSlug);
+  await callSelfMcpTool(request, orgSlug, "ORGANIZATION_SETTINGS_UPDATE", {
+    organizationId,
+    flags,
+  });
+}

--- a/packages/e2e/tests/cms-publish-stages.spec.ts
+++ b/packages/e2e/tests/cms-publish-stages.spec.ts
@@ -30,7 +30,7 @@ import {
   seedStubRepo,
   uniqueOwner,
 } from "../fixtures/fast-preview";
-import { callSelfMcpTool } from "../fixtures/mcp-tools";
+import { callSelfMcpTool, setOrgFlags } from "../fixtures/mcp-tools";
 import { expect, test } from "../fixtures/test";
 
 /** Cold-Vite route compile on a loaded box; the agent shell is a lazy route. */
@@ -117,6 +117,10 @@ test.describe("fast preview publish stages", () => {
       await bodiesReleased;
       await route.continue();
     });
+
+    // The publish actions sit in the chat header only while the main panel is
+    // closed AND the org is off the first-class navigation.
+    await setOrgFlags(api, orgSlug, { nav_v2: false });
 
     await page.goto(
       `/${orgSlug}/${thread.item.id}?virtualmcpid=${project.vmcpId}`,

--- a/packages/e2e/tests/cms-publish-surface.spec.ts
+++ b/packages/e2e/tests/cms-publish-surface.spec.ts
@@ -32,7 +32,7 @@ import {
   seedStubRepo,
   uniqueOwner,
 } from "../fixtures/fast-preview";
-import { callSelfMcpTool } from "../fixtures/mcp-tools";
+import { callSelfMcpTool, setOrgFlags } from "../fixtures/mcp-tools";
 import { expect, test } from "../fixtures/test";
 
 /**
@@ -120,6 +120,10 @@ test.describe("fast preview publish surface", () => {
      * nothing", so it is pinned here where the failure stays legible.
      */
     expect(thread.item.branch).toBe(branch);
+
+    // The publish actions sit in the chat header only while the main panel is
+    // closed AND the org is off the first-class navigation.
+    await setOrgFlags(api, orgSlug, { nav_v2: false });
 
     await page.goto(
       `/${orgSlug}/${thread.item.id}?virtualmcpid=${project.vmcpId}`,

--- a/packages/e2e/tests/nav-v2.spec.ts
+++ b/packages/e2e/tests/nav-v2.spec.ts
@@ -1,19 +1,23 @@
 /**
  * E2E: the first-class navigation (`nav_v2` org flag).
  *
- * With the flag OFF the sidebar renders the chat list; with it ON the sidebar
- * renders destinations (Home, Tasks, Library) and the chat list moves into a
- * menu at the top of the chat panel. Reports is conditional: it joins the list
- * ONLY once the org actually has a Commerce Discovery report, so both the
- * absent and present cases are asserted here.
+ * ON (the seeded default for new orgs) renders destinations and moves the chat
+ * list into the chat panel's menu; OFF is the opt-out and is set up as one here.
+ * Reports joins the list only once the org has a Commerce Discovery report, so
+ * both the absent and present cases are asserted.
  *
  * Wire-contract strings (flag name, `?main=` values, labels) are inlined on
  * purpose — this suite owns its contract (see ban-e2e-app-imports).
  */
 
-import type { APIRequestContext, Page } from "@playwright/test";
+import type { Page } from "@playwright/test";
 import { z } from "zod";
-import { callSelfMcpTool, createHttpConnection } from "../fixtures/mcp-tools";
+import { connectDevDb } from "../fixtures/db";
+import {
+  callSelfMcpTool,
+  createHttpConnection,
+  findOrgId,
+} from "../fixtures/mcp-tools";
 import {
   startTestMcpServer,
   type TestMcpServer,
@@ -61,30 +65,36 @@ async function expandSidebar(page: Page, settled: string) {
   throw new Error(`sidebar never showed "${settled}"`);
 }
 
-/** Turn the flag on the way a user would: the org settings switch. */
-async function enableNavV2(page: Page, orgSlug: string): Promise<void> {
+/** Opt out the way a user would: the org settings switch, which a new org
+ *  finds already on. Persists an explicit `nav_v2: false`. */
+async function disableNavV2(page: Page, orgSlug: string): Promise<void> {
   await page.goto(`/${orgSlug}/settings/general`);
   const toggle = page.getByRole("switch", { name: /first-class navigation/i });
   await toggle.waitFor({ state: "visible", timeout: SHELL_TIMEOUT_MS });
-  await expect(toggle).not.toBeChecked();
-  await toggle.click();
   await expect(toggle).toBeChecked();
+  await toggle.click();
+  await expect(toggle).not.toBeChecked();
 }
 
-/** Resolve the org id for a slug via Better Auth's organization list. */
-async function findOrgId(
-  request: APIRequestContext,
-  orgSlug: string,
-): Promise<string> {
-  const res = await request.get("/api/auth/organization/list");
-  if (!res.ok()) throw new Error(`organization/list → HTTP ${res.status()}`);
-  const body = (await res.json()) as
-    | Array<{ id: string; slug: string }>
-    | { data?: Array<{ id: string; slug: string }> };
-  const orgs = Array.isArray(body) ? body : (body.data ?? []);
-  const org = orgs.find((o) => o.slug === orgSlug);
-  if (!org) throw new Error(`org ${orgSlug} not found in organization/list`);
-  return org.id;
+/**
+ * Drop the creation-time `nav_v2` seed so the flag reads UNSET again.
+ *
+ * Raw SQL because ORGANIZATION_SETTINGS_UPDATE shallow-merges the flags bag and
+ * has no way to remove a key — the state an org created before the seed is in
+ * is unreachable through the tool API.
+ */
+async function clearSeededNavV2(orgId: string): Promise<void> {
+  const db = await connectDevDb();
+  try {
+    await db.query(
+      `UPDATE organization_settings
+          SET flags = flags - 'nav_v2'
+        WHERE "organizationId" = $1`,
+      [orgId],
+    );
+  } finally {
+    await db.end();
+  }
 }
 
 /** A Commerce Discovery MCP that answers with one completed diagnostic. */
@@ -121,9 +131,49 @@ test.describe("first-class navigation", () => {
    *  timeout fires first and reports a misleading "element not found". */
   test.describe.configure({ timeout: 240_000 });
 
-  test("flag off keeps the chat list in the sidebar", async ({
+  test("a new org lands on the first-class navigation with nothing configured", async ({
     authedPage: { page, orgSlug },
   }) => {
+    await page.goto(`/${orgSlug}`);
+    await expandSidebar(page, "Home");
+
+    await expect(
+      page.getByRole("button", { name: "Home", exact: true }),
+    ).toBeVisible({ timeout: SHELL_TIMEOUT_MS });
+    await expect(
+      page.getByRole("button", { name: "Library", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Tasks", exact: true }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: /filter chats/i }),
+    ).toHaveCount(0);
+  });
+
+  test("the seed stores nav_v2 rather than resolving it at read time", async ({
+    authedPage: { page, orgSlug },
+  }) => {
+    const orgId = await findOrgId(page.context().request, orgSlug);
+    const db = await connectDevDb();
+    try {
+      const { rows } = await db.query<{ nav_v2: string | null }>(
+        `SELECT flags ->> 'nav_v2' AS nav_v2
+           FROM organization_settings
+          WHERE "organizationId" = $1`,
+        [orgId],
+      );
+      expect(rows).toHaveLength(1);
+      expect(rows[0]?.nav_v2).toBe("true");
+    } finally {
+      await db.end();
+    }
+  });
+
+  test("opting out from settings brings the chat list back to the sidebar", async ({
+    authedPage: { page, orgSlug },
+  }) => {
+    await disableNavV2(page, orgSlug);
     await page.goto(`/${orgSlug}`);
     await expandSidebar(page, "Filter chats");
 
@@ -138,10 +188,9 @@ test.describe("first-class navigation", () => {
     ).toBeVisible();
   });
 
-  test("flag on lists destinations and moves chats to the chat header", async ({
+  test("the first-class sidebar lists destinations and moves chats to the chat header", async ({
     authedPage: { page, orgSlug },
   }) => {
-    await enableNavV2(page, orgSlug);
     await page.goto(`/${orgSlug}`);
     await expandSidebar(page, "Home");
 
@@ -199,7 +248,6 @@ test.describe("first-class navigation", () => {
   test("Reports is hidden until the org has a report, then opens the report app", async ({
     authedPage: { page, orgSlug },
   }) => {
-    await enableNavV2(page, orgSlug);
     await page.goto(`/${orgSlug}`);
     await expandSidebar(page, "Home");
 
@@ -251,6 +299,7 @@ test.describe("first-class navigation", () => {
       organizationId: orgId,
       flags: { reports_only: true },
     });
+    await clearSeededNavV2(orgId);
 
     await page.goto(`/${orgSlug}`);
     await expandSidebar(page, "Home");
@@ -322,7 +371,6 @@ test.describe("first-class navigation", () => {
       { data: { virtual_mcp_id: agent.item.id } },
     );
 
-    await enableNavV2(page, orgSlug);
     await page.goto(
       `/${orgSlug}/${thread.item.id}?virtualmcpid=${agent.item.id}`,
     );

--- a/packages/e2e/tests/sidebar-per-group-show-more.spec.ts
+++ b/packages/e2e/tests/sidebar-per-group-show-more.spec.ts
@@ -16,7 +16,7 @@
  *   7. Assert the "Show more" button is hidden once all threads are loaded.
  */
 
-import { callSelfMcpTool } from "../fixtures/mcp-tools";
+import { callSelfMcpTool, setOrgFlags } from "../fixtures/mcp-tools";
 import { addSidebarPersonalAgentOrderInitScriptForSlug } from "../fixtures/sidebar-order";
 import { expect, test } from "../fixtures/test";
 
@@ -79,6 +79,9 @@ test.describe("Sidebar My threads Show more", () => {
       user.userId,
       [agentId],
     );
+
+    // This pager only exists in the classic sidebar.
+    await setOrgFlags(request, orgSlug, { nav_v2: false });
 
     await page.goto(`/${orgSlug}`);
     // Wait until the org home content has settled (URL confirmed, shell rendered).

--- a/packages/e2e/tests/standalone-blocks-panel.spec.ts
+++ b/packages/e2e/tests/standalone-blocks-panel.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "../fixtures/test";
-import { callSelfMcpTool, createHttpConnection } from "../fixtures/mcp-tools";
+import {
+  callSelfMcpTool,
+  createHttpConnection,
+  setOrgFlags,
+} from "../fixtures/mcp-tools";
 
 async function createClonableAgent(
   api: Parameters<typeof createHttpConnection>[0],
@@ -87,6 +91,8 @@ test.describe("Blocks preview mode", () => {
       page.context().request,
       orgSlug,
     );
+    // The View dropdown drops its Settings option under the new nav.
+    await setOrgFlags(page.context().request, orgSlug, { nav_v2: false });
     await page.goto(
       `/${orgSlug}/${threadId}?virtualmcpid=${agentId}&sidepanel=0&main=settings`,
     );

--- a/packages/shared/src/organization/schema.test.ts
+++ b/packages/shared/src/organization/schema.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "bun:test";
-import { DEFAULT_ON_FLAGS, orgFlagEnabled } from "./schema";
+import {
+  DEFAULT_ON_FLAGS,
+  NEW_ORG_DEFAULT_FLAGS,
+  OrgFlagsSchema,
+  orgFlagEnabled,
+} from "./schema";
 
 describe("orgFlagEnabled", () => {
   it("default-on flags read as enabled unless stored exactly false", () => {
@@ -35,5 +40,28 @@ describe("orgFlagEnabled", () => {
       orgFlagEnabled({ qa_agent_enabled: "true" }, "qa_agent_enabled"),
     ).toBe(true);
     expect(orgFlagEnabled({ auto_merge: "true" }, "auto_merge")).toBe(false);
+  });
+});
+
+describe("NEW_ORG_DEFAULT_FLAGS", () => {
+  it("only contains keys the flags schema declares", () => {
+    // The seed writes through storage, bypassing the tool's .strict() parse.
+    expect(
+      OrgFlagsSchema.strict().safeParse(NEW_ORG_DEFAULT_FLAGS).success,
+    ).toBe(true);
+  });
+
+  it("starts new orgs on the first-class navigation", () => {
+    expect(NEW_ORG_DEFAULT_FLAGS.nav_v2).toBe(true);
+  });
+
+  it("is a stored-value mechanism, not a read-time default", () => {
+    // DEFAULT_ON_FLAGS is read-time: it would flip existing orgs too.
+    for (const flag of Object.keys(NEW_ORG_DEFAULT_FLAGS)) {
+      expect(
+        DEFAULT_ON_FLAGS.has(flag as keyof typeof NEW_ORG_DEFAULT_FLAGS),
+      ).toBe(false);
+    }
+    expect(orgFlagEnabled({}, "nav_v2")).toBe(false);
   });
 });

--- a/packages/shared/src/organization/schema.ts
+++ b/packages/shared/src/organization/schema.ts
@@ -141,7 +141,7 @@ export const OrgFlagsSchema = z.object({
     .boolean()
     .optional()
     .describe(
-      "First-class navigation: the sidebar lists destinations (Reports, Library, Tasks) instead of chat threads, and the thread list moves into a menu at the top of the chat panel. Always on for reports_only orgs.",
+      "First-class navigation: the sidebar lists destinations (Reports, Library, Tasks) instead of chat threads, and the thread list moves into a menu at the top of the chat panel. Seeded on for newly created orgs (see NEW_ORG_DEFAULT_FLAGS) and defaults on for reports_only orgs; an explicit false wins over both.",
     ),
   qa_agent_enabled: z
     .boolean()
@@ -190,6 +190,15 @@ export const DEFAULT_ON_FLAGS: ReadonlySet<keyof OrgFlags> = new Set([
   "qa_agent_enabled",
   "code_reviewer_enabled",
 ]);
+
+/**
+ * Flags STORED in a new org's bag at creation (`seedOrgDefaultFlags`, apps/api).
+ * Unlike {@link DEFAULT_ON_FLAGS} — a read-time rule that retroactively changes
+ * every org — this only reaches orgs created after it ships.
+ */
+export const NEW_ORG_DEFAULT_FLAGS: OrgFlags = {
+  nav_v2: true,
+};
 
 /**
  * Resolve one org flag to its effective boolean. Honors {@link DEFAULT_ON_FLAGS}


### PR DESCRIPTION
New organizations are seeded `nav_v2: true` at creation, so they land on the first-class navigation (sidebar lists destinations; chat list moves into the chat panel's menu). **Existing orgs are untouched** and opt in from Settings.

## Why not `DEFAULT_ON_FLAGS`

The obvious change — adding `nav_v2` to `DEFAULT_ON_FLAGS` — would have been a **silent no-op**. That set is only consulted by `orgFlagEnabled`, and `useNavV2` deliberately reads the raw tri-state value so an explicit `false` can beat the `reports_only` fallback:

```ts
(s) => s.flags?.nav_v2 ?? s.flags?.reports_only ?? false
```

The schema would have declared the flag on while every screen kept rendering the old nav. It is also a *read-time* rule with no notion of "new", so even wired up correctly it would have flipped **every existing org** on deploy.

## What this does instead

The default is **stored data**, not a read-time rule:

| File | Change |
|---|---|
| `packages/shared/.../schema.ts` | `NEW_ORG_DEFAULT_FLAGS = { nav_v2: true }`, documented as explicitly *not* `DEFAULT_ON_FLAGS` |
| `apps/api/src/auth/org.ts` | `seedOrgDefaultFlags()` — its own try/catch |
| `apps/api/src/auth/index.ts` | Called in `afterCreate`, **before** `seedOrgDb` |
| web hook doc, en/pt-br copy | "unset" now means "created before this default" |

Two details that are load-bearing:

- **Its own try/catch, before `seedOrgDb`.** That function wraps its whole body in one catch that logs *"Error creating default MCP connections"*, so folding the write in would let a flaky MCP fetch silently mint orgs on the old nav under a misleading log line.
- **No read-before-write race.** Better Auth awaits `afterCreate` before returning the create response, so no client can read settings before the seed lands.

## Testing

- **Unit** (3 new, `schema.test.ts`): the seed parses against `OrgFlagsSchema.strict()` — it writes through storage directly, bypassing the `.strict()` parse `ORGANIZATION_SETTINGS_UPDATE` applies — and stays out of `DEFAULT_ON_FLAGS`.
- **E2E** (`nav-v2.spec.ts`): **inverted** the flag-off test into an opt-out test; added a new-org default test plus a DB-level assertion that the seed persisted; **repaired** the `reports_only` inheritance test, which would otherwise have passed while testing nothing (raw SQL is required to clear the key — `ORGANIZATION_SETTINGS_UPDATE` shallow-merges and cannot delete one).
- **Pinned** `sidebar-per-group-show-more` and `standalone-blocks-panel`'s mobile test to `nav_v2: false` via a new `setOrgFlags` fixture helper; both assert surfaces that only exist off the new nav.

Ran and passing: `bun run check` (14 workspaces), `bun run lint` (0 errors), `knip` (clean), unit tests.

## ⚠️ Before merge

**The e2e specs were never executed.** They type-check and enumerate correctly, but a local run was not possible (another worktree owned the dev ports, embedded Postgres would not start, Docker down). More importantly, this flips the default shell for **every `authedPage` spec** — I only touched the four whose breakage was confirmed by reading, so **a full-suite run is the real gate**, not just the specs in this diff.

Separately: `packages/shared/src/tools/tool-io.ts` is stale on `main` (`TASK_BOARD_ITEM_LIST` is missing `repos: string[]`). Regenerating produces a zero diff for *this* change, so I left the unrelated drift alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
New organizations now start with the first-class navigation (`nav_v2: true`), moving chats into the chat panel and listing destinations in the sidebar. Existing organizations are unchanged and can opt in from Settings.

- Persist the default at org creation via `NEW_ORG_DEFAULT_FLAGS` and `seedOrgDefaultFlags` (Better Auth `afterCreate`, before `seedOrgDb`); separate try/catch avoids `seedOrgDb` masking failures.
- Keep `useNavV2` as a raw tri-state read; do not add `nav_v2` to `DEFAULT_ON_FLAGS` to avoid retroactively flipping existing orgs and to honor explicit `false`.
- E2E: default-on tests added/updated; DB assertion verifies seed storage; new helpers `findOrgId` and `setOrgFlags`; raw SQL helper clears the seed for the `reports_only` inheritance test; classic-only specs pinned to `nav_v2: false`, including the Fast Preview publish specs (`cms-publish-stages` and `cms-publish-surface`), `sidebar-per-group-show-more`, and `standalone-blocks-panel`’s mobile test.
- Copy updated in `en` and `pt-br` to say it’s on by default for new and report organizations.
- Reviewer action: run the full E2E suite; the new default changes the shell for all `authedPage` specs.

<sup>Written for commit a515d78059b8f879b36b01dd36aa1429f1f65cb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

