### PR TITLE
perf(github): collapse the Fast Preview PR panel onto one GraphQL read

### DIFF
--- a/apps/api/src/api/routes/sandbox-proxy.ts
+++ b/apps/api/src/api/routes/sandbox-proxy.ts
@@ -42,7 +42,10 @@ import {
 } from "../../lib/suggest-commit-message";
 import { judgeRequiresReviewWithLlm } from "../../lib/judge-requires-review";
 import { gitDataClientForRepo } from "../../decofile/client-for-repo";
-import { GitHubApiError } from "../../decofile/github-git-data";
+import {
+  GitHubApiError,
+  GitHubRateLimitError,
+} from "../../decofile/github-git-data";
 import {
   githubGitDiff,
   githubGitDiscard,
@@ -315,6 +318,15 @@ async function fastPreviewGitClient(c: Context<VmEnv>) {
 }
 
 function fastPreviewGitError(c: Context<VmEnv>, err: unknown): Response {
+  /** 429 with GitHub's own wait, so the client backs off instead of retrying. */
+  if (err instanceof GitHubRateLimitError) {
+    return c.json({ error: err.message }, 429, {
+      ...SANDBOX_PROXY_CACHE_HEADERS,
+      ...(err.retryAfterMs === null
+        ? {}
+        : { "Retry-After": String(Math.ceil(err.retryAfterMs / 1000)) }),
+    });
+  }
   if (err instanceof GitHubApiError) {
     const status =
       err.status === 404

--- a/apps/api/src/decofile/git-compat.ts
+++ b/apps/api/src/decofile/git-compat.ts
@@ -123,19 +123,44 @@ export function buildPublishStatus(args: {
   };
 }
 
-/** The manifest rides on the drift check: `compareDetailed` hits the URL
- *  `compare` already hit and shares its ETag entry. */
+const NO_DRIFT: CompareDetail = { aheadBy: 0, behindBy: 0, files: [] };
+
+/**
+ * Compare `base…branch`, tolerating a branch that does not exist yet: on first
+ * CMS touch the compare 404s, so the retry waits on `materialized` — the
+ * concurrent {@link resolveOrCreateHead} that mints it — before asking again.
+ */
+async function compareAfterMaterializing(
+  client: GitDataClient,
+  base: string,
+  branch: string,
+  materialized: Promise<unknown>,
+): Promise<CompareDetail> {
+  try {
+    return await client.compareDetailed(base, branch);
+  } catch (err) {
+    if (!(err instanceof GitHubApiError) || err.status !== 404) throw err;
+    await materialized;
+    return client.compareDetailed(base, branch);
+  }
+}
+
+/** The manifest rides free on the drift check: same URL, same ETag entry. */
 export async function githubGitStatus(
   client: GitDataClient,
   branch: string,
 ): Promise<CompatGitStatus> {
   const base = await client.getDefaultBranch();
   // Materialize thread-minted branches exactly like the decofile read does.
-  const headSha = await resolveOrCreateHead(client, branch);
-  const compared =
-    base === branch
-      ? { aheadBy: 0, behindBy: 0, files: [] }
-      : await client.compareDetailed(base, branch);
+  if (base === branch) {
+    const headSha = await resolveOrCreateHead(client, branch);
+    return buildPublishStatus({ base, branch, headSha, compared: NO_DRIFT });
+  }
+  const materialized = resolveOrCreateHead(client, branch);
+  const [headSha, compared] = await Promise.all([
+    materialized,
+    compareAfterMaterializing(client, base, branch, materialized),
+  ]);
   return buildPublishStatus({ base, branch, headSha, compared });
 }
 
@@ -146,33 +171,9 @@ export interface CompatGitDiff {
 }
 
 /**
- * Base-side blob sha per path, read off the merge-base tree.
- *
- * Empty for an all-additions diff: nothing has a base side, so the two calls
- * this makes would be discarded. That is also the whole-repo recursive read,
- * which the ETag cache excludes and which 502s as `tree listing truncated by
- * GitHub` on large repos — so the common "created a page" publish stops
- * paying for it, and stops failing on it.
- */
-async function baseBlobShas(
-  client: GitDataClient,
-  mergeBaseSha: string,
-  files: Array<{ status: string }>,
-): Promise<Map<string, string>> {
-  const byPath = new Map<string, string>();
-  if (files.every((f) => f.status === "added")) return byPath;
-  const baseTreeSha = await client.getCommitTreeSha(mergeBaseSha);
-  for (const entry of await client.getTreeRecursive(baseTreeSha)) {
-    if (entry.type === "blob") byPath.set(entry.path, entry.sha);
-  }
-  return byPath;
-}
-
-/**
- * Base…head diff with full file contents, assembled from a detailed compare:
- * head-side blobs come straight off the compare entries; base-side blobs are
- * resolved through the merge-base tree. Bounded and capped — a runaway diff
- * returns the first {@link DIFF_MAX_FILES} paths rather than ballooning.
+ * Base…head diff with full file contents: head-side blobs come off the compare
+ * entries, base-side contents are read by path at the merge base (see
+ * {@link GitDataClient.getFileTextAtRef}). Capped at {@link DIFF_MAX_FILES}.
  */
 export async function githubGitDiff(
   client: GitDataClient,
@@ -187,18 +188,15 @@ export async function githubGitDiff(
     return { diffs: {}, mergeBaseSha: detailed.mergeBaseSha };
   }
 
-  const baseBlobByPath = await baseBlobShas(
-    client,
-    detailed.mergeBaseSha,
-    files,
-  );
-
   const entries = await mapBounded(files, DIFF_FETCH_CONCURRENCY, async (f) => {
+    // A renamed file's base content lives at its previous path, not its new one.
     const basePath = f.previousFilename ?? f.filename;
-    const baseSha =
-      f.status === "added" ? undefined : baseBlobByPath.get(basePath);
-    const from = baseSha ? await client.getBlobText(baseSha) : null;
-    const to = f.status === "removed" ? null : await client.getBlobText(f.sha);
+    const [from, to] = await Promise.all([
+      f.status === "added"
+        ? null
+        : client.getFileTextAtRef(detailed.mergeBaseSha, basePath),
+      f.status === "removed" ? null : client.getBlobText(f.sha),
+    ]);
     return [f.filename, { from, to }] as const;
   });
 
@@ -225,12 +223,15 @@ export async function githubGitRebase(
 ): Promise<void> {
   for (let attempt = 1; ; attempt++) {
     // Read first: the pre-force check re-reads it, catching any later autosave.
-    const branchHead = await client.getHeadSha(branch);
-    const compared = await client.compareDetailed(base, branch);
+    const [branchHead, compared] = await Promise.all([
+      client.getHeadSha(branch),
+      client.compareDetailed(base, branch),
+    ]);
 
     // Already one commit on base: nothing to bring in, nothing to flatten.
     if (compared.behindBy === 0 && compared.aheadBy <= 1) return;
 
+    // Not hoisted into the pair above: pure waste on that early return.
     const baseHead = await client.getHeadSha(base);
 
     // No commits of its own: a fast-forward, which needs no force.

--- a/apps/api/src/decofile/github-git-data.ts
+++ b/apps/api/src/decofile/github-git-data.ts
@@ -8,12 +8,40 @@
  * local stub — tests must never reach api.github.com.
  */
 
+import {
+  countGithubRateLimited,
+  githubRetryAfterMs,
+  isGithubRateLimited,
+  recordGithubRateLimit,
+} from "@/observability/github-rate-limit";
+
 const DEFAULT_TIMEOUT_MS = 15_000;
 
 /** e2e seam: set GITHUB_API_BASE_URL to a local stub. Read per call site so a
  * long-lived process (dev server) and the test webServer agree on one value. */
 function githubApiBaseUrl(): string {
   return process.env.GITHUB_API_BASE_URL ?? "https://api.github.com";
+}
+
+/**
+ * `default_branch` per repo, cached across requests — a client instance lives
+ * for ONE of them (see `client-for-repo.ts`), so its own memo never survives.
+ *
+ * Ten minutes, not an hour: a renamed default branch compares against a branch
+ * that no longer exists until this expires. Keyed by full URL, so the e2e stub
+ * and api.github.com can never share an entry.
+ */
+const DEFAULT_BRANCH_TTL_MS = 10 * 60_000;
+const defaultBranchCache = new Map<string, { value: string; at: number }>();
+
+function cachedDefaultBranch(url: string): string | null {
+  const hit = defaultBranchCache.get(url);
+  if (!hit) return null;
+  if (Date.now() - hit.at > DEFAULT_BRANCH_TTL_MS) {
+    defaultBranchCache.delete(url);
+    return null;
+  }
+  return hit.value;
 }
 
 /**
@@ -49,6 +77,8 @@ function etagCacheable(method: string, path: string): boolean {
     method === "GET" &&
     !path.includes("/git/blobs/") &&
     !path.includes("/git/trees/") &&
+    // `/contents/{path}?ref=<sha>` is sha-pinned, hence content-addressed too.
+    !path.includes("/contents/") &&
     !path.includes("/tarball/")
   );
 }
@@ -93,6 +123,33 @@ export class GitHubApiError extends Error {
   }
 }
 
+/**
+ * GitHub refused the call for rate reasons. NOT retriable: retrying a secondary
+ * limit is the burst being limited. `retryAfterMs` tells the caller when to come
+ * back; it is never slept on inside a request.
+ */
+export class GitHubRateLimitError extends GitHubApiError {
+  constructor(
+    status: number,
+    method: string,
+    path: string,
+    readonly kind: "primary" | "secondary",
+    readonly retryAfterMs: number | null,
+  ) {
+    super(
+      status,
+      method,
+      path,
+      `GitHub ${kind} rate limit reached${
+        retryAfterMs === null
+          ? ""
+          : `; retry in ${Math.ceil(retryAfterMs / 1000)}s`
+      }`,
+    );
+    this.name = "GitHubRateLimitError";
+  }
+}
+
 export interface TreeEntry {
   path: string;
   mode: string;
@@ -134,6 +191,12 @@ export interface GitDataClient {
   getCommitTreeSha(commitSha: string): Promise<string>;
   getTreeRecursive(treeSha: string): Promise<TreeEntry[]>;
   getBlobText(blobSha: string): Promise<string>;
+  /**
+   * One file's text at a ref, addressed by PATH rather than blob sha — null when
+   * the path does not exist there. The base side of a diff needs this: the
+   * compare response's `files[].sha` is the HEAD blob, never the base one.
+   */
+  getFileTextAtRef(ref: string, filePath: string): Promise<string | null>;
   createBlob(content: string): Promise<string>;
   createTree(baseTreeSha: string, entries: TreeWriteEntry[]): Promise<string>;
   createCommit(params: {
@@ -231,8 +294,23 @@ export function createGitDataClient(params: {
       body: body !== undefined ? JSON.stringify(body) : undefined,
       signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
     });
+    recordGithubRateLimit(res.headers, { lane: "rest", operation: method });
+
     if (conditional && res.status === 304) {
       return { status: 200, json: conditional.body as T };
+    }
+    if (isGithubRateLimited(res)) {
+      const kind =
+        res.headers.get("retry-after") !== null ? "secondary" : "primary";
+      countGithubRateLimited({ lane: "rest", operation: method, kind });
+      await res.body?.cancel().catch(() => {});
+      throw new GitHubRateLimitError(
+        res.status,
+        method,
+        path,
+        kind,
+        githubRetryAfterMs(res.headers),
+      );
     }
     if (!res.ok && !opts?.allow?.includes(res.status)) {
       const text = await res.text().catch(() => "");
@@ -259,8 +337,15 @@ export function createGitDataClient(params: {
 
     async getDefaultBranch() {
       if (defaultBranch) return defaultBranch;
+      const url = `${githubApiBaseUrl()}${repoBase}`;
+      const shared = cachedDefaultBranch(url);
+      if (shared) {
+        defaultBranch = shared;
+        return shared;
+      }
       const { json } = await call<{ default_branch: string }>("GET", repoBase);
       defaultBranch = json.default_branch;
+      defaultBranchCache.set(url, { value: defaultBranch, at: Date.now() });
       return defaultBranch;
     },
 
@@ -332,6 +417,28 @@ export function createGitDataClient(params: {
           "GET",
           `${repoBase}/git/blobs/${blobSha}`,
           `unexpected blob encoding ${json.encoding}`,
+        );
+      }
+      return Buffer.from(json.content, "base64").toString("utf-8");
+    },
+
+    async getFileTextAtRef(ref, filePath) {
+      const { status, json } = await call<{
+        content?: string;
+        encoding?: string;
+      }>(
+        "GET",
+        `${repoBase}/contents/${encodeRefPath(filePath)}?ref=${encodeURIComponent(ref)}`,
+        undefined,
+        { allow: [404] },
+      );
+      if (status === 404 || json?.content === undefined) return null;
+      if (json.encoding !== "base64") {
+        throw new GitHubApiError(
+          502,
+          "GET",
+          `${repoBase}/contents/${filePath}`,
+          `unexpected content encoding ${json.encoding}`,
         );
       }
       return Buffer.from(json.content, "base64").toString("utf-8");

--- a/apps/api/src/observability/github-rate-limit.test.ts
+++ b/apps/api/src/observability/github-rate-limit.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "bun:test";
+import {
+  githubRetryAfterMs,
+  isGithubRateLimited,
+  readGithubRateLimit,
+} from "./github-rate-limit";
+
+const headers = (init: Record<string, string>) => new Headers(init);
+
+describe("readGithubRateLimit", () => {
+  it("reads the whole family", () => {
+    expect(
+      readGithubRateLimit(
+        headers({
+          "x-ratelimit-limit": "5000",
+          "x-ratelimit-remaining": "4987",
+          "x-ratelimit-reset": "1787236000",
+          "x-ratelimit-used": "13",
+          "x-ratelimit-resource": "core",
+        }),
+      ),
+    ).toEqual({
+      limit: 5000,
+      remaining: 4987,
+      reset: 1787236000,
+      used: 13,
+      resource: "core",
+    });
+  });
+
+  it("nulls what the response did not carry", () => {
+    expect(readGithubRateLimit(headers({}))).toEqual({
+      limit: null,
+      remaining: null,
+      reset: null,
+      used: null,
+      resource: null,
+    });
+  });
+
+  it("nulls a non-numeric value rather than reporting NaN", () => {
+    expect(
+      readGithubRateLimit(headers({ "x-ratelimit-remaining": "n/a" }))
+        .remaining,
+    ).toBeNull();
+  });
+});
+
+describe("isGithubRateLimited", () => {
+  it("treats 429 as a limit unconditionally", () => {
+    expect(isGithubRateLimited({ status: 429, headers: headers({}) })).toBe(
+      true,
+    );
+  });
+
+  it("treats a 403 carrying retry-after as the secondary limit", () => {
+    expect(
+      isGithubRateLimited({
+        status: 403,
+        headers: headers({ "retry-after": "60" }),
+      }),
+    ).toBe(true);
+  });
+
+  it("treats a 403 with an exhausted window as the primary limit", () => {
+    expect(
+      isGithubRateLimited({
+        status: 403,
+        headers: headers({ "x-ratelimit-remaining": "0" }),
+      }),
+    ).toBe(true);
+  });
+
+  /**
+   * A 403 for missing scopes is a permission problem. Reporting it as a rate
+   * limit would tell the user to wait for a window that will never help.
+   */
+  it("does not treat a plain 403 as a limit", () => {
+    expect(
+      isGithubRateLimited({
+        status: 403,
+        headers: headers({ "x-ratelimit-remaining": "4999" }),
+      }),
+    ).toBe(false);
+    expect(isGithubRateLimited({ status: 403, headers: headers({}) })).toBe(
+      false,
+    );
+  });
+
+  it("does not treat other failures as limits", () => {
+    expect(isGithubRateLimited({ status: 404, headers: headers({}) })).toBe(
+      false,
+    );
+    expect(isGithubRateLimited({ status: 500, headers: headers({}) })).toBe(
+      false,
+    );
+  });
+});
+
+describe("githubRetryAfterMs", () => {
+  const NOW = 1_787_236_000_000;
+
+  it("reads retry-after as seconds", () => {
+    expect(githubRetryAfterMs(headers({ "retry-after": "60" }), NOW)).toBe(
+      60_000,
+    );
+  });
+
+  it("falls back to the window reset, which is an absolute instant", () => {
+    expect(
+      githubRetryAfterMs(headers({ "x-ratelimit-reset": "1787236120" }), NOW),
+    ).toBe(120_000);
+  });
+
+  it("prefers retry-after over the window reset", () => {
+    expect(
+      githubRetryAfterMs(
+        headers({ "retry-after": "5", "x-ratelimit-reset": "1787236120" }),
+        NOW,
+      ),
+    ).toBe(5_000);
+  });
+
+  it("never reports a negative wait for a window that already reset", () => {
+    expect(
+      githubRetryAfterMs(headers({ "x-ratelimit-reset": "1787235000" }), NOW),
+    ).toBe(0);
+  });
+
+  it("is null when GitHub said nothing about when to come back", () => {
+    expect(githubRetryAfterMs(headers({}), NOW)).toBeNull();
+  });
+});

--- a/apps/api/src/observability/github-rate-limit.ts
+++ b/apps/api/src/observability/github-rate-limit.ts
@@ -1,0 +1,146 @@
+/**
+ * GitHub rate-limit telemetry. Every path that talks to api.github.com competes
+ * for ONE budget per installation token; `dbos-github-read.ts` records that
+ * budget shutting for 17 hours, and the ceiling it added was sized against an
+ * estimate because nothing measured the real thing.
+ *
+ * `lane` tags the transport, not the caller: the question to answer is which of
+ * our ways of reaching GitHub spends the budget. `resource` stays an attribute
+ * rather than being collapsed — REST and GraphQL are metered separately
+ * (requests/hour vs points/hour) through these same headers, so a remaining
+ * count means nothing without knowing which pool it drained.
+ */
+
+import type { Counter, Gauge } from "@opentelemetry/api";
+import { meter } from "./index";
+
+/** Which transport spent the budget. */
+export type GithubLane = "rest" | "graphql";
+
+export interface GithubRateLimitSnapshot {
+  limit: number | null;
+  remaining: number | null;
+  /** Epoch SECONDS at which the window resets, as GitHub reports it. */
+  reset: number | null;
+  used: number | null;
+  /** GitHub's own name for the pool: "core", "graphql", "search", … */
+  resource: string | null;
+}
+
+function readInt(headers: Headers, name: string): number | null {
+  const raw = headers.get(name);
+  if (raw === null) return null;
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Pull the `x-ratelimit-*` family off a response.
+ *
+ * Exported and pure so the parsing is unit-testable without a metrics SDK —
+ * every other export here has a side effect on a live meter.
+ */
+export function readGithubRateLimit(headers: Headers): GithubRateLimitSnapshot {
+  return {
+    limit: readInt(headers, "x-ratelimit-limit"),
+    remaining: readInt(headers, "x-ratelimit-remaining"),
+    reset: readInt(headers, "x-ratelimit-reset"),
+    used: readInt(headers, "x-ratelimit-used"),
+    resource: headers.get("x-ratelimit-resource"),
+  };
+}
+
+/**
+ * True when the response is GitHub refusing us for rate reasons. A 403 counts
+ * only with `retry-after` (secondary limit) or an exhausted primary window — a
+ * 403 for missing scopes is a permission problem, and reporting it as a limit
+ * would tell the user to wait for a window that will never help.
+ */
+export function isGithubRateLimited(res: {
+  status: number;
+  headers: Headers;
+}): boolean {
+  if (res.status === 429) return true;
+  if (res.status !== 403) return false;
+  if (res.headers.get("retry-after") !== null) return true;
+  return readInt(res.headers, "x-ratelimit-remaining") === 0;
+}
+
+/**
+ * How long GitHub asked us to wait, in ms, or null when it did not say.
+ * `retry-after` is seconds; `x-ratelimit-reset` is an absolute epoch-seconds
+ * instant. `now` is injected so the conversion is testable.
+ */
+export function githubRetryAfterMs(
+  headers: Headers,
+  now: number = Date.now(),
+): number | null {
+  const retryAfter = readInt(headers, "retry-after");
+  if (retryAfter !== null) return Math.max(0, retryAfter * 1000);
+  const reset = readInt(headers, "x-ratelimit-reset");
+  if (reset !== null) return Math.max(0, reset * 1000 - now);
+  return null;
+}
+
+/** Lazily created so they bind the post-SDK-start meter (`meter` is a live
+ *  binding reassigned when the SDK starts — same pattern as disk-cache.ts). */
+let remainingGauge: Gauge | null = null;
+let usedGauge: Gauge | null = null;
+let callCounter: Counter | null = null;
+let limitedCounter: Counter | null = null;
+
+/**
+ * Record one GitHub response's rate-limit position. A response without the
+ * headers still counts the call; nothing here throws into the path it observes.
+ */
+export function recordGithubRateLimit(
+  headers: Headers,
+  attrs: { lane: GithubLane; operation: string },
+): GithubRateLimitSnapshot {
+  const snapshot = readGithubRateLimit(headers);
+  const labels = {
+    lane: attrs.lane,
+    operation: attrs.operation,
+    resource: snapshot.resource ?? "unknown",
+  };
+
+  callCounter ??= meter.createCounter("github_api_calls", {
+    description: "Calls to the GitHub API, by transport and operation",
+    unit: "{calls}",
+  });
+  callCounter.add(1, labels);
+
+  if (snapshot.remaining !== null) {
+    remainingGauge ??= meter.createGauge("github_rate_limit_remaining", {
+      description: "Requests (REST) or points (GraphQL) left in the window",
+      unit: "{requests}",
+    });
+    remainingGauge.record(snapshot.remaining, labels);
+  }
+  if (snapshot.used !== null) {
+    usedGauge ??= meter.createGauge("github_rate_limit_used", {
+      description: "Requests (REST) or points (GraphQL) spent in the window",
+      unit: "{requests}",
+    });
+    usedGauge.record(snapshot.used, labels);
+  }
+
+  return snapshot;
+}
+
+/**
+ * Count a refusal. Separate from {@link recordGithubRateLimit} because a
+ * rate-limited response is exactly the one whose headers are least complete.
+ */
+export function countGithubRateLimited(attrs: {
+  lane: GithubLane;
+  operation: string;
+  /** "primary" when the window is exhausted, "secondary" for a burst refusal. */
+  kind: "primary" | "secondary";
+}): void {
+  limitedCounter ??= meter.createCounter("github_rate_limited", {
+    description: "GitHub responses refused for rate-limit reasons",
+    unit: "{responses}",
+  });
+  limitedCounter.add(1, attrs);
+}

--- a/apps/api/src/tools/github/graphql.test.ts
+++ b/apps/api/src/tools/github/graphql.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test";
+import { parseGraphqlBody, unwrapGraphqlData } from "./graphql";
+
+const LABEL = "branch search for acme/site";
+
+describe("parseGraphqlBody", () => {
+  it("parses a well-formed JSON body", () => {
+    expect(parseGraphqlBody('{"data":{"repository":null}}', LABEL)).toEqual({
+      data: { repository: null },
+    });
+  });
+
+  it("throws a named error instead of a raw SyntaxError on a malformed 2xx body", () => {
+    expect(() =>
+      parseGraphqlBody("<html>upstream error</html>", LABEL),
+    ).toThrow(/acme\/site returned invalid JSON: <html>upstream error<\/html>/);
+  });
+
+  it("truncates a huge body so the message stays readable", () => {
+    expect(() => parseGraphqlBody("x".repeat(5000), LABEL)).toThrow(
+      /invalid JSON: x{300}$/,
+    );
+  });
+});
+
+describe("unwrapGraphqlData", () => {
+  it("returns data when GitHub reported no errors", () => {
+    expect(
+      unwrapGraphqlData({ data: { repository: { id: 1 } } }, LABEL),
+    ).toEqual({ repository: { id: 1 } });
+  });
+
+  /** A 200 carrying `errors` is the shape `res.ok` cannot catch. */
+  it("throws on a GraphQL error rather than reporting an empty result", () => {
+    expect(() =>
+      unwrapGraphqlData(
+        { errors: [{ message: "Resource not accessible by integration" }] },
+        LABEL,
+      ),
+    ).toThrow(/Resource not accessible by integration/);
+  });
+
+  it("prefers the reported error over the missing-data message", () => {
+    expect(() =>
+      unwrapGraphqlData(
+        { data: null, errors: [{ message: "Bad credentials" }] },
+        LABEL,
+      ),
+    ).toThrow(/Bad credentials/);
+  });
+
+  it("throws when a 200 carried neither data nor errors", () => {
+    expect(() => unwrapGraphqlData({}, LABEL)).toThrow(/returned no data/);
+  });
+});

--- a/apps/api/src/tools/github/graphql.ts
+++ b/apps/api/src/tools/github/graphql.ts
@@ -1,0 +1,187 @@
+/**
+ * Shared GitHub GraphQL transport for the app-only GitHub tools. Every one of
+ * them needs the same five things and gets them exactly once here: the
+ * org-ownership guard on the connection, the minted token, the single 401
+ * refresh-and-retry, the not-JSON-despite-200 guard, and the
+ * errors-inside-a-200 guard that plain `res.ok` misses.
+ *
+ * GraphQL is metered against a budget SEPARATE from REST's (points/hour vs
+ * requests/hour) — moving a read here spends a quota REST is not competing for.
+ */
+
+import type { StudioContext } from "@/core/studio-context";
+import {
+  githubConnectionAccessToken,
+  isGithubConnection,
+} from "@/oauth/github-mint";
+import { RECONNECT_ERROR } from "@/oauth/token-refresh";
+import {
+  countGithubRateLimited,
+  githubRetryAfterMs,
+  isGithubRateLimited,
+  recordGithubRateLimit,
+} from "@/observability/github-rate-limit";
+
+/** e2e seam, mirroring `decofile/github-git-data.ts`. Read per call site so a
+ *  long-lived dev server and a test webServer agree on one value. */
+function githubGraphqlUrl(): string {
+  return process.env.GITHUB_GRAPHQL_URL ?? "https://api.github.com/graphql";
+}
+
+/** Matches the Git Data client's per-attempt timeout. */
+const GITHUB_TIMEOUT_MS = 15_000;
+
+export interface GraphqlEnvelope<T> {
+  data?: T | null;
+  errors?: Array<{ message?: string }>;
+}
+
+/**
+ * A 2xx response body isn't guaranteed to be JSON (a proxy/outage page can
+ * still answer 200), and `res.json()` throwing a raw `SyntaxError` on that
+ * would surface as an opaque "Unexpected token" instead of naming what failed.
+ */
+export function parseGraphqlBody<T>(
+  text: string,
+  label: string,
+): GraphqlEnvelope<T> {
+  try {
+    return JSON.parse(text) as GraphqlEnvelope<T>;
+  } catch (cause) {
+    throw new Error(
+      `GitHub GraphQL ${label} returned invalid JSON: ${text.slice(0, 300)}`,
+      { cause },
+    );
+  }
+}
+
+/**
+ * Unwrap `data`, turning GraphQL's 200-with-`errors` into a throw.
+ *
+ * Throws rather than returning a plausible empty result when GitHub reported an
+ * error, so "no matches" never masks "not allowed to look".
+ */
+export function unwrapGraphqlData<T>(
+  payload: GraphqlEnvelope<T>,
+  label: string,
+): T {
+  const error = payload.errors?.[0]?.message;
+  if (error) {
+    throw new Error(`GitHub GraphQL ${label} failed: ${error}`);
+  }
+  if (payload.data == null) {
+    throw new Error(`GitHub GraphQL ${label} returned no data`);
+  }
+  return payload.data;
+}
+
+/**
+ * Resolve a GitHub connection the caller's org owns. A connection id is
+ * caller-supplied, so it is re-read scoped to the authenticated org before its
+ * credential is used — no cross-org token reads (as GITHUB_LIST_USER_ORGS does).
+ */
+async function resolveGithubConnection(
+  ctx: StudioContext,
+  connectionId: string,
+) {
+  const organizationId = ctx.organization?.id;
+  if (!organizationId) {
+    throw new Error("Organization context required");
+  }
+  const connection = await ctx.storage.connections.findById(
+    connectionId,
+    organizationId,
+  );
+  if (!connection) {
+    throw new Error("Connection not found");
+  }
+  if (!isGithubConnection(connection)) {
+    throw new Error("Connection is not a GitHub connection");
+  }
+  return connection;
+}
+
+/**
+ * POST one GraphQL operation on behalf of a connection and return its `data`.
+ *
+ * `label` names the operation in every error message — it is what tells a
+ * reader whether "not accessible" came from a branch search or a PR read.
+ */
+export async function githubGraphql<T>(
+  ctx: StudioContext,
+  args: {
+    connectionId: string;
+    query: string;
+    variables: Record<string, unknown>;
+    label: string;
+  },
+): Promise<T> {
+  const connection = await resolveGithubConnection(ctx, args.connectionId);
+
+  const accessToken = await githubConnectionAccessToken(ctx, connection);
+  if (!accessToken) {
+    throw new Error(RECONNECT_ERROR);
+  }
+
+  const post = (token: string) =>
+    fetch(githubGraphqlUrl(), {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ query: args.query, variables: args.variables }),
+      signal: AbortSignal.timeout(GITHUB_TIMEOUT_MS),
+    });
+
+  let res = await post(accessToken);
+
+  // Token revoked/rotated behind our clock: one refresh + retry, then give up.
+  if (res.status === 401) {
+    // Drain the discarded 401 body so its connection is released.
+    try {
+      await res.body?.cancel();
+    } catch {
+      /* ignore */
+    }
+    const refreshed = await githubConnectionAccessToken(ctx, connection, {
+      forceRefresh: true,
+    });
+    if (!refreshed) {
+      throw new Error(RECONNECT_ERROR);
+    }
+    res = await post(refreshed);
+    if (res.status === 401) {
+      throw new Error(RECONNECT_ERROR);
+    }
+  }
+
+  recordGithubRateLimit(res.headers, {
+    lane: "graphql",
+    operation: args.label,
+  });
+
+  // Never retried here: retrying a secondary limit IS the burst being limited.
+  if (isGithubRateLimited(res)) {
+    const kind =
+      res.headers.get("retry-after") !== null ? "secondary" : "primary";
+    countGithubRateLimited({ lane: "graphql", operation: args.label, kind });
+    const waitMs = githubRetryAfterMs(res.headers);
+    throw new Error(
+      `GitHub ${kind} rate limit reached${
+        waitMs === null ? "" : `; retry in ${Math.ceil(waitMs / 1000)}s`
+      }`,
+    );
+  }
+
+  if (!res.ok) {
+    throw new Error(`GitHub GraphQL ${args.label} failed: ${res.status}`);
+  }
+
+  // GraphQL reports failures as 200 + `errors`, so an ok status isn't enough.
+  return unwrapGraphqlData<T>(
+    parseGraphqlBody<T>(await res.text(), args.label),
+    args.label,
+  );
+}

--- a/apps/api/src/tools/github/index.ts
+++ b/apps/api/src/tools/github/index.ts
@@ -7,3 +7,5 @@
 
 export { GITHUB_LIST_USER_ORGS } from "./list-user-orgs";
 export { GITHUB_SEARCH_BRANCHES } from "./search-branches";
+export { GITHUB_PR_STATE } from "./pr-state";
+export { GITHUB_LAST_PUBLISHED_PR } from "./last-published-pr";

--- a/apps/api/src/tools/github/last-published-pr.test.ts
+++ b/apps/api/src/tools/github/last-published-pr.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import { parseLastPublishedPr } from "./last-published-pr";
+
+describe("parseLastPublishedPr", () => {
+  it("maps the merged pull request", () => {
+    const { pullRequest } = parseLastPublishedPr({
+      repository: {
+        pullRequests: {
+          nodes: [
+            {
+              number: 12,
+              title: "Publish homepage copy",
+              body: "",
+              mergedAt: "2026-08-19T10:00:00Z",
+              url: "https://github.com/acme/site/pull/12",
+              baseRefName: "main",
+              headRefName: "claude/copy",
+              headRefOid: "def456",
+              author: { login: "gimenes" },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(pullRequest).toEqual({
+      number: 12,
+      title: "Publish homepage copy",
+      body: "",
+      mergedAt: "2026-08-19T10:00:00Z",
+      base: "main",
+      head: "claude/copy",
+      headSha: "def456",
+      htmlUrl: "https://github.com/acme/site/pull/12",
+      author: "gimenes",
+    });
+  });
+
+  it("returns null when nothing was ever merged into the base", () => {
+    expect(
+      parseLastPublishedPr({ repository: { pullRequests: { nodes: [] } } }),
+    ).toEqual({ pullRequest: null });
+  });
+
+  /** "Never published" and "not allowed to look" must not read the same. */
+  it("throws when the repository is hidden", () => {
+    expect(() => parseLastPublishedPr({ repository: null })).toThrow(
+      /not found or not accessible/,
+    );
+  });
+});

--- a/apps/api/src/tools/github/last-published-pr.ts
+++ b/apps/api/src/tools/github/last-published-pr.ts
@@ -1,0 +1,134 @@
+import { z } from "zod";
+import { defineTool } from "../../core/define-tool";
+import { githubGraphql } from "./graphql";
+
+/**
+ * The most recent merged pull request into a base branch — in Fast Preview
+ * every publish is a squash-merged PR, so this IS the last publish.
+ *
+ * `states: MERGED` is why this is exact. REST can only filter `state: closed`,
+ * which interleaves PRs closed WITHOUT merging, so it takes a page of PRs to
+ * answer and still reports "never published" for a base whose whole page was
+ * abandoned.
+ */
+const LAST_PUBLISHED_QUERY = `
+query LastPublishedPr($owner: String!, $repo: String!, $base: String!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequests(
+      states: MERGED
+      baseRefName: $base
+      first: 1
+      orderBy: { field: UPDATED_AT, direction: DESC }
+    ) {
+      nodes {
+        number
+        title
+        body
+        mergedAt
+        url
+        baseRefName
+        headRefName
+        headRefOid
+        author { login }
+      }
+    }
+  }
+}`;
+
+const lastPublishedOutput = z.object({
+  /** null when nothing has ever been merged into this base. */
+  pullRequest: z
+    .object({
+      number: z.number(),
+      title: z.string(),
+      body: z.string(),
+      mergedAt: z.string().nullable(),
+      base: z.string(),
+      head: z.string(),
+      headSha: z.string(),
+      htmlUrl: z.string(),
+      author: z.string(),
+    })
+    .nullable(),
+});
+
+export type LastPublishedPrResult = z.infer<typeof lastPublishedOutput>;
+
+export interface LastPublishedPrResponse {
+  repository?: {
+    pullRequests?: {
+      nodes?: Array<{
+        number?: number | null;
+        title?: string | null;
+        body?: string | null;
+        mergedAt?: string | null;
+        url?: string | null;
+        baseRefName?: string | null;
+        headRefName?: string | null;
+        headRefOid?: string | null;
+        author?: { login?: string | null } | null;
+      } | null> | null;
+    } | null;
+  } | null;
+}
+
+/** Throws rather than reporting "never published" when the repo was hidden. */
+export function parseLastPublishedPr(
+  payload: LastPublishedPrResponse,
+): LastPublishedPrResult {
+  const repository = payload.repository;
+  if (!repository) {
+    throw new Error(
+      "Repository not found or not accessible by this connection",
+    );
+  }
+  const pr = repository.pullRequests?.nodes?.[0];
+  if (!pr) return { pullRequest: null };
+
+  return {
+    pullRequest: {
+      number: pr.number ?? 0,
+      title: pr.title ?? "",
+      body: pr.body ?? "",
+      mergedAt: pr.mergedAt ?? null,
+      base: pr.baseRefName ?? "main",
+      head: pr.headRefName ?? "",
+      headSha: pr.headRefOid ?? "",
+      htmlUrl: pr.url ?? "",
+      author: pr.author?.login ?? "",
+    },
+  };
+}
+
+export const GITHUB_LAST_PUBLISHED_PR = defineTool({
+  name: "GITHUB_LAST_PUBLISHED_PR",
+  description:
+    "Read the most recently merged pull request into a base branch — in Fast Preview, the last publish.",
+  annotations: {
+    title: "Read Last Published Pull Request",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  _meta: { ui: { visibility: "app" } },
+  inputSchema: z.object({
+    connectionId: z.string().describe("ID of the mcp-github connection to use"),
+    owner: z.string().describe("Repository owner (user or org login)"),
+    repo: z.string().describe("Repository name"),
+    base: z.string().describe("Base branch publishes merge into"),
+  }),
+  outputSchema: lastPublishedOutput,
+  handler: async (input, ctx) => {
+    await ctx.access.check();
+
+    const data = await githubGraphql<LastPublishedPrResponse>(ctx, {
+      connectionId: input.connectionId,
+      query: LAST_PUBLISHED_QUERY,
+      variables: { owner: input.owner, repo: input.repo, base: input.base },
+      label: `last published pull request for ${input.owner}/${input.repo}@${input.base}`,
+    });
+
+    return parseLastPublishedPr(data);
+  },
+});

--- a/apps/api/src/tools/github/pr-state.test.ts
+++ b/apps/api/src/tools/github/pr-state.test.ts
@@ -1,0 +1,305 @@
+import { describe, expect, it } from "bun:test";
+import { parsePrState, type PrStateResponse } from "./pr-state";
+
+function payload(over: Record<string, unknown> = {}): PrStateResponse {
+  return {
+    repository: {
+      pullRequests: {
+        nodes: [
+          {
+            number: 42,
+            title: "Add hero section",
+            body: "",
+            state: "OPEN",
+            merged: false,
+            mergedAt: null,
+            isDraft: false,
+            mergeable: "MERGEABLE",
+            reviewDecision: null,
+            changedFiles: 3,
+            url: "https://github.com/acme/site/pull/42",
+            baseRefName: "main",
+            headRefName: "claude/hero",
+            headRefOid: "abc123",
+            headRepository: { nameWithOwner: "acme/site" },
+            author: { login: "gimenes" },
+            reviewThreads: { nodes: [] },
+            comments: { nodes: [] },
+            commits: { nodes: [] },
+            ...over,
+          },
+        ],
+      },
+    },
+  };
+}
+
+describe("parsePrState", () => {
+  it("maps a clean open pull request", () => {
+    const { pullRequest } = parsePrState(payload());
+
+    expect(pullRequest).toMatchObject({
+      number: 42,
+      state: "open",
+      merged: false,
+      base: "main",
+      head: "claude/hero",
+      headSha: "abc123",
+      headRepoFullName: "acme/site",
+      author: "gimenes",
+      draft: false,
+      mergeableState: "clean",
+      unresolvedConversations: 0,
+      missingRequiredApprovals: false,
+      changedFiles: 3,
+    });
+  });
+
+  it("returns null when the branch has no pull request", () => {
+    expect(
+      parsePrState({ repository: { pullRequests: { nodes: [] } } }),
+    ).toEqual({ pullRequest: null });
+  });
+
+  it("throws when the repository is hidden rather than reporting no PR", () => {
+    expect(() => parsePrState({ repository: null })).toThrow(
+      /not found or not accessible/,
+    );
+  });
+
+  /** GraphQL splits MERGED out of CLOSED; the panel's vocabulary does not. */
+  it("reports a merged pull request as closed and merged", () => {
+    const { pullRequest } = parsePrState(
+      payload({
+        state: "MERGED",
+        merged: true,
+        mergedAt: "2026-08-19T10:00:00Z",
+      }),
+    );
+
+    expect(pullRequest).toMatchObject({
+      state: "closed",
+      merged: true,
+      mergedAt: "2026-08-19T10:00:00Z",
+    });
+  });
+
+  it("reads conflicts off `mergeable`", () => {
+    expect(
+      parsePrState(payload({ mergeable: "CONFLICTING" })).pullRequest,
+    ).toMatchObject({ mergeableState: "dirty" });
+  });
+
+  it("reports UNKNOWN mergeability rather than guessing clean", () => {
+    expect(
+      parsePrState(payload({ mergeable: "UNKNOWN" })).pullRequest,
+    ).toMatchObject({ mergeableState: "unknown" });
+  });
+
+  /**
+   * The REST path inferred this from `mergeable_state === "blocked"` with no
+   * unresolved conversations — a guess that was wrong whenever branch
+   * protection blocked for any other reason. `reviewDecision` states it.
+   */
+  it("reads missing approvals off reviewDecision, not a mergeable_state guess", () => {
+    expect(
+      parsePrState(payload({ reviewDecision: "REVIEW_REQUIRED" })).pullRequest,
+    ).toMatchObject({
+      missingRequiredApprovals: true,
+      mergeableState: "blocked",
+    });
+
+    expect(
+      parsePrState(payload({ reviewDecision: "CHANGES_REQUESTED" }))
+        .pullRequest,
+    ).toMatchObject({
+      missingRequiredApprovals: true,
+      mergeableState: "blocked",
+    });
+
+    expect(
+      parsePrState(payload({ reviewDecision: "APPROVED" })).pullRequest,
+    ).toMatchObject({
+      missingRequiredApprovals: false,
+      mergeableState: "clean",
+    });
+  });
+
+  /**
+   * The REST path used the raw `review_comments` COUNT, which counts every
+   * review comment ever left — resolved ones included. Only unresolved threads
+   * are something a person still has to act on.
+   */
+  it("counts unresolved review threads, not every review comment", () => {
+    const { pullRequest } = parsePrState(
+      payload({
+        reviewThreads: {
+          nodes: [
+            { isResolved: true },
+            { isResolved: false },
+            { isResolved: true },
+            { isResolved: false },
+          ],
+        },
+      }),
+    );
+
+    expect(pullRequest).toMatchObject({
+      unresolvedConversations: 2,
+      mergeableState: "blocked",
+    });
+  });
+
+  it("maps check runs, keeping the REST id GET_CHECK_RUN needs", () => {
+    const { pullRequest } = parsePrState(
+      payload({
+        commits: {
+          nodes: [
+            {
+              commit: {
+                statusCheckRollup: {
+                  contexts: {
+                    nodes: [
+                      {
+                        __typename: "CheckRun",
+                        databaseId: 987,
+                        name: "build",
+                        status: "COMPLETED",
+                        conclusion: "SUCCESS",
+                        detailsUrl: "https://github.com/acme/site/runs/987",
+                        startedAt: "2026-08-19T10:00:00Z",
+                        completedAt: "2026-08-19T10:01:30Z",
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(pullRequest?.checks).toEqual([
+      {
+        id: "987",
+        name: "build",
+        status: "completed",
+        conclusion: "success",
+        htmlUrl: "https://github.com/acme/site/runs/987",
+        durationMs: 90_000,
+      },
+    ]);
+  });
+
+  it("drops legacy status contexts, which the panel does not draw", () => {
+    const { pullRequest } = parsePrState(
+      payload({
+        commits: {
+          nodes: [
+            {
+              commit: {
+                statusCheckRollup: {
+                  contexts: {
+                    nodes: [
+                      { __typename: "StatusContext", context: "ci/legacy" },
+                      {
+                        __typename: "CheckRun",
+                        databaseId: 1,
+                        name: "test",
+                        status: "IN_PROGRESS",
+                        conclusion: null,
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(pullRequest?.checks).toHaveLength(1);
+    expect(pullRequest?.checks[0]).toMatchObject({
+      name: "test",
+      status: "in_progress",
+      conclusion: null,
+      durationMs: null,
+    });
+  });
+
+  it("folds the conclusions REST has no word for onto ones the panel draws", () => {
+    const rollup = (conclusion: string) => ({
+      commits: {
+        nodes: [
+          {
+            commit: {
+              statusCheckRollup: {
+                contexts: {
+                  nodes: [
+                    {
+                      __typename: "CheckRun",
+                      databaseId: 1,
+                      name: "n",
+                      status: "COMPLETED",
+                      conclusion,
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(
+      parsePrState(payload(rollup("STARTUP_FAILURE"))).pullRequest?.checks[0]
+        ?.conclusion,
+    ).toBe("failure");
+    expect(
+      parsePrState(payload(rollup("STALE"))).pullRequest?.checks[0]?.conclusion,
+    ).toBe("neutral");
+  });
+
+  it("survives a deleted fork and a commit with no GitHub account", () => {
+    const { pullRequest } = parsePrState(
+      payload({ headRepository: null, author: null }),
+    );
+
+    expect(pullRequest).toMatchObject({
+      headRepoFullName: null,
+      author: "",
+    });
+  });
+
+  it("maps issue comments", () => {
+    const { pullRequest } = parsePrState(
+      payload({
+        comments: {
+          nodes: [
+            {
+              databaseId: 7,
+              author: { login: "octocat" },
+              body: "ship it",
+              createdAt: "2026-08-19T09:00:00Z",
+              url: "https://github.com/acme/site/pull/42#issuecomment-7",
+            },
+            null,
+          ],
+        },
+      }),
+    );
+
+    expect(pullRequest?.comments).toEqual([
+      {
+        id: 7,
+        author: "octocat",
+        body: "ship it",
+        createdAt: "2026-08-19T09:00:00Z",
+        htmlUrl: "https://github.com/acme/site/pull/42#issuecomment-7",
+      },
+    ]);
+  });
+});

--- a/apps/api/src/tools/github/pr-state.ts
+++ b/apps/api/src/tools/github/pr-state.ts
@@ -1,0 +1,364 @@
+import { z } from "zod";
+import { defineTool } from "../../core/define-tool";
+import { githubGraphql } from "./graphql";
+
+/**
+ * One read for everything the PR panel shows: the branch's pull request, its
+ * check runs, its review state and its comments, at ONE instant — four separate
+ * polls could render a PR's checks beside a different poll's mergeability.
+ *
+ * `reviewDecision` and `reviewThreads.isResolved` are the point. REST exposes
+ * neither, so the panel used to infer "blocked on a human" from
+ * `mergeable_state` and count unresolved conversations as every review comment
+ * ever left.
+ *
+ * Matched by `headRefName`, not by walking `repository.ref(...)`: a ref deleted
+ * after its merge makes the ref walk answer null, losing a merged PR the panel
+ * still shows. This matches the head ref the PR RECORDS, as REST's `head:` did.
+ */
+const PR_STATE_QUERY = `
+query PrState($owner: String!, $repo: String!, $branch: String!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequests(
+      headRefName: $branch
+      first: 1
+      orderBy: { field: UPDATED_AT, direction: DESC }
+    ) {
+      nodes {
+        number
+        title
+        body
+        state
+        merged
+        mergedAt
+        isDraft
+        mergeable
+        reviewDecision
+        changedFiles
+        url
+        baseRefName
+        headRefName
+        headRefOid
+        headRepository { nameWithOwner }
+        author { login }
+        reviewThreads(first: 100) { nodes { isResolved } }
+        comments(last: 50) {
+          nodes { databaseId author { login } body createdAt url }
+        }
+        commits(last: 1) {
+          nodes {
+            commit {
+              statusCheckRollup {
+                contexts(first: 100) {
+                  nodes {
+                    __typename
+                    ... on CheckRun {
+                      databaseId
+                      name
+                      status
+                      conclusion
+                      detailsUrl
+                      startedAt
+                      completedAt
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+const checkRunSchema = z.object({
+  /** REST check-run id — what GET_CHECK_RUN takes to load the run's output. */
+  id: z.string(),
+  name: z.string(),
+  status: z.enum(["queued", "in_progress", "completed"]),
+  conclusion: z
+    .enum([
+      "success",
+      "failure",
+      "neutral",
+      "cancelled",
+      "skipped",
+      "timed_out",
+      "action_required",
+    ])
+    .nullable(),
+  htmlUrl: z.string(),
+  durationMs: z.number().nullable(),
+});
+
+const commentSchema = z.object({
+  id: z.number(),
+  author: z.string(),
+  body: z.string(),
+  createdAt: z.string(),
+  htmlUrl: z.string(),
+});
+
+const pullRequestSchema = z.object({
+  number: z.number(),
+  title: z.string(),
+  body: z.string(),
+  state: z.enum(["open", "closed"]),
+  merged: z.boolean(),
+  mergedAt: z.string().nullable(),
+  base: z.string(),
+  head: z.string(),
+  headSha: z.string(),
+  /** `owner/name` of the head repo; null when a fork was deleted. */
+  headRepoFullName: z.string().nullable(),
+  htmlUrl: z.string(),
+  author: z.string(),
+  draft: z.boolean(),
+  /** Kept in the app's REST vocabulary so the panel state machine is unchanged. */
+  mergeableState: z.enum(["clean", "dirty", "blocked", "unknown"]),
+  /** Review threads GitHub reports as unresolved — a count, not a guess. */
+  unresolvedConversations: z.number(),
+  missingRequiredApprovals: z.boolean(),
+  /** Files the PR touches — the Changes tab's badge, without reading bodies. */
+  changedFiles: z.number(),
+  checks: z.array(checkRunSchema),
+  comments: z.array(commentSchema),
+});
+
+const prStateOutput = z.object({
+  /** null when the branch has no pull request at all. */
+  pullRequest: pullRequestSchema.nullable(),
+});
+
+export type PrStateResult = z.infer<typeof prStateOutput>;
+type PullRequestState = z.infer<typeof pullRequestSchema>;
+type CheckRunState = z.infer<typeof checkRunSchema>;
+
+interface RawCheckRun {
+  __typename?: string | null;
+  databaseId?: number | null;
+  name?: string | null;
+  status?: string | null;
+  conclusion?: string | null;
+  detailsUrl?: string | null;
+  startedAt?: string | null;
+  completedAt?: string | null;
+}
+
+interface RawPullRequest {
+  number?: number | null;
+  title?: string | null;
+  body?: string | null;
+  state?: string | null;
+  merged?: boolean | null;
+  mergedAt?: string | null;
+  isDraft?: boolean | null;
+  mergeable?: string | null;
+  reviewDecision?: string | null;
+  changedFiles?: number | null;
+  url?: string | null;
+  baseRefName?: string | null;
+  headRefName?: string | null;
+  headRefOid?: string | null;
+  headRepository?: { nameWithOwner?: string | null } | null;
+  author?: { login?: string | null } | null;
+  reviewThreads?: {
+    nodes?: Array<{ isResolved?: boolean | null } | null> | null;
+  } | null;
+  comments?: {
+    nodes?: Array<{
+      databaseId?: number | null;
+      author?: { login?: string | null } | null;
+      body?: string | null;
+      createdAt?: string | null;
+      url?: string | null;
+    } | null> | null;
+  } | null;
+  commits?: {
+    nodes?: Array<{
+      commit?: {
+        statusCheckRollup?: {
+          contexts?: { nodes?: Array<RawCheckRun | null> | null } | null;
+        } | null;
+      } | null;
+    } | null> | null;
+  } | null;
+}
+
+export interface PrStateResponse {
+  repository?: {
+    pullRequests?: { nodes?: Array<RawPullRequest | null> | null } | null;
+  } | null;
+}
+
+/** GraphQL's status enum is wider than the three states the panel draws. */
+function mapCheckStatus(
+  raw: string | null | undefined,
+): CheckRunState["status"] {
+  if (raw === "IN_PROGRESS") return "in_progress";
+  if (raw === "COMPLETED") return "completed";
+  return "queued";
+}
+
+/**
+ * GraphQL carries two conclusions REST's vocabulary has no word for.
+ * `STARTUP_FAILURE` is a failure by any reading; `STALE` is a run superseded
+ * before it concluded, which is informational — neither may leak through as an
+ * unhandled string.
+ */
+function mapCheckConclusion(
+  raw: string | null | undefined,
+): CheckRunState["conclusion"] {
+  switch (raw) {
+    case "SUCCESS":
+      return "success";
+    case "FAILURE":
+    case "STARTUP_FAILURE":
+      return "failure";
+    case "NEUTRAL":
+    case "STALE":
+      return "neutral";
+    case "CANCELLED":
+      return "cancelled";
+    case "SKIPPED":
+      return "skipped";
+    case "TIMED_OUT":
+      return "timed_out";
+    case "ACTION_REQUIRED":
+      return "action_required";
+    default:
+      return null;
+  }
+}
+
+/** The rollup also carries legacy StatusContexts; the panel draws check runs. */
+function mapChecks(pr: RawPullRequest): CheckRunState[] {
+  const contexts =
+    pr.commits?.nodes?.[0]?.commit?.statusCheckRollup?.contexts?.nodes ?? [];
+  const runs: CheckRunState[] = [];
+  for (const node of contexts) {
+    if (!node || node.__typename !== "CheckRun") continue;
+    const startedAt = node.startedAt;
+    const completedAt = node.completedAt;
+    runs.push({
+      id: node.databaseId == null ? "" : String(node.databaseId),
+      name: node.name ?? "",
+      status: mapCheckStatus(node.status),
+      conclusion: mapCheckConclusion(node.conclusion),
+      htmlUrl: node.detailsUrl ?? "",
+      durationMs:
+        startedAt && completedAt
+          ? new Date(completedAt).getTime() - new Date(startedAt).getTime()
+          : null,
+    });
+  }
+  return runs;
+}
+
+/**
+ * Fold the GraphQL payload into the panel's shape. `mergeableState` keeps REST's
+ * vocabulary (the panel state machine is written against it) but is derived, not
+ * reported: "blocked" means blocked on a PERSON. Required status checks belong
+ * to `checks`, which the panel draws precisely rather than as a generic block.
+ */
+export function parsePrState(payload: PrStateResponse): PrStateResult {
+  const repository = payload.repository;
+  if (!repository) {
+    throw new Error(
+      "Repository not found or not accessible by this connection",
+    );
+  }
+  const pr = repository.pullRequests?.nodes?.[0];
+  if (!pr) return { pullRequest: null };
+
+  const unresolvedConversations = (pr.reviewThreads?.nodes ?? []).filter(
+    (thread) => thread?.isResolved === false,
+  ).length;
+  const decision = pr.reviewDecision;
+  const missingRequiredApprovals =
+    decision === "REVIEW_REQUIRED" || decision === "CHANGES_REQUESTED";
+
+  const mergeableState: PullRequestState["mergeableState"] =
+    pr.mergeable === "CONFLICTING"
+      ? "dirty"
+      : pr.mergeable !== "MERGEABLE"
+        ? "unknown"
+        : missingRequiredApprovals || unresolvedConversations > 0
+          ? "blocked"
+          : "clean";
+
+  return {
+    pullRequest: {
+      number: pr.number ?? 0,
+      title: pr.title ?? "",
+      body: pr.body ?? "",
+      // GraphQL splits merged out of closed; the panel's vocabulary does not.
+      state: pr.state === "OPEN" ? "open" : "closed",
+      merged: pr.merged === true,
+      mergedAt: pr.mergedAt ?? null,
+      base: pr.baseRefName ?? "main",
+      head: pr.headRefName ?? "",
+      headSha: pr.headRefOid ?? "",
+      headRepoFullName: pr.headRepository?.nameWithOwner ?? null,
+      htmlUrl: pr.url ?? "",
+      author: pr.author?.login ?? "",
+      draft: pr.isDraft === true,
+      mergeableState,
+      unresolvedConversations,
+      missingRequiredApprovals,
+      changedFiles: pr.changedFiles ?? 0,
+      checks: mapChecks(pr),
+      comments: (pr.comments?.nodes ?? []).flatMap((comment) =>
+        comment
+          ? [
+              {
+                id: comment.databaseId ?? 0,
+                author: comment.author?.login ?? "",
+                body: comment.body ?? "",
+                createdAt: comment.createdAt ?? "",
+                htmlUrl: comment.url ?? "",
+              },
+            ]
+          : [],
+      ),
+    },
+  };
+}
+
+export const GITHUB_PR_STATE = defineTool({
+  name: "GITHUB_PR_STATE",
+  description:
+    "Read a branch's pull request with its check runs, review state and comments in a single GitHub GraphQL query.",
+  annotations: {
+    title: "Read GitHub Pull Request State",
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  _meta: { ui: { visibility: "app" } },
+  inputSchema: z.object({
+    connectionId: z.string().describe("ID of the mcp-github connection to use"),
+    owner: z.string().describe("Repository owner (user or org login)"),
+    repo: z.string().describe("Repository name"),
+    branch: z.string().describe("Head branch of the pull request to read"),
+  }),
+  outputSchema: prStateOutput,
+  handler: async (input, ctx) => {
+    await ctx.access.check();
+
+    const data = await githubGraphql<PrStateResponse>(ctx, {
+      connectionId: input.connectionId,
+      query: PR_STATE_QUERY,
+      variables: {
+        owner: input.owner,
+        repo: input.repo,
+        branch: input.branch,
+      },
+      label: `pull request state for ${input.owner}/${input.repo}@${input.branch}`,
+    });
+
+    return parsePrState(data);
+  },
+});

--- a/apps/api/src/tools/github/search-branches.test.ts
+++ b/apps/api/src/tools/github/search-branches.test.ts
@@ -1,10 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { isGithubConnection } from "@/oauth/github-mint";
-import {
-  branchSearchErrorMessage,
-  parseBranchSearchResponse,
-  parseJsonBody,
-} from "./search-branches";
+import { parseBranchSearchResponse } from "./search-branches";
 
 const REPO = "acme/site";
 
@@ -12,21 +8,19 @@ describe("parseBranchSearchResponse", () => {
   it("maps refs to branches with their author", () => {
     const result = parseBranchSearchResponse(
       {
-        data: {
-          repository: {
-            refs: {
-              totalCount: 2,
-              nodes: [
-                {
-                  name: "feat/search",
-                  target: { author: { user: { login: "gimenes" } } },
-                },
-                {
-                  name: "main",
-                  target: { author: { user: { login: "octocat" } } },
-                },
-              ],
-            },
+        repository: {
+          refs: {
+            totalCount: 2,
+            nodes: [
+              {
+                name: "feat/search",
+                target: { author: { user: { login: "gimenes" } } },
+              },
+              {
+                name: "main",
+                target: { author: { user: { login: "octocat" } } },
+              },
+            ],
           },
         },
       },
@@ -45,12 +39,10 @@ describe("parseBranchSearchResponse", () => {
   it("nulls the author when the committer has no linked GitHub account", () => {
     const result = parseBranchSearchResponse(
       {
-        data: {
-          repository: {
-            refs: {
-              totalCount: 1,
-              nodes: [{ name: "fix-workspace-wallet", target: { author: {} } }],
-            },
+        repository: {
+          refs: {
+            totalCount: 1,
+            nodes: [{ name: "fix-workspace-wallet", target: { author: {} } }],
           },
         },
       },
@@ -64,11 +56,7 @@ describe("parseBranchSearchResponse", () => {
 
   it("nulls the author when the ref target is not a Commit", () => {
     const result = parseBranchSearchResponse(
-      {
-        data: {
-          repository: { refs: { totalCount: 1, nodes: [{ name: "odd" }] } },
-        },
-      },
+      { repository: { refs: { totalCount: 1, nodes: [{ name: "odd" }] } } },
       REPO,
     );
 
@@ -78,11 +66,7 @@ describe("parseBranchSearchResponse", () => {
   it("keeps totalCount above the returned page so callers can report the rest", () => {
     const result = parseBranchSearchResponse(
       {
-        data: {
-          repository: {
-            refs: { totalCount: 195, nodes: [{ name: "fix-ui" }] },
-          },
-        },
+        repository: { refs: { totalCount: 195, nodes: [{ name: "fix-ui" }] } },
       },
       REPO,
     );
@@ -93,26 +77,17 @@ describe("parseBranchSearchResponse", () => {
 
   it("returns an empty result when nothing matched", () => {
     const result = parseBranchSearchResponse(
-      { data: { repository: { refs: { totalCount: 0, nodes: [] } } } },
+      { repository: { refs: { totalCount: 0, nodes: [] } } },
       REPO,
     );
 
     expect(result).toEqual({ branches: [], totalCount: 0 });
   });
 
-  it("throws on a GraphQL error rather than reporting zero matches", () => {
-    expect(() =>
-      parseBranchSearchResponse(
-        { errors: [{ message: "Resource not accessible by integration" }] },
-        REPO,
-      ),
-    ).toThrow(/Resource not accessible by integration/);
-  });
-
   it("throws when the repository is hidden, naming the repo", () => {
-    expect(() =>
-      parseBranchSearchResponse({ data: { repository: null } }, REPO),
-    ).toThrow(/acme\/site not found or not accessible/);
+    expect(() => parseBranchSearchResponse({ repository: null }, REPO)).toThrow(
+      /acme\/site not found or not accessible/,
+    );
   });
 });
 
@@ -134,46 +109,5 @@ describe("isGithubConnection", () => {
   it("rejects a connection with no slug", () => {
     expect(isGithubConnection({})).toBe(false);
     expect(isGithubConnection({ slug: null })).toBe(false);
-  });
-});
-
-describe("branchSearchErrorMessage", () => {
-  it("surfaces retry-after guidance on a 403 rate limit", () => {
-    expect(branchSearchErrorMessage(403, "42")).toBe(
-      "GitHub GraphQL branch search rate-limited, retry after 42s",
-    );
-  });
-
-  it("surfaces retry-after guidance on a 429", () => {
-    expect(branchSearchErrorMessage(429, "5")).toBe(
-      "GitHub GraphQL branch search rate-limited, retry after 5s",
-    );
-  });
-
-  it("falls back to a generic status message without a retry-after header", () => {
-    expect(branchSearchErrorMessage(403, null)).toBe(
-      "GitHub GraphQL branch search failed: 403",
-    );
-  });
-
-  it("falls back to a generic status message for an unrelated failure", () => {
-    expect(branchSearchErrorMessage(500, null)).toBe(
-      "GitHub GraphQL branch search failed: 500",
-    );
-  });
-});
-
-describe("parseJsonBody", () => {
-  it("parses a well-formed JSON body", async () => {
-    const body = { data: { repository: null } };
-    const res = new Response(JSON.stringify(body));
-    expect(await parseJsonBody(res, REPO)).toEqual(body);
-  });
-
-  it("throws a named error instead of a raw SyntaxError on a malformed 2xx body", async () => {
-    const res = new Response("<html>upstream error</html>");
-    await expect(parseJsonBody(res, REPO)).rejects.toThrow(
-      /acme\/site returned invalid JSON: <html>upstream error<\/html>/,
-    );
   });
 });

--- a/apps/api/src/tools/github/search-branches.ts
+++ b/apps/api/src/tools/github/search-branches.ts
@@ -1,14 +1,6 @@
 import { z } from "zod";
 import { defineTool } from "../../core/define-tool";
-import {
-  githubConnectionAccessToken,
-  isGithubConnection,
-} from "@/oauth/github-mint";
-import { RECONNECT_ERROR } from "@/oauth/token-refresh";
-
-const GITHUB_GRAPHQL = "https://api.github.com/graphql";
-/** Matches the Git Data client's per-attempt timeout in `decofile/github-git-data.ts`. */
-const GITHUB_TIMEOUT_MS = 15_000;
+import { githubGraphql } from "./graphql";
 
 /**
  * Server-side branch search.
@@ -65,78 +57,31 @@ const branchSearchOutput = z.object({
 
 export type BranchSearchResult = z.infer<typeof branchSearchOutput>;
 
-/**
- * A 2xx response body isn't guaranteed to be JSON (a proxy/outage page can
- * still answer 200), and `res.json()` throwing a raw `SyntaxError` on that
- * would surface as an opaque "Unexpected token" instead of naming what
- * failed. Same gap the Jira client closed for its own 2xx-but-malformed
- * case (#6308).
- */
-export async function parseJsonBody(
-  res: Response,
-  repoLabel: string,
-): Promise<BranchSearchResponse> {
-  const text = await res.text();
-  try {
-    return JSON.parse(text) as BranchSearchResponse;
-  } catch (cause) {
-    throw new Error(
-      `GitHub GraphQL branch search for ${repoLabel} returned invalid JSON: ${text.slice(0, 300)}`,
-      { cause },
-    );
-  }
-}
-
-/**
- * A secondary-rate-limit or abuse-detection response (403/429 + `Retry-After`)
- * looks identical to a real permissions/server failure once reduced to a bare
- * status code, so callers can't tell "wait and retry" from "this is broken".
- */
-export function branchSearchErrorMessage(
-  status: number,
-  retryAfterHeader: string | null,
-): string {
-  if ((status === 403 || status === 429) && retryAfterHeader) {
-    return `GitHub GraphQL branch search rate-limited, retry after ${retryAfterHeader}s`;
-  }
-  return `GitHub GraphQL branch search failed: ${status}`;
-}
-
-interface BranchSearchResponse {
-  data?: {
-    repository?: {
-      refs?: {
-        totalCount?: number;
-        nodes?: Array<{
-          name?: string | null;
-          target?: {
-            author?: { user?: { login?: string | null } | null } | null;
-          } | null;
-        } | null> | null;
-      } | null;
+export interface BranchSearchData {
+  repository?: {
+    refs?: {
+      totalCount?: number;
+      nodes?: Array<{
+        name?: string | null;
+        target?: {
+          author?: { user?: { login?: string | null } | null } | null;
+        } | null;
+      } | null> | null;
     } | null;
-  };
-  errors?: Array<{ message?: string }>;
+  } | null;
 }
 
 /**
- * Narrow the GraphQL payload to the tool's output.
- *
- * Every level is optional in the schema: a commit authored by an address with
- * no GitHub account has `author.user === null`, as does a ref whose target the
- * union does not resolve to a Commit. Throws rather than returning a plausible
- * empty result when GitHub reported an error or hid the repository, so "no
- * matches" never masks "not allowed to look".
+ * Narrow the GraphQL payload to the tool's output. Every level is optional: a
+ * commit authored by an address with no GitHub account has `author.user ===
+ * null`, as does a ref whose target does not resolve to a Commit. A hidden
+ * repository throws, so "no matches" never masks "not allowed to look".
  */
 export function parseBranchSearchResponse(
-  payload: BranchSearchResponse,
+  payload: BranchSearchData,
   repoLabel: string,
 ): BranchSearchResult {
-  const error = payload.errors?.[0]?.message;
-  if (error) {
-    throw new Error(`GitHub GraphQL branch search failed: ${error}`);
-  }
-  const repository = payload.data?.repository;
+  const repository = payload.repository;
   if (!repository) {
     throw new Error(
       `Repository ${repoLabel} not found or not accessible by this connection`,
@@ -186,82 +131,21 @@ export const GITHUB_SEARCH_BRANCHES = defineTool({
   handler: async (input, ctx) => {
     await ctx.access.check();
 
-    // Ownership guard (as in GITHUB_LIST_USER_ORGS): no cross-org token reads.
-    const organizationId = ctx.organization?.id;
-    if (!organizationId) {
-      throw new Error("Organization context required");
-    }
-    const connection = await ctx.storage.connections.findById(
-      input.connectionId,
-      organizationId,
-    );
-    if (!connection) {
-      throw new Error("Connection not found");
-    }
-    if (!isGithubConnection(connection)) {
-      throw new Error("Connection is not a GitHub connection");
-    }
-
-    const accessToken = await githubConnectionAccessToken(ctx, connection);
-    if (!accessToken) {
-      throw new Error(RECONNECT_ERROR);
-    }
-
-    const search = input.query.trim();
-    const post = (token: string) =>
-      fetch(GITHUB_GRAPHQL, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          Accept: "application/vnd.github+json",
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          query: BRANCH_SEARCH_QUERY,
-          variables: {
-            owner: input.owner,
-            repo: input.repo,
-            // null is GraphQL's "no filter".
-            query: search === "" ? null : search,
-            limit: input.limit,
-          },
-        }),
-        signal: AbortSignal.timeout(GITHUB_TIMEOUT_MS),
-      });
-
-    let res = await post(accessToken);
-
-    // Token revoked/rotated behind our clock: one refresh + retry, then give up.
-    if (res.status === 401) {
-      // Drain the discarded 401 body so its connection is released.
-      try {
-        await res.body?.cancel();
-      } catch {
-        /* ignore */
-      }
-      const refreshed = await githubConnectionAccessToken(ctx, connection, {
-        forceRefresh: true,
-      });
-      if (!refreshed) {
-        throw new Error(RECONNECT_ERROR);
-      }
-      res = await post(refreshed);
-      if (res.status === 401) {
-        throw new Error(RECONNECT_ERROR);
-      }
-    }
-
-    if (!res.ok) {
-      throw new Error(
-        branchSearchErrorMessage(res.status, res.headers.get("retry-after")),
-      );
-    }
-
-    // GraphQL reports failures as 200 + `errors`, so an ok status isn't enough.
     const repoLabel = `${input.owner}/${input.repo}`;
-    return parseBranchSearchResponse(
-      await parseJsonBody(res, repoLabel),
-      repoLabel,
-    );
+    const search = input.query.trim();
+    const data = await githubGraphql<BranchSearchData>(ctx, {
+      connectionId: input.connectionId,
+      query: BRANCH_SEARCH_QUERY,
+      variables: {
+        owner: input.owner,
+        repo: input.repo,
+        // null is GraphQL's "no filter".
+        query: search === "" ? null : search,
+        limit: input.limit,
+      },
+      label: `branch search for ${repoLabel}`,
+    });
+
+    return parseBranchSearchResponse(data, repoLabel);
   },
 });

--- a/apps/api/src/tools/index.ts
+++ b/apps/api/src/tools/index.ts
@@ -238,6 +238,8 @@ export const CORE_TOOLS = [
   // GitHub tools (app-only)
   GitHubTools.GITHUB_LIST_USER_ORGS,
   GitHubTools.GITHUB_SEARCH_BRANCHES,
+  GitHubTools.GITHUB_PR_STATE,
+  GitHubTools.GITHUB_LAST_PUBLISHED_PR,
 
   // Link tools
 

--- a/apps/web/src/components/sandbox/hooks/use-pr-diff.ts
+++ b/apps/web/src/components/sandbox/hooks/use-pr-diff.ts
@@ -100,7 +100,7 @@ export function usePrDiff(args: {
       }
     },
     enabled: enabled && !!branch && !!headSha && !!connectionId,
-    refetchInterval: 30_000,
-    staleTime: 10_000,
+    /** `headSha` is in the key, so for a fixed key this content cannot change. */
+    staleTime: Infinity,
   });
 }

--- a/apps/web/src/components/thread/github/checks-tab.tsx
+++ b/apps/web/src/components/thread/github/checks-tab.tsx
@@ -41,7 +41,7 @@ export function ChecksTab({ pr, connectionId, owner, repo }: Props) {
     connectionId,
     owner,
     repo,
-    prNumber: pr.number,
+    branch: pr.head,
   });
 
   const rerun = (name: string) =>

--- a/apps/web/src/components/thread/github/cms-header-actions.tsx
+++ b/apps/web/src/components/thread/github/cms-header-actions.tsx
@@ -182,7 +182,7 @@ export function CmsHeaderActions({ virtualMcpId }: Props) {
     connectionId: githubRepo?.connectionId ?? "",
     owner: githubRepo?.owner ?? "",
     repo: githubRepo?.name ?? "",
-    prNumber: pr && pr.state === "open" ? pr.number : null,
+    branch: githubHeadBranch,
   });
 
   const reviewsQuery = usePrReviews({
@@ -191,7 +191,7 @@ export function CmsHeaderActions({ virtualMcpId }: Props) {
     connectionId: githubRepo?.connectionId ?? "",
     owner: githubRepo?.owner ?? "",
     repo: githubRepo?.name ?? "",
-    prNumber: pr && pr.state === "open" ? pr.number : null,
+    branch: githubHeadBranch,
   });
 
   const settling = isCmsStateSettling({
@@ -201,12 +201,9 @@ export function CmsHeaderActions({ virtualMcpId }: Props) {
     reviewsQuery,
   });
 
+  /** One refetch covers checks and reviews too — they share this cache entry. */
   const refreshPrState = async () => {
-    await Promise.all([
-      prQuery.refetch(),
-      checksQuery.refetch(),
-      reviewsQuery.refetch(),
-    ]);
+    await prQuery.refetch();
   };
 
   /**

--- a/apps/web/src/components/thread/github/cms-panel-state.test.ts
+++ b/apps/web/src/components/thread/github/cms-panel-state.test.ts
@@ -75,6 +75,7 @@ function pr(over: Partial<PrSummary> = {}): PrSummary {
     headRepoFullName: "acme/web",
     htmlUrl: "https://github.com/acme/web/pull/42",
     author: "me",
+    changedFiles: 3,
     ...over,
   };
 }
@@ -346,7 +347,8 @@ describe("selectCmsHeaderButton — 5. ready to publish", () => {
     expect(r.action).toBe("publish");
   });
 
-  test.each(["unstable", "behind", "unknown"] as const)(
+  /** "unstable"/"behind" left with `mergeable_state`; CI now lives in `checks`. */
+  test.each(["clean", "unknown"] as const)(
     "mergeableState=%s → Review & Publish",
     (mergeableState) => {
       const r = selectCmsHeaderButton(
@@ -497,21 +499,17 @@ describe("selectCmsHeaderButton — 7. up to date", () => {
     expect(r.menu).toEqual([]);
   });
 
-  test("disabled primary still carries a Get latest menu when behind", () => {
+  /** A branch behind base is not up to date — that label would be a lie. */
+  test("behind base → Get latest as the primary, not a disabled pill", () => {
     const r = selectCmsHeaderButton(
       input({ branch: ready({ behindBase: 4 }) }),
     );
-    expect(r.label).toBe("Up to date");
-    expect(r.disabled).toBe(true);
-    expect(r.action).toBeUndefined();
-    expect(r.menu).toEqual([
-      {
-        key: "get-latest",
-        label: "Get latest",
-        action: "get-latest",
-        tooltip: "Bring in new changes from production",
-      },
-    ]);
+    expect(r.label).toBe("Get latest");
+    expect(r.action).toBe("get-latest");
+    expect(r.variant).toBe("default");
+    expect(r.disabled).toBeFalsy();
+    expect(r.tooltip).toBe("Bring in new changes from production");
+    expect(r.menu).toEqual([]);
   });
 });
 
@@ -545,11 +543,12 @@ describe("selectCmsHeaderButton — Get latest in every menu when behind", () =>
     expect(menuKeys(r.menu)).toEqual(["request-approval", "get-latest"]);
   });
 
-  test("state 7 (up to date) appends Get latest", () => {
+  test("state 7 promotes Get latest to the primary instead of the menu", () => {
     const r = selectCmsHeaderButton(
       input({ branch: ready({ behindBase: 1 }) }),
     );
-    expect(menuKeys(r.menu)).toEqual(["get-latest"]);
+    expect(r.action).toBe("get-latest");
+    expect(menuKeys(r.menu)).toEqual([]);
   });
 
   test("behindBase = 0 → no Get latest anywhere", () => {
@@ -817,6 +816,20 @@ describe("merged pull request", () => {
     expect(r.label).toBe(threadEn["thread.headerActions.upToDate"]);
     expect(r.disabled).toBe(true);
     expect(r.action).toBeUndefined();
+  });
+
+  /** Publishing is done, so syncing this branch is not the next step. */
+  test("a merged PR behind base stays Up to date, Get latest in the menu", () => {
+    const r = selectCmsHeaderButton(
+      input({
+        branch: ready({ aheadOfBase: 2, behindBase: 3, headSha: "merged-sha" }),
+        pr: pr({ state: "closed", merged: true, headSha: "merged-sha" }),
+      }),
+    );
+    expect(r.label).toBe(threadEn["thread.headerActions.upToDate"]);
+    expect(r.disabled).toBe(true);
+    expect(r.action).toBeUndefined();
+    expect(menuKeys(r.menu)).toEqual(["get-latest"]);
   });
 
   test("offers to publish again once the branch advances past the merge", () => {

--- a/apps/web/src/components/thread/github/cms-panel-state.ts
+++ b/apps/web/src/components/thread/github/cms-panel-state.ts
@@ -39,8 +39,7 @@ export interface CmsMenuItem {
  *
  * An absent `action` means the primary half is an inert status pill. `loading`
  * puts a spinner in the primary half and is reserved for a genuine wait.
- * `disabled` and a non-empty `menu` can coexist: "Up to date" has nothing to
- * publish yet still offers "Get latest" when the branch is behind.
+ * `disabled` and a non-empty `menu` can coexist.
  */
 export interface CmsHeaderButton {
   label: string;
@@ -85,7 +84,7 @@ function viewOnGithubItem(t: TFunction): CmsMenuItem {
 /**
  * Appends "Get latest" to `menu` when the branch has commits on `base` it
  * hasn't taken in yet. Applied to every state whose primary action isn't
- * already `get-latest`, including the disabled "Up to date" pill.
+ * already `get-latest`.
  */
 function withGetLatest(
   menu: CmsMenuItem[],
@@ -349,11 +348,20 @@ export function selectCmsHeaderButton(
     };
   }
 
-  // Disabled primary, live menu: nothing to publish but base may have moved.
+  // Behind base is not "up to date", so the sync is the primary, not a menu entry.
+  if (branch.behindBase > 0) {
+    return {
+      label: t("thread.cmsActions.getLatest"),
+      action: "get-latest",
+      variant: "default",
+      tooltip: t("thread.cmsActions.getLatestTooltip"),
+      menu: [],
+    };
+  }
   return {
     label: t("thread.headerActions.upToDate"),
     variant: "outline",
     disabled: true,
-    menu: withGetLatest([], branch, t),
+    menu: [],
   };
 }

--- a/apps/web/src/components/thread/github/description-tab.tsx
+++ b/apps/web/src/components/thread/github/description-tab.tsx
@@ -23,7 +23,7 @@ export function DescriptionTab({ pr, connectionId, owner, repo }: Props) {
     connectionId,
     owner,
     repo,
-    prNumber: pr.number,
+    branch: pr.head,
   });
 
   return (

--- a/apps/web/src/components/thread/github/header-actions.tsx
+++ b/apps/web/src/components/thread/github/header-actions.tsx
@@ -232,7 +232,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
     connectionId: githubRepo?.connectionId ?? "",
     owner: githubRepo?.owner ?? "",
     repo: githubRepo?.name ?? "",
-    prNumber: pr && pr.state === "open" ? pr.number : null,
+    branch: githubHeadBranch,
   });
 
   const reviewsQuery = usePrReviews({
@@ -241,7 +241,7 @@ export function HeaderActions({ virtualMcpId }: Props) {
     connectionId: githubRepo?.connectionId ?? "",
     owner: githubRepo?.owner ?? "",
     repo: githubRepo?.name ?? "",
-    prNumber: pr && pr.state === "open" ? pr.number : null,
+    branch: githubHeadBranch,
   });
 
   /** Git state comes solely from the daemon's `branch` SSE event, which applies the boot-dirty baseline filter a raw /git/status poll would miss. */
@@ -337,12 +337,9 @@ export function HeaderActions({ virtualMcpId }: Props) {
   const baseBranch =
     effectiveBranchMeta.kind === "ready" ? effectiveBranchMeta.base : "main";
 
+  /** One refetch covers checks and reviews too — they share this cache entry. */
   const refreshPrState = async () => {
-    await Promise.all([
-      prQuery.refetch(),
-      checksQuery.refetch(),
-      reviewsQuery.refetch(),
-    ]);
+    await prQuery.refetch();
   };
 
   const switchToFreshBranch = async () => {

--- a/apps/web/src/components/thread/github/panel-state.test.ts
+++ b/apps/web/src/components/thread/github/panel-state.test.ts
@@ -78,6 +78,7 @@ function pr(over: Partial<PrSummary> = {}): PrSummary {
     headRepoFullName: "acme/web",
     htmlUrl: "https://github.com/acme/web/pull/42",
     author: "me",
+    changedFiles: 3,
     ...over,
   };
 }
@@ -313,15 +314,16 @@ describe("selectHeaderButton", () => {
     expect(r.menu).toEqual([]);
   });
 
-  test("up to date but behind base → disabled pill with Get latest in the menu", () => {
+  /** A branch behind base is not up to date — that label would be a lie. */
+  test("behind base → Get latest as the primary, not a disabled pill", () => {
     const r = selectHeaderButton(
       happyInput({ branch: ready({ behindBase: 2 }) }),
     );
-    expect(r.label).toBe("Up to date");
-    expect(r.disabled).toBe(true);
-    expect(menuKeys(r)).toEqual(["get-latest"]);
-    expect(menuItem(r, "get-latest")?.label).toBe("Get latest");
-    expect(menuItem(r, "get-latest")?.action).toBe("sync");
+    expect(r.label).toBe("Get latest");
+    expect(r.action).toBe("sync");
+    expect(r.variant).toBe("default");
+    expect(r.disabled).toBeFalsy();
+    expect(menuKeys(r)).toEqual([]);
   });
 
   test("dirty working tree → Review & Publish with Submit for review in the menu", () => {
@@ -427,6 +429,25 @@ describe("selectHeaderButton", () => {
     expect(r.variant).toBe("outline");
     expect(r.tooltip).toBe("PR #42 merged into main");
     expect(menuKeys(r)).toEqual(["view-on-github"]);
+  });
+
+  /** Publishing is done, so syncing this branch is not the next step. */
+  test("merged PR behind base stays Up to date, Get latest in the menu", () => {
+    const r = selectHeaderButton(
+      happyInput({
+        branch: ready({ aheadOfBase: 3, behindBase: 2, headSha: "abc123" }),
+        pr: pr({
+          state: "closed",
+          merged: true,
+          mergedAt: "2026-04-22T00:00:00Z",
+          headSha: "abc123",
+        }),
+      }),
+    );
+    expect(r.label).toBe("Up to date");
+    expect(r.disabled).toBe(true);
+    expect(r.tooltip).toBe("PR #42 merged into main");
+    expect(menuKeys(r)).toEqual(["view-on-github", "get-latest"]);
   });
 
   test("merged PR, branch advanced past merge head → Continue (special)", () => {

--- a/apps/web/src/components/thread/github/panel-state.ts
+++ b/apps/web/src/components/thread/github/panel-state.ts
@@ -151,7 +151,7 @@ function withPrLink(
   return [...menu, viewOnGithubItem(t)];
 }
 
-/** Appends "Get latest" when the branch is behind, including on the disabled "Up to date" pill. */
+/** Appends "Get latest" when the branch is behind and it isn't already the primary. */
 function withGetLatest(
   menu: HeaderMenuItem[],
   branch: BranchMeta,
@@ -503,6 +503,16 @@ export function selectHeaderButton(
     );
   }
 
+  // Behind base is not "in sync", so the sync is the primary, not a menu entry.
+  if (ready.behindBase > 0) {
+    return {
+      label: t("thread.cmsActions.getLatest"),
+      action: "sync",
+      variant: "default",
+      tooltip: t("thread.cmsActions.getLatestTooltip"),
+      menu: [],
+    };
+  }
   return {
     label: t("thread.headerActions.upToDate"),
     disabled: true,
@@ -510,6 +520,6 @@ export function selectHeaderButton(
     tooltip: t("thread.headerActions.branchInSyncTooltip", {
       base: ready.base,
     }),
-    menu: withGetLatest([], ready, t),
+    menu: [],
   };
 }

--- a/apps/web/src/components/thread/github/pr-sub-tabs.tsx
+++ b/apps/web/src/components/thread/github/pr-sub-tabs.tsx
@@ -35,6 +35,9 @@ export function PrSubTabs({
   repo,
 }: Props) {
   const { org } = useProjectContext();
+  const [activeValue, setActiveValue] = useState<TabValue>("changes");
+
+  /** File bodies are the panel's most expensive read — only load them on view. */
   const diffQuery = usePrDiff({
     orgSlug: org.slug,
     orgId: org.id,
@@ -46,12 +49,13 @@ export function PrSubTabs({
     connectionId,
     owner,
     repo,
+    enabled: activeValue === "changes",
   });
-  const diffCount = diffQuery.data
-    ? countGitDiffFiles(diffQuery.data)
-    : undefined;
 
-  const [activeValue, setActiveValue] = useState<TabValue>("changes");
+  /** The PR read already knows the count; the bodies only confirm it. */
+  const diffCount =
+    pr.changedFiles ??
+    (diffQuery.data ? countGitDiffFiles(diffQuery.data) : undefined);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">

--- a/apps/web/src/components/thread/github/sandbox-git-api.ts
+++ b/apps/web/src/components/thread/github/sandbox-git-api.ts
@@ -93,6 +93,16 @@ export function isSandboxUnreachable(error: unknown): boolean {
   );
 }
 
+/**
+ * Retry predicate for the Fast Preview git queries: a 429 is GitHub refusing us
+ * for rate reasons, and retrying that is the burst that keeps the window shut.
+ * Everything else keeps the client's default single retry.
+ */
+function retryGitRequest(failureCount: number, error: unknown): boolean {
+  if (error instanceof SandboxGitError && error.status === 429) return false;
+  return failureCount < 1;
+}
+
 async function parseJson<T>(res: Response): Promise<T> {
   const body = (await res.json()) as T & { error?: string };
   if (!res.ok) {
@@ -441,6 +451,7 @@ export function sandboxGitStatusQueryOptions(
     queryKey: sandboxGitStatusQueryKey(orgSlug, virtualMcpId, branch),
     queryFn: () => fetchGitStatus(orgSlug, virtualMcpId, branch),
     staleTime: GIT_STATUS_STALE_MS,
+    retry: retryGitRequest,
   };
 }
 

--- a/apps/web/src/components/thread/github/use-cms-publish-actions.ts
+++ b/apps/web/src/components/thread/github/use-cms-publish-actions.ts
@@ -91,8 +91,8 @@ export function useCmsPublishActions(
             }),
       );
       onOpenChange(false);
-      await onPullRequestChanged?.();
-      await onPublished?.();
+      // Together: awaiting the PR re-read first let the stale open PR render.
+      await Promise.all([onPullRequestChanged?.(), onPublished?.()]);
     } catch (error) {
       const failure = reportPublishFailure(error, t);
       setPublishError(failure.message);

--- a/apps/web/src/components/thread/github/use-pr-data.ts
+++ b/apps/web/src/components/thread/github/use-pr-data.ts
@@ -1,19 +1,20 @@
 /**
- * PR panel data hooks.
+ * PR panel data hooks. The branch's PR, its check runs, its review state and its
+ * comments all come from ONE polled read — the `GITHUB_PR_STATE` tool. The hooks
+ * below are selectors over that one cache entry (they share
+ * `KEYS.githubPrState`), so mounting all four costs one request and every
+ * surface reads the same instant of the PR.
  *
- * All reads go through the unified `pull_request_read` tool on
- * github-mcp-server, which exposes sub-calls via a `method` arg:
- *   method: "get"             → PR details
- *   method: "get_files"       → files changed
- *   method: "get_check_runs"  → CI check runs for the head commit
- *   method: "get_comments"    → issue-level comments
- *   method: "get_reviews"     → submitted reviews
- *
- * Tool args use camelCase (pullNumber, perPage). Listing PRs by branch
- * still goes through the separate `list_pull_requests` tool.
+ * Still on github-mcp-server: `list_pull_requests` for the branch picker's
+ * "PRs" tab (a repo-wide list, not this PR), and `GET_CHECK_RUN` for one run's
+ * `output` markdown when a Checks row is expanded.
  */
 
+import { useQuery } from "@tanstack/react-query";
+
 import { useMCPClient, useMCPToolCallQuery } from "@/sdk";
+import { callStudioTool } from "@/lib/studio-tools";
+import { KEYS } from "@/lib/query-keys";
 
 import { extractPullRequestList } from "./github-pr-api.ts";
 import { assertToolOk, extractToolJson } from "./extract-tool-json.ts";
@@ -28,7 +29,7 @@ export interface PrSummary {
   mergedAt: string | null;
   base: string;
   head: string;
-  /** SHA of the PR head commit — used to fetch check runs. */
+  /** SHA of the PR head commit — used to key the diff. */
   headSha: string;
   /**
    * `owner/name` of the repo the head branch lives in. Differs from the base
@@ -38,6 +39,11 @@ export interface PrSummary {
   headRepoFullName: string | null;
   htmlUrl: string;
   author: string;
+  /**
+   * Files the PR touches. null when the source could not say — the repo-wide
+   * PR list does not carry it — so a caller must not read null as "no changes".
+   */
+  changedFiles: number | null;
 }
 
 const POLL = 60_000;
@@ -93,7 +99,11 @@ export interface PrComment {
   htmlUrl: string;
 }
 
-/** Maps a raw github-mcp list/get PR object into the app's PrSummary. */
+type PrState = Awaited<
+  ReturnType<typeof callStudioTool<"GITHUB_PR_STATE">>
+>["pullRequest"];
+
+/** Maps a raw github-mcp list PR object into the app's PrSummary. */
 function mapRawPr(p: Record<string, unknown>): PrSummary {
   const base = p.base as Record<string, unknown> | undefined;
   const head = p.head as Record<string, unknown> | undefined;
@@ -112,92 +122,128 @@ function mapRawPr(p: Record<string, unknown>): PrSummary {
     headRepoFullName: (headRepo?.full_name as string) ?? null,
     htmlUrl: (p.html_url as string) ?? "",
     author: (user?.login as string) ?? "",
+    changedFiles: null,
+  };
+}
+
+/** The PrSummary view of the unified read. */
+function toPrSummary(pr: NonNullable<PrState>): PrSummary {
+  return {
+    number: pr.number,
+    title: pr.title,
+    body: pr.body,
+    state: pr.state,
+    merged: pr.merged,
+    mergedAt: pr.mergedAt,
+    base: pr.base,
+    head: pr.head,
+    headSha: pr.headSha,
+    headRepoFullName: pr.headRepoFullName,
+    htmlUrl: pr.htmlUrl,
+    author: pr.author,
+    changedFiles: pr.changedFiles,
   };
 }
 
 /**
- * Fetches the first PR matching a branch head (open or closed).
- * Returns null when no PR exists yet for that branch.
+ * The one PR read every panel hook selects from. Spread this rather than
+ * restating the key — two hooks that disagree about it would double the poll.
  */
-export function usePrByBranch(args: RepoArgs & { branch: string | null }) {
-  const client = useMCPClient({
-    connectionId: args.connectionId,
-    orgId: args.orgId,
-    orgSlug: args.orgSlug,
-  });
-
-  return useMCPToolCallQuery<PrSummary | null>({
-    client,
-    toolName: "list_pull_requests",
-    toolArguments: {
-      owner: args.owner,
-      repo: args.repo,
-      state: "all",
-      ...(args.branch ? { head: `${args.owner}:${args.branch}` } : {}),
-      perPage: 1,
-    },
-    enabled:
-      !!args.branch && !!args.connectionId && !!args.owner && !!args.repo,
+export function prStateQueryOptions(
+  args: RepoArgs & { branch: string | null },
+) {
+  const { orgSlug, connectionId, owner, repo, branch } = args;
+  return {
+    queryKey: KEYS.githubPrState(orgSlug, connectionId, owner, repo, branch),
+    queryFn: () =>
+      callStudioTool(orgSlug, "GITHUB_PR_STATE", {
+        connectionId,
+        owner,
+        repo,
+        branch: branch as string,
+      }),
+    enabled: !!branch && !!connectionId && !!owner && !!repo,
     refetchInterval: POLL,
     refetchIntervalInBackground: false,
     staleTime: STALE,
-    select: (r) => {
-      assertToolOk(r);
-      const arr = extractPullRequestList(r);
-      if (arr.length === 0) return null;
-      return mapRawPr(arr[0]!);
-    },
+  };
+}
+
+/**
+ * The branch's most recent pull request (open or closed).
+ * Returns null when no PR exists yet for that branch.
+ */
+export function usePrByBranch(args: RepoArgs & { branch: string | null }) {
+  return useQuery({
+    ...prStateQueryOptions(args),
+    select: (r): PrSummary | null =>
+      r.pullRequest ? toPrSummary(r.pullRequest) : null,
   });
 }
 
-/** The most recent merged PR into `base` — in Fast Preview every publish is a
- * squash-merged PR, so this IS the last publish. Mounted by the header so the
- * "last published" line is warm before the publish surface opens; never
- * polled, because `list_pull_requests` is rate-limit-heavy (see
- * `openPullRequestForBranch`). `sort: updated` can interleave non-merged
- * closed PRs, hence a small page filtered client-side.
+/**
+ * Check runs for the PR's head commit. Empty unless the PR is open — a closed
+ * PR's checks describe work nobody can act on.
+ */
+export function useChecks(args: RepoArgs & { branch: string | null }) {
+  return useQuery({
+    ...prStateQueryOptions(args),
+    select: (r): CheckRun[] =>
+      r.pullRequest?.state === "open" ? r.pullRequest.checks : [],
+  });
+}
+
+/**
+ * Issue-level comments on the PR. Does NOT include review comments tied to a
+ * file + line — those belong near the diff on the Changes tab.
+ */
+export function usePrComments(args: RepoArgs & { branch: string | null }) {
+  return useQuery({
+    ...prStateQueryOptions(args),
+    select: (r): PrComment[] => r.pullRequest?.comments ?? [],
+  });
+}
+
+/**
+ * The last publish — in Fast Preview every publish is a squash-merged PR.
+ * Mounted by the header so the line is warm before the publish surface opens;
+ * never polled, because it changes only when someone publishes.
  */
 export function useLastPublishedPr(
   args: RepoArgs & { base: string | null; enabled?: boolean },
 ) {
-  const client = useMCPClient({
-    connectionId: args.connectionId,
-    orgId: args.orgId,
-    orgSlug: args.orgSlug,
-  });
-
-  return useMCPToolCallQuery<PrSummary | null>({
-    client,
-    toolName: "list_pull_requests",
-    toolArguments: {
-      owner: args.owner,
-      repo: args.repo,
-      state: "closed",
-      base: args.base ?? "",
-      sort: "updated",
-      direction: "desc",
-      perPage: LAST_PUBLISHED_PER_PAGE,
-    },
+  const { orgSlug, connectionId, owner, repo, base } = args;
+  return useQuery({
+    queryKey: KEYS.githubLastPublishedPr(
+      orgSlug,
+      connectionId,
+      owner,
+      repo,
+      base,
+    ),
+    queryFn: () =>
+      callStudioTool(orgSlug, "GITHUB_LAST_PUBLISHED_PR", {
+        connectionId,
+        owner,
+        repo,
+        base: base as string,
+      }),
     enabled:
-      (args.enabled ?? true) &&
-      !!args.base &&
-      !!args.connectionId &&
-      !!args.owner &&
-      !!args.repo,
+      (args.enabled ?? true) && !!base && !!connectionId && !!owner && !!repo,
     staleTime: LAST_PUBLISHED_STALE,
-    select: (r) => {
-      assertToolOk(r);
-      return (
-        extractPullRequestList(r)
-          .map(mapRawPr)
-          .find((p) => p.merged) ?? null
-      );
-    },
+    select: (r): PrSummary | null =>
+      r.pullRequest
+        ? {
+            ...r.pullRequest,
+            state: "closed" as const,
+            merged: true,
+            headRepoFullName: null,
+            changedFiles: null,
+          }
+        : null,
   });
 }
 
-/** Closed PRs read per lookup; `sort: updated` mixes in non-merged ones. */
-const LAST_PUBLISHED_PER_PAGE = 10;
 /** The last publish changes only when someone publishes — cheap to keep. */
 const LAST_PUBLISHED_STALE = 5 * 60_000;
 
@@ -241,68 +287,10 @@ export function useOpenPrs(args: RepoArgs & { enabled?: boolean }) {
 }
 
 /**
- * Fetches CI check runs for a PR's head commit via
- * pull_request_read(get_check_runs).
- */
-export function useChecks(
-  args: RepoArgs & { prNumber: number | null | undefined },
-) {
-  const client = useMCPClient({
-    connectionId: args.connectionId,
-    orgId: args.orgId,
-    orgSlug: args.orgSlug,
-  });
-
-  return useMCPToolCallQuery<CheckRun[]>({
-    client,
-    toolName: "pull_request_read",
-    toolArguments: {
-      method: "get_check_runs",
-      owner: args.owner,
-      repo: args.repo,
-      pullNumber: args.prNumber ?? 0,
-    },
-    enabled: !!args.prNumber,
-    refetchInterval: POLL,
-    refetchIntervalInBackground: false,
-    staleTime: STALE,
-    select: (r) => {
-      assertToolOk(r);
-      // Accept both `{ check_runs: [...] }` envelopes and raw arrays.
-      const raw = extractToolJson<
-        { check_runs?: Record<string, unknown>[] } | Record<string, unknown>[]
-      >(r);
-      const runs = Array.isArray(raw) ? raw : (raw?.check_runs ?? []);
-      return runs.map((c): CheckRun => {
-        const startedAt = (c as { started_at?: string }).started_at;
-        const completedAt = (c as { completed_at?: string }).completed_at;
-        const durationMs =
-          startedAt && completedAt
-            ? new Date(completedAt).getTime() - new Date(startedAt).getTime()
-            : null;
-        return {
-          id: String((c as { id?: unknown }).id ?? ""),
-          name: String((c as { name?: unknown }).name ?? ""),
-          status:
-            ((c as { status?: unknown }).status as CheckRun["status"]) ??
-            "completed",
-          conclusion:
-            ((c as { conclusion?: unknown }).conclusion as
-              | CheckRun["conclusion"]
-              | undefined) ?? null,
-          htmlUrl: String((c as { html_url?: unknown }).html_url ?? ""),
-          durationMs,
-        };
-      });
-    },
-  });
-}
-
-/**
  * Fetches a single check run's full `output` (title/summary/text markdown) via
- * the github-mcp first-party GET_CHECK_RUN tool. The list tool
- * (pull_request_read get_check_runs) returns a minimal shape without `output`,
- * so the Checks tab lazily loads this when a row is expanded.
+ * the github-mcp first-party GET_CHECK_RUN tool. The unified PR read returns a
+ * minimal check shape without `output`, so the Checks tab lazily loads this
+ * when a row is expanded.
  */
 export function useCheckRunDetail(
   args: RepoArgs & { checkRunId: number | null; enabled: boolean },
@@ -331,51 +319,6 @@ export function useCheckRunDetail(
         summary: d?.output?.summary ?? null,
         text: d?.output?.text ?? null,
       };
-    },
-  });
-}
-
-/**
- * Issue-level comments on a PR via pull_request_read(get_comments).
- * Does NOT return review comments tied to a file + line — those belong
- * near the diff on the Changes tab and are out of scope for this hook.
- */
-export function usePrComments(
-  args: RepoArgs & { prNumber: number | null | undefined },
-) {
-  const client = useMCPClient({
-    connectionId: args.connectionId,
-    orgId: args.orgId,
-    orgSlug: args.orgSlug,
-  });
-
-  return useMCPToolCallQuery<PrComment[]>({
-    client,
-    toolName: "pull_request_read",
-    toolArguments: {
-      method: "get_comments",
-      owner: args.owner,
-      repo: args.repo,
-      pullNumber: args.prNumber ?? 0,
-    },
-    enabled: !!args.prNumber,
-    refetchInterval: POLL,
-    refetchIntervalInBackground: false,
-    staleTime: STALE,
-    select: (r) => {
-      assertToolOk(r);
-      const arr = extractToolJson<Record<string, unknown>[]>(r);
-      if (!Array.isArray(arr)) return [];
-      return arr.map((c): PrComment => {
-        const user = (c as { user?: { login?: string } }).user;
-        return {
-          id: Number((c as { id?: unknown }).id ?? 0),
-          author: user?.login ?? "",
-          body: String((c as { body?: unknown }).body ?? ""),
-          createdAt: String((c as { created_at?: unknown }).created_at ?? ""),
-          htmlUrl: String((c as { html_url?: unknown }).html_url ?? ""),
-        };
-      });
     },
   });
 }

--- a/apps/web/src/components/thread/github/use-pr-reviews.ts
+++ b/apps/web/src/components/thread/github/use-pr-reviews.ts
@@ -1,27 +1,17 @@
 /**
- * usePrReviews — fetches draft/mergeable/unresolved-conversation/missing-
- * approvals signals for an open PR. Backed by github-mcp-server's
- * `get_pull_request`. Mirrors the polling and stale-time conventions of
- * usePrByBranch and useChecks.
+ * usePrReviews — draft/mergeable/unresolved-conversation/missing-approvals
+ * signals for the branch's PR. A selector over the same `GITHUB_PR_STATE` entry
+ * `usePrByBranch` and `useChecks` read, so it costs no extra request.
  *
- * Semantic notes:
- * - `missingRequiredApprovals` is a heuristic: mergeable_state="blocked"
- *   and no unresolved conversations. GitHub doesn't expose approval-
- *   requirement state via this endpoint directly; this is the best signal
- *   available without an additional review-threads call.
+ * `missingRequiredApprovals` is `reviewDecision` and `unresolvedConversations`
+ * counts unresolved review threads — both were inferences over REST before.
  */
 
-import { useMCPClient, useMCPToolCallQuery } from "@/sdk";
+import { useQuery } from "@tanstack/react-query";
 
-import { assertToolOk, extractToolJson } from "./extract-tool-json.ts";
+import { prStateQueryOptions } from "./use-pr-data.ts";
 
-export type MergeableState =
-  | "clean"
-  | "dirty"
-  | "unstable"
-  | "blocked"
-  | "unknown"
-  | "behind";
+export type MergeableState = "clean" | "dirty" | "blocked" | "unknown";
 
 export interface PrReviewSignals {
   draft: boolean;
@@ -30,54 +20,26 @@ export interface PrReviewSignals {
   missingRequiredApprovals: boolean;
 }
 
-const POLL = 60_000;
-const STALE = 30_000;
-
 interface Args {
   orgId: string;
   orgSlug: string;
   connectionId: string;
   owner: string;
   repo: string;
-  prNumber: number | null | undefined;
+  branch: string | null;
 }
 
 export function usePrReviews(args: Args) {
-  const client = useMCPClient({
-    connectionId: args.connectionId,
-    orgId: args.orgId,
-    orgSlug: args.orgSlug,
-  });
-
-  return useMCPToolCallQuery<PrReviewSignals | null>({
-    client,
-    toolName: "pull_request_read",
-    toolArguments: {
-      method: "get",
-      owner: args.owner,
-      repo: args.repo,
-      pullNumber: args.prNumber ?? 0,
-    },
-    enabled: !!args.prNumber,
-    refetchInterval: POLL,
-    refetchIntervalInBackground: false,
-    staleTime: STALE,
-    select: (r) => {
-      assertToolOk(r);
-      const p = extractToolJson<Record<string, unknown>>(r);
-      if (!p) return null;
-      const ms = (p.mergeable_state as MergeableState | undefined) ?? "unknown";
-      const draft = Boolean(p.draft ?? false);
-      const reviewCommentsCount = Number(p.review_comments ?? 0);
-      const unresolvedConversations =
-        ms === "blocked" && reviewCommentsCount > 0 ? reviewCommentsCount : 0;
-      const missingRequiredApprovals =
-        ms === "blocked" && unresolvedConversations === 0;
+  return useQuery({
+    ...prStateQueryOptions(args),
+    select: (r): PrReviewSignals | null => {
+      const pr = r.pullRequest;
+      if (!pr) return null;
       return {
-        draft,
-        mergeableState: ms,
-        unresolvedConversations,
-        missingRequiredApprovals,
+        draft: pr.draft,
+        mergeableState: pr.mergeableState,
+        unresolvedConversations: pr.unresolvedConversations,
+        missingRequiredApprovals: pr.missingRequiredApprovals,
       };
     },
   });

--- a/apps/web/src/lib/query-keys.ts
+++ b/apps/web/src/lib/query-keys.ts
@@ -199,6 +199,35 @@ export const KEYS = {
     repo: string,
   ) => ["github-branches", orgId, orgSlug, connectionId, owner, repo] as const,
 
+  /**
+   * The branch's pull request with its checks, review state and comments — ONE
+   * key for all four, so those hooks share a single request (see
+   * GITHUB_PR_STATE).
+   */
+  githubPrState: (
+    orgSlug: string,
+    connectionId: string | null | undefined,
+    owner: string,
+    repo: string,
+    branch: string | null,
+  ) => ["github-pr-state", orgSlug, connectionId, owner, repo, branch] as const,
+
+  githubLastPublishedPr: (
+    orgSlug: string,
+    connectionId: string | null | undefined,
+    owner: string,
+    repo: string,
+    base: string | null,
+  ) =>
+    [
+      "github-last-published-pr",
+      orgSlug,
+      connectionId,
+      owner,
+      repo,
+      base,
+    ] as const,
+
   githubBranchSearch: (
     orgId: string,
     orgSlug: string,

--- a/packages/e2e/fixtures/github-stub.ts
+++ b/packages/e2e/fixtures/github-stub.ts
@@ -24,6 +24,7 @@
  *   GET   /repos/{o}/{r}/git/commits/{sha}            -> { tree: { sha }, parents }
  *   GET   /repos/{o}/{r}/git/trees/{sha}?recursive=1  -> { tree: [...], truncated }
  *   GET   /repos/{o}/{r}/git/blobs/{sha}              -> { content, encoding }
+ *   GET   /repos/{o}/{r}/contents/{path}?ref={sha}    -> { sha, content, encoding }
  *   POST  /repos/{o}/{r}/git/blobs                    -> { sha }
  *   POST  /repos/{o}/{r}/git/trees                    -> { sha } (entry sha:null deletes)
  *   POST  /repos/{o}/{r}/git/commits                  -> { sha }
@@ -463,6 +464,28 @@ async function handleRepos(
         // cold-read path pre-validates tarball downloads against it.
         size: Buffer.byteLength(repo.blobs.get(blobSha) ?? "", "utf8"),
       })),
+    });
+    return;
+  }
+
+  // GET /repos/{o}/{r}/contents/{path}?ref={sha|branch}
+  if (req.method === "GET" && rest[0] === "contents" && rest.length > 1) {
+    const filePath = rest.slice(1).join("/");
+    const ref = url.searchParams.get("ref") ?? repo.defaultBranch;
+    const commitSha = repo.refs.get(ref) ?? ref;
+    const blobSha = treeOfCommit(repo, commitSha).get(filePath);
+    const content = blobSha ? repo.blobs.get(blobSha) : undefined;
+    if (content === undefined) {
+      notFound(res);
+      return;
+    }
+    json(res, 200, {
+      type: "file",
+      path: filePath,
+      sha: blobSha,
+      size: Buffer.byteLength(content, "utf8"),
+      content: Buffer.from(content, "utf-8").toString("base64"),
+      encoding: "base64",
     });
     return;
   }

--- a/packages/shared/src/tools/registry-metadata.ts
+++ b/packages/shared/src/tools/registry-metadata.ts
@@ -242,6 +242,8 @@ const ALL_TOOL_NAMES = [
   // GitHub tools (app-only)
   "GITHUB_LIST_USER_ORGS",
   "GITHUB_SEARCH_BRANCHES",
+  "GITHUB_PR_STATE",
+  "GITHUB_LAST_PUBLISHED_PR",
 
   // Search tools
   "GLOBAL_SEARCH",
@@ -1137,6 +1139,18 @@ export const MANAGEMENT_TOOLS: ToolMetadata[] = [
     description: "Search a repository's branches by name substring",
     category: "GitHub",
   },
+  {
+    name: "GITHUB_PR_STATE",
+    description:
+      "Read a branch's pull request with its checks, review state and comments",
+    category: "GitHub",
+  },
+  {
+    name: "GITHUB_LAST_PUBLISHED_PR",
+    description:
+      "Read the most recently merged pull request into a base branch",
+    category: "GitHub",
+  },
   // Search tools
   {
     name: "GLOBAL_SEARCH",
@@ -1314,6 +1328,9 @@ const PERMISSION_CAPABILITIES: PermissionCapability[] = [
       "SANDBOX_START",
       "SANDBOX_DELETE",
       "GITHUB_SEARCH_BRANCHES",
+      // The PR panel's whole read side, for anyone who can open a preview
+      "GITHUB_PR_STATE",
+      "GITHUB_LAST_PUBLISHED_PR",
       // Cross-resource discovery / command palette
       "GLOBAL_SEARCH",
       // App-shell essentials (read-only) — every member hits these on first

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -395,6 +395,7 @@ export interface StudioToolIO {
         updatedBy: string;
         updatedAt: string;
       }[];
+      repos: string[];
     };
   };
   TASK_BOARD_ITEM_UPDATE: {
@@ -7081,6 +7082,74 @@ export interface StudioToolIO {
     output: {
       branches: { name: string; author: string | null }[];
       totalCount: number;
+    };
+  };
+  GITHUB_PR_STATE: {
+    input: {
+      connectionId: string;
+      owner: string;
+      repo: string;
+      branch: string;
+    };
+    output: {
+      pullRequest: {
+        number: number;
+        title: string;
+        body: string;
+        state: "open" | "closed";
+        merged: boolean;
+        mergedAt: string | null;
+        base: string;
+        head: string;
+        headSha: string;
+        headRepoFullName: string | null;
+        htmlUrl: string;
+        author: string;
+        draft: boolean;
+        mergeableState: "unknown" | "clean" | "dirty" | "blocked";
+        unresolvedConversations: number;
+        missingRequiredApprovals: boolean;
+        changedFiles: number;
+        checks: {
+          id: string;
+          name: string;
+          status: "in_progress" | "completed" | "queued";
+          conclusion:
+            | "success"
+            | "skipped"
+            | "cancelled"
+            | "failure"
+            | "neutral"
+            | "timed_out"
+            | "action_required"
+            | null;
+          htmlUrl: string;
+          durationMs: number | null;
+        }[];
+        comments: {
+          id: number;
+          author: string;
+          body: string;
+          createdAt: string;
+          htmlUrl: string;
+        }[];
+      } | null;
+    };
+  };
+  GITHUB_LAST_PUBLISHED_PR: {
+    input: { connectionId: string; owner: string; repo: string; base: string };
+    output: {
+      pullRequest: {
+        number: number;
+        title: string;
+        body: string;
+        mergedAt: string | null;
+        base: string;
+        head: string;
+        headSha: string;
+        htmlUrl: string;
+        author: string;
+      } | null;
     };
   };
   GLOBAL_SEARCH: {


### PR DESCRIPTION
## What is this contribution about?

An audit of every GitHub call the Fast Preview flow makes, and the fixes it turned up. Three unrelated transports reach GitHub — the browser through the MCP proxy, the API through a hand-rolled REST client, and the GraphQL tool from #6273 — and they share one installation token, so one budget.

The cost was concentrated in the **read** surfaces. Six findings, in rough order of traffic removed:

**1. The PR diff polled content that cannot change.** `usePrDiff` set `refetchInterval: 30_000` on a query whose key already pins `headSha`. On the GitHub fallback that is one file-list page plus **two blob reads per changed file** — 83 upstream calls every 30 seconds for a 40-file PR, per viewer, re-fetching an answer it already had. It also mounted regardless of active tab, purely to compute a badge number. Now `staleTime: Infinity`, gated on the Changes tab, with the count taken off the PR read.

**2. PR panel state was four polled REST reads.** `usePrByBranch`, `useChecks`, `usePrReviews` and `usePrComments` each polled independently over a four-hop chain, describing one pull request at one instant. `GITHUB_PR_STATE` answers all four in one GraphQL query, and the hooks are now selectors over a single cache entry.

Two of those reads were also answering with guesses, because REST does not expose what the panel asks:
- "blocked on a human?" was inferred from `mergeable_state === "blocked"` with no unresolved conversations → now `reviewDecision`.
- "how many unresolved conversations?" was the raw `review_comments` count, every review comment ever left → now `reviewThreads[].isResolved`.

**3. The diff's base side read the entire repo tree.** `githubGitDiff` resolved base-side blob shas from the merge base's full recursive tree — a whole-repo read to look up a handful of paths, excluded from the ETag cache, and a hard 502 past GitHub's tree-truncation ceiling, so a large repo could not publish a *modification* at all. Now reads the wanted paths directly, same one call per file.

**4. No rate-limit awareness on the busiest path.** The Git Data client read no `x-ratelimit-*`, no `Retry-After`, and had no 403/429 handling, while the task board — same token — carries a whole subsystem built after its own comments record the App's limit shutting for 17 hours. Added metrics tagged by lane, plus a typed non-retriable `GitHubRateLimitError` surfaced as a 429 with `Retry-After`.

**5. `/git/status` was three serial round trips.** `default_branch` is now cached across requests (its memo lived on a client that exists for one request), and the head read runs against the compare.

**6. "Up to date" while behind base.** The header rendered a disabled pill and demoted "Get latest" to the dropdown when the branch had nothing of its own to publish — but a branch behind base is not up to date, and the coding-session tooltip claimed it was "in sync with" base while it was behind. Both state machines now promote the sync to the primary. A merged PR stays terminal.

`GITHUB_LAST_PUBLISHED_PR` also replaces reading ten closed PRs and scanning for a merged one — `states: MERGED` makes `first: 1` exact, and fixes reporting "never published" for a base whose whole page was abandoned.

**Deliberately not in scope**, each wanting its own flagged PR: webhook fan-out to replace the polls (`github-webhook.ts` already verifies push events and ignores everything else), server-side publish orchestration, and cursor pagination to unify the branch picker's browse path.

## How did you verify your code works?

**Unit tests — 47 new, 3 inverted.**
- `pr-state.test.ts` (16) — the GraphQL fold: MERGED-vs-CLOSED state, `reviewDecision` → `missingRequiredApprovals`, unresolved-thread counting, check-run mapping keeping the `databaseId` that `GET_CHECK_RUN` needs, legacy `StatusContext` filtering, `STARTUP_FAILURE`/`STALE` folding, deleted forks and commits with no linked account.
- `github-rate-limit.test.ts` (17) — header parsing, and specifically that a plain 403 is **not** treated as a limit (a missing-scope 403 must not tell you to wait for a window that will never help).
- `graphql.test.ts` (8), `last-published-pr.test.ts` (3).
- Inverted rather than appended, since they encoded the old behaviour: the two `"Up to date"`-while-behind cases, and the `mergeableState` parameterisation over `"unstable"`/`"behind"` (states GraphQL does not report).

**Measured, not estimated.** Drove `githubGitStatus`/`githubGitDiff` against the e2e GitHub stub with every upstream call logged:
- `/git/status`: 3 calls / 3 serial RTTs → **2 calls / 1 RTT** (and 0 calls for the default branch on a warm process).
- `/git/diff`, three changed files: 7 calls → **5**, whole-repo tree read gone.
- First-touch branch (compare 404s, waits on ref creation, retries): correct `aheadOfBase: 0`.
- Post-publish fresh branch: `aheadOfBase: 0, behindBase: 0` — confirming the button lands on "Up to date" and the new `behindBase` branch does not fire.

**Server smoke.** Ran the dev server; `POST /api/:org/tools/GITHUB_PR_STATE` returns 403 (access check reached) where an invented tool name returns 404, confirming registration, contract generation and the permission grant.

**Gate.** `bun run fmt`, `bun run lint` (0 errors), `bun run check:ci` (all 14 workspaces), `bun run knip` (clean), and the touched-area suites — 722 passing.

**Not run:** the `.integration.test.ts` tier (needs Postgres) and Playwright (needs Docker); neither is available in this worktree. The Playwright specs are the real coverage for `githubGitDiff`, so **a full e2e run before merge is worth it** — I added a `/contents/{path}?ref=` handler to the stub for the new read path and exercised it directly, but not through the suite. The UI itself is unverified: the browser driver was unavailable, so the flows below need a human.

## Screenshots/Demonstration

N/A — no visual redesign. The one user-visible copy change is the header button reading "Get latest" instead of a disabled "Up to date" when the branch is behind base.

## How to Test

Needs a `mcp-github` connection with a repo that has an open PR.

1. **One request, not four.** Open a project on a branch with an open PR, open the PR panel. In DevTools → Network filter `tools/GITHUB_PR_STATE`: exactly **one** request per 60s poll, no `mcp/` calls for PR state. Description, Changes and Checks tabs should all populate from it.
2. **Diff gating.** Stay on Description → **no** `/git/diff` call. Click Changes → fires once. Leave it open several minutes → never fires again.
3. **Review signals.** On a PR with *resolved* review comments, the "Address feedback" count should now be lower (and right) — it counts unresolved threads, not every comment ever left. A PR needing approval → "Waiting for review"; a conflicted PR → "Get latest".
4. **Behind base.** Put a branch behind its base with nothing of its own to publish → primary reads **"Get latest"**, not a disabled "Up to date". Level with base → unchanged pill. Sitting on a merged PR → pill, with "Get latest" in the menu.
5. **Publish.** Edit a block, publish. A **modified** file (not just an added one) exercises the new base-side read; renames too if you can produce one. The button should go "Publishing…" → "Loading…" → "Up to date", with no flash of "Review & Publish".
6. **Rate-limit metrics.** `curl -s localhost:<api>/metrics | grep github_` shows `github_api_calls` by lane (`rest` vs `graphql`) and `github_rate_limit_remaining`. Quickest confirmation that the panel really dropped to one call.

## Migration Notes

N/A — no schema changes. Two new app-only tools are registered and granted under basic usage, so `packages/shared/src/tools/tool-io.ts` and `registry-metadata.ts` are regenerated/updated accordingly.

## Review Checklist
- [x] PR title is clear and descriptive
- [x] Changes are tested and working
- [x] Documentation is updated (if needed)
- [ ] No breaking changes — see the two behaviour changes below

**Behaviour changes to review deliberately:**
- `mergeableState` no longer carries `unstable` or `behind`. Required status checks surface through `checks` rather than folding into a generic "blocked". This changes which header state some PRs land in.
- PR comments come back as the newest 50 rather than the oldest 30 (`comments(last: 50)` vs one REST page). An improvement, but a different list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Collapses the Fast Preview PR panel onto one GraphQL read and stops polling immutable diffs, cutting GitHub API calls and rate‑limit pressure. Adds rate‑limit metering/handling, removes whole‑repo tree reads, and promotes “Get latest” when a branch is behind base.

- One `GITHUB_PR_STATE` query replaces four polled REST reads; checks, reviews, and comments select from a single cache entry. Uses `reviewDecision` and `reviewThreads.isResolved`; `mergeableState` is now `clean/dirty/blocked/unknown` (drops `unstable/behind`). PR comments return the newest 50. Adds `GITHUB_LAST_PUBLISHED_PR` (exact via `states: MERGED`). Shared `tools/github/graphql.ts` handles token mint/refresh and JSON/GraphQL error guards; `GITHUB_SEARCH_BRANCHES` is refactored onto it.
- Diff no longer refetches (`staleTime: Infinity`) and only loads on the Changes tab; the badge count comes from `changedFiles` on the PR read.
- Git data: base-side blobs are read via `/contents/{path}?ref=` instead of the full recursive tree; `/git/status` caches `default_branch` for 10m and overlaps reads (3 → 1 RTT).
- Rate limiting: publishes `github_api_calls`, `github_rate_limit_remaining`, `github_rate_limit_used`, and `github_rate_limited` tagged by lane (`rest`/`graphql`). When limited, responses return 429 with `Retry-After`; Fast Preview git queries never retry a 429.
- Tools/registry: adds `GITHUB_PR_STATE` and `GITHUB_LAST_PUBLISHED_PR`; `packages/shared` tool IO/registry updated; e2e stub gains `/contents/{path}?ref=`.

**Reviewer notes**
- Header: when behind base, the primary is “Get latest” (merged PRs stay terminal).
- Behavior shifts: required checks surface through checks, not `mergeableState`; enable the Changes tab to load file bodies.
- Rollout: no schema changes; Playwright/e2e should cover the new `/contents/{path}?ref=` read path.

<sup>Written for commit 91ececd3684eceee91bbccaa7232970501b255e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

