### PR TITLE
perf(storage): index threads.metadata->githubRepo->connectionId

### DIFF
--- a/apps/api/migrations/173-thread-github-repo-connection-index.ts
+++ b/apps/api/migrations/173-thread-github-repo-connection-index.ts
@@ -1,0 +1,23 @@
+import { sql, type Kysely } from "kysely";
+
+/**
+ * `Connections.isReferencedByThread()` (called on every delete of a
+ * repo-backed virtual MCP connection) scans `threads` filtering on
+ * `metadata -> 'githubRepo' ->> 'connectionId'` with no index behind it —
+ * a full table scan of `threads`, which grows unbounded. This adds a
+ * partial expression index on that exact predicate so the lookup becomes
+ * an index scan instead.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_threads_github_repo_connection_id
+    ON threads ((metadata -> 'githubRepo' ->> 'connectionId'))
+    WHERE metadata -> 'githubRepo' ->> 'connectionId' IS NOT NULL
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP INDEX IF EXISTS idx_threads_github_repo_connection_id`.execute(
+    db,
+  );
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -171,6 +171,7 @@ import * as migration169taskboardmergefailedactivity from "./169-task-board-merg
 import * as migration170taskboarditemrepo from "./170-task-board-item-repo.ts";
 import * as migration171jiraintegration from "./171-jira-integration.ts";
 import * as migration172taskboarditemkeyseq from "./172-task-board-item-key-seq.ts";
+import * as migration173threadgithubrepoconnectionindex from "./173-thread-github-repo-connection-index.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -371,6 +372,8 @@ const migrations: Record<string, Migration> = {
   "170-task-board-item-repo": migration170taskboarditemrepo,
   "171-jira-integration": migration171jiraintegration,
   "172-task-board-item-key-seq": migration172taskboarditemkeyseq,
+  "173-thread-github-repo-connection-index":
+    migration173threadgithubrepoconnectionindex,
 };
 
 export default migrations;


### PR DESCRIPTION
Follows issue #2995 (DB latency amplification) — profiling the storage connection layer for missing indexes.

`Connections.isReferencedByThread()` (apps/api/src/storage/connection.ts) checks whether any thread is pinned to a repo connection via `metadata -> 'githubRepo' ->> 'connectionId'`. That predicate has no index behind it, so every call does a full sequential scan of the `threads` table — and `threads` grows unbounded over the org's lifetime. This is on the delete path for repo-backed virtual MCP connections (apps/api/src/tools/virtual/delete.ts), so a delete on an org with a large thread history pays for a full scan.

This adds a partial expression index (`WHERE ... IS NOT NULL`) on exactly that predicate, so Postgres can satisfy the lookup with an index scan instead. No application code changes — behavior is identical, this only adds an index.

How to confirm: `EXPLAIN ANALYZE SELECT id FROM threads WHERE metadata -> 'githubRepo' ->> 'connectionId' = '<id>' LIMIT 1;` before/after the migration — should switch from `Seq Scan on threads` to `Index Scan using idx_threads_github_repo_connection_id`.

Locally verified: `bun run fmt`, `cd apps/api && bunx tsc --noEmit`, `bunx oxlint` on both changed files — all clean. No existing test covers this path beyond the current `isReferencedByThread` integration test (unchanged, still passes conceptually since behavior is unchanged); full CI runs the migration test suite and integration tests against real Postgres.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Indexes `threads.metadata->'githubRepo'->>'connectionId'` to eliminate full table scans when checking if any thread references a GitHub repo connection. Deletes of repo-backed virtual MCP connections now use an index scan instead of a sequential scan; behavior is unchanged.

- Adds partial expression index `idx_threads_github_repo_connection_id` on `(metadata -> 'githubRepo' ->> 'connectionId') WHERE ... IS NOT NULL`, registered as migration `173-thread-github-repo-connection-index`.
- Migration uses `CREATE INDEX IF NOT EXISTS` (not CONCURRENTLY). Expect a brief write lock on `threads` during migration; schedule accordingly.
- Verify: `EXPLAIN ANALYZE SELECT id FROM threads WHERE metadata -> 'githubRepo' ->> 'connectionId' = '<id>' LIMIT 1;` should show `Index Scan using idx_threads_github_repo_connection_id`.

<sup>Written for commit a034cec02fb205957bf7dcfdbae0d98650025ea9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

