### PR TITLE
fix(task-board): clear card selection when filters change

### DIFF
--- a/apps/web/src/layouts/task-board/index.tsx
+++ b/apps/web/src/layouts/task-board/index.tsx
@@ -137,6 +137,7 @@ import {
   TaskFiltersBar,
   TaskFiltersDrawer,
   taskMatchesFilters,
+  type TaskFilters,
 } from "./task-filters";
 import { useBoardSearch } from "./filters-search";
 import { usePanelActions } from "@/layouts/shell-layout";
@@ -428,6 +429,11 @@ export function TaskBoardPage() {
       return next;
     });
   const clearSelection = () => setSelectedIds(new Set());
+  // A filter change can hide selected cards the same way the list-view toggle does.
+  const handleFiltersChange = (next: TaskFilters) => {
+    setFilters(next);
+    clearSelection();
+  };
   const [dialogOpen, setDialogOpen] = useState(false);
   const [editingItem, setEditingItem] = useState<TaskBoardItem | null>(null);
   // Status a newly-created task should start in (set by a lane's "+"); null for
@@ -603,7 +609,7 @@ export function TaskBoardPage() {
                   members={members}
                   tags={orgTags}
                   repos={repos}
-                  onChange={setFilters}
+                  onChange={handleFiltersChange}
                 />
               </div>
               <div className="hidden sm:block">
@@ -612,7 +618,7 @@ export function TaskBoardPage() {
                   members={members}
                   tags={orgTags}
                   repos={repos}
-                  onChange={setFilters}
+                  onChange={handleFiltersChange}
                 />
               </div>
             </>
@@ -662,7 +668,7 @@ export function TaskBoardPage() {
             <Button
               variant="outline"
               size="sm"
-              onClick={() => setFilters(EMPTY_FILTERS)}
+              onClick={() => handleFiltersChange(EMPTY_FILTERS)}
             >
               {t("taskBoard.taskBoard.clearFilters")}
             </Button>


### PR DESCRIPTION
Follows #6368 (filters/layout moved into the URL). #6368's own list-view toggle already carries this exact fix with a comment explaining why: "Selection is a board-only concept... leaving it wedges the floating bulk-action bar on-screen, operating on a selection the user can no longer see." Applying a filter has the identical effect — it hides cards from the board just like switching to List does — but `setFilters` (used by `TaskFiltersBar`, `TaskFiltersDrawer`, and the "Clear filters" button) never got that same guard.

Failure scenario: select several cards on the board, then narrow the filters (e.g. by assignee) so some selected cards drop out of view. The floating bulk-action bar still reports the old count and a bulk action (status change, rerun, delete) is applied to cards the user can no longer see or reconsider.

Fix: route all three `setFilters` call sites through a `handleFiltersChange` wrapper that also clears the selection, mirroring the existing list-view-toggle handler one screen down in the same file.

To confirm: select cards on the board, then change any filter (or hit "Clear filters") — the bulk-action bar should disappear immediately instead of staying pinned to a now-invisible selection.

Verified locally: `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (no errors in the touched file), `bunx oxlint apps/web/src/layouts/task-board/index.tsx` (0 warnings/errors). No unit test added — this is UI-state wiring in a React component with no existing component-test harness in this file; full CI/e2e covers the rendered behavior.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears selected cards when task-board filters change to prevent bulk actions from applying to hidden cards. Previously, changing filters left the selection active and kept the bulk-action bar visible; now, any filter change or Clear filters resets the selection, matching the list-view toggle.

**Review notes**
- Adds handleFiltersChange(TaskFilters) that calls setFilters and then clears selection.
- Routes TaskFiltersBar, TaskFiltersDrawer, and the Clear filters button through this handler.
- No API changes; only selection state behavior changes on filter updates.

<sup>Written for commit c73b0ab2b62fec5832a87b824b24c6f9b959d327. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

