### PR TITLE
feat(virtual-mcp): allow renaming agents with a linked GitHub repo

### DIFF
--- a/apps/api/src/api/routes/editor-resolve.ts
+++ b/apps/api/src/api/routes/editor-resolve.ts
@@ -19,7 +19,10 @@
  */
 
 import { Hono } from "hono";
-import { isValidSiteSlug } from "@decocms/shared/site-slug";
+import {
+  isValidSiteSlug,
+  resolveAgentSiteSlug,
+} from "@decocms/shared/site-slug";
 import { isOrgArchived } from "@decocms/shared/organization/org-archived";
 import type { Env } from "../hono-env";
 import { getUserId } from "@/core/studio-context";
@@ -91,8 +94,9 @@ export function createEditorResolveRoutes() {
       if (!org.slug || isOrgArchived(org)) continue;
       const vms = await ctx.storage.virtualMcps.list(org.id);
       for (const vm of vms) {
-        if (vm.title.toLowerCase() !== slug) continue;
-        // Match by name, but only code agents (repo-backed); skip Decopilot-only.
+        // Match on the site slug, not the (renameable) title.
+        if (resolveAgentSiteSlug(vm) !== slug) continue;
+        // Only code agents (repo-backed); skip Decopilot-only.
         if (!hasClonableSource(vm.metadata)) continue;
         matches.push({
           orgSlug: org.slug,

--- a/apps/api/src/tools/virtual/pin-site-slug.test.ts
+++ b/apps/api/src/tools/virtual/pin-site-slug.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "bun:test";
+import { pinnedSiteSlugOnRename } from "./pin-site-slug";
+
+describe("pinnedSiteSlugOnRename", () => {
+  it("pins the outgoing title when a slugless agent is renamed", () => {
+    expect(
+      pinnedSiteSlugOnRename({
+        nextTitle: "Acme Store",
+        currentTitle: "acmestore",
+        currentSiteSlug: null,
+      }),
+    ).toBe("acmestore");
+  });
+
+  it("normalizes the outgoing title it pins", () => {
+    expect(
+      pinnedSiteSlugOnRename({
+        nextTitle: "renamed",
+        currentTitle: "  AcmeStore  ",
+        currentSiteSlug: undefined,
+      }),
+    ).toBe("acmestore");
+  });
+
+  it("leaves an already-stamped slug alone", () => {
+    expect(
+      pinnedSiteSlugOnRename({
+        nextTitle: "Acme Store",
+        currentTitle: "acmestore",
+        currentSiteSlug: "some-other-site",
+      }),
+    ).toBeNull();
+  });
+
+  it("does nothing when the title is absent or unchanged", () => {
+    expect(
+      pinnedSiteSlugOnRename({
+        nextTitle: undefined,
+        currentTitle: "acmestore",
+        currentSiteSlug: null,
+      }),
+    ).toBeNull();
+    expect(
+      pinnedSiteSlugOnRename({
+        nextTitle: "acmestore",
+        currentTitle: "acmestore",
+        currentSiteSlug: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("skips titles that were never usable as a slug", () => {
+    for (const currentTitle of [
+      "My Cool Agent",
+      "-leading-hyphen",
+      "under_score",
+      "a".repeat(61),
+      "",
+      "   ",
+      null,
+    ]) {
+      expect(
+        pinnedSiteSlugOnRename({
+          nextTitle: "renamed",
+          currentTitle,
+          currentSiteSlug: null,
+        }),
+      ).toBeNull();
+    }
+  });
+
+  it("treats a blank stamped slug as unset", () => {
+    expect(
+      pinnedSiteSlugOnRename({
+        nextTitle: "renamed",
+        currentTitle: "acmestore",
+        currentSiteSlug: "   ",
+      }),
+    ).toBe("acmestore");
+  });
+});

--- a/apps/api/src/tools/virtual/pin-site-slug.ts
+++ b/apps/api/src/tools/virtual/pin-site-slug.ts
@@ -1,0 +1,25 @@
+import { isValidSiteSlug } from "@decocms/shared/site-slug";
+
+/**
+ * Agents imported before `metadata.siteSlug` was persisted resolve their asset
+ * tenancy (and the storefront "." shortcut) from their title. Renaming one
+ * would move that tenancy, so the first rename freezes the outgoing title as
+ * the slug — materializing the value that was already in effect.
+ *
+ * Returns the slug to stamp, or `null` when there is nothing to pin: the agent
+ * already has a slug, the title isn't changing, or the outgoing title was never
+ * a usable slug (so it resolved nothing to begin with).
+ */
+export function pinnedSiteSlugOnRename(args: {
+  nextTitle: string | undefined;
+  currentTitle: string | null | undefined;
+  currentSiteSlug: string | null | undefined;
+}): string | null {
+  const { nextTitle, currentTitle, currentSiteSlug } = args;
+
+  if (currentSiteSlug?.trim()) return null;
+  if (nextTitle === undefined || nextTitle === currentTitle) return null;
+
+  const outgoing = currentTitle?.trim().toLowerCase() ?? "";
+  return isValidSiteSlug(outgoing) ? outgoing : null;
+}

--- a/apps/api/src/tools/virtual/update.ts
+++ b/apps/api/src/tools/virtual/update.ts
@@ -15,6 +15,7 @@ import { writeAgentPrompts } from "../../file-storage/agent-prompts";
 import { VirtualMCPEntitySchema, VirtualMCPUpdateDataSchema } from "./schema";
 import { requireOrgAdminForPinnedField } from "./require-org-admin-for-pin";
 import { requireConnectionsInOrganization } from "./require-connections-in-org";
+import { pinnedSiteSlugOnRename } from "./pin-site-slug";
 
 /**
  * Input schema for updating a virtual MCP
@@ -74,6 +75,20 @@ export const COLLECTION_VIRTUAL_MCP_UPDATE = defineTool({
     const { prompts, ...data } = input.data;
     if (data.metadata && existing.metadata) {
       data.metadata = { ...existing.metadata, ...data.metadata };
+    }
+
+    // A rename must not move the agent's asset tenancy.
+    const pinnedSiteSlug = pinnedSiteSlugOnRename({
+      nextTitle: data.title,
+      currentTitle: existing.title,
+      currentSiteSlug: existing.metadata?.siteSlug,
+    });
+    if (pinnedSiteSlug) {
+      data.metadata = {
+        ...existing.metadata,
+        ...data.metadata,
+        siteSlug: pinnedSiteSlug,
+      };
     }
 
     if (data.pinned !== undefined && data.pinned !== existing.pinned) {

--- a/apps/web/src/layouts/main-panel-tabs/assets-tab.tsx
+++ b/apps/web/src/layouts/main-panel-tabs/assets-tab.tsx
@@ -1,6 +1,6 @@
 /**
  * Assets tab — a native, per-site browser over the S3 bucket associated with
- * this project's name (matched via `matchSiteSlugConfig`). Replaces
+ * this project's site slug (matched via `matchSiteSlugConfig`). Replaces
  * the deco.cx admin-MCP `fetch_assets` iframe view: it lists, uploads, and
  * deletes objects directly against the configured bucket using the same
  * FILE_* tools the CMS file picker uses. The tab only appears when a bucket is
@@ -53,6 +53,7 @@ import {
   useFilePickerUpload,
 } from "@/hooks/use-file-picker";
 import { matchSiteSlugConfig } from "@/components/file-picker/match-site-slug-config";
+import { resolveAgentSiteSlug } from "@decocms/shared/site-slug";
 import {
   basename,
   extensionTag,
@@ -63,8 +64,7 @@ import {
 export function AssetsTab({ virtualMcpId }: { virtualMcpId: string }) {
   const entity = useVirtualMCP(virtualMcpId);
   const configs = useFileConfigs();
-  const siteName = entity?.title ?? null;
-  const config = matchSiteSlugConfig(configs, siteName);
+  const config = matchSiteSlugConfig(configs, resolveAgentSiteSlug(entity));
 
   if (!config) {
     return <NoBucketState />;

--- a/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
+++ b/apps/web/src/layouts/main-panel-tabs/use-main-panel-tabs.ts
@@ -62,6 +62,7 @@ import {
 import { useCapability } from "@/hooks/use-capability";
 import { useFileConfigsQuery } from "@/hooks/use-file-configs";
 import { matchSiteSlugConfig } from "@/components/file-picker/match-site-slug-config";
+import { resolveAgentSiteSlug } from "@decocms/shared/site-slug";
 import { useNavV2, useReportsOnly } from "@/hooks/use-organization-settings";
 import { useT } from "@/i18n/use-t.ts";
 
@@ -255,14 +256,16 @@ export function useMainPanelTabs(ctx: {
 
   /**
    * Assets is a per-site tab: it shows whenever an S3 bucket is associated to
-   * this project's name (managed `deco-assets-<name>` or a BYOB bucket). Uses
-   * the non-suspense configs query so the bar never blocks on the bucket list.
+   * this project's site slug (managed `deco-assets-<slug>` or a BYOB bucket).
+   * Resolved through `resolveAgentSiteSlug` so renaming the project doesn't
+   * move its tenancy. Uses the non-suspense configs query so the bar never
+   * blocks on the bucket list.
    */
-  const siteName = entity?.title ?? null;
+  const siteSlug = resolveAgentSiteSlug(entity);
   const fileConfigsQuery = useFileConfigsQuery();
   const showAssetsTab = !!matchSiteSlugConfig(
     fileConfigsQuery.data?.configs ?? [],
-    siteName,
+    siteSlug,
   );
   // Don't bounce a deep-linked `?main=assets` away before the first config load resolves.
   const assetsTabPending = fileConfigsQuery.isPending;

--- a/apps/web/src/views/virtual-mcp/index.tsx
+++ b/apps/web/src/views/virtual-mcp/index.tsx
@@ -812,11 +812,10 @@ function VirtualMcpDetailViewWithData({
                         field.onBlur();
                         flushAndSave();
                       }}
-                      disabled={hasGithubRepo}
                       placeholder={t(
                         "virtualMcp.virtualMcp.agentNamePlaceholder",
                       )}
-                      className="text-lg font-medium leading-tight text-foreground bg-transparent border-none outline-none px-1 -mx-1 rounded hover:bg-input/25 focus:bg-input/25 transition-colors w-full truncate disabled:hover:bg-transparent disabled:focus:bg-transparent disabled:opacity-50"
+                      className="text-lg font-medium leading-tight text-foreground bg-transparent border-none outline-none px-1 -mx-1 rounded hover:bg-input/25 focus:bg-input/25 transition-colors w-full truncate"
                     />
                   )}
                 />
@@ -835,11 +834,10 @@ function VirtualMcpDetailViewWithData({
                         field.onBlur();
                         flushAndSave();
                       }}
-                      disabled={hasGithubRepo}
                       placeholder={t(
                         "virtualMcp.virtualMcp.descriptionPlaceholder",
                       )}
-                      className="text-sm text-muted-foreground bg-transparent border-none outline-none px-1 -mx-1 rounded hover:bg-input/25 focus:bg-input/25 transition-colors w-full truncate disabled:hover:bg-transparent disabled:focus:bg-transparent disabled:opacity-50"
+                      className="text-sm text-muted-foreground bg-transparent border-none outline-none px-1 -mx-1 rounded hover:bg-input/25 focus:bg-input/25 transition-colors w-full truncate"
                     />
                   )}
                 />
@@ -1292,7 +1290,6 @@ function VirtualMcpDetailViewWithData({
                     field.onBlur();
                     flushAndSave();
                   }}
-                  disabled={hasGithubRepo}
                   placeholder={t(
                     "virtualMcp.virtualMcp.instructionsPlaceholder",
                   )}

--- a/packages/e2e/tests/clonable-agent-identity.spec.ts
+++ b/packages/e2e/tests/clonable-agent-identity.spec.ts
@@ -1,15 +1,15 @@
 /**
- * E2E: clonable agents (connected GitHub repo) allow editing the icon/logo
- * on the settings tab. Title, description, and instructions remain locked
- * to the repo — those are intentionally NOT asserted here.
- *
- * See docs/superpowers/specs/2026-06-03-clonable-agent-logo-editable-design.md
+ * E2E: clonable agents (connected GitHub repo) allow editing their whole
+ * identity — icon/logo, name and description — on the settings tab. A linked
+ * repo is addressed by `metadata.githubRepo` and its site tenancy by
+ * `metadata.siteSlug`, so neither is keyed off the title and none of these
+ * fields needs to be read-only.
  */
 import { expect, test } from "../fixtures/test";
 import { callSelfMcpTool, createHttpConnection } from "../fixtures/mcp-tools";
 
-test.describe("clonable agent logo (settings tab)", () => {
-  test("icon picker is interactive when the agent has a connected GitHub repo", async ({
+test.describe("clonable agent identity (settings tab)", () => {
+  test("icon, name and description are editable when the agent has a connected GitHub repo", async ({
     authedPage,
   }) => {
     const { page, orgSlug } = authedPage;
@@ -32,7 +32,7 @@ test.describe("clonable agent logo (settings tab)", () => {
       "COLLECTION_VIRTUAL_MCP_CREATE",
       {
         data: {
-          title: "clonable logo e2e",
+          title: "clonable identity e2e",
           description: "from a repo",
           status: "active",
           pinned: false,
@@ -67,21 +67,36 @@ test.describe("clonable agent logo (settings tab)", () => {
     const titleInput = page.getByPlaceholder("Agent name");
     await expect(titleInput).toBeVisible({ timeout: 15_000 });
 
-    // Sanity-check the asymmetry first: the title input is still disabled,
-    // confirming the agent is clonable (agentHasConnectedGithub === true).
-    // If this fails, the metadata wiring or the route navigation broke,
-    // and the icon-button assertion below would be testing the wrong thing.
-    await expect(titleInput).toBeDisabled();
-
     // The IconPicker trigger button is tagged with data-testid so the
     // locator doesn't depend on DOM-tree shape (button order, wrapper
     // divs, etc.). The testid lives on the <button> at the root of
     // <IconPicker> in apps/web/src/components/icon-picker.tsx.
     const iconButton = page.getByTestId("icon-picker-trigger");
 
-    // The assertion under test: the button must be enabled. Without the
-    // fix, `disabled={hasGithubRepo}` makes this fail with the trigger
-    // button reporting `disabled`.
+    // Under test: `disabled={hasGithubRepo}` locked each of these.
     await expect(iconButton).toBeEnabled();
+    await expect(titleInput).toBeEnabled();
+    const descriptionInput = page.getByPlaceholder("Add a description...");
+    await expect(descriptionInput).toBeEnabled();
+
+    // A rename must reach the row — the form autosaves on blur.
+    const renamed = `renamed identity e2e ${Date.now()}`;
+    await titleInput.fill(renamed);
+    await titleInput.blur();
+
+    await expect
+      .poll(
+        async () => {
+          const got = await callSelfMcpTool<{ item: { title: string } }>(
+            api,
+            orgSlug,
+            "COLLECTION_VIRTUAL_MCP_GET",
+            { id: agent.item.id },
+          );
+          return got.item.title;
+        },
+        { timeout: 15_000 },
+      )
+      .toBe(renamed);
   });
 });

--- a/packages/e2e/tests/editor-resolve.spec.ts
+++ b/packages/e2e/tests/editor-resolve.spec.ts
@@ -9,7 +9,8 @@
  *   - the same site across two of the caller's orgs yields two matches;
  *   - a signed-in user who isn't a member sees nothing (empty, not 403);
  *   - an anonymous caller is refused (401);
- *   - a malformed slug fails cleanly (400).
+ *   - a malformed slug fails cleanly (400);
+ *   - renaming a project does not break the shortcut.
  */
 
 import type { APIRequestContext } from "@playwright/test";
@@ -61,7 +62,7 @@ async function createProjectForSite(
     "COLLECTION_VIRTUAL_MCP_CREATE",
     {
       data: {
-        // The project name (`title`) is what editor-resolve matches on.
+        // With no `metadata.siteSlug`, the title is the slug resolved against.
         title: siteSlug,
         connections: [],
         metadata: {
@@ -142,5 +143,55 @@ test.describe("Editor resolve (choose-editor backend)", () => {
     await ownerCtx.dispose();
     await otherCtx.dispose();
     await anonCtx.dispose();
+  });
+
+  test("a renamed project still resolves — the slug is pinned, not the title", async ({
+    playwright,
+  }) => {
+    const ownerCtx = await newApiContext(playwright);
+    const owner = await signUpViaApi(ownerCtx);
+
+    const suffix = `${Date.now()}${Math.random().toString(36).slice(2, 8)}`;
+    const slug = `e2e-rename-${suffix}`;
+
+    const project = await createProjectForSite(ownerCtx, owner.orgSlug, slug);
+
+    const resolveUrl = (site: string) =>
+      `/api/_editor-resolve?site=${encodeURIComponent(site)}`;
+
+    const before = (await (
+      await ownerCtx.get(resolveUrl(slug))
+    ).json()) as ResolveResult;
+    expect(before.matches.map((m) => m.project.id)).toEqual([project]);
+
+    // Rename it to something that could never be a slug (spaces + capitals).
+    const renamedTitle = "Renamed After Import";
+    await callSelfMcpTool(
+      ownerCtx,
+      owner.orgSlug,
+      "COLLECTION_VIRTUAL_MCP_UPDATE",
+      { id: project, data: { title: renamedTitle } },
+    );
+
+    // UPDATE pinned the outgoing title as `metadata.siteSlug`.
+    const after = (await (
+      await ownerCtx.get(resolveUrl(slug))
+    ).json()) as ResolveResult;
+    expect(after.matches.map((m) => m.project.id)).toEqual([project]);
+    expect(after.matches[0]?.project.title).toBe(renamedTitle);
+
+    // A second rename must not re-pin to the now-stale title.
+    await callSelfMcpTool(
+      ownerCtx,
+      owner.orgSlug,
+      "COLLECTION_VIRTUAL_MCP_UPDATE",
+      { id: project, data: { title: "Renamed Again" } },
+    );
+    const afterSecond = (await (
+      await ownerCtx.get(resolveUrl(slug))
+    ).json()) as ResolveResult;
+    expect(afterSecond.matches.map((m) => m.project.id)).toEqual([project]);
+
+    await ownerCtx.dispose();
   });
 });

--- a/packages/shared/src/site-slug.test.ts
+++ b/packages/shared/src/site-slug.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { isValidSiteSlug } from "./site-slug";
+import { isValidSiteSlug, resolveAgentSiteSlug } from "./site-slug";
 
 describe("isValidSiteSlug", () => {
   it("accepts valid lowercase slugs", () => {
@@ -28,5 +28,61 @@ describe("isValidSiteSlug", () => {
     ]) {
       expect(isValidSiteSlug(slug)).toBe(false);
     }
+  });
+});
+
+describe("resolveAgentSiteSlug", () => {
+  it("prefers the stamped siteSlug so a rename never moves the tenancy", () => {
+    expect(
+      resolveAgentSiteSlug({
+        title: "Acme Store (renamed)",
+        metadata: { siteSlug: "acmestore" },
+      }),
+    ).toBe("acmestore");
+  });
+
+  it("falls back to the title for agents imported before siteSlug existed", () => {
+    expect(resolveAgentSiteSlug({ title: "acmestore", metadata: {} })).toBe(
+      "acmestore",
+    );
+    expect(resolveAgentSiteSlug({ title: "acmestore" })).toBe("acmestore");
+    expect(resolveAgentSiteSlug({ title: "acmestore", metadata: null })).toBe(
+      "acmestore",
+    );
+  });
+
+  it("normalizes case and surrounding whitespace on both keys", () => {
+    expect(resolveAgentSiteSlug({ title: "  AcmeStore  " })).toBe("acmestore");
+    expect(
+      resolveAgentSiteSlug({ title: "x", metadata: { siteSlug: " ACME " } }),
+    ).toBe("acme");
+  });
+
+  it("treats a blank siteSlug as unset and keeps falling back", () => {
+    expect(
+      resolveAgentSiteSlug({ title: "acmestore", metadata: { siteSlug: "" } }),
+    ).toBe("acmestore");
+    expect(
+      resolveAgentSiteSlug({
+        title: "acmestore",
+        metadata: { siteSlug: "   " },
+      }),
+    ).toBe("acmestore");
+    expect(
+      resolveAgentSiteSlug({
+        title: "acmestore",
+        metadata: { siteSlug: null },
+      }),
+    ).toBe("acmestore");
+  });
+
+  it("returns null when there is nothing to resolve", () => {
+    expect(resolveAgentSiteSlug(null)).toBeNull();
+    expect(resolveAgentSiteSlug(undefined)).toBeNull();
+    expect(resolveAgentSiteSlug({})).toBeNull();
+    expect(resolveAgentSiteSlug({ title: "   " })).toBeNull();
+    expect(
+      resolveAgentSiteSlug({ title: null, metadata: { siteSlug: null } }),
+    ).toBeNull();
   });
 });

--- a/packages/shared/src/site-slug.ts
+++ b/packages/shared/src/site-slug.ts
@@ -10,3 +10,29 @@ export const SITE_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,59}$/;
 export function isValidSiteSlug(slug: string): boolean {
   return SITE_SLUG_RE.test(slug);
 }
+
+/**
+ * The site slug an agent resolves against — its managed-asset tenancy and the
+ * storefront "." shortcut (`/api/_editor-resolve`).
+ *
+ * `metadata.siteSlug` is stamped once at import and never re-derived, so it
+ * survives a rename. The `title` fallback covers agents imported before that
+ * key was persisted, where the title *was* the effective slug. Because a title
+ * is user-editable, nothing new should key off it — resolve through here.
+ */
+export function resolveAgentSiteSlug(
+  agent:
+    | {
+        title?: string | null;
+        metadata?: { siteSlug?: string | null } | null;
+      }
+    | null
+    | undefined,
+): string | null {
+  const normalize = (value: string | null | undefined) =>
+    typeof value === "string" ? value.trim().toLowerCase() : "";
+
+  return (
+    normalize(agent?.metadata?.siteSlug) || normalize(agent?.title) || null
+  );
+}


### PR DESCRIPTION
## Summary

The **name** and **description** inputs on the agent settings tab were disabled whenever the agent had a connected GitHub repo. That gate came from `3c1877eb0`, which locked the *whole* identity form because the instructions were repo-derived and read-only. Both premises are gone — #4128 re-enabled instructions editing and #3679 re-enabled the icon picker — leaving name and description locked for no remaining reason.

Removing the gate is only safe once nothing keys off the title, so I audited every use of a Virtual MCP's `title`/`description` beyond display before touching it.

## The audit found two real breakages — both fixed here

Both are reachable **only** for repo-backed agents, i.e. exactly the population this change unlocks renaming for:

| Where | What broke on rename |
|---|---|
| `apps/api/src/api/routes/editor-resolve.ts:94` | Matched `vm.title.toLowerCase() !== slug`. Renaming a deco-imported project **permanently** broke the storefront `.` shortcut for every member of the org — `/choose-editor` hit its dead-end state, with nothing in the UI hinting the rename caused it, and no self-heal. |
| `use-main-panel-tabs.ts:261` + `assets-tab.tsx:66` | Resolved the S3 bucket from `entity.title`. A rename hid the Assets tab and orphaned the bucket; renaming *onto another site's slug* pointed the tab at **that** site's bucket. |

Both now resolve through a new `resolveAgentSiteSlug` (`packages/shared/src/site-slug.ts`), which prefers the `metadata.siteSlug` stamped at import — never re-derived, so it survives a rename — and falls back to the title. The correct key already existed and was already used by the sections-editor family; these two call sites were the outliers.

**Legacy rows:** agents imported before `metadata.siteSlug` existed have only their title, so `COLLECTION_VIRTUAL_MCP_UPDATE` now freezes the outgoing title as the slug on the *first* rename — materializing the value that was already in effect. Guarded by `isValidSiteSlug`, so a title that was never a usable slug (spaces, capitals) is never stamped.

## Also fixed

The fullscreen instructions dialog still carried the same leftover `disabled={hasGithubRepo}` that #4128 removed from the inline textarea — the *same field* was editable inline but locked in its expanded view.

## What the audit cleared

Verified as safe, with the mechanism checked in source (several looked alarming and were refuted):

- **MCP wire surface** — `serverInfo.name` is `virtualMcp.id`; `title`/`description` are display-only (`api/routes/virtual-mcp.ts:200-206`). Installed clients keep working; the URL is id-based.
- **No silent revert** — nothing writes `title` back from the repo. `github-repo-picker.tsx` sets `title: repo.name` at *create* only, and its post-import sync writes `metadata.instructions` alone.
- **Repo-scoped child connection** — named `GitHub: ${owner}/${repo}`, and teardown looks it up by `metadata.githubRepo.connectionId`, not by the agent title.
- **Query keys / React keys / routes / caches** — all id-based.
- `packages/runtime/src/agents.ts` `createAgent` is idempotent-by-title, but cannot produce a repo-backed agent, so it's unreachable for this population.

## Testing

- **Unit (new):** `resolveAgentSiteSlug` (5 cases) + `pinnedSiteSlugOnRename` (6 cases) — 13 assertions total, `bun test` green.
- **E2E (new):** `editor-resolve.spec.ts` — "a renamed project still resolves — the slug is pinned, not the title", covering a rename to a non-slug string and a second rename that must not re-pin. **Verified passing** against a real server + Postgres, along with the pre-existing test in that file.
- **E2E (inverted):** `clonable-agent-logo.spec.ts` asserted `expect(titleInput).toBeDisabled()` — it encoded the old behavior and now asserts `toBeEnabled()` for icon, name and description, plus that the rename reaches the row. Renamed to `clonable-agent-identity.spec.ts` to match its widened scope.
- `bun run check`, `bun run lint` (0 errors), `bun run fmt`, and `knip` all clean.

> ⚠️ **One gap:** I could not get a valid local signal on `clonable-agent-identity.spec.ts`. My machine has an unrelated Next.js dev server on port 3000 — the port that spec hardcodes for its dummy connection URL — and moving off the default ports breaks the spec a different way. Every local failure was "page never rendered" or "auth 401", i.e. it never reached the assertion under test; none was the input reporting `disabled`. Worth a look at the CI result for that spec specifically.

## Screenshots

Not included — the visible change is that two previously greyed-out inputs are now editable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow renaming GitHub‑linked Virtual MCP agents. Previously, name and description were locked; now they are editable, and renames no longer break the storefront “.” shortcut or move asset tenancy.

- `/api/_editor-resolve` and the Assets tab now resolve via a site slug using `resolveAgentSiteSlug` from `@decocms/shared/site-slug` (prefers `metadata.siteSlug`, falls back to title for legacy agents).
- Legacy agents without `metadata.siteSlug`: on the first rename, `COLLECTION_VIRTUAL_MCP_UPDATE` stamps the outgoing, normalized title as `metadata.siteSlug` if valid; otherwise no stamp. This prevents tenancy moves and keeps the shortcut working.
- Removed leftover `disabled` on the fullscreen instructions dialog to match inline editability.
- Tests: unit for slug resolution and pinning; e2e covering editor resolve after rename and settings editability.

<sup>Written for commit 8bbca14d553f299ab0ea6b1e6f6fa514bc844b4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

