### PR TITLE
fix(blog): let a published post always be unpublished

### DIFF
--- a/apps/web/src/components/sandbox/content/blog/blog-data.test.ts
+++ b/apps/web/src/components/sandbox/content/blog/blog-data.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   addCategoryToPost,
   blockComponentName,
+  blocksPublishToggle,
   buildBlogBlock,
   discoverBlogBlockTypes,
   emptyBlogPayload,
@@ -392,6 +393,29 @@ describe("missingPostFields", () => {
         image: "https://cdn/cover.jpg",
       }),
     ).toEqual([]);
+  });
+});
+
+describe("blocksPublishToggle", () => {
+  test("blocks publishing an incomplete draft", () => {
+    expect(blocksPublishToggle({ status: "draft" })).toBe(true);
+  });
+
+  test("allows unpublishing a published post that later lost a required field", () => {
+    expect(blocksPublishToggle({ status: "published" })).toBe(false);
+  });
+
+  test("allows publishing a complete draft", () => {
+    expect(
+      blocksPublishToggle({
+        status: "draft",
+        title: "Hello",
+        slug: "hello",
+        categories: ["news"],
+        excerpt: "A short summary.",
+        image: "https://cdn/cover.jpg",
+      }),
+    ).toBe(false);
   });
 });
 

--- a/apps/web/src/components/sandbox/content/blog/blog-data.ts
+++ b/apps/web/src/components/sandbox/content/blog/blog-data.ts
@@ -349,6 +349,17 @@ export function missingPostFields(payload: Record<string, unknown>): string[] {
 }
 
 /**
+ * Whether the publish toggle should be disabled: only when turning it ON
+ * (missing required fields blocks *becoming* published), never when turning
+ * it OFF — an already-published post that later lost a required field (e.g.
+ * its category was deleted) must still be unpublishable, or the toggle would
+ * lock the post published forever.
+ */
+export function blocksPublishToggle(payload: Record<string, unknown>): boolean {
+  return !isPostPublished(payload) && missingPostFields(payload).length > 0;
+}
+
+/**
  * All posts paired with the metadata the posts list filters and sorts on.
  * Reads the denormalized `categories`/`authors` arrays, tolerating either
  * strings or `{slug}`/`{email}` objects.

--- a/apps/web/src/components/sandbox/content/blog/post-editor.tsx
+++ b/apps/web/src/components/sandbox/content/blog/post-editor.tsx
@@ -20,6 +20,7 @@ import { ImageField } from "@/components/sections-editor/fields/image-field";
 import { StringField } from "@/components/sections-editor/fields/string-field";
 import { type LiveMeta } from "@/components/sections-editor/resolve-schema";
 import {
+  blocksPublishToggle,
   buildBlogBlock,
   getBlogPayload,
   isPostPublished,
@@ -225,7 +226,8 @@ function PostSettings({
   const t = useT();
   const isPublished = isPostPublished(post);
   const missing = missingPostFields(post);
-  const hasErrors = missing.length > 0;
+  // Blocks only publishing, not unpublishing — see `blocksPublishToggle`.
+  const publishToggleDisabled = blocksPublishToggle(post);
   const missingLabel =
     missing.length === 1
       ? t("sandbox.postEditor.missingFieldSingular", {
@@ -248,14 +250,14 @@ function PostSettings({
                 id="post-published"
                 className="data-[state=checked]:bg-success"
                 checked={isPublished}
-                disabled={hasErrors}
+                disabled={publishToggleDisabled}
                 onCheckedChange={(checked) =>
                   onChange("status", checked ? "published" : "draft")
                 }
               />
             </span>
           </TooltipTrigger>
-          {hasErrors && (
+          {publishToggleDisabled && (
             <TooltipContent side="bottom">{missingLabel}</TooltipContent>
           )}
         </Tooltip>


### PR DESCRIPTION
Fixes a bug introduced by #6373 (merged today), which added `disabled={hasErrors}` to the post-settings publish `Switch` with no exception for an already-published post.

Failure scenario: a post is published, then loses a required field later (its only category gets deleted, or the cover image/excerpt is cleared). `missingPostFields` now returns non-empty, so the switch is permanently disabled — the post can never be unpublished through the toggle again, only by editing the raw block.

Fix: added `blocksPublishToggle(post)` in `blog-data.ts`, which only blocks turning the toggle *on* (`!isPostPublished(post) && missingPostFields(post).length > 0`); turning it off is always allowed regardless of validity. `post-editor.tsx` now disables the switch on that instead of on `hasErrors` directly (the preview-button gating stays on `hasErrors`, unaffected).

Regression test: `blocksPublishToggle` in `blog-data.test.ts` covers (1) blocking publish of an incomplete draft, (2) allowing unpublish of a published-but-now-invalid post, (3) allowing publish of a complete draft.

Reviewer check: `bun test apps/web/src/components/sandbox/content/blog/blog-data.test.ts`

Locally verified: `bun run fmt`, `cd apps/web && bunx tsc --noEmit`, the targeted test above, and `bunx oxlint` on the three touched files. Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the publish toggle from locking a post in Published when required fields are missing. Previously, missing fields disabled the toggle entirely; now it only blocks turning publish on, while turning it off is always allowed.

- Adds blocksPublishToggle in blog-data.ts and uses it in post-editor.tsx; preview button gating stays on hasErrors.
- Adds tests in apps/web/src/components/sandbox/content/blog/blog-data.test.ts for blocking incomplete drafts, allowing unpublish of invalid published posts, and allowing publish of complete drafts.

<sup>Written for commit cf856867713d717f61c74bf59e303f9c3a77c8cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6378?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

