### PR TITLE
refactor(sandbox-proxy): dedupe the preview-fetch/preview-invoke upstream relay

### DIFF
--- a/apps/api/src/api/routes/sandbox-proxy.ts
+++ b/apps/api/src/api/routes/sandbox-proxy.ts
@@ -340,6 +340,40 @@ function fastPreviewGitError(c: Context<VmEnv>, err: unknown): Response {
   return c.json({ error: message }, 502, SANDBOX_PROXY_CACHE_HEADERS);
 }
 
+/**
+ * Fetches an upstream preview response and relays its body/status, mapping
+ * both a failed fetch and a failed body read to the same 502 shape. Shared by
+ * `preview-fetch` and `preview-invoke`, which otherwise repeated this
+ * fetch-or-502 / text-or-502 dance verbatim.
+ */
+async function proxyPreviewUpstream(
+  c: Context<VmEnv>,
+  url: string,
+  init?: RequestInit,
+): Promise<Response> {
+  let upstream: Response;
+  try {
+    upstream = await fetch(url, init);
+  } catch {
+    return c.json({ error: "Preview unreachable" }, 502);
+  }
+
+  let text: string;
+  try {
+    text = await upstream.text();
+  } catch {
+    return c.json({ error: "Preview unreachable" }, 502);
+  }
+
+  return new Response(text, {
+    status: upstream.status,
+    headers: {
+      "content-type":
+        upstream.headers.get("content-type") ?? "application/json",
+    },
+  });
+}
+
 async function fastPreviewGitStatus(c: Context<VmEnv>): Promise<Response> {
   try {
     const client = await fastPreviewGitClient(c);
@@ -1181,27 +1215,8 @@ export const createSandboxRoutes = () => {
 
     const base = previewUrl.replace(/\/+$/, "");
     const loopback = loopbackPreviewTarget(`${base}${path}`);
-    let upstream: Response;
-    try {
-      upstream = await fetch(loopback?.url ?? `${base}${path}`, {
-        ...(loopback ? { headers: { host: loopback.hostHeader } } : {}),
-      });
-    } catch {
-      return c.json({ error: "Preview unreachable" }, 502);
-    }
-
-    let text: string;
-    try {
-      text = await upstream.text();
-    } catch {
-      return c.json({ error: "Preview unreachable" }, 502);
-    }
-    return new Response(text, {
-      status: upstream.status,
-      headers: {
-        "content-type":
-          upstream.headers.get("content-type") ?? "application/json",
-      },
+    return proxyPreviewUpstream(c, loopback?.url ?? `${base}${path}`, {
+      ...(loopback ? { headers: { host: loopback.hostHeader } } : {}),
     });
   });
 
@@ -1245,33 +1260,14 @@ export const createSandboxRoutes = () => {
 
       const invokeUrl = buildLoaderInvokeUrl(previewUrl, invoke.resolveType);
       const loopback = loopbackPreviewTarget(invokeUrl);
-      let upstream: Response;
-      try {
-        upstream = await fetch(loopback?.url ?? invokeUrl, {
-          method: "POST",
-          headers: {
-            "content-type": "application/json",
-            ...(loopback ? { host: loopback.hostHeader } : {}),
-          },
-          body: JSON.stringify(invoke.payload),
-          signal: AbortSignal.timeout(30_000),
-        });
-      } catch {
-        return c.json({ error: "Preview unreachable" }, 502);
-      }
-
-      let text: string;
-      try {
-        text = await upstream.text();
-      } catch {
-        return c.json({ error: "Preview unreachable" }, 502);
-      }
-      return new Response(text, {
-        status: upstream.status,
+      return proxyPreviewUpstream(c, loopback?.url ?? invokeUrl, {
+        method: "POST",
         headers: {
-          "content-type":
-            upstream.headers.get("content-type") ?? "application/json",
+          "content-type": "application/json",
+          ...(loopback ? { host: loopback.hostHeader } : {}),
         },
+        body: JSON.stringify(invoke.payload),
+        signal: AbortSignal.timeout(30_000),
       });
     },
   );


### PR DESCRIPTION
Follows the codebase-strategy audit (#4468) hint to simplify duplicated routing logic under `apps/api/src/api/routes`.

`preview-fetch` and `preview-invoke` in `apps/api/src/api/routes/sandbox-proxy.ts` each independently: fetched the (possibly loopback-routed) upstream preview URL, mapped a failed `fetch()` *or* a failed `upstream.text()` to the same `502 { error: "Preview unreachable" }`, then relayed the body with the upstream's status and a `content-type` fallback of `application/json`. That's the same ~14-line sequence copy-pasted verbatim between the two routes.

Extracted the sequence into `proxyPreviewUpstream(c, url, init)` and call it from both routes with their existing `fetch` args unchanged (loopback URL/headers for the GET, method/body/timeout for the POST). Net: **-46 / +42** lines, one concern.

Behavior is unchanged: same fetch arguments, same catch → 502 mapping for both failure points, same success `Response` shape (status + content-type passthrough). Confirmed by reading both call sites before/after — no branch or header changed, only the code moved into a shared helper.

**To verify:** `bun test apps/api/src/api/routes/sandbox-proxy.test.ts` (13 pass, unchanged) and `cd apps/api && bunx tsc --noEmit` (clean).

Locally ran: `bun run fmt`, `bunx tsc --noEmit` (apps/api), `bun test apps/api/src/api/routes/sandbox-proxy.test.ts`, `bunx oxlint apps/api/src/api/routes/sandbox-proxy.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates the upstream preview relay for `preview-fetch` and `preview-invoke` by extracting a shared helper `proxyPreviewUpstream` in `apps/api/src/api/routes/sandbox-proxy.ts`. Behavior is unchanged: same fetch arguments, same 502 on fetch/body read failures, and same status/content-type passthrough.

- Both routes now call `proxyPreviewUpstream` with their prior params: GET preserves loopback host header; POST preserves method, JSON body, 30s timeout, and loopback host header when present.
- Error surface is unchanged: both a failed fetch and a failed upstream body read return 502 { error: "Preview unreachable" }.
- Response relay is unchanged: upstream status is forwarded; content-type is passed through with a fallback to application/json.

<sup>Written for commit 008271bb2dbb823daea55de104d24de61180ed10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

