### PR TITLE
fix(sandbox): surface a SandboxGitError on a malformed git-api response body

### DIFF
--- a/apps/web/src/components/thread/github/sandbox-git-api.test.ts
+++ b/apps/web/src/components/thread/github/sandbox-git-api.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
 import {
   canPublishDirectly,
   combinePublishDiffs,
   DEFAULT_PUBLISH_POLICY,
+  fetchGitStatus,
   hasGitLocalWork,
   hasLocalWorkToPush,
   hasNothingToReview,
@@ -10,6 +11,7 @@ import {
   hasUnpublishedWork,
   isDecoOnlyDiff,
   isDecoOnlyPaths,
+  isSandboxUnreachable,
   needsSmartReviewJudgment,
   normalizePublishPolicy,
   resolvePathGate,
@@ -653,5 +655,25 @@ describe("hasNothingToReview", () => {
     ).toBe(false);
     expect(hasNothingToReview({ ...cleanStatus, aheadOfBase: 1 })).toBe(false);
     expect(hasNothingToReview({ ...cleanStatus, unpushed: 1 })).toBe(false);
+  });
+});
+
+describe("fetchGitStatus with a malformed response body", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  test("surfaces a SandboxGitError instead of a raw SyntaxError", async () => {
+    globalThis.fetch = (() =>
+      Promise.resolve(
+        new Response("<html>Bad Gateway</html>", { status: 502 }),
+      )) as unknown as typeof fetch;
+
+    const error = await fetchGitStatus("org", "vm", "feat").catch((e) => e);
+    expect(isSandboxUnreachable(error)).toBe(false);
+    expect(error).toHaveProperty("status", 502);
+    expect(error.message).toBe("Request failed (502)");
   });
 });

--- a/apps/web/src/components/thread/github/sandbox-git-api.ts
+++ b/apps/web/src/components/thread/github/sandbox-git-api.ts
@@ -104,7 +104,13 @@ function retryGitRequest(failureCount: number, error: unknown): boolean {
 }
 
 async function parseJson<T>(res: Response): Promise<T> {
-  const body = (await res.json()) as T & { error?: string };
+  let body: T & { error?: string };
+  try {
+    body = (await res.json()) as T & { error?: string };
+  } catch {
+    // Malformed body must surface as SandboxGitError, not a raw SyntaxError.
+    throw new SandboxGitError(`Request failed (${res.status})`, res.status);
+  }
   if (!res.ok) {
     throw new SandboxGitError(
       typeof body.error === "string"


### PR DESCRIPTION
**Source**: bug found while auditing `apps/web/src/components/thread/github/sandbox-git-api.ts` (the Fast Preview / sandbox git plumbing behind `usePrDiff` and the publish popover) for resilience against network hiccups.

**Why a maintainer wants this**: `fetchGitStatus`/`fetchGitDiff`/`publishGitChanges`/`rebaseGitBranch`/`fetchSuggestCommitMessage`/`fetchReviewVerdict`/`discardGitFiles` all funnel through one `parseJson()` that called `res.json()` unguarded. A response whose body isn't valid JSON — a proxy's HTML error page, a timeout returning a truncated body — throws a raw `SyntaxError` instead of the `SandboxGitError` every caller is written to expect.

**Failure scenario**: `isSandboxUnreachable(error)` (used by the status-poll backoff) only recognizes `SandboxGitError` with status 503/410/404. A malformed-body response from an unreachable sandbox now fails that check — the poller doesn't back off and keeps hitting a dead sandbox every 3s instead of the intended graceful backoff. The regression test in `sandbox-git-api.test.ts` reproduces this: a 502 with an HTML body now surfaces as `SandboxGitError` with `status: 502` instead of an unrecognized `SyntaxError`.

**Fix**: wrap the `res.json()` read in try/catch inside `parseJson`; on parse failure, throw `SandboxGitError('Request failed (<status>)', status)` — the same shape callers already branch on.

**Reviewer check**: `cd apps/web && bun test src/components/thread/github/sandbox-git-api.test.ts`

**Verified locally**: `bun run fmt`, `bunx tsc --noEmit` (apps/web), the one targeted test file, `bunx oxlint` on both changed files — all clean. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces `SandboxGitError(status)` when the git-api returns a malformed JSON body, restoring consistent error handling and correct backoff. Previously, `parseJson` called `res.json()` unguarded, so HTML/truncated bodies threw a raw `SyntaxError` that callers (e.g., the status poller) could not classify.

- Wraps `res.json()` in try/catch inside `parseJson`; on parse failure, throws `SandboxGitError("Request failed (<status>)", status)`.
- Adds a test that a 502 with HTML yields `SandboxGitError` (status 502) and is not treated as unreachable by `isSandboxUnreachable`.

**Review notes**
- Run: cd apps/web && bun test src/components/thread/github/sandbox-git-api.test.ts
- No migration required.

<sup>Written for commit 58ca40c794eda962b811921350d2a180f1fcd8e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6359?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

