### PR TITLE
fix(preview): don't crash the preview panel on a malformed iframeBase URL

### DIFF
--- a/apps/web/src/components/sandbox/preview/preview.test.ts
+++ b/apps/web/src/components/sandbox/preview/preview.test.ts
@@ -2,7 +2,7 @@ import { setupComponentTest } from "../../../../test/setup";
 setupComponentTest();
 
 import { describe, expect, it } from "bun:test";
-import { withDecoFBT, withDeviceHint } from "./preview";
+import { resolvePreviewUrl, withDecoFBT, withDeviceHint } from "./preview";
 
 describe("withDeviceHint", () => {
   it("sets deviceHint on a well-formed URL", () => {
@@ -29,5 +29,17 @@ describe("withDecoFBT", () => {
 
   it("falls back to the original string instead of throwing on a malformed URL", () => {
     expect(withDecoFBT("http://[::1")).toBe("http://[::1");
+  });
+});
+
+describe("resolvePreviewUrl", () => {
+  it("resolves path against base", () => {
+    expect(resolvePreviewUrl("/foo", "https://example.com")).toBe(
+      "https://example.com/foo",
+    );
+  });
+
+  it("returns null instead of throwing when base is malformed", () => {
+    expect(resolvePreviewUrl("/foo", "http://[::1")).toBe(null);
   });
 });

--- a/apps/web/src/components/sandbox/preview/preview.tsx
+++ b/apps/web/src/components/sandbox/preview/preview.tsx
@@ -243,6 +243,20 @@ function previewOrigin(previewUrl: string | null): string | null {
 }
 
 /**
+ * Resolves `path` against `base` (both come from the sandbox daemon /
+ * production preview server, so treat as untrusted), or `null` on a
+ * malformed value instead of throwing mid-render — same defensive shape as
+ * `previewOrigin` above.
+ */
+export function resolvePreviewUrl(path: string, base: string): string | null {
+  try {
+    return new URL(path, base).href;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Renders nothing; fires `onOpen` exactly once when mounted to auto-open the
  * CMS. Headless run-once helper mirroring `PathParamAutoFill`: the parent
  * mounts it only while the auto-open should happen (see `shouldAutoOpenCms`)
@@ -662,7 +676,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   // mode, or once no `iframeBase` is available yet.
   const productionOrigin =
     display.mode === "production" && display.iframeBase
-      ? new URL(display.iframeBase).origin
+      ? previewOrigin(display.iframeBase)
       : null;
   // In the desktop app, an external production origin must be registered
   // with the native shell's navigation policy BEFORE the iframe below is
@@ -684,7 +698,9 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
     display.mode === "sandbox"
       ? withVariantMatcherOverride(
           withDeviceHint(
-            directPreviewUrl ?? new URL(resolvedPath, display.iframeBase!).href,
+            directPreviewUrl ??
+              resolvePreviewUrl(resolvedPath, display.iframeBase!) ??
+              display.iframeBase!,
             previewDeviceSize,
           ),
           workspace.state.variantOverride ?? [],
@@ -697,7 +713,8 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
               withDraftPointer(
                 directPreviewUrl ??
                   draftPreviewUrl ??
-                  new URL(resolvedPath, display.iframeBase!).href,
+                  resolvePreviewUrl(resolvedPath, display.iframeBase!) ??
+                  display.iframeBase!,
                 display.showWakingPill ? DRAFT_OFF : null,
               ),
               previewDeviceSize,
@@ -748,7 +765,7 @@ export function PreviewContent({ virtualMcpId }: { virtualMcpId: string }) {
   const productionOpenTabBase =
     draftPreviewUrl ??
     (display.iframeBase
-      ? new URL(resolvedPath, display.iframeBase).href
+      ? resolvePreviewUrl(resolvedPath, display.iframeBase)
       : null);
   const openInNewTabUrl =
     display.mode === "production"


### PR DESCRIPTION
Follows #6362, which wrapped `withDeviceHint`/`withDecoFBT`'s `new URL()` calls in try/catch after a malformed `directPreviewUrl`/`previewUrl` crashed the whole preview panel mid-render — matching `previewOrigin`'s existing defensive shape.

It missed four sibling call sites that construct URLs from the same untrusted `display.iframeBase` (set from the sandbox daemon / production preview server, see `preview-display.ts`): `productionOrigin`, the two `iframeSrc` branches (sandbox and production modes), and `productionOpenTabBase`. Each still called `new URL(...)` unguarded as an argument expression — a malformed `iframeBase` (e.g. an unparseable host) throws before `withDeviceHint`'s own try/catch ever runs, taking the whole panel down the same way #6362 fixed for the other inputs.

**Failure scenario:** the sandbox daemon or Fast Preview server reports an `iframeBase` that isn't a valid absolute URL (malformed host, stray bracket in an IPv6 literal, etc.) — the preview panel throws during render and goes blank instead of degrading gracefully.

**Fix:** added `resolvePreviewUrl()`, the same try/catch-and-fall-back-to-`null` shape as the existing `previewOrigin` helper, and used it (or `previewOrigin` itself, for the origin-only case) at all four call sites. Added a regression test mirroring the existing `withDeviceHint`/`withDecoFBT` malformed-URL tests.

**To verify:** `bun test apps/web/src/components/sandbox/preview/preview.test.ts`

**Checked locally:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, `bun test apps/web/src/components/sandbox/preview/preview.test.ts` (7 pass), `bunx oxlint` on both touched files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the preview panel from crashing when `display.iframeBase` is malformed. Previously, `new URL(...)` at several sites threw during render; now URL resolution is guarded and falls back instead of throwing.

- Add `resolvePreviewUrl(path, base)`: try/catch, returns href or null, same defensive shape as `previewOrigin`.
- Use guarded resolution at four sites: `productionOrigin`, sandbox `iframeSrc`, production `iframeSrc`, and `productionOpenTabBase`.
- Behavior with malformed base: panel stays up; iframe may fail to load; “Open in new tab” may be disabled when the URL is null. Valid bases behave unchanged.
- Add regression tests for `resolvePreviewUrl`. Verify with: `bun test apps/web/src/components/sandbox/preview/preview.test.ts`.

<sup>Written for commit 093e6ac86a27ae22fc2c9b8512511ff220f354c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

