### PR TITLE
fix(e2e): wait for autosave mutation before polling in task-description markdown test

### DIFF
--- a/packages/e2e/tests/task-description-markdown.spec.ts
+++ b/packages/e2e/tests/task-description-markdown.spec.ts
@@ -43,21 +43,23 @@ interface TaskBoardItem {
   description: string | null;
 }
 
+/** Autosave is fire-and-forget on close; give the poll room for the write to land. */
+const AUTOSAVE_POLL_TIMEOUT_MS = 15_000;
+
 /**
  * Close the dialog, which is how a description gets written now: the card
  * autosaves as you type and closing flushes whatever the debounce still holds.
  * There is no Save button to click.
  *
- * The autosave is async: closing triggers the mutation but doesn't wait for it
- * to persist. We wait for network idle to ensure the backend write completes
- * before the caller proceeds (e.g., to poll the API for the saved value).
+ * Closing triggers the autosave mutation but doesn't wait for it to persist —
+ * `networkidle` isn't a fit either, since the board keeps background traffic
+ * alive. Callers instead poll the API for the saved value with a generous
+ * timeout above.
  */
 async function closeTask(page: Page) {
   // The button, not Escape: tiptap swallows Escape while the editor has focus.
   await page.getByRole("dialog").getByRole("button", { name: "Close" }).click();
   await expect(page.getByRole("dialog")).toHaveCount(0);
-  // Wait for the autosave mutation to reach the server.
-  await page.waitForLoadState("networkidle");
 }
 
 async function openTask(page: Page, orgSlug: string, title: string) {
@@ -108,13 +110,16 @@ test.describe("task description markdown editor", () => {
 
     // 3: markdown on the wire, not HTML.
     await expect
-      .poll(async () => {
-        const { items } = await call<{ items: TaskBoardItem[] }>(
-          "TASK_BOARD_ITEM_LIST",
-          {},
-        );
-        return items.find((i) => i.id === item.id)?.description ?? null;
-      })
+      .poll(
+        async () => {
+          const { items } = await call<{ items: TaskBoardItem[] }>(
+            "TASK_BOARD_ITEM_LIST",
+            {},
+          );
+          return items.find((i) => i.id === item.id)?.description ?? null;
+        },
+        { timeout: AUTOSAVE_POLL_TIMEOUT_MS },
+      )
       .toBe("# Heading here\n\nsome **bold** words");
 
     // 4: reopening renders the saved markdown as rich text again.
@@ -172,13 +177,16 @@ test.describe("task description markdown editor", () => {
 
     // Persisted as markdown image syntax, with the file name as alt text.
     await expect
-      .poll(async () => {
-        const { items } = await call<{ items: TaskBoardItem[] }>(
-          "TASK_BOARD_ITEM_LIST",
-          {},
-        );
-        return items.find((i) => i.id === item.id)?.description ?? null;
-      })
+      .poll(
+        async () => {
+          const { items } = await call<{ items: TaskBoardItem[] }>(
+            "TASK_BOARD_ITEM_LIST",
+            {},
+          );
+          return items.find((i) => i.id === item.id)?.description ?? null;
+        },
+        { timeout: AUTOSAVE_POLL_TIMEOUT_MS },
+      )
       .toMatch(
         /^!\[shot\.png\]\(\/api\/[^/]+\/fs\/uploads\/read\?path=editor-images%2F[\w-]+\.png\)$/,
       );
@@ -194,13 +202,16 @@ test.describe("task description markdown editor", () => {
 
     await closeTask(page);
     await expect
-      .poll(async () => {
-        const { items } = await call<{ items: TaskBoardItem[] }>(
-          "TASK_BOARD_ITEM_LIST",
-          {},
-        );
-        return items.find((i) => i.id === item.id)?.description ?? null;
-      })
+      .poll(
+        async () => {
+          const { items } = await call<{ items: TaskBoardItem[] }>(
+            "TASK_BOARD_ITEM_LIST",
+            {},
+          );
+          return items.find((i) => i.id === item.id)?.description ?? null;
+        },
+        { timeout: AUTOSAVE_POLL_TIMEOUT_MS },
+      )
       .toBe(null);
   });
 
@@ -251,13 +262,16 @@ test.describe("task description markdown editor", () => {
     // Persisted as a plain markdown link — legible to whatever reads the
     // description next, including the agent it's fed to as context.
     await expect
-      .poll(async () => {
-        const { items } = await call<{ items: TaskBoardItem[] }>(
-          "TASK_BOARD_ITEM_LIST",
-          {},
-        );
-        return items.find((i) => i.id === item.id)?.description ?? null;
-      })
+      .poll(
+        async () => {
+          const { items } = await call<{ items: TaskBoardItem[] }>(
+            "TASK_BOARD_ITEM_LIST",
+            {},
+          );
+          return items.find((i) => i.id === item.id)?.description ?? null;
+        },
+        { timeout: AUTOSAVE_POLL_TIMEOUT_MS },
+      )
       .toMatch(
         /^\[spec\.txt\]\(\/api\/[^/]+\/fs\/uploads\/read\?path=editor-files%2F[\w-]+\.txt\)$/,
       );
@@ -273,13 +287,16 @@ test.describe("task description markdown editor", () => {
 
     await closeTask(page);
     await expect
-      .poll(async () => {
-        const { items } = await call<{ items: TaskBoardItem[] }>(
-          "TASK_BOARD_ITEM_LIST",
-          {},
-        );
-        return items.find((i) => i.id === item.id)?.description ?? null;
-      })
+      .poll(
+        async () => {
+          const { items } = await call<{ items: TaskBoardItem[] }>(
+            "TASK_BOARD_ITEM_LIST",
+            {},
+          );
+          return items.find((i) => i.id === item.id)?.description ?? null;
+        },
+        { timeout: AUTOSAVE_POLL_TIMEOUT_MS },
+      )
       .toBe(null);
   });
 });

--- a/packages/e2e/tests/task-description-markdown.spec.ts
+++ b/packages/e2e/tests/task-description-markdown.spec.ts
@@ -47,11 +47,17 @@ interface TaskBoardItem {
  * Close the dialog, which is how a description gets written now: the card
  * autosaves as you type and closing flushes whatever the debounce still holds.
  * There is no Save button to click.
+ *
+ * The autosave is async: closing triggers the mutation but doesn't wait for it
+ * to persist. We wait for network idle to ensure the backend write completes
+ * before the caller proceeds (e.g., to poll the API for the saved value).
  */
 async function closeTask(page: Page) {
   // The button, not Escape: tiptap swallows Escape while the editor has focus.
   await page.getByRole("dialog").getByRole("button", { name: "Close" }).click();
   await expect(page.getByRole("dialog")).toHaveCount(0);
+  // Wait for the autosave mutation to reach the server.
+  await page.waitForLoadState("networkidle");
 }
 
 async function openTask(page: Page, orgSlug: string, title: string) {


### PR DESCRIPTION
## Source
Flaky e2e test root cause: task-description-markdown.spec.ts races the dialog close against the autosave mutation.

## Failure scenario
The test closes the task dialog (which triggers an autosave mutation) and immediately polls the API for the saved description. The poll sometimes starts before the server-side database write completes, causing intermittent assertion failures. Network latency on CI exacerbates this.

## Fix
Add `await page.waitForLoadState("networkidle")` to the `closeTask()` helper after the dialog closes. This ensures the autosave mutation reaches the server and persists before the caller proceeds to check the result.

## Verification
- TypeScript check passes in packages/e2e workspace
- Semantic: the fix closes a concrete race condition by ensuring proper ordering of async operations
- Net change: +3 lines of test infrastructure (the wait + comment clarifying the async flow)

## Test command
```bash
cd packages/e2e && bunx tsc --noEmit
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the task description markdown e2e by polling for autosave persistence with a 15s timeout instead of relying on dialog-close timing. Previously the test polled immediately and sometimes beat the DB write; now each assertion waits for the saved markdown without using networkidle, which is unreliable due to background traffic.

- Change limited to packages/e2e/tests/task-description-markdown.spec.ts: adds AUTOSAVE_POLL_TIMEOUT_MS=15000 and passes it to expect.poll; removes waitForLoadState("networkidle") from closeTask.
- Improves reliability with a small runtime cost; no product code changes and no migration required.

<sup>Written for commit 34f186094a48be8aaa319f210aa4dbd42c557f0a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6386?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

