### PR TITLE
fix(github): pick the actually-last-merged PR, not GraphQL's updatedAt top hit

### DIFF
--- a/apps/api/src/tools/github/last-published-pr.test.ts
+++ b/apps/api/src/tools/github/last-published-pr.test.ts
@@ -36,6 +36,46 @@ describe("parseLastPublishedPr", () => {
     });
   });
 
+  /**
+   * A page ordered by `updatedAt` can list a stale merged PR first (a
+   * post-merge comment bumped its `updatedAt` past a newer merge) — the
+   * result must still be the one with the latest `mergedAt`.
+   */
+  it("picks the max mergedAt, not the first node in the updatedAt-ordered page", () => {
+    const { pullRequest } = parseLastPublishedPr({
+      repository: {
+        pullRequests: {
+          nodes: [
+            {
+              number: 10,
+              title: "Older publish, commented on recently",
+              body: "",
+              mergedAt: "2026-08-10T10:00:00Z",
+              url: "https://github.com/acme/site/pull/10",
+              baseRefName: "main",
+              headRefName: "claude/old",
+              headRefOid: "aaa111",
+              author: { login: "gimenes" },
+            },
+            {
+              number: 12,
+              title: "Actually the last publish",
+              body: "",
+              mergedAt: "2026-08-19T10:00:00Z",
+              url: "https://github.com/acme/site/pull/12",
+              baseRefName: "main",
+              headRefName: "claude/copy",
+              headRefOid: "def456",
+              author: { login: "gimenes" },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(pullRequest?.number).toBe(12);
+  });
+
   it("returns null when nothing was ever merged into the base", () => {
     expect(
       parseLastPublishedPr({ repository: { pullRequests: { nodes: [] } } }),

--- a/apps/api/src/tools/github/last-published-pr.ts
+++ b/apps/api/src/tools/github/last-published-pr.ts
@@ -10,6 +10,13 @@ import { githubGraphql } from "./graphql";
  * which interleaves PRs closed WITHOUT merging, so it takes a page of PRs to
  * answer and still reports "never published" for a base whose whole page was
  * abandoned.
+ *
+ * GraphQL's `PullRequestOrder` has no `MERGED_AT` field, only `UPDATED_AT` —
+ * and a comment or label change on an OLDER merged PR bumps its `updatedAt`
+ * past a more-recently-merged one, so the top-1 node isn't reliably the last
+ * publish. `first: 20` pulls a window of recent activity and
+ * {@link parseLastPublishedPr} picks the max `mergedAt` within it instead of
+ * trusting position.
  */
 const LAST_PUBLISHED_QUERY = `
 query LastPublishedPr($owner: String!, $repo: String!, $base: String!) {
@@ -17,7 +24,7 @@ query LastPublishedPr($owner: String!, $repo: String!, $base: String!) {
     pullRequests(
       states: MERGED
       baseRefName: $base
-      first: 1
+      first: 20
       orderBy: { field: UPDATED_AT, direction: DESC }
     ) {
       nodes {
@@ -72,6 +79,28 @@ export interface LastPublishedPrResponse {
   } | null;
 }
 
+/**
+ * Pick the actually-most-recently-merged node from a page ordered by
+ * `updatedAt` — the two diverge whenever an older merged PR was touched
+ * (comment, label) more recently than a newer merge landed.
+ */
+function pickMostRecentlyMerged(
+  nodes: NonNullable<
+    NonNullable<LastPublishedPrResponse["repository"]>["pullRequests"]
+  >["nodes"],
+) {
+  let best: NonNullable<typeof nodes>[number] | null = null;
+  let bestMergedAt = -Infinity;
+  for (const node of nodes ?? []) {
+    if (!node?.mergedAt) continue;
+    const mergedAt = Date.parse(node.mergedAt);
+    if (Number.isNaN(mergedAt) || mergedAt <= bestMergedAt) continue;
+    best = node;
+    bestMergedAt = mergedAt;
+  }
+  return best;
+}
+
 /** Throws rather than reporting "never published" when the repo was hidden. */
 export function parseLastPublishedPr(
   payload: LastPublishedPrResponse,
@@ -82,7 +111,7 @@ export function parseLastPublishedPr(
       "Repository not found or not accessible by this connection",
     );
   }
-  const pr = repository.pullRequests?.nodes?.[0];
+  const pr = pickMostRecentlyMerged(repository.pullRequests?.nodes);
   if (!pr) return { pullRequest: null };
 
   return {


### PR DESCRIPTION
Follows the recent GraphQL-transport hardening on `apps/api/src/tools/github/graphql.ts` (#6356/#6363/#6365) — same file family, a fresh correctness gap in `GITHUB_LAST_PUBLISHED_PR`.

GraphQL's `PullRequestOrder` enum has no `MERGED_AT` field, only `CREATED_AT`/`UPDATED_AT`, so the query orders merged PRs by `updatedAt` and takes `nodes[0]` as "the last publish." A comment, label change, or any other activity on an OLDER merged PR bumps ITS `updatedAt` past a more-recently-merged PR's, so the top-1 node isn't reliably the last publish — the Fast Preview UI (which treats this tool's answer as ground truth for "what did we last publish") can show a stale PR's title/diff instead of the real last one.

Fix: widen the query window (`first: 1` -> `first: 20`) and pick the node with the max `mergedAt` in `parseLastPublishedPr` instead of trusting GraphQL's position. Net: the query cost is unchanged in shape (still one page, one field set); this only changes the client-side selection, no schema/behavior change to callers (same output shape).

Regression test: `picks the max mergedAt, not the first node in the updatedAt-ordered page` — feeds a page where an older PR (mergedAt earlier) appears first and a newer one second, asserts the newer one wins.

Reviewer check: `bun test apps/api/src/tools/github/last-published-pr.test.ts`

Locally ran: `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean on the touched file), `bunx oxlint` on both changed files (0 errors), and the targeted test file (4 pass). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes last-published PR selection to pick the most recently merged PR instead of the top result by `updatedAt`. Previously we returned `nodes[0]` from an `UPDATED_AT`-ordered page, which could surface an older PR bumped by comments/labels; now we select the max `mergedAt`. This prevents Fast Preview from showing a stale publish.

- Query widens from `first: 1` to `first: 20` and `parseLastPublishedPr` chooses the node with the latest `mergedAt`; ordering remains `UPDATED_AT`.
- Output shape and callers are unchanged; still a single-page query with similar cost.
- Adds a regression test that ensures a newer `mergedAt` beats an older PR listed first by `updatedAt`. Run: bun test apps/api/src/tools/github/last-published-pr.test.ts

<sup>Written for commit f14e5dc7398220342506a3ebaa263213be462ea1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6377?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

