### PR TITLE
fix(observability): stop GitHub GraphQL metrics from keying on repo/branch

### DIFF
--- a/apps/api/src/tools/github/graphql.ts
+++ b/apps/api/src/tools/github/graphql.ts
@@ -106,6 +106,12 @@ async function resolveGithubConnection(
  *
  * `label` names the operation in every error message — it is what tells a
  * reader whether "not accessible" came from a branch search or a PR read.
+ *
+ * `operation` is the metrics tag, kept separate from `label`: every call site's
+ * `label` interpolates the caller-supplied owner/repo/branch, and feeding that
+ * straight into an OTel attribute would mint one time series per repo/branch
+ * ever queried. `operation` is a fixed, small-cardinality name instead
+ * ("pr_state", not "pull request state for acme/site@my-branch").
  */
 export async function githubGraphql<T>(
   ctx: StudioContext,
@@ -114,6 +120,7 @@ export async function githubGraphql<T>(
     query: string;
     variables: Record<string, unknown>;
     label: string;
+    operation: string;
   },
 ): Promise<T> {
   const connection = await resolveGithubConnection(ctx, args.connectionId);
@@ -159,14 +166,18 @@ export async function githubGraphql<T>(
 
   recordGithubRateLimit(res.headers, {
     lane: "graphql",
-    operation: args.label,
+    operation: args.operation,
   });
 
   // Never retried here: retrying a secondary limit IS the burst being limited.
   if (isGithubRateLimited(res)) {
     const kind =
       res.headers.get("retry-after") !== null ? "secondary" : "primary";
-    countGithubRateLimited({ lane: "graphql", operation: args.label, kind });
+    countGithubRateLimited({
+      lane: "graphql",
+      operation: args.operation,
+      kind,
+    });
     const waitMs = githubRetryAfterMs(res.headers);
     throw new Error(
       `GitHub ${kind} rate limit reached${

--- a/apps/api/src/tools/github/last-published-pr.ts
+++ b/apps/api/src/tools/github/last-published-pr.ts
@@ -127,6 +127,7 @@ export const GITHUB_LAST_PUBLISHED_PR = defineTool({
       query: LAST_PUBLISHED_QUERY,
       variables: { owner: input.owner, repo: input.repo, base: input.base },
       label: `last published pull request for ${input.owner}/${input.repo}@${input.base}`,
+      operation: "last_published_pr",
     });
 
     return parseLastPublishedPr(data);

--- a/apps/api/src/tools/github/pr-state.ts
+++ b/apps/api/src/tools/github/pr-state.ts
@@ -357,6 +357,7 @@ export const GITHUB_PR_STATE = defineTool({
         branch: input.branch,
       },
       label: `pull request state for ${input.owner}/${input.repo}@${input.branch}`,
+      operation: "pr_state",
     });
 
     return parsePrState(data);

--- a/apps/api/src/tools/github/search-branches.ts
+++ b/apps/api/src/tools/github/search-branches.ts
@@ -144,6 +144,7 @@ export const GITHUB_SEARCH_BRANCHES = defineTool({
         limit: input.limit,
       },
       label: `branch search for ${repoLabel}`,
+      operation: "branch_search",
     });
 
     return parseBranchSearchResponse(data, repoLabel);


### PR DESCRIPTION
**Source:** hardening follow-up to #6355 (perf(github): collapse the Fast Preview PR panel onto one GraphQL read), which introduced `apps/api/src/observability/github-rate-limit.ts` and its `githubGraphql` metrics wiring.

**The bug:** `githubGraphql` in `apps/api/src/tools/github/graphql.ts` takes a `label` used to name the call in error messages, and reused that same string as the `operation` attribute on every rate-limit metric it records (`github_api_calls`, `github_rate_limit_remaining`, `github_rate_limit_used`, `github_rate_limited`). All three current callers build `label` by interpolating caller-supplied `owner`/`repo`/`branch` — e.g. `pull request state for acme/site@my-branch` in `pr-state.ts`, similarly in `last-published-pr.ts` and `search-branches.ts`. Since these are OpenTelemetry counter/gauge attributes, every distinct repo or branch anyone in any org queries mints a brand-new time series. That's unbounded cardinality driven entirely by end-user data (repo names, branch names) — exactly the kind of metrics blow-up that degrades or breaks a Prometheus-style backend over time. The REST git-data client (`github-git-data.ts`) was not affected: it tags metrics on HTTP method, which is bounded.

**Fix:** split the two concerns. `githubGraphql` now takes both `label` (unchanged, still used only in error text) and a new `operation` field — a small fixed set of names (`pr_state`, `last_published_pr`, `branch_search`) — and metrics now key on `operation` instead of `label`.

**Verified:**
- `cd apps/api && bunx tsc --noEmit` — clean
- `bunx oxlint` on the four touched files — 0 warnings/errors
- `bun test apps/api/src/tools/github/graphql.test.ts apps/api/src/tools/github/pr-state.test.ts apps/api/src/tools/github/last-published-pr.test.ts apps/api/src/tools/github/search-branches.test.ts` — 32 pass

Behavior-preserving: error messages are unchanged (still built from `label`), only the metric attribute value changes. Full CI (`bun run check`/`bun run lint`) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops GitHub GraphQL rate-limit metrics from keying on repo/branch. Previously `githubGraphql` used the interpolated `label` (owner/repo@branch) as the `operation` metric attribute, creating unbounded time series; now metrics use a fixed `operation` value and `label` is only used in error messages.

- All `githubGraphql` call sites must pass `operation`; use one of: `pr_state`, `last_published_pr`, `branch_search`. Updated for `GITHUB_PR_STATE`, `GITHUB_LAST_PUBLISHED_PR`, `GITHUB_SEARCH_BRANCHES`.
- Update dashboards/alerts that filter on `operation` for `github_api_calls`, `github_rate_limit_remaining`, `github_rate_limit_used`, `github_rate_limited` to expect the new bounded values. No change to error text or API behavior.

<sup>Written for commit 1a0f15ba77655b9ced8df8b943d8efc9a5a10f6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

