### PR TITLE
fix(preview): don't crash the preview panel on a malformed URL in withVariantMatcherOverride

### DIFF
--- a/apps/web/src/components/sections-editor/variant-matcher-override.test.ts
+++ b/apps/web/src/components/sections-editor/variant-matcher-override.test.ts
@@ -151,4 +151,11 @@ describe("withVariantMatcherOverride", () => {
     const url = new URL(href);
     expect(url.searchParams.getAll(MATCHER_OVERRIDE_QS)).toEqual(["fresh=1"]);
   });
+
+  it("falls back to the unmodified href on a malformed URL instead of throwing", () => {
+    const href = "http://[::1";
+    expect(
+      withVariantMatcherOverride(href, ["a@sections.0.variants.0.rule=0"]),
+    ).toBe(href);
+  });
 });

--- a/apps/web/src/components/sections-editor/variant-matcher-override.ts
+++ b/apps/web/src/components/sections-editor/variant-matcher-override.ts
@@ -155,19 +155,29 @@ export function buildSectionVariantOverrideParams({
   });
 }
 
-/** Append override params to a preview URL, returning the new href. */
+/**
+ * Append override params to a preview URL, returning the new href. Falls
+ * back to the unmodified `href` on a malformed input instead of throwing
+ * mid-render — `href` comes from the same untrusted sandbox/production
+ * preview base as `previewOrigin`/`withDeviceHint` in preview.tsx, which use
+ * this same defensive shape (see #6362/#6374).
+ */
 export function withVariantMatcherOverride(
   href: string,
   params: string[],
 ): string {
   if (params.length === 0) return href;
-  const url = new URL(href, "http://local");
-  url.searchParams.delete(MATCHER_OVERRIDE_QS);
-  for (const param of params) {
-    url.searchParams.append(MATCHER_OVERRIDE_QS, param);
+  try {
+    const url = new URL(href, "http://local");
+    url.searchParams.delete(MATCHER_OVERRIDE_QS);
+    for (const param of params) {
+      url.searchParams.append(MATCHER_OVERRIDE_QS, param);
+    }
+    // Preserve relative hrefs when the input had no origin.
+    return href.startsWith("http")
+      ? url.toString()
+      : `${url.pathname}${url.search}${url.hash}`;
+  } catch {
+    return href;
   }
-  // Preserve relative hrefs when the input had no origin.
-  return href.startsWith("http")
-    ? url.toString()
-    : `${url.pathname}${url.search}${url.hash}`;
 }


### PR DESCRIPTION
Follows #6362/#6374, which found that a malformed sandbox/production preview base (`display.iframeBase`, an untrusted value from the sandbox daemon or production preview server config) crashed the whole preview panel mid-render, and wrapped every `new URL(...)` call site that builds `preview.tsx`'s `iframeSrc`/`openInNewTabUrl` (`withDeviceHint`, `withDecoFBT`, `previewOrigin`, `resolvePreviewUrl`) in try/catch, falling back to the unmodified input on failure.

They missed one sibling: `withVariantMatcherOverride` (called on that same href from all three `iframeSrc`/`openInNewTabUrl` branches in `preview.tsx` whenever a Blocks variant override is active — `workspace.state.variantOverride`) still calls `new URL(href, "http://local")` unguarded once `params.length > 0`. A malformed href (e.g. an unparseable host) reaching this call throws synchronously during render, taking down the panel the same way #6362 fixed for the other call sites — but only reproduces while a variant override is selected, which is why it slipped through both prior fixes.

**Fix**: wrap the `new URL` call in try/catch, falling back to the unmodified `href`, matching the shape already used by every other URL-construction site in this file.

**Regression test**: `withVariantMatcherOverride("http://[::1", ["a@sections.0.variants.0.rule=0"])` — a host string that's malformed even when resolved against a base — now returns the href unchanged instead of throwing; before the fix this test fails with `TypeError: "http://[::1" cannot be parsed as a URL.`

Reviewer check: `bun test apps/web/src/components/sections-editor/variant-matcher-override.test.ts`

Locally verified: `bun run fmt`, the targeted test file above (10 pass), and `bunx oxlint` on both changed files (0 warnings/errors). No type signatures changed, so skipped a full `tsc --noEmit`; full CI covers the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the preview panel from crashing when `withVariantMatcherOverride` receives a malformed preview URL. Previously, with a variant override selected, `new URL(href, "http://local")` threw during render; now we catch and return the original href, aligning with other preview URL builders.

- Matches the defensive try/catch used by `withDeviceHint`, `withDecoFBT`, `previewOrigin`, and `resolvePreviewUrl`; preserves relative href behavior; no API or type changes.
- Adds a regression test ensuring malformed hosts return the input unchanged. Run: bun test apps/web/src/components/sections-editor/variant-matcher-override.test.ts

<sup>Written for commit c6aa46845a4fb93cfddc7f8a3a38890b5c5912bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

