### PR TITLE
fix(preview): don't crash the preview panel on a malformed iframe URL

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview.test.ts
+++ b/apps/web/src/components/sandbox/preview/preview.test.ts
@@ -1,0 +1,33 @@
+import { setupComponentTest } from "../../../../test/setup";
+setupComponentTest();
+
+import { describe, expect, it } from "bun:test";
+import { withDecoFBT, withDeviceHint } from "./preview";
+
+describe("withDeviceHint", () => {
+  it("sets deviceHint on a well-formed URL", () => {
+    expect(withDeviceHint("https://example.com/foo", "mobile")).toBe(
+      "https://example.com/foo?deviceHint=mobile",
+    );
+  });
+
+  it("falls back to the original string instead of throwing on a malformed URL", () => {
+    expect(withDeviceHint("http://[::1", "mobile")).toBe("http://[::1");
+  });
+});
+
+describe("withDecoFBT", () => {
+  it("passes null through", () => {
+    expect(withDecoFBT(null)).toBe(null);
+  });
+
+  it("sets __decoFBT=0 on a well-formed URL", () => {
+    expect(withDecoFBT("https://example.com/foo")).toBe(
+      "https://example.com/foo?__decoFBT=0",
+    );
+  });
+
+  it("falls back to the original string instead of throwing on a malformed URL", () => {
+    expect(withDecoFBT("http://[::1")).toBe("http://[::1");
+  });
+});

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -198,24 +198,38 @@ const DEVICE_LABEL_KEYS: Record<PreviewDeviceSize, TranslationKey> = {
   desktop: "sandbox.preview.deviceDesktop",
 };
 
-/** Deco reads `deviceHint` to force SSR device matchers (see deco `deviceOf`). */
-function withDeviceHint(url: string, device: PreviewDeviceSize): string {
-  const parsed = new URL(url, window.location.href);
-  parsed.searchParams.set("deviceHint", device);
-  return parsed.href;
+/**
+ * Deco reads `deviceHint` to force SSR device matchers (see deco `deviceOf`).
+ * Falls back to the unmodified `url` on a malformed input instead of throwing
+ * mid-render and taking down the whole preview panel (same defensive shape as
+ * `previewOrigin` below).
+ */
+export function withDeviceHint(url: string, device: PreviewDeviceSize): string {
+  try {
+    const parsed = new URL(url, window.location.href);
+    parsed.searchParams.set("deviceHint", device);
+    return parsed.href;
+  } catch {
+    return url;
+  }
 }
 
 /**
  * Force `__decoFBT=0` on the preview URL — disables deco's loader/block-tree
  * cache so edits render immediately in the iframe (same param the "Open result
  * in new tab" invoke path sets, see `buildInvokeRunUrl`). Passes `null` through
- * so it can wrap the whole `iframeSrc` computation regardless of mode.
+ * so it can wrap the whole `iframeSrc` computation regardless of mode, and
+ * falls back to the unmodified `url` on a malformed input instead of throwing.
  */
-function withDecoFBT(url: string | null): string | null {
+export function withDecoFBT(url: string | null): string | null {
   if (!url) return null;
-  const parsed = new URL(url, window.location.href);
-  parsed.searchParams.set("__decoFBT", "0");
-  return parsed.href;
+  try {
+    const parsed = new URL(url, window.location.href);
+    parsed.searchParams.set("__decoFBT", "0");
+    return parsed.href;
+  } catch {
+    return url;
+  }
 }
 
 /** Origin of the preview iframe's own site, or `null` if `previewUrl` is unset/invalid. */


### PR DESCRIPTION
Follows #6357 (`withDecoFBT`) hardening.

`withDeviceHint` and `withDecoFBT` in `preview.tsx` call `new URL(url, window.location.href)` directly in the render path with no guard. Right next to them, `previewOrigin` already treats a malformed URL as non-fatal (`try { ... } catch { return null }`) — these two don't follow that pattern.

**Failure scenario:** if `directPreviewUrl`/`previewUrl` (sourced from the sandbox daemon / draft preview state) is ever an unparseable string — e.g. `http://[::1` (bad IPv6 literal) — `new URL(...)` throws synchronously during render, taking down the whole `PreviewContent` tree instead of just failing to apply the `deviceHint`/`__decoFBT` query param.

**Fix:** wrap both in try/catch and fall back to returning the original `url` unmodified, matching `previewOrigin`'s existing shape in the same file.

**Regression test:** `apps/web/src/components/sandbox/preview/preview.test.ts` — exercises both helpers on a well-formed URL and on a URL that throws inside the WHATWG URL parser (`http://[::1`), asserting the malformed case returns the input unchanged instead of throwing.

Reviewer check: `bun test apps/web/src/components/sandbox/preview/preview.test.ts`

Locally verified: `bun run fmt` (no changes), `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint` on both changed files (0 warnings/errors), targeted test above (5/5 pass). Full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the preview panel from crashing on a malformed iframe URL by hardening `withDeviceHint` and `withDecoFBT`. Previously `new URL(...)` threw during render; now both helpers catch parse errors and return the original URL, so only the query param is skipped.

- Behavior: malformed `previewUrl`/`directPreviewUrl` no longer breaks `PreviewContent`; `deviceHint`/`__decoFBT` may be omitted in that case. Matches `previewOrigin`’s defensive handling.
- Review: see `apps/web/src/components/sandbox/preview/preview.tsx` (try/catch wrappers). Tests in `apps/web/src/components/sandbox/preview/preview.test.ts`; run `bun test apps/web/src/components/sandbox/preview/preview.test.ts`.

<sup>Written for commit 84895b08f83de2c8ae34fc17c30e7ba943fd35a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

