### PR TITLE
feat(task-board): persist filters and layout in the URL

### DIFF
--- a/apps/web/src/layouts/task-board/filters-search.test.ts
+++ b/apps/web/src/layouts/task-board/filters-search.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test";
+import { boardSearchParams, parseBoardSearch } from "./filters-search";
+import { EMPTY_FILTERS, type TaskFilters } from "./task-filters";
+
+const filters: TaskFilters = {
+  search: "login",
+  assignee: "user-1",
+  priority: "high",
+  due: "today",
+  tags: ["tag-1", "tag-2"],
+  repo: "acme/site",
+};
+
+describe("board search params", () => {
+  test("round-trips filters and layout through the URL", () => {
+    const params = boardSearchParams(filters, "list");
+    expect(parseBoardSearch(params)).toEqual({ filters, layout: "list" });
+  });
+
+  test("defaults are omitted from the URL", () => {
+    expect(boardSearchParams(EMPTY_FILTERS, "board")).toEqual({
+      view: undefined,
+      q: undefined,
+      assignee: undefined,
+      priority: undefined,
+      due: undefined,
+      tags: undefined,
+      repo: undefined,
+    });
+  });
+
+  test("an empty URL is the empty state", () => {
+    expect(parseBoardSearch({})).toEqual({
+      filters: EMPTY_FILTERS,
+      layout: "board",
+    });
+  });
+
+  test("unrecognized values are dropped, not trusted", () => {
+    expect(
+      parseBoardSearch({
+        view: "kanban",
+        priority: "critical",
+        due: "yesterday",
+        tags: ",,",
+      }),
+    ).toEqual({ filters: EMPTY_FILTERS, layout: "board" });
+  });
+});

--- a/apps/web/src/layouts/task-board/filters-search.ts
+++ b/apps/web/src/layouts/task-board/filters-search.ts
@@ -1,0 +1,93 @@
+/**
+ * Task board view state (filters + layout) lives in the URL search params, so a
+ * refresh, a back/forward, or a shared link keeps the board as you left it.
+ *
+ * ponytail: TanStack Router's search params already are the store — no zustand,
+ * no persist middleware, no localStorage to reconcile with the URL.
+ */
+
+import { useNavigate, useSearch } from "@tanstack/react-router";
+import type { DueFilter, TaskFilters } from "./task-filters";
+import { PRIORITIES, type TaskBoardItemPriority } from "./config";
+
+export type Layout = "board" | "list";
+
+const DUE_FILTERS: DueFilter[] = ["overdue", "today", "week", "none"];
+
+/** Search-param names, kept short since they show up in shared links. */
+type BoardSearch = {
+  view?: string;
+  q?: string;
+  assignee?: string;
+  priority?: string;
+  due?: string;
+  tags?: string;
+  repo?: string;
+};
+
+const str = (v: unknown): string | null =>
+  typeof v === "string" && v !== "" ? v : null;
+
+/** Anything unrecognized in the URL is dropped, not trusted. */
+export function parseBoardSearch(search: BoardSearch): {
+  filters: TaskFilters;
+  layout: Layout;
+} {
+  const priority = str(search.priority);
+  const due = str(search.due);
+  const tags = str(search.tags);
+  return {
+    layout: search.view === "list" ? "list" : "board",
+    filters: {
+      search: str(search.q) ?? "",
+      assignee: str(search.assignee),
+      priority: PRIORITIES.includes(priority as TaskBoardItemPriority)
+        ? (priority as TaskBoardItemPriority)
+        : null,
+      due: DUE_FILTERS.includes(due as DueFilter) ? (due as DueFilter) : null,
+      tags: tags ? tags.split(",").filter(Boolean) : [],
+      repo: str(search.repo),
+    },
+  };
+}
+
+/** Defaults are written as `undefined` so they drop out of the URL entirely. */
+export function boardSearchParams(
+  filters: TaskFilters,
+  layout: Layout,
+): Record<keyof BoardSearch, string | undefined> {
+  return {
+    view: layout === "list" ? "list" : undefined,
+    q: filters.search === "" ? undefined : filters.search,
+    assignee: filters.assignee ?? undefined,
+    priority: filters.priority ?? undefined,
+    due: filters.due ?? undefined,
+    tags: filters.tags.length > 0 ? filters.tags.join(",") : undefined,
+    repo: filters.repo ?? undefined,
+  };
+}
+
+/** `useState`-shaped replacement for the board's filters + layout state. */
+export function useBoardSearch() {
+  const search = useSearch({ strict: false }) as BoardSearch;
+  const navigate = useNavigate();
+  const { filters, layout } = parseBoardSearch(search);
+
+  const write = (nextFilters: TaskFilters, nextLayout: Layout) =>
+    navigate({
+      to: ".",
+      search: (prev: Record<string, unknown>) => ({
+        ...prev,
+        ...boardSearchParams(nextFilters, nextLayout),
+      }),
+      // Typing in the search box would otherwise push a history entry per key.
+      replace: true,
+    });
+
+  return {
+    filters,
+    layout,
+    setFilters: (next: TaskFilters) => write(next, layout),
+    setLayout: (next: Layout) => write(filters, next),
+  };
+}

