### PR TITLE
fix(task-board): give the filter search inputs an accessible name

### DIFF
--- a/apps/web/src/layouts/task-board/task-filters.tsx
+++ b/apps/web/src/layouts/task-board/task-filters.tsx
@@ -258,6 +258,7 @@ function AssigneeFilter({
         <Command>
           <CommandInput
             placeholder={t("taskBoard.taskFilters.assigneeFilterPlaceholder")}
+            aria-label={t("taskBoard.taskFilters.assigneeFilterPlaceholder")}
             className="h-9"
           />
           <CommandList>
@@ -475,6 +476,7 @@ function TagFilter({
         <Command>
           <CommandInput
             placeholder={t("taskBoard.taskFilters.tagsFilterPlaceholder")}
+            aria-label={t("taskBoard.taskFilters.tagsFilterPlaceholder")}
             className="h-9"
           />
           <CommandList>
@@ -545,6 +547,7 @@ function RepoFilter({
         <Command>
           <CommandInput
             placeholder={t("taskBoard.taskFilters.repoFilterPlaceholder")}
+            aria-label={t("taskBoard.taskFilters.repoFilterPlaceholder")}
             className="h-9"
           />
           <CommandList>
@@ -628,6 +631,7 @@ function SearchToggle({
             if (value === "") setOpen(false);
           }}
           placeholder={t("taskBoard.taskFilters.searchPlaceholder")}
+          aria-label={t("taskBoard.taskFilters.searchPlaceholder")}
           className="w-full min-w-0 bg-transparent text-xs outline-none placeholder:text-muted-foreground"
         />
       )}


### PR DESCRIPTION
The task-board filter bar has four text inputs (assignee, tag, repo search boxes, and the free-text search toggle) that only had a `placeholder`, no `aria-label`. Placeholder text disappears the moment a user types and isn't guaranteed to be exposed as the accessible name by every screen reader, so these inputs could read as unlabeled to assistive tech.

This passes the same already-localized placeholder string as `aria-label` on each input — no visual change, no behavior change, just an accessible name that survives typing.

How to verify: `cd apps/web && bunx tsc --noEmit`, then open the task board filter bar with a screen reader (or inspect the accessibility tree) and confirm each search input now announces its purpose.

Checks run locally: `bun run fmt`, `bunx tsc --noEmit` (apps/web), `bun test apps/web/src/layouts/task-board/task-filters.test.ts` (22 pass), `bunx oxlint apps/web/src/layouts/task-board/task-filters.tsx` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `aria-label` to the task-board filter search inputs so they have persistent accessible names. Previously they relied on placeholders that disappear when typing and may not be exposed; now screen readers announce consistent names with no visual or functional change.

- Applies to Assignee, Tag, Repo, and free-text search toggle inputs by mirroring their existing localized placeholder strings as `aria-label` in apps/web/src/layouts/task-board/task-filters.tsx.
- Verify by inspecting the accessibility tree or using a screen reader: each input should announce its purpose while typing.

<sup>Written for commit 1d18aa3b9a1647deaaa0d702990422b8eeeff31b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

