### PR TITLE
feat(preview): inject __decoFBT=0 into the preview iframe URL

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -205,6 +205,19 @@ function withDeviceHint(url: string, device: PreviewDeviceSize): string {
   return parsed.href;
 }
 
+/**
+ * Force `__decoFBT=0` on the preview URL — disables deco's loader/block-tree
+ * cache so edits render immediately in the iframe (same param the "Open result
+ * in new tab" invoke path sets, see `buildInvokeRunUrl`). Passes `null` through
+ * so it can wrap the whole `iframeSrc` computation regardless of mode.
+ */
+function withDecoFBT(url: string | null): string | null {
+  if (!url) return null;
+  const parsed = new URL(url, window.location.href);
+  parsed.searchParams.set("__decoFBT", "0");
+  return parsed.href;
+}
+
 /** Origin of the preview iframe's own site, or `null` if `previewUrl` is unset/invalid. */
 function previewOrigin(previewUrl: string | null): string | null {
   if (!previewUrl) return null;
@@ -653,7 +666,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
       ? productionOrigin
       : previewOrigin(previewUrl);
 
-  const iframeSrc =
+  const iframeSrc = withDecoFBT(
     display.mode === "sandbox"
       ? withVariantMatcherOverride(
           withDeviceHint(
@@ -677,7 +690,8 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
             ),
             workspace.state.variantOverride ?? [],
           )
-        : null;
+        : null,
+  );
 
   // Registers `productionOrigin` with the native shell before the iframe
   // above is allowed to navigate there (see `productionOriginReady`).


### PR DESCRIPTION
## Summary

Adds the `__decoFBT=0` query param to the preview iframe URL so deco's loader/block-tree cache is bypassed and content edits render immediately in the preview.

The param is injected via a small `withDecoFBT()` decorator wrapped around the whole `iframeSrc` computation, so it applies to **both** display modes:
- **sandbox** dev server
- **production** Fast Preview (including the `directPreviewUrl` global-section flow)

Because every imperative navigation (refresh, save-reload, iframe recovery, and sandbox "open in new tab") reads from the same `iframeSrc`, the param flows through consistently.

This mirrors the existing `__decoFBT=0` usage on the "Open result in new tab" invoke path (`use-run-block.ts` / `buildInvokeRunUrl`).

## Notes / scope
- The production "open in new tab" link (`productionOpenTabBase`) is a separate, intentionally-shareable URL flow (it also strips `deviceHint`), so `__decoFBT=0` was **not** added there.

## Testing
- `bun run fmt` ✅
- `bun run --cwd=apps/web check` (tsc) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables the preview loader/block-tree cache by injecting the `__decoFBT=0` query param into the iframe URL so edits render immediately. Previously, previews could show cached content; now both sandbox and production Fast Preview always bypass this cache in the iframe.

- Wraps the entire `iframeSrc` computation with a `withDecoFBT()` helper, covering sandbox and production (including the `directPreviewUrl` path).
- The param flows through refresh, save-reload, iframe recovery, and sandbox “open in new tab” since they read from the same `iframeSrc`.
- Mirrors the existing param used on the “Open result in new tab” invoke path (`buildInvokeRunUrl`).
- Does not change the production shareable “open in new tab” link (`productionOpenTabBase`) by design.

<sup>Written for commit 6709eeb4b904e0357f25417b1713835e9cf9883f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

