### PR TITLE
fix(github): surface the real failure when GraphQL retries are exhausted

### DIFF
--- a/apps/api/src/tools/github/graphql.test.ts
+++ b/apps/api/src/tools/github/graphql.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it } from "bun:test";
+import { RetryError } from "@decocms/shared/std";
 import {
   isGithubTransientServerError,
   parseGraphqlBody,
   unwrapGraphqlData,
+  unwrapRetryError,
 } from "./graphql";
 
 const LABEL = "branch search for acme/site";
@@ -55,6 +57,18 @@ describe("unwrapGraphqlData", () => {
 
   it("throws when a 200 carried neither data nor errors", () => {
     expect(() => unwrapGraphqlData({}, LABEL)).toThrow(/returned no data/);
+  });
+});
+
+describe("unwrapRetryError", () => {
+  it("surfaces the wrapped cause on retry exhaustion", () => {
+    const cause = new Error("GitHub GraphQL transient error: 503");
+    expect(unwrapRetryError(new RetryError(cause, 3))).toBe(cause);
+  });
+
+  it("passes through a plain error unchanged", () => {
+    const error = new Error("Connection is not a GitHub connection");
+    expect(unwrapRetryError(error)).toBe(error);
   });
 });
 

--- a/apps/api/src/tools/github/graphql.ts
+++ b/apps/api/src/tools/github/graphql.ts
@@ -9,7 +9,7 @@
  * requests/hour) — moving a read here spends a quota REST is not competing for.
  */
 
-import { retry } from "@decocms/shared/std";
+import { retry, RetryError } from "@decocms/shared/std";
 import type { StudioContext } from "@/core/studio-context";
 import {
   githubConnectionAccessToken,
@@ -35,6 +35,11 @@ const GITHUB_TIMEOUT_MS = 15_000;
 /** A GitHub-side outage, not a real answer — worth retrying, unlike a 4xx. */
 export function isGithubTransientServerError(status: number): boolean {
   return status >= 500 && status < 600;
+}
+
+/** Surface the last real failure instead of RetryError's generic message. */
+export function unwrapRetryError(error: unknown): unknown {
+  return error instanceof RetryError ? error.cause : error;
 }
 
 export interface GraphqlEnvelope<T> {
@@ -149,19 +154,24 @@ export async function githubGraphql<T>(
     });
 
   // Every call here is a read, so a 5xx (or a fetch that never lands) is safe to retry.
-  const postWithRetry = (token: string) =>
-    retry(
-      async () => {
-        const res = await post(token);
-        if (isGithubTransientServerError(res.status)) {
-          const status = res.status;
-          await res.body?.cancel().catch(() => {});
-          throw new Error(`GitHub GraphQL transient error: ${status}`);
-        }
-        return res;
-      },
-      { maxAttempts: 3, minTimeout: 300, maxTimeout: 3000, jitter: 1 },
-    );
+  const postWithRetry = async (token: string) => {
+    try {
+      return await retry(
+        async () => {
+          const res = await post(token);
+          if (isGithubTransientServerError(res.status)) {
+            const status = res.status;
+            await res.body?.cancel().catch(() => {});
+            throw new Error(`GitHub GraphQL transient error: ${status}`);
+          }
+          return res;
+        },
+        { maxAttempts: 3, minTimeout: 300, maxTimeout: 3000, jitter: 1 },
+      );
+    } catch (error) {
+      throw unwrapRetryError(error);
+    }
+  };
 
   let res = await postWithRetry(accessToken);
 


### PR DESCRIPTION
Follows #6363 (retry a transient 5xx on the shared GraphQL transport).

**The gap:** `githubGraphql`'s `postWithRetry` retries a transient 5xx (or a fetch that never lands) up to 3 times via `retry()`, but never unwraps the `RetryError` it throws on exhaustion. Every caller (and any log line built from `error.message`) then sees retry's generic `"Retrying exceeded the maxAttempts (3)."` instead of the actual failure (`"GitHub GraphQL transient error: 503"` or the underlying fetch/timeout error) — the message that actually tells someone what went wrong during an outage.

Every other `retry()` call site in this repo already does this unwrap for exactly this reason: `apps/api/src/tools/task-board/prs-get.ts`, `apps/api/src/file-storage/tenant-credentials.ts`, `apps/api/src/api/routes/oauth-proxy.ts`, `apps/api/src/event-bus/index.ts`, `apps/api/src/services/dev-nats-toxiproxy.ts`. `graphql.ts` was the one holdout, likely because #6363 added the retry without following the existing pattern.

**Fix:** extract the unwrap into a tiny pure `unwrapRetryError()` helper (mirroring the inline `err instanceof RetryError ? err.cause : err` idiom used elsewhere) and apply it in `postWithRetry`'s catch. Behavior-preserving otherwise — retry count/backoff/timing unchanged, only the error identity on final exhaustion changes.

**Verify:** `cd apps/api && bunx tsc --noEmit`, `bun test apps/api/src/tools/github/graphql.test.ts` (new `unwrapRetryError` cases plus all existing cases pass), `bunx oxlint apps/api/src/tools/github/graphql.ts apps/api/src/tools/github/graphql.test.ts` (0 warnings/errors). `bun run fmt` applied. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces the real GitHub GraphQL failure when retries are exhausted. Previously `githubGraphql` threw a generic `RetryError` after three attempts; now it unwraps and throws the original cause. Retry count and backoff are unchanged.

- Introduces `unwrapRetryError` and applies it in `postWithRetry`; imports `RetryError` from `@decocms/shared/std`.
- Adds unit tests for `unwrapRetryError`; no changes to request/response logic.
- Impact: callers now receive the original error instead of `RetryError`; update any code that matches on `RetryError` if present.

<sup>Written for commit 999f86a53c45c02ac735311b18f15ec212286fd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6365?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

