### PR TITLE
fix(github): degrade a malformed installations-list body instead of raw SyntaxError

### DIFF
--- a/apps/api/src/tools/github/list-user-orgs.test.ts
+++ b/apps/api/src/tools/github/list-user-orgs.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+import { parseInstallationsBody } from "./list-user-orgs";
+
+describe("parseInstallationsBody", () => {
+  it("parses a well-formed installations page", () => {
+    expect(
+      parseInstallationsBody(
+        '{"installations":[{"id":1,"account":{"login":"acme","avatar_url":"u","type":"Organization"}}],"total_count":1}',
+      ),
+    ).toEqual({
+      installations: [
+        {
+          id: 1,
+          account: { login: "acme", avatar_url: "u", type: "Organization" },
+        },
+      ],
+      total_count: 1,
+    });
+  });
+
+  it("throws a named error instead of a raw SyntaxError on a malformed 2xx body", () => {
+    expect(() => parseInstallationsBody("<html>upstream error</html>")).toThrow(
+      /GitHub \/user\/installations returned invalid JSON: <html>upstream error<\/html>/,
+    );
+  });
+
+  it("truncates a huge body so the message stays readable", () => {
+    expect(() => parseInstallationsBody("x".repeat(5000))).toThrow(
+      /invalid JSON: x{300}$/,
+    );
+  });
+});

--- a/apps/api/src/tools/github/list-user-orgs.ts
+++ b/apps/api/src/tools/github/list-user-orgs.ts
@@ -13,6 +13,31 @@ const GITHUB_API = "https://api.github.com";
 /** Matches the Git Data client's per-attempt timeout in `decofile/github-git-data.ts`. */
 const GITHUB_TIMEOUT_MS = 15_000;
 
+interface InstallationsPage {
+  installations: Array<{
+    id: number;
+    account: { login: string; avatar_url: string; type: string };
+  }>;
+  total_count: number;
+}
+
+/**
+ * A 2xx response body isn't guaranteed to be JSON (a proxy/outage page can
+ * still answer 200) — `res.json()` throwing a raw `SyntaxError` on that would
+ * surface as an opaque "Unexpected token" instead of naming what failed.
+ * Mirrors `parseGraphqlBody` in `graphql.ts`.
+ */
+export function parseInstallationsBody(text: string): InstallationsPage {
+  try {
+    return JSON.parse(text) as InstallationsPage;
+  } catch (cause) {
+    throw new Error(
+      `GitHub /user/installations returned invalid JSON: ${text.slice(0, 300)}`,
+      { cause },
+    );
+  }
+}
+
 export const GITHUB_LIST_USER_ORGS = defineTool({
   name: "GITHUB_LIST_USER_ORGS",
   description:
@@ -139,13 +164,7 @@ export const GITHUB_LIST_USER_ORGS = defineTool({
         throw new Error(`GitHub /user/installations failed: ${res.status}`);
       }
 
-      const data = (await res.json()) as {
-        installations: Array<{
-          id: number;
-          account: { login: string; avatar_url: string; type: string };
-        }>;
-        total_count: number;
-      };
+      const data = parseInstallationsBody(await res.text());
 
       for (const inst of data.installations) {
         installations.push({


### PR DESCRIPTION
**Source:** bug found while auditing `apps/api/src/tools/github/` — this file was missed by the same hardening pass `graphql.ts` already got (see its `parseGraphqlBody` + test, and the merged lane of PRs #6293/#6295/#6298 doing the identical fix for other GitHub/Jira response paths).

**Why a maintainer wants it:** `GITHUB_LIST_USER_ORGS` calls `res.json()` directly on a 2xx response from `/user/installations`. A 2xx status doesn't guarantee a JSON body — a proxy/outage page in front of api.github.com can still answer 200 with HTML — and `res.json()` throwing a raw `SyntaxError` on that surfaces to the caller as an opaque "Unexpected token" instead of naming what actually failed.

**Failure scenario:** GitHub (or an intermediate proxy) returns a 200 with a non-JSON body during an outage → `res.json()` throws `SyntaxError: Unexpected token '<'` with no context about which request failed or why → the org-list picker just shows a cryptic error.

**Fix:** extracted a small `parseInstallationsBody(text)` helper (mirrors `parseGraphqlBody` in `graphql.ts` in the same folder) that JSON-parses the body and throws a named error identifying the endpoint and a truncated snippet of the bad body on failure. The handler now reads `res.text()` and parses through this helper instead of calling `res.json()` directly. Pure refactor of the parsing step — same shape returned on success.

**Regression test:** `apps/api/src/tools/github/list-user-orgs.test.ts` — parses a well-formed page, throws a named error (not a raw SyntaxError) on a malformed body, and truncates a huge body so the error message stays readable. Same three cases `graphql.test.ts` already covers for the GraphQL path.

**To verify:** `bun test apps/api/src/tools/github/list-user-orgs.test.ts`

**Checked locally:** `bun run fmt`, `cd apps/api && bunx tsc --noEmit` (clean), the targeted test above (3 pass), and `bunx oxlint` on both changed files (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened GitHub installations list parsing to degrade malformed 2xx bodies into a named error. Previously `res.json()` threw a raw SyntaxError; now we parse text and throw an error that names `/user/installations` and includes a truncated body. Successful responses are unchanged.

- Replaces `res.json()` with `res.text()` + `parseInstallationsBody`, mirroring `parseGraphqlBody`; errors read “GitHub /user/installations returned invalid JSON: …”.
- Adds unit tests for valid JSON, malformed body, and message truncation. No API or response shape changes; only error messaging on malformed bodies.

<sup>Written for commit c6e14b940e044552f87748750061ba925d058788. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

