### PR TITLE
fix(blog): disable the publish toggle when the post is missing required fields

### DIFF
--- a/apps/web/src/components/sandbox/content/blog/post-editor.tsx
+++ b/apps/web/src/components/sandbox/content/blog/post-editor.tsx
@@ -224,6 +224,16 @@ function PostSettings({
 }) {
   const t = useT();
   const isPublished = isPostPublished(post);
+  const missing = missingPostFields(post);
+  const hasErrors = missing.length > 0;
+  const missingLabel =
+    missing.length === 1
+      ? t("sandbox.postEditor.missingFieldSingular", {
+          fields: missing.join(", "),
+        })
+      : t("sandbox.postEditor.missingFieldPlural", {
+          fields: missing.join(", "),
+        });
 
   return (
     <div className="space-y-5">
@@ -231,14 +241,24 @@ function PostSettings({
         <Label htmlFor="post-published">
           {t("sandbox.postEditor.publishedLabel")}
         </Label>
-        <Switch
-          id="post-published"
-          className="data-[state=checked]:bg-success"
-          checked={isPublished}
-          onCheckedChange={(checked) =>
-            onChange("status", checked ? "published" : "draft")
-          }
-        />
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span>
+              <Switch
+                id="post-published"
+                className="data-[state=checked]:bg-success"
+                checked={isPublished}
+                disabled={hasErrors}
+                onCheckedChange={(checked) =>
+                  onChange("status", checked ? "published" : "draft")
+                }
+              />
+            </span>
+          </TooltipTrigger>
+          {hasErrors && (
+            <TooltipContent side="bottom">{missingLabel}</TooltipContent>
+          )}
+        </Tooltip>
       </div>
       <div className="space-y-2">
         <Label htmlFor="post-excerpt">


### PR DESCRIPTION
Follows #6360 (post publish toggle + status filter on the posts list).

**Bug:** #6360 added a Published/Draft switch to the post's Settings tab that writes `status: "published"` directly on toggle, with no validation. The same panel already computes `missingPostFields` (title/slug/category/excerpt/cover image) and uses it to disable the Preview button — but the new publish switch ignored it, so a post missing required fields (e.g. no slug, no category) could be flipped to "published" and would then be live/broken on the storefront.

**Fix:** the publish switch is now disabled whenever `missingPostFields(post)` is non-empty, with a tooltip listing the missing fields — the same pattern already used for the Preview button just above it in this file.

**Verify:** open a post missing e.g. its slug or category in the blog editor's Settings tab; the Published switch should be disabled with a tooltip naming the missing fields, and become enabled once they're filled in.

**Checks run locally:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint apps/web/src/components/sandbox/content/blog/post-editor.tsx` (0 warnings/errors). No behavior-affecting logic outside this one file; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents publishing blog posts with missing required fields by disabling the Published switch when validation fails. Previously the switch set status to "published" even when required fields were missing; now it is disabled and shows a tooltip listing the missing fields.

- Review notes:
  - Change is scoped to the Post Settings UI in apps/web/src/components/sandbox/content/blog/post-editor.tsx; it uses existing missingPostFields(post) and mirrors the Preview button gating.
  - No data model, API, or backend changes; only UI/interaction is affected.

- Verification:
  - Open a post missing a slug or category; the Published switch is disabled with a tooltip naming the missing fields, and becomes enabled once fields are filled.
  - When enabled, toggling still updates status between "published" and "draft" as before.

<sup>Written for commit f8d29be65108da284d8520417b34422c0c999762. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

