### PR TITLE
fix(sandbox): make synced-repo skills reach the run

### DIFF
--- a/packages/sandbox/daemon-go/internal/orgfs/links.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/links.go
@@ -398,13 +398,57 @@ func (l *Links) ensurePublicSkillLinksLocked() {
 	}()
 }
 
+// skillSet is one directory to scan for `<skill>/SKILL.md` children, with the
+// name its links are prefixed by.
+type skillSet struct {
+	name string
+	dir  string
+}
+
+// Mount paths under `org/` that are not skill sets: the org home (linked as the
+// USER skill dir already), and the two hidden per-thread volumes.
+var nonSkillVolumeDirs = map[string]bool{
+	"home": true, ".outputs": true, ".uploads": true,
+}
+
+// skillSetRoots is every directory whose children are candidate skills: the
+// read-only public sets (`org/public/<set>`) plus each repo-sync volume
+// (`org/<volume>`). Synced volumes are read off the live mount list rather than
+// by listing `org/` — a stray local dir there is not a mount and must not be
+// scanned. Reads `ActiveMounts` rather than `mountsOrWait`: this runs after the
+// mounts are already up (the public ReadDir above only succeeds through one), so
+// paying the grace wait here would only stall the retry path.
+func (l *Links) skillSetRoots() []skillSet {
+	orgRoot := filepath.Join(l.AppRoot, "org")
+	var out []skillSet
+	if sets, err := os.ReadDir(filepath.Join(orgRoot, "public")); err == nil {
+		for _, set := range sets {
+			if !set.IsDir() || !safeSegment.MatchString(set.Name()) {
+				continue
+			}
+			out = append(out, skillSet{set.Name(), filepath.Join(orgRoot, "public", set.Name())})
+		}
+	}
+	for _, m := range l.ActiveMounts() {
+		name := filepath.Base(m.MountPath)
+		if filepath.Dir(m.MountPath) != orgRoot || nonSkillVolumeDirs[name] {
+			continue
+		}
+		if !safeSegment.MatchString(name) {
+			continue
+		}
+		out = append(out, skillSet{name, m.MountPath})
+	}
+	return out
+}
+
 // syncPublicSkills does the linking, reporting whether anything was linked. Runs
 // without `mu`: it touches only the checkout's skills dir and the read-only
 // public mounts, which no other link path writes.
 func (l *Links) syncPublicSkills() bool {
-	sets, err := os.ReadDir(filepath.Join(l.AppRoot, "org", "public"))
-	if err != nil {
-		// No public mount on this pod (older sandbox, or none configured).
+	sets := l.skillSetRoots()
+	if len(sets) == 0 {
+		// No public or synced mount on this pod (older sandbox, or none configured).
 		return false
 	}
 	dir := filepath.Join(l.RepoDir, ".claude", "skills")
@@ -425,10 +469,7 @@ func (l *Links) syncPublicSkills() bool {
 
 	linked, unreadable := 0, 0
 	for _, set := range sets {
-		if !set.IsDir() || !safeSegment.MatchString(set.Name()) {
-			continue
-		}
-		setDir := filepath.Join(l.AppRoot, "org", "public", set.Name())
+		setDir := set.dir
 		names := skillDirNames(setDir)
 		if len(names) == 0 {
 			continue
@@ -442,14 +483,14 @@ func (l *Links) syncPublicSkills() bool {
 			filepath.Join(setDir, names[0], "SKILL.md"), skillReadBudget,
 		); !ok {
 			slog.Warn("org-fs public skills skipped: set does not read",
-				"set", set.Name(), "probe", names[0], "skills", len(names), "err", err)
+				"set", set.name, "probe", names[0], "skills", len(names), "err", err)
 			unreadable += len(names)
 			continue
 		}
 		for _, name := range names {
 			// `<set>-<skill>`: collision-free across sets. Cosmetic — the name the
 			// model sees comes from SKILL.md's frontmatter, not the directory.
-			link := filepath.Join(dir, publicSkillPrefix+set.Name()+"-"+name)
+			link := filepath.Join(dir, publicSkillPrefix+set.name+"-"+name)
 			if err := os.Symlink(filepath.Join(setDir, name), link); err != nil {
 				slog.Warn("org-fs public skill link failed", "skill", name, "err", err)
 				continue

--- a/packages/sandbox/daemon-go/internal/orgfs/links.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/links.go
@@ -12,6 +12,7 @@ package orgfs
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -67,6 +68,10 @@ type Links struct {
 	lastOutputThread string
 	skillsLinked     bool
 	publicSkillsRun  bool
+	// Closed when the in-flight skill-link sync finishes; nil before the first
+	// one starts. `WaitSkillLinks` is what turns the async sync back into a
+	// barrier for the run that needs it.
+	publicSkillsDone chan struct{}
 }
 
 // Expected reports whether org-fs volumes should exist on this pod.
@@ -245,14 +250,8 @@ func (l *Links) ensureSkillsLinkLocked() {
 	// skills dir has no file to hang on, and linking it is what gives the agent
 	// somewhere durable to write — skip the link there and the agent writes its
 	// skill into the checkout, which is the whole bug this exists to fix.
-	if names := skillDirNames(target); len(names) > 0 {
-		if ok, err := readableWithin(
-			filepath.Join(target, names[0], "SKILL.md"), skillReadBudget,
-		); !ok {
-			slog.Warn("org-fs skills link skipped: home mount does not read",
-				"probe", names[0], "budget", skillReadBudget, "err", err)
-			return
-		}
+	if names := skillDirNames(target); len(names) > 0 && !setReads(target, names) {
+		return
 	}
 	link := filepath.Join(dir, "skills")
 	if st, err := os.Lstat(link); err == nil {
@@ -283,6 +282,37 @@ func (l *Links) ensureSkillsLinkLocked() {
 // How long a single org-fs read may take before the mount counts as unusable
 // for skills. Generous for a network filesystem, tiny next to a dead run.
 const skillReadBudget = 3 * time.Second
+
+// errReadTimeout marks the ONE probe failure that speaks for the whole mount: a
+// read that never answered. Every other error is one object's problem.
+var errReadTimeout = errors.New("read did not answer within budget")
+
+// setReads reports whether a skill set's mount serves reads, probing skills in
+// order until one answers.
+//
+// The distinction is the point. A TIMEOUT is the mount's answer for the entire
+// set — one volume, one backend — and probing past it would spend the budget
+// again on exactly the wedged mount this gate exists to catch, so it condemns
+// the set on the spot. Any other error belongs to that single object (bytes that
+// were never uploaded surface as EIO) and returns immediately, so it must not
+// take the healthy skills behind it down: condemning a set on its alphabetically
+// first skill is how 84 good skills disappeared.
+func setReads(setDir string, names []string) bool {
+	for _, name := range names {
+		ok, err := readableWithin(filepath.Join(setDir, name, "SKILL.md"), skillReadBudget)
+		if ok {
+			return true
+		}
+		if errors.Is(err, errReadTimeout) {
+			slog.Warn("org-fs skills skipped: mount does not read",
+				"dir", setDir, "probe", name, "skills", len(names), "err", err)
+			return false
+		}
+		slog.Warn("org-fs skills: unreadable skill, probing past it",
+			"dir", setDir, "probe", name, "err", err)
+	}
+	return false
+}
 
 // readableWithin reports whether path's first byte can be read within d, and
 // why not when it fails. The reason matters: "hung mount" and "backend returns
@@ -319,7 +349,7 @@ func readableWithin(path string, d time.Duration) (bool, error) {
 	case err := <-done:
 		return err == nil, err
 	case <-time.After(d):
-		return false, fmt.Errorf("read did not answer within %s", d)
+		return false, fmt.Errorf("%w (%s)", errReadTimeout, d)
 	}
 }
 
@@ -383,12 +413,13 @@ func (l *Links) ensurePublicSkillLinksLocked() {
 	// sync; released again below if nothing linked, so a mount that recovers gets
 	// another attempt.
 	l.publicSkillsRun = true
-	// OFF the caller's thread: this walks a network filesystem, and it ran under
-	// the lock on the dispatch path — 33 unreadable skills × the read budget put
-	// two minutes of dead air in front of a run that was otherwise ready. The
-	// cost of racing the harness's own startup scan is at worst a skill missing
-	// from THIS run; the cost of blocking was the run.
+	done := make(chan struct{})
+	l.publicSkillsDone = done
+	// OFF the caller's thread: this walks a network filesystem and would
+	// otherwise hold `mu` across it. Callers that must not race the harness's own
+	// startup skill scan await `done` via WaitSkillLinks instead of blocking here.
 	go func() {
+		defer close(done)
 		if l.syncPublicSkills() {
 			return
 		}
@@ -396,6 +427,32 @@ func (l *Links) ensurePublicSkillLinksLocked() {
 		l.publicSkillsRun = false
 		l.mu.Unlock()
 	}()
+}
+
+// WaitSkillLinks blocks until the in-flight skill-link sync finishes, or budget
+// elapses. Call it on the dispatch path after the links are triggered and before
+// the harness starts: Claude Code scans its skill dirs ONCE at startup, so a
+// symlink that lands a moment later is invisible for the whole run — which is
+// how a freshly-synced repo's skills went missing while being correctly mounted.
+//
+// Bounded, and fail-open. The sync spends the read budget at most once per set
+// (a timeout condemns that set immediately; every other probe error returns
+// without waiting), so the honest worst case is small — but a run must never
+// hang behind a symlink, so the deadline is the backstop and a miss only costs
+// this run's late skills, which the next dispatch picks up.
+func (l *Links) WaitSkillLinks(budget time.Duration) {
+	l.mu.Lock()
+	done := l.publicSkillsDone
+	l.mu.Unlock()
+	if done == nil {
+		return
+	}
+	select {
+	case <-done:
+	case <-time.After(budget):
+		slog.Warn("org-fs skill links still syncing; starting the run without them",
+			"waited", budget)
+	}
 }
 
 // skillSet is one directory to scan for `<skill>/SKILL.md` children, with the
@@ -474,16 +531,10 @@ func (l *Links) syncPublicSkills() bool {
 		if len(names) == 0 {
 			continue
 		}
-		// ONE probe per set, not per skill. `stat` is served from the mount's
-		// metadata and succeeds on a backend whose GETs hang forever, so a read
-		// has to be proven — but a set is one volume with one backend, so the
-		// first skill's answer is the whole set's answer. Per-skill probing cost
-		// 33 × the budget on a wedged mount.
-		if ok, err := readableWithin(
-			filepath.Join(setDir, names[0], "SKILL.md"), skillReadBudget,
-		); !ok {
-			slog.Warn("org-fs public skills skipped: set does not read",
-				"set", set.name, "probe", names[0], "skills", len(names), "err", err)
+		// `stat` is served from the mount's metadata and succeeds on a backend
+		// whose GETs hang forever, so a read has to be proven before these are
+		// exposed to Claude Code's startup scan.
+		if !setReads(setDir, names) {
 			unreadable += len(names)
 			continue
 		}

--- a/packages/sandbox/daemon-go/internal/orgfs/links_test.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/links_test.go
@@ -279,6 +279,53 @@ func TestPublicSkillLinks(t *testing.T) {
 	}
 }
 
+func TestSyncedVolumeSkillLinks(t *testing.T) {
+	appRoot := t.TempDir()
+	repoDir := filepath.Join(appRoot, "repo")
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(t.TempDir(), "config"))
+	statusPath := filepath.Join(t.TempDir(), "status.json")
+	if err := os.MkdirAll(filepath.Join(repoDir, ".git", "info"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A repo-sync volume mounts at `org/<volume>`; home and the hidden per-thread
+	// volumes mount alongside it and must NOT be scanned for skills.
+	for _, dir := range []string{"decocms-skills/unslopify", "home/skills/mine", ".outputs/t1"} {
+		if err := os.MkdirAll(filepath.Join(appRoot, "org", dir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(
+			filepath.Join(appRoot, "org", dir, "SKILL.md"), []byte("---\nname: x\n---\n"), 0o644,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+	raw, _ := json.Marshal(sidecarStatus{Mounts: []Mount{
+		{Volume: "decocms-skills", MountPath: filepath.Join(appRoot, "org", "decocms-skills")},
+		{Volume: "home", MountPath: filepath.Join(appRoot, "org", "home")},
+		{Volume: "outputs", MountPath: filepath.Join(appRoot, "org", ".outputs")},
+	}})
+	if err := os.WriteFile(statusPath, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	l := &Links{AppRoot: appRoot, RepoDir: repoDir, StatusPath: statusPath, ConfigPath: "unused"}
+	l.syncPublicSkills()
+
+	skillsDir := filepath.Join(repoDir, ".claude", "skills")
+	target, err := os.Readlink(filepath.Join(skillsDir, "orgfs-decocms-skills-unslopify"))
+	if err != nil {
+		t.Fatalf("synced-repo skill not linked: %v", err)
+	}
+	if want := filepath.Join(appRoot, "org", "decocms-skills", "unslopify"); target != want {
+		t.Errorf("link → %q, want %q", target, want)
+	}
+	for _, name := range []string{"orgfs-home-skills", "orgfs-.outputs-t1"} {
+		if _, err := os.Lstat(filepath.Join(skillsDir, name)); err == nil {
+			t.Errorf("linked a non-skill-set volume: %s", name)
+		}
+	}
+}
+
 func TestAdoptStrayRepoSkills(t *testing.T) {
 	appRoot := t.TempDir()
 	repoDir := filepath.Join(appRoot, "repo")

--- a/packages/sandbox/daemon-go/internal/orgfs/links_test.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/links_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // The end-to-end behavior lives in daemon.orgfs.e2e.test.ts. Here: the one
@@ -323,6 +324,71 @@ func TestSyncedVolumeSkillLinks(t *testing.T) {
 		if _, err := os.Lstat(filepath.Join(skillsDir, name)); err == nil {
 			t.Errorf("linked a non-skill-set volume: %s", name)
 		}
+	}
+}
+
+// A set whose FIRST skill is unreadable must still expose the rest — the failure
+// belongs to that object, not to the mount.
+func TestUnreadableSkillDoesNotCondemnSet(t *testing.T) {
+	appRoot := t.TempDir()
+	repoDir := filepath.Join(appRoot, "repo")
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(t.TempDir(), "config"))
+	if err := os.MkdirAll(filepath.Join(repoDir, ".git", "info"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	setDir := filepath.Join(appRoot, "org", "public", "core")
+	// "aaa-broken" sorts first, so it is the probe the old code condemned on. Its
+	// SKILL.md is a DIRECTORY: `skillDirNames` still picks the skill up (that is a
+	// stat, which passes) and the read then fails immediately — the EIO shape, not
+	// a hang. A directory rather than a chmod so the case holds as root too.
+	if err := os.MkdirAll(filepath.Join(setDir, "aaa-broken", "SKILL.md"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(setDir, "slides"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(setDir, "slides", "SKILL.md"), []byte("---\nname: x\n---\n"), 0o644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	l := &Links{AppRoot: appRoot, RepoDir: repoDir, ConfigPath: "unused"}
+	if !l.syncPublicSkills() {
+		t.Fatal("set condemned by one unreadable skill")
+	}
+	if _, err := os.Readlink(filepath.Join(repoDir, ".claude", "skills", "orgfs-core-slides")); err != nil {
+		t.Errorf("healthy skill behind the bad probe was not linked: %v", err)
+	}
+}
+
+func TestWaitSkillLinks(t *testing.T) {
+	appRoot := t.TempDir()
+	repoDir := filepath.Join(appRoot, "repo")
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(t.TempDir(), "config"))
+	skill := filepath.Join(appRoot, "org", "public", "core", "slides")
+	if err := os.MkdirAll(skill, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skill, "SKILL.md"), []byte("---\nname: x\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(repoDir, ".git", "info"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	l := &Links{AppRoot: appRoot, RepoDir: repoDir, ConfigPath: "unused"}
+	// No sync started yet — the waiter must not block.
+	l.WaitSkillLinks(time.Second)
+
+	l.mu.Lock()
+	l.ensurePublicSkillLinksLocked()
+	l.mu.Unlock()
+	// The whole point: after this returns the links are on disk, so the harness's
+	// one-shot startup scan cannot miss them.
+	l.WaitSkillLinks(10 * time.Second)
+	if _, err := os.Readlink(filepath.Join(repoDir, ".claude", "skills", "orgfs-core-slides")); err != nil {
+		t.Errorf("WaitSkillLinks returned before the link landed: %v", err)
 	}
 }
 

--- a/packages/sandbox/daemon-go/main.go
+++ b/packages/sandbox/daemon-go/main.go
@@ -181,6 +181,12 @@ func (d *daemon) getActiveTasks() []events.ActiveTaskSummary {
 
 const fileChangedDebounce = 300 * time.Millisecond
 
+// How long a dispatch waits for the org-fs skill links before starting the
+// harness anyway. The sync spends its read budget at most once per skill set, so
+// this is slack, not the expected cost — it is the backstop that keeps a wedged
+// mount from ever holding a run.
+const skillLinkWait = 15 * time.Second
+
 func (d *daemon) emitFileChanged(path string) {
 	d.fileChangedMu.Lock()
 	defer d.fileChangedMu.Unlock()
@@ -973,6 +979,11 @@ func main() {
 		// link; never blocks the run.
 		BeforeRun: func(info dispatch.RunInfo) {
 			d.orgFsLinks.RepointForRun(info.ThreadId)
+			// RepointForRun kicks the skill-link sync off-thread; wait for it here.
+			// Claude Code scans its skill dirs once at startup, so a symlink that
+			// lands after that is invisible for the entire run. Bounded — a miss
+			// costs this run's late skills, not the run.
+			d.orgFsLinks.WaitSkillLinks(skillLinkWait)
 			catalogSync.Sync(toolscatalog.Endpoint{
 				URL:       info.McpURL,
 				Headers:   info.McpHeaders,


### PR DESCRIPTION
## Problem

Adding a repo through **Synced repos** does not make its skills available to a run. Reproduced on `thrd_vJ26l4gJ9FAJAavOqIoAL` (`deco-studio`): the agent reported 21 skills and none of the 85 in the freshly-synced `decocms/skills`.

Every layer upstream was fine — checked in prod:

| Layer | State |
|---|---|
| `org_repo_sync` | `decocms/skills@main` → volume `decocms-skills`, enabled, synced, no error |
| `org_fs_entry` | 576 rows, **85 `SKILL.md` at depth 1** |
| Sandbox mount config (created *after* the sync) | `{"volume":"decocms-skills","path":"decocms-skills","readonly":true}` |

The break is the last hop. That run used `harness_id=claude-code`, which discovers skills from the **filesystem** (`skills: "all"` in `packages/harness-runner/claude-code.ts`), not from Studio's `<available-skills>` block. The daemon is what exposes org skills to it, and `syncPublicSkills()` only ever walked one directory:

```go
sets, err := os.ReadDir(filepath.Join(l.AppRoot, "org", "public"))
```

Repo-sync volumes mount at `org/<volume>`, not `org/public/<set>`. So they were mounted, readable, and never symlinked into `.claude/skills/`. `buildSyncedEntries` in `skill-catalog.ts` *does* enumerate them, which is why the decopilot catalog path sees them and this one didn't.

## Fix

`skillSetRoots()` returns both root kinds: the `org/public/*` dirs plus every live mount directly under `org/` that isn't `home` / `.outputs` / `.uploads`. Synced volumes come off the **mount list**, not a `ReadDir` of `org/` — a stray local dir there is not a mount and must not be scanned. Everything downstream is unchanged: the one-probe-per-set readability check, the `orgfs-` link prefix, clear-then-rebuild, the single git-exclude line.

It reads `ActiveMounts()` rather than `mountsOrWait()` — this already runs after the mounts are up (the public `ReadDir` only succeeds through one), so paying the 10s grace wait here would only stall the retry path.

## Testing

- `TestSyncedVolumeSkillLinks` (new) — a `decocms-skills` mount gets linked as `orgfs-decocms-skills-<skill>`; `home` and `.outputs` mounts alongside it are **not** scanned.
- `TestPublicSkillLinks` unchanged and passing — public sets still come from the `ReadDir` path, and the mount loop skips `org/public/<set>` (its parent is `org/public`, not `org/`) so nothing is linked twice.
- `go test ./...` green in `packages/sandbox/daemon-go`.

## Affected areas

Sandbox daemon only (`internal/orgfs/links.go`). Behavior change is additive — more symlinks in the checkout's `.claude/skills/`, all under the existing `orgfs-*` prefix that is already git-excluded and rebuilt from scratch each sync.

## Out of scope

- **Nesting.** Only `<volume>/<skill>/SKILL.md` is discovered, matching public-set behavior. A repo that nests its skills under `skills/` still needs the sync's `paths[].from` pointed at that subtree.
- **Mid-session remount.** `ORGFS_CONFIG` is baked at sandbox boot, so a repo added while a sandbox is live still lands on the next sandbox start. Pre-existing, documented in `mintOrgFsConfigJson`.
- **A second, separate bug found while debugging:** the same run also lost the 24 `public-storefront` skills it had seen in an earlier run. `syncPublicSkills` runs in a goroutine racing the SDK's startup scan, and one unreadable probe skips an entire set. Needs its own fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Links skills from synced repos into Claude Code’s `.claude/skills/` and removes two causes of missing skills: the startup race and condemning a whole set due to one bad file. Previously we only scanned `org/public/<set>` and linked asynchronously; now we also scan live repo-sync mounts and wait (bounded) for links before the harness starts.

- Discovery now includes live mounts under `org/<volume>` from `ActiveMounts()`, excluding `home`, `.outputs`, and `.uploads`; public sets under `org/public/<set>` remain unchanged.
- Dispatch calls `WaitSkillLinks` (15s budget) after triggering the link sync and before starting the Claude Code harness, preventing the one-shot startup scan from missing newly created symlinks; the sync still runs off-thread and fails open on timeout.
- A new `setReads` probe treats read timeouts as a set-level failure but continues past other per-file errors, so one unreadable `SKILL.md` no longer suppresses healthy skills; the home-skill gate shares this logic.
- Keeps existing behavior: per-set readability check, `orgfs-<set>-<skill>` symlink names, clear-then-rebuild, and the existing git-exclude. Tests cover synced volume links, non-skill mounts excluded, unreadable-first-skill not condemning a set, and `WaitSkillLinks` ensuring links land before startup.

<sup>Written for commit 27bd495baadc173680c036779a4766cf88b0ced0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6370?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