--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -137,8 +137,8 @@ import {
   TaskFiltersBar,
   TaskFiltersDrawer,
   taskMatchesFilters,
-  type TaskFilters,
 } from "./task-filters";
+import { useBoardSearch } from "./filters-search";
 import { usePanelActions } from "@/layouts/shell-layout";
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useThreadActions } from "@/components/chat/store/hooks";
@@ -149,8 +149,6 @@ import { toast } from "sonner";
 
 // Warm the chat chunk so opening a task's activity doesn't cold-load it (flash).
 void import("../agent-shell-layout/index.tsx").catch(() => {});
-
-type Layout = "board" | "list";
 
 const DATE_FMT = new Intl.DateTimeFormat(undefined, {
   month: "short",
@@ -411,8 +409,8 @@ export function TaskBoardPage() {
   const members = (membersData?.data?.members ?? []) as Member[];
   const memberByUserId = new Map(members.map((m) => [m.userId, m]));
 
-  const [layout, setLayout] = useState<Layout>("board");
-  const [filters, setFilters] = useState<TaskFilters>(EMPTY_FILTERS);
+  // Filters + layout live in the URL, so a refresh or a shared link keeps them.
+  const { filters, setFilters, layout, setLayout } = useBoardSearch();
   const [preferences] = usePreferences();
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const toggleSelect = (id: string) =>

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -345,6 +345,15 @@ const unifiedChatSearchSchema = z.object({
   contentPageId: z.string().optional(),
   contentPath: z.string().optional(),
   contentPathTemplate: z.string().optional(),
+  /** Task board view state (`main=board`) — persisted in the URL so a refresh
+   *  or a shared link keeps the layout and filters. See `filters-search.ts`. */
+  view: z.string().optional(),
+  q: z.string().optional(),
+  assignee: z.string().optional(),
+  priority: z.string().optional(),
+  due: z.string().optional(),
+  tags: z.string().optional(),
+  repo: z.string().optional(),
 });
 
 const unifiedChatRoute = createRoute({


### PR DESCRIPTION
## Summary

Task board filters (search, assignee, priority, due, tags, repo) and the board/list toggle were `useState`, so a refresh or a shared link lost them. They now live in the URL search params.

No new dependency: TanStack Router's search params are already the store, so no zustand persist middleware and no localStorage to reconcile with the URL. Defaults are written as `undefined` so a clean board has a clean URL; writes use `replace: true` so typing in the search box doesn't spam history.

`parseBoardSearch` is defensive — an unknown `view`/`priority`/`due` from a hand-edited URL falls back to the empty state rather than filtering everything out.

## Testing

- `apps/web/src/layouts/task-board/filters-search.test.ts` — round-trip, defaults omitted, empty URL, junk values dropped (4 pass).
- `bun run check` (only the pre-existing `mustache` error on `main`), `bun run lint`, `bun run fmt`.

## Affected areas

Task board only (`main=board`). The seven new params are added to `unifiedChatSearchSchema`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist task board filters and board/list layout in the URL to survive refresh, navigation, and shared links. Previously this state was `useState` and was lost; now it’s stored in search params via `@tanstack/react-router`, with defensive parsing to ignore unknown values.

- Introduces `useBoardSearch` and replaces local state in `TaskBoardPage`.
- Adds short search params: view, q, assignee, priority, due, tags, repo; defaults write as undefined for a clean URL; updates use history replace to avoid spam.
- Validates `priority` and `due` against known sets; drops unrecognized values; `tags` is comma-separated.
- Extends `unifiedChatSearchSchema` with the seven optional params; scope is task board only (`main=board`). No new dependencies.
- Tests cover round-trip, defaults omission, empty URL behavior, and junk-value handling.

<sup>Written for commit 37cd62013ac594c01a56779a7d1e20d6611f1459. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6368?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

