### PR TITLE
fix(task-board): show a visible focus ring on filter chip buttons

### DIFF
--- a/apps/web/src/layouts/task-board/task-filters.tsx
+++ b/apps/web/src/layouts/task-board/task-filters.tsx
@@ -195,7 +195,7 @@ const DUE_OPTIONS_LABEL_KEYS: Record<DueFilter, TranslationKey> = {
  */
 function chipClass(active: boolean, block = false): string {
   return cn(
-    "inline-flex h-8 items-center gap-1.5 rounded-lg border px-2.5 text-xs font-medium outline-none transition-colors",
+    "inline-flex h-8 items-center gap-1.5 rounded-lg border px-2.5 text-xs font-medium outline-none transition-colors focus-visible:border-ring focus-visible:ring-[2px] focus-visible:ring-ring/20",
     block && "h-10 w-full justify-start px-3 text-sm",
     active
       ? "border-transparent bg-accent text-foreground"


### PR DESCRIPTION
**Source:** bug found while auditing `apps/web/src/layouts/task-board/task-filters.tsx` for keyboard-navigation issues (this tick's focus area: task-board UI polish).

**Why:** `chipClass` (the shared style for the assignee/priority/due-date/tag/repo filter triggers and the mobile filter-drawer trigger) sets `outline-none` with no compensating `focus-visible` ring, so tabbing through the filter bar with a keyboard gives zero visual indication of which control has focus — a real accessibility regression for keyboard users.

**Fix:** add the same `focus-visible:border-ring focus-visible:ring-[2px] focus-visible:ring-ring/20` treatment the shared design-system `Button` component (`packages/ui/src/components/button.tsx`) already uses, so these raw `<button>` triggers get a visible focus ring consistent with the rest of the app.

**Verify:** tab through the task-board filter bar (`/{org}/tasks` or wherever the board lives) with the mouse untouched — each chip (search, assignee, priority, due date, tags, repo) and the mobile filter-drawer trigger should show a visible ring when focused.

**Checks run locally:** `bun run fmt` (clean), `bunx oxlint apps/web/src/layouts/task-board/task-filters.tsx` (0 warnings/errors). No type changes, so `tsc` was skipped per the verification gate. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a visible focus ring on task-board filter chips to restore keyboard focus indication. Previously these buttons removed the outline and had no focus state; now they use the same focus-visible ring as the `packages/ui` Button, improving accessibility without changing mouse behavior.

- Add `focus-visible:border-ring focus-visible:ring-[2px] focus-visible:ring-ring/20` to the shared `chipClass` used by search, assignee, priority, due date, tags, repo, and the mobile filter-drawer trigger.
- Verify by tabbing through the filter bar: each chip shows a ring when focused.

<sup>Written for commit eaeb00646c92ebe33e757abba2eef8b12467e856. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

