### PR TITLE
fix(github): retry a transient 5xx on the shared GraphQL transport

### DIFF
--- a/apps/api/src/tools/github/graphql.test.ts
+++ b/apps/api/src/tools/github/graphql.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { parseGraphqlBody, unwrapGraphqlData } from "./graphql";
+import {
+  isGithubTransientServerError,
+  parseGraphqlBody,
+  unwrapGraphqlData,
+} from "./graphql";
 
 const LABEL = "branch search for acme/site";
 
@@ -51,5 +55,24 @@ describe("unwrapGraphqlData", () => {
 
   it("throws when a 200 carried neither data nor errors", () => {
     expect(() => unwrapGraphqlData({}, LABEL)).toThrow(/returned no data/);
+  });
+});
+
+describe("isGithubTransientServerError", () => {
+  it("flags 5xx as retriable outages", () => {
+    expect(isGithubTransientServerError(500)).toBe(true);
+    expect(isGithubTransientServerError(502)).toBe(true);
+    expect(isGithubTransientServerError(503)).toBe(true);
+  });
+
+  it("does not flag a 4xx as transient", () => {
+    expect(isGithubTransientServerError(401)).toBe(false);
+    expect(isGithubTransientServerError(403)).toBe(false);
+    expect(isGithubTransientServerError(404)).toBe(false);
+    expect(isGithubTransientServerError(429)).toBe(false);
+  });
+
+  it("does not flag a 2xx as transient", () => {
+    expect(isGithubTransientServerError(200)).toBe(false);
   });
 });

--- a/apps/api/src/tools/github/graphql.ts
+++ b/apps/api/src/tools/github/graphql.ts
@@ -9,6 +9,7 @@
  * requests/hour) — moving a read here spends a quota REST is not competing for.
  */
 
+import { retry } from "@decocms/shared/std";
 import type { StudioContext } from "@/core/studio-context";
 import {
   githubConnectionAccessToken,
@@ -30,6 +31,11 @@ function githubGraphqlUrl(): string {
 
 /** Matches the Git Data client's per-attempt timeout. */
 const GITHUB_TIMEOUT_MS = 15_000;
+
+/** A GitHub-side outage, not a real answer — worth retrying, unlike a 4xx. */
+export function isGithubTransientServerError(status: number): boolean {
+  return status >= 500 && status < 600;
+}
 
 export interface GraphqlEnvelope<T> {
   data?: T | null;
@@ -142,7 +148,22 @@ export async function githubGraphql<T>(
       signal: AbortSignal.timeout(GITHUB_TIMEOUT_MS),
     });
 
-  let res = await post(accessToken);
+  // Every call here is a read, so a 5xx (or a fetch that never lands) is safe to retry.
+  const postWithRetry = (token: string) =>
+    retry(
+      async () => {
+        const res = await post(token);
+        if (isGithubTransientServerError(res.status)) {
+          const status = res.status;
+          await res.body?.cancel().catch(() => {});
+          throw new Error(`GitHub GraphQL transient error: ${status}`);
+        }
+        return res;
+      },
+      { maxAttempts: 3, minTimeout: 300, maxTimeout: 3000, jitter: 1 },
+    );
+
+  let res = await postWithRetry(accessToken);
 
   // Token revoked/rotated behind our clock: one refresh + retry, then give up.
   if (res.status === 401) {
@@ -158,7 +179,7 @@ export async function githubGraphql<T>(
     if (!refreshed) {
       throw new Error(RECONNECT_ERROR);
     }
-    res = await post(refreshed);
+    res = await postWithRetry(refreshed);
     if (res.status === 401) {
       throw new Error(RECONNECT_ERROR);
     }


### PR DESCRIPTION
Follows the same hardening lane as #6334/#6313/#6295/#6310 on `apps/api/src/tools/github/graphql.ts` — the shared transport behind `GITHUB_SEARCH_BRANCHES`, `GITHUB_PR_STATE`, and `GITHUB_LAST_PUBLISHED_PR`.

**Bug:** `githubGraphql()` treated any non-2xx response, including a bare 500/502/503/504 from GitHub's own infra, as a hard failure with no retry. A momentary GitHub outage (which does happen — see the 401-refresh and rate-limit handling already in this file) surfaced immediately as a tool error to the branch picker / PR panel, even though every call through this function is a read and safe to retry.

**Fix:** wrap the POST in `retry()` from `@decocms/shared/std` (the repo's canonical retry helper — no hand-rolled backoff), retrying only on a 5xx status or a fetch that never lands (default `isRetriable`), up to 3 attempts with jittered backoff. The existing 401-refresh-then-retry-once and the rate-limit (403/429) paths are unchanged and still not retried — a rate limit refusal is deliberately left alone (retrying a secondary limit IS the burst being limited), and this only adds retry around genuine server-side outages.

**Verify:** `cd apps/api && bun test src/tools/github/graphql.test.ts` — added `isGithubTransientServerError` unit tests (500/502/503 → true, 401/403/404/429/200 → false).

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), `bunx oxlint` on both touched files (0 warnings/errors), and the targeted test file above. Full CI runs the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries transient 5xx responses on the shared GitHub GraphQL transport to reduce user-visible failures in branch search and PR panels. Previously any non-2xx (including 500/502/503/504) failed immediately; now 5xx and network failures are retried, while 401 refresh and 403/429 rate-limit paths remain unchanged and are not retried.

- Uses `retry` from `@decocms/shared/std` around the POST (max 3 attempts, jittered backoff, per-attempt 15s timeout). Cancels response bodies before retry to free resources.
- After a 401, we still refresh once; the retried call also uses the same retry wrapper. Rate limits (403/429) are still surfaced without retry.
- Adds and exports `isGithubTransientServerError(status)` with unit tests (5xx → true; 2xx/4xx → false).
- No changes required for callers; no config or migration needed. Potential side effect is a brief delay during GitHub outages, trading latency for improved resilience.

<sup>Written for commit 1ecd77e66678b3bb0a7c0bffa0e2a01e405f1593. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

