### PR TITLE
fix(settings): don't hide the infra tab while owned-sites is still loading

### DIFF
--- a/apps/web/src/components/settings/use-settings-tabs.ts
+++ b/apps/web/src/components/settings/use-settings-tabs.ts
@@ -22,10 +22,12 @@ export type VisibleSettingsTabs = Record<SettingsGroupKey, SettingsTabDef[]>;
  */
 export function useVisibleSettingsTabs(): VisibleSettingsTabs {
   const { capabilities, isPrivileged, loading, error } = useCapabilities();
-  const ownsSites = useOwnedSites().sites.length > 0;
+  const { sites, isLoading: sitesLoading } = useOwnedSites();
+  const ownsSites = sites.length > 0;
 
   const canSee = (tab: SettingsTabDef) => {
-    if (tab.requiresOwnedSites && !ownsSites) return false;
+    // Same optimistic-while-loading rule as capabilities: don't hide mid-fetch.
+    if (tab.requiresOwnedSites && !ownsSites && !sitesLoading) return false;
     if (loading || error) return true;
     if (tab.privilegedOnly) return isPrivileged;
     if (!tab.requires) return true;


### PR DESCRIPTION
Bug found while reviewing the org-settings tab strip (`use-settings-tabs.ts`), the same flicker family as #6340.

`useVisibleSettingsTabs` gates the Billing group's "Infrastructure" tab on `requiresOwnedSites`, reading `useOwnedSites().sites.length > 0` directly. `useOwnedSites` is a plain `useQuery` that starts with `data` undefined, so `sites` is `[]` until the request resolves — on every settings page load, an org that actually owns legacy sites momentarily has the tab hidden, then it pops in once the query completes. The capability-gated tabs already avoid this exact flicker via an explicit `loading` check (see the hook's own doc comment: "Mirrors the sidebar's optimistic-while-loading rule... so owners never see the tab strip flicker") — the owned-sites gate was just never wired into that rule.

Fix: destructure `isLoading` from `useOwnedSites()` and don't hide the tab while it's still loading, matching the capabilities gate below it.

Failure scenario: an org that owns a legacy deco.cx site opens Settings → Billing; the "Infrastructure" tab is briefly absent from the tab strip, then appears once `INFRA_BILLING_SITES_LIST` resolves — a visible layout shift on a page that otherwise (post #6340) is supposed to stay stable while tabs load.

Reviewer check: `cd apps/web && bunx tsc --noEmit` (green). No test added — this is a plain react-query-derived boolean with no branch worth mocking a query client for; behavior is directly readable from the diff.

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/web), `bunx oxlint` on the changed file — all clean. Full CI (lint, unit, e2e) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop hiding the Billing “Infrastructure” tab while owned sites are still loading to eliminate a first-render flicker. Previously the tab was hidden until `useOwnedSites` resolved (empty array by default); now it stays visible during loading and hides only if the loaded result has no owned sites.

**Reviewer notes**
- Behavior change: tabs with `requiresOwnedSites` remain visible while `useOwnedSites` is loading; they hide only after load confirms no sites, matching the capabilities gate and preventing layout shift on Settings → Billing.
- Validate with an org that owns a legacy site: the tab should not flicker on initial render. No migration or config changes.

<sup>Written for commit e2b6e31070180690407e947e640ddc9cb8e30ae4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

