### PR TITLE
perf(sandbox): prefetch org skills to pod disk instead of mounting them

### DIFF
--- a/packages/sandbox/daemon-go/internal/orgfs/links.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/links.go
@@ -456,14 +456,15 @@ func (l *Links) WaitSkillLinks(budget time.Duration) {
 }
 
 // skillSet is one directory to scan for `<skill>/SKILL.md` children, with the
-// name its links are prefixed by.
+// name its copies are prefixed by.
 type skillSet struct {
 	name string
 	dir  string
 }
 
-// Mount paths under `org/` that are not skill sets: the org home (linked as the
-// USER skill dir already), and the two hidden per-thread volumes.
+// Mount paths under `org/` that are not skill sets: the org home (linked, not
+// copied — the agent writes skills there and they must sync back), and the two
+// hidden per-thread volumes.
 var nonSkillVolumeDirs = map[string]bool{
 	"home": true, ".outputs": true, ".uploads": true,
 }
@@ -499,9 +500,15 @@ func (l *Links) skillSetRoots() []skillSet {
 	return out
 }
 
-// syncPublicSkills does the linking, reporting whether anything was linked. Runs
-// without `mu`: it touches only the checkout's skills dir and the read-only
-// public mounts, which no other link path writes.
+// syncPublicSkills copies every read-only set's skills onto the pod's disk under
+// `<repoDir>/.claude/skills/`, reporting whether anything landed. Runs without
+// `mu`: it touches only the checkout's skills dir and the read-only mounts,
+// which no other link path writes.
+//
+// Copied rather than symlinked — see skillcopy.go for why. The pod therefore
+// holds a snapshot for its lifetime, which is what we want: this already ran
+// once per boot (`publicSkillsRun` latches on success), and a skill that
+// changes underneath a running agent is a hazard, not a feature.
 func (l *Links) syncPublicSkills() bool {
 	sets := l.skillSetRoots()
 	if len(sets) == 0 {
@@ -510,11 +517,11 @@ func (l *Links) syncPublicSkills() bool {
 	}
 	dir := filepath.Join(l.RepoDir, ".claude", "skills")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		slog.Warn("org-fs public skills link failed", "err", err)
+		slog.Warn("org-fs public skills copy failed", "err", err)
 		return false
 	}
-	// Ours are cleared first: a set that lost a skill must not leave a symlink
-	// pointing at nothing, which Claude Code reports as a broken skill.
+	// Ours are cleared first: a set that lost a skill must not leave a stale copy
+	// behind, and a partial copy from a previous attempt must not be reused.
 	if entries, err := os.ReadDir(dir); err == nil {
 		for _, e := range entries {
 			if strings.HasPrefix(e.Name(), publicSkillPrefix) {
@@ -524,33 +531,33 @@ func (l *Links) syncPublicSkills() bool {
 	}
 	gitx.EnsureExclude(l.RepoDir, "/.claude/skills/"+publicSkillPrefix+"*")
 
-	linked, unreadable := 0, 0
+	var jobs []skillJob
+	unreadable := 0
 	for _, set := range sets {
-		setDir := set.dir
-		names := skillDirNames(setDir)
+		names := skillDirNames(set.dir)
 		if len(names) == 0 {
 			continue
 		}
 		// `stat` is served from the mount's metadata and succeeds on a backend
-		// whose GETs hang forever, so a read has to be proven before these are
-		// exposed to Claude Code's startup scan.
-		if !setReads(setDir, names) {
+		// whose GETs hang forever, so a read has to be proven before we commit to
+		// copying a whole set off it.
+		if !setReads(set.dir, names) {
 			unreadable += len(names)
 			continue
 		}
 		for _, name := range names {
 			// `<set>-<skill>`: collision-free across sets. Cosmetic — the name the
 			// model sees comes from SKILL.md's frontmatter, not the directory.
-			link := filepath.Join(dir, publicSkillPrefix+set.name+"-"+name)
-			if err := os.Symlink(filepath.Join(setDir, name), link); err != nil {
-				slog.Warn("org-fs public skill link failed", "skill", name, "err", err)
-				continue
-			}
-			linked++
+			jobs = append(jobs, skillJob{
+				src: filepath.Join(set.dir, name),
+				dst: filepath.Join(dir, publicSkillPrefix+set.name+"-"+name),
+			})
 		}
 	}
-	slog.Info("org-fs public skills linked", "count", linked, "unreadable", unreadable)
-	return linked > 0
+	copied := prefetchSkills(jobs)
+	slog.Info("org-fs skills prefetched",
+		"count", copied, "of", len(jobs), "unreadable", unreadable)
+	return copied > 0
 }
 
 // repointThreadLink points `org/<linkName>` at `<mountDir>/<threadId>`, creating

--- a/packages/sandbox/daemon-go/internal/orgfs/links_test.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/links_test.go
@@ -216,6 +216,24 @@ func TestSkillsLinkNeverShadowsARealDir(t *testing.T) {
 // read-only — so they reach Claude Code as project skills in the checkout. The
 // invariants: the repo's own skills survive, ours are rebuilt (no dangling
 // symlink when a set loses a skill), and they never reach a commit.
+// assertSkillPresent checks the skill was materialized on LOCAL disk — a real
+// SKILL.md with content, not a symlink into the mount. That distinction is the
+// whole point of the prefetch, so the assertion has to be able to see it.
+func assertSkillPresent(t *testing.T, skillsDir, name string) {
+	t.Helper()
+	path := filepath.Join(skillsDir, name, "SKILL.md")
+	st, err := os.Lstat(path)
+	if err != nil {
+		t.Fatalf("skill %s not prefetched: %v", name, err)
+	}
+	if st.Mode()&os.ModeSymlink != 0 {
+		t.Fatalf("skill %s is a symlink into the mount, not a local copy", name)
+	}
+	if b, err := os.ReadFile(path); err != nil || len(b) == 0 {
+		t.Fatalf("skill %s copied empty: %v", name, err)
+	}
+}
+
 func TestPublicSkillLinks(t *testing.T) {
 	appRoot := t.TempDir()
 	repoDir := filepath.Join(appRoot, "repo")
@@ -247,15 +265,9 @@ func TestPublicSkillLinks(t *testing.T) {
 	l.syncPublicSkills()
 
 	skillsDir := filepath.Join(repoDir, ".claude", "skills")
-	target, err := os.Readlink(filepath.Join(skillsDir, "orgfs-core-slides"))
-	if err != nil {
-		t.Fatalf("public skill not linked: %v", err)
-	}
-	if want := filepath.Join(appRoot, "org", "public", "core", "slides"); target != want {
-		t.Errorf("link → %q, want %q", target, want)
-	}
+	assertSkillPresent(t, skillsDir, "orgfs-core-slides")
 	if _, err := os.Lstat(filepath.Join(skillsDir, "orgfs-core-not-a-skill")); err == nil {
-		t.Error("linked a directory with no SKILL.md")
+		t.Error("copied a directory with no SKILL.md")
 	}
 	if _, err := os.Stat(ownSkill); err != nil {
 		t.Errorf("clobbered the repo's own skill: %v", err)
@@ -273,11 +285,9 @@ func TestPublicSkillLinks(t *testing.T) {
 	l.publicSkillsRun = false
 	l.syncPublicSkills()
 	if _, err := os.Lstat(filepath.Join(skillsDir, "orgfs-core-pdf")); err == nil {
-		t.Error("stale symlink kept for a skill that no longer exists")
+		t.Error("stale copy kept for a skill that no longer exists")
 	}
-	if _, err := os.Readlink(filepath.Join(skillsDir, "orgfs-core-slides")); err != nil {
-		t.Errorf("rebuild dropped a live skill: %v", err)
-	}
+	assertSkillPresent(t, skillsDir, "orgfs-core-slides")
 }
 
 func TestSyncedVolumeSkillLinks(t *testing.T) {
@@ -313,18 +323,18 @@ func TestSyncedVolumeSkillLinks(t *testing.T) {
 	l.syncPublicSkills()
 
 	skillsDir := filepath.Join(repoDir, ".claude", "skills")
-	target, err := os.Readlink(filepath.Join(skillsDir, "orgfs-decocms-skills-unslopify"))
-	if err != nil {
-		t.Fatalf("synced-repo skill not linked: %v", err)
-	}
-	if want := filepath.Join(appRoot, "org", "decocms-skills", "unslopify"); target != want {
-		t.Errorf("link → %q, want %q", target, want)
-	}
+	assertSkillPresent(t, skillsDir, "orgfs-decocms-skills-unslopify")
 	for _, name := range []string{"orgfs-home-skills", "orgfs-.outputs-t1"} {
 		if _, err := os.Lstat(filepath.Join(skillsDir, name)); err == nil {
-			t.Errorf("linked a non-skill-set volume: %s", name)
+			t.Errorf("copied a non-skill-set volume: %s", name)
 		}
 	}
+	// The copy must outlive the mount — that is what takes the harness's startup
+	// scan off the network entirely.
+	if err := os.RemoveAll(filepath.Join(appRoot, "org", "decocms-skills")); err != nil {
+		t.Fatal(err)
+	}
+	assertSkillPresent(t, skillsDir, "orgfs-decocms-skills-unslopify")
 }
 
 // A set whose FIRST skill is unreadable must still expose the rest — the failure
@@ -357,9 +367,7 @@ func TestUnreadableSkillDoesNotCondemnSet(t *testing.T) {
 	if !l.syncPublicSkills() {
 		t.Fatal("set condemned by one unreadable skill")
 	}
-	if _, err := os.Readlink(filepath.Join(repoDir, ".claude", "skills", "orgfs-core-slides")); err != nil {
-		t.Errorf("healthy skill behind the bad probe was not linked: %v", err)
-	}
+	assertSkillPresent(t, filepath.Join(repoDir, ".claude", "skills"), "orgfs-core-slides")
 }
 
 func TestWaitSkillLinks(t *testing.T) {
@@ -387,9 +395,57 @@ func TestWaitSkillLinks(t *testing.T) {
 	// The whole point: after this returns the links are on disk, so the harness's
 	// one-shot startup scan cannot miss them.
 	l.WaitSkillLinks(10 * time.Second)
-	if _, err := os.Readlink(filepath.Join(repoDir, ".claude", "skills", "orgfs-core-slides")); err != nil {
-		t.Errorf("WaitSkillLinks returned before the link landed: %v", err)
+	// The whole point of the barrier: the bytes are on disk before the run starts.
+	assertSkillPresent(t, filepath.Join(repoDir, ".claude", "skills"), "orgfs-core-slides")
+}
+
+// Prefetched skills are real directories with real content now, not symlinks, so
+// they look exactly like a skill the model authored. Adopting them would copy
+// every public and synced skill into the org's home on every run.
+func TestPrefetchedSkillsAreNotAdopted(t *testing.T) {
+	appRoot := t.TempDir()
+	repoDir := filepath.Join(appRoot, "repo")
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(t.TempDir(), "config"))
+	statusPath := filepath.Join(t.TempDir(), "status.json")
+	homeMount := filepath.Join(appRoot, "org", "home")
+	if err := os.MkdirAll(filepath.Join(homeMount, "skills"), 0o755); err != nil {
+		t.Fatal(err)
 	}
+	skill := filepath.Join(appRoot, "org", "public", "core", "slides")
+	if err := os.MkdirAll(skill, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skill, "SKILL.md"), []byte("---\nname: x\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := json.Marshal(sidecarStatus{Mounts: []Mount{{Volume: "home", MountPath: homeMount}}})
+	if err := os.WriteFile(statusPath, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A real git repo — the exclusion is git's `--exclude-standard` reading
+	// `.git/info/exclude`, so a fake .git directory would not exercise it.
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{{"init"}, {"config", "user.email", "t@t"}, {"config", "user.name", "t"}} {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v %s", args, err, out)
+		}
+	}
+
+	l := &Links{AppRoot: appRoot, RepoDir: repoDir, StatusPath: statusPath, ConfigPath: "unused"}
+	l.syncPublicSkills()
+	assertSkillPresent(t, filepath.Join(repoDir, ".claude", "skills"), "orgfs-core-slides")
+
+	l.AdoptStrayRepoSkills()
+
+	if _, err := os.Stat(filepath.Join(homeMount, "skills", "orgfs-core-slides")); err == nil {
+		t.Error("prefetched skill was adopted into the org home")
+	}
+	// And it is still where the harness expects it.
+	assertSkillPresent(t, filepath.Join(repoDir, ".claude", "skills"), "orgfs-core-slides")
 }
 
 func TestAdoptStrayRepoSkills(t *testing.T) {

--- a/packages/sandbox/daemon-go/internal/orgfs/skillcopy.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/skillcopy.go
@@ -1,0 +1,167 @@
+package orgfs
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Prefetching skills onto the pod's own disk instead of symlinking them into the
+// org-fs mount. The mount is a network filesystem reached over WebDAV+rclone,
+// two round trips per file (a presign against the studio, then the object
+// itself), and Claude Code reads EVERY skill it can see during startup, on the
+// thread pool that then owes the run its `init`. In prod that scan is ~136
+// SKILL.md files / ~1.3MB per pod — trivial bandwidth, a few hundred serialized
+// round trips of latency, and an unbounded hang whenever the backend is wedged.
+//
+// Copying moves all of that off the harness's critical path: the daemon pays it
+// once, in parallel, before the run starts, and every read the harness then does
+// is local disk. It also retires the failure mode the read gate exists to
+// contain — a wedged mount cannot hang a scan that never touches the mount.
+//
+// Only READ-ONLY sets are copied (public sets and repo-sync volumes). The org's
+// home skills stay a live mount: a skill the agent authors there has to sync
+// back, which is the whole point of that link.
+
+// Ceiling on what the prefetch may write to the pod's disk. Skill sets are
+// kilobytes, but a repo-sync volume is arbitrary user content — without a cap, a
+// synced repo with a large file parked in a skill directory fills the pod's
+// ephemeral disk and takes the sandbox with it. Skills past the budget are
+// skipped, loudly.
+const skillCopyBudget int64 = 64 << 20
+
+// Per-skill deadline. Same bargain as `readableWithin`: a copy that never
+// answers leaks its goroutine inside the daemon, where it costs one skill,
+// rather than inside the CLI, where it costs the run.
+const skillCopyTimeout = 30 * time.Second
+
+var errSkillBudget = errors.New("skill prefetch budget exhausted")
+
+// copySkillTreeWithin copies the skill directory src to dst, charging bytes
+// against budget, and gives up after skillCopyTimeout. dst is left behind on
+// failure for the caller to remove — a half-copied skill must not be exposed.
+func copySkillTreeWithin(src, dst string, budget *atomic.Int64) error {
+	done := make(chan error, 1)
+	go func() { done <- copyTree(src, dst, budget) }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(skillCopyTimeout):
+		return fmt.Errorf("copy did not finish within %s", skillCopyTimeout)
+	}
+}
+
+// copyTree recursively copies regular files and directories, preserving the mode
+// bits (org-fs serves read-only volumes as 0755, and skill helper scripts need
+// the exec bit). Anything else — symlink, socket, device — is skipped: org-fs
+// stores only files and dirs, so an oddity here is not ours to reproduce.
+func copyTree(src, dst string, budget *atomic.Int64) error {
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return err
+	}
+	for _, e := range entries {
+		from, to := filepath.Join(src, e.Name()), filepath.Join(dst, e.Name())
+		if e.IsDir() {
+			if err := copyTree(from, to, budget); err != nil {
+				return err
+			}
+			continue
+		}
+		if !e.Type().IsRegular() {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			return err
+		}
+		// Charge before copying, and hand it back if the copy fails: two workers
+		// racing must not both be told there is room for the last megabyte.
+		if budget.Add(-info.Size()) < 0 {
+			budget.Add(info.Size())
+			return fmt.Errorf("%w (at %s)", errSkillBudget, e.Name())
+		}
+		if err := copyFile(from, to, info.Mode().Perm()); err != nil {
+			budget.Add(info.Size())
+			return err
+		}
+	}
+	return nil
+}
+
+func copyFile(src, dst string, perm os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+// prefetchSkill materializes one skill at dst, reporting whether it is usable.
+// A partial copy is removed rather than left for the harness to trip over.
+func prefetchSkill(src, dst string, budget *atomic.Int64) bool {
+	if err := copySkillTreeWithin(src, dst, budget); err != nil {
+		slog.Warn("org-fs skill prefetch failed", "skill", filepath.Base(src), "err", err)
+		os.RemoveAll(dst)
+		return false
+	}
+	return true
+}
+
+// skillJob is one skill directory to materialize: read it from src, land it at
+// dst.
+type skillJob struct{ src, dst string }
+
+// How many skills are copied at once. These are network reads with two round
+// trips each, so the win is overlap, not CPU — but every one of them is also a
+// FUSE request against a single rclone process, so the pool stays small enough
+// not to become the queue it is trying to drain.
+const skillCopyConcurrency = 8
+
+// prefetchSkills copies every job onto local disk, bounded-parallel, and reports
+// how many landed. One shared byte budget across all of them: the cap protects
+// the pod's disk, so it cannot be per set or per worker.
+func prefetchSkills(jobs []skillJob) int {
+	budget := &atomic.Int64{}
+	budget.Store(skillCopyBudget)
+
+	work := make(chan skillJob)
+	var wg sync.WaitGroup
+	var copied atomic.Int64
+	workers := min(skillCopyConcurrency, len(jobs))
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := range work {
+				if prefetchSkill(j.src, j.dst, budget) {
+					copied.Add(1)
+				}
+			}
+		}()
+	}
+	for _, j := range jobs {
+		work <- j
+	}
+	close(work)
+	wg.Wait()
+	return int(copied.Load())
+}

--- a/packages/sandbox/daemon-go/internal/orgfs/skillcopy_test.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/skillcopy_test.go
@@ -1,0 +1,92 @@
+package orgfs
+
+import (
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+)
+
+func writeSkillDir(t *testing.T, root, name string, files map[string]int) {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for f, size := range files {
+		path := filepath.Join(dir, f)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, make([]byte, size), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func budgetOf(n int64) *atomic.Int64 {
+	b := &atomic.Int64{}
+	b.Store(n)
+	return b
+}
+
+// A synced repo is arbitrary user content: an oversized file inside a skill dir
+// must be refused, not written to the pod's ephemeral disk.
+func TestSkillCopyRespectsBudget(t *testing.T) {
+	src, dstRoot := t.TempDir(), t.TempDir()
+	writeSkillDir(t, src, "fat", map[string]int{"SKILL.md": 64, "blob.bin": 4096})
+
+	budget := budgetOf(1024)
+	dst := filepath.Join(dstRoot, "fat")
+	if prefetchSkill(filepath.Join(src, "fat"), dst, budget) {
+		t.Fatal("copied a skill past the disk budget")
+	}
+	// A refused skill must leave nothing behind — a half-copied skill is worse
+	// than a missing one, since the harness would read and trust it.
+	if _, err := os.Stat(dst); !os.IsNotExist(err) {
+		t.Errorf("partial copy left on disk: %v", err)
+	}
+	// The refusal must not have permanently eaten the budget: a smaller skill
+	// behind the fat one still fits.
+	writeSkillDir(t, src, "thin", map[string]int{"SKILL.md": 64})
+	if !prefetchSkill(filepath.Join(src, "thin"), filepath.Join(dstRoot, "thin"), budget) {
+		t.Error("budget not returned after a refused copy")
+	}
+}
+
+// Skill helper scripts are executed. Losing the exec bit in the copy would break
+// every skill that ships one, silently.
+func TestSkillCopyPreservesExecBit(t *testing.T) {
+	src, dstRoot := t.TempDir(), t.TempDir()
+	writeSkillDir(t, src, "s", map[string]int{"SKILL.md": 16, "bin/run.sh": 16})
+	script := filepath.Join(src, "s", "bin", "run.sh")
+	if err := os.Chmod(script, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(dstRoot, "s")
+	if !prefetchSkill(filepath.Join(src, "s"), dst, budgetOf(skillCopyBudget)) {
+		t.Fatal("copy failed")
+	}
+	st, err := os.Stat(filepath.Join(dst, "bin", "run.sh"))
+	if err != nil {
+		t.Fatalf("nested file not copied: %v", err)
+	}
+	if st.Mode().Perm()&0o111 == 0 {
+		t.Errorf("exec bit lost: mode %v", st.Mode().Perm())
+	}
+}
+
+func TestPrefetchSkillsSharesOneBudget(t *testing.T) {
+	src, dstRoot := t.TempDir(), t.TempDir()
+	var jobs []skillJob
+	// Each skill is a quarter of the cap, so the fifth must not fit however the
+	// workers interleave.
+	for _, n := range []string{"a", "b", "c", "d", "e"} {
+		writeSkillDir(t, src, n, map[string]int{"SKILL.md": int(skillCopyBudget / 4)})
+		jobs = append(jobs, skillJob{filepath.Join(src, n), filepath.Join(dstRoot, n)})
+	}
+	if got := prefetchSkills(jobs); got != 4 {
+		t.Errorf("copied %d skills, want 4 (the budget fits exactly four)", got)
+	}
+}


### PR DESCRIPTION
Follow-up to #6370 (merged), which is what made this worth doing: linking the synced volume tripled the startup scan.

## Problem

Claude Code reads **every** skill it can see during startup, to parse frontmatter for its listing — on the thread pool that then owes the run its `init`. Today those reads go through the org-fs mount, and each one costs **two** round trips: `client.readResponse` asks the studio for a presign, then fetches the object from S3.

Measured in prod:

| Volume | SKILL.md | Bytes |
|---|---|---|
| `decocms-skills` | 103 | 1058 kB |
| `public-storefront` | 24 | 201 kB |
| `public-core` | 9 | 27 kB |
| **scanned at every pod boot** | **136** | **~1.3 MB** |

So ~270 round trips plus the PROPFIND listings, paid by every sandbox pod, before the harness can start. The bandwidth is nothing; the latency and the request count are not — and a wedged backend turns any one of those reads into an *indefinite* block, which is the whole reason `readableWithin` and its read gate exist.

## Change

The daemon copies the read-only sets onto the pod's own disk before the run starts, and the harness reads local files. `<repoDir>/.claude/skills/orgfs-<set>-<skill>/` goes from a symlink into FUSE to a real directory.

This does not just move the cost — it changes its shape:

- **Off the critical path.** Paid once by the daemon, bounded-parallel (8 workers), behind the `WaitSkillLinks` barrier added in #6370, instead of ~270 serialized round trips inside the CLI's startup scan.
- **The hang class is gone.** A wedged mount cannot hang a scan that never touches the mount. The read gate stays as the pre-flight check, but it is no longer the only thing between a wedged backend and a dead run.
- **Snapshot per pod, which is what we want.** The links were already built once per boot (`publicSkillsRun` latches on success); only their targets stayed live. A skill mutating underneath a running agent is a hazard, not a feature.

**Only read-only sets are copied.** The org's home skills stay a live mount — a skill the agent authors there has to sync back, and that is the entire purpose of that link.

## Bounds

A public set is kilobytes of ours; a **repo-sync volume is arbitrary user content**. So the copy is capped:

- One **64 MB budget across all sets** — the cap protects the pod's disk, so it cannot be per set or per worker.
- Charged **atomically before** the copy and **refunded on failure**, so two workers cannot both be told there is room for the last megabyte.
- A refused or partial copy is **removed**, never left for the harness to read and trust.
- Per-skill 30s deadline. Same bargain as `readableWithin`: a copy that never answers leaks its goroutine inside the daemon, where it costs one skill, not inside the CLI, where it costs the run.
- Mode bits preserved — skill helper scripts are executed, and silently losing the exec bit would break every skill that ships one.

## Testing

`go test ./...` green in `packages/sandbox/daemon-go`. New:

| Test | Asserts |
|---|---|
| `TestSkillCopyRespectsBudget` | an oversized skill is refused, leaves nothing on disk, and does not permanently consume the budget |
| `TestPrefetchSkillsSharesOneBudget` | five quarter-cap skills → exactly four land, however the workers interleave |
| `TestSkillCopyPreservesExecBit` | a nested `bin/run.sh` keeps `+x` |
| `TestPrefetchedSkillsAreNotAdopted` | `AdoptStrayRepoSkills` does not sweep the prefetched copies into the org home |

That last one is the sharp edge of this change and the reason it gets a real test: the copies are now indistinguishable from a skill the model authored, and adopting them would write all 136 into the org's home volume on **every run**. Two guards already prevent it (the `orgfs-` prefix skip and git's `--exclude-standard` reading `.git/info/exclude`); the test uses a **real** `git init` so the exclude path is genuinely exercised, and it was verified to fail — `prefetched skill was adopted into the org home` — with both guards removed.

The existing link tests were rewritten from `os.Readlink` to `assertSkillPresent`, which checks a real non-symlink `SKILL.md` with content. `TestSyncedVolumeSkillLinks` now also deletes the mount afterwards and re-asserts, which is the property this PR is actually buying.

## Affected areas

Sandbox daemon only (`internal/orgfs/`). Same paths, same `orgfs-*` prefix, same clear-then-rebuild, same git-exclude line — a real directory where a symlink used to be.

## Not in this PR

**Public sets are deployment-global.** `public-core` + `public-storefront` are byte-identical for every org and every pod in the cluster (348 kB), so even after this change each pod fetches them from S3 once. The right fix is per-node or image-baked, not per-org — worth its own PR, and worth noting a per-org fs pod would be the wrong shape for it: it would swap a cheap, infinitely-parallel S3 GET for a stateful hop on the run's hot path, and one flaky pod would take down every sandbox in that org at once.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefetches read-only org skills to the pod’s disk and reads them locally instead of symlinking to the org-fs mount. Previously the harness scanned skills through the mount on startup; now the daemon copies them under `<repoDir>/.claude/skills/`, cutting hundreds of network round trips and removing hangs from a wedged mount.

- Old vs new: symlinked skills in FUSE → real directories on local disk; org-home skills remain mounted and writable.
- Behavior details: copies run once per boot behind the `WaitSkillLinks` barrier; unreadable sets are skipped; previous copies are cleared before rebuild to avoid stale/partial data.
- Safety bounds: one 64 MB shared budget across sets; 30s per-skill timeout; failed or partial copies are deleted; mode bits preserved so helper scripts remain executable; up to 8 concurrent copy workers.
- Adoption guard: prefetched skills are excluded from `AdoptStrayRepoSkills` via the `orgfs-` prefix and git’s `--exclude-standard`.
- Scope: changes are limited to the sandbox daemon in `internal/orgfs/`; no API or CLI changes. Tests cover budget enforcement, shared budget behavior, exec-bit preservation, and adoption guards.

<sup>Written for commit 8166c617882bc64a137d1992317f771995967e3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

