### PR TITLE
perf(mcp): skip the duplicate connection lookup on the proxy error path

### DIFF
--- a/apps/api/src/api/routes/proxy.ts
+++ b/apps/api/src/api/routes/proxy.ts
@@ -247,6 +247,8 @@ export const createProxyRoutes = () => {
       );
     }
 
+    // Hoisted so the catch block can reuse it instead of re-querying.
+    let connection: ConnectionEntity | null = null;
     try {
       try {
         // Organization context is required — without it the ownership
@@ -256,7 +258,7 @@ export const createProxyRoutes = () => {
         }
 
         // Fetch connection scoped to the caller's organization
-        const connection = await ctx.tracer.startActiveSpan(
+        connection = await ctx.tracer.startActiveSpan(
           "studio.connection.lookup",
           { attributes: { "connection.id": connectionId } },
           async (span) => {
@@ -284,9 +286,11 @@ export const createProxyRoutes = () => {
         if (!connection) {
           throw new Error("Connection not found");
         }
+        // Narrows `connection` for the closures below.
+        const foundConnection = connection;
 
         // Validate organization ownership
-        if (connection.organization_id !== ctx.organization.id) {
+        if (foundConnection.organization_id !== ctx.organization.id) {
           throw new Error(
             "Connection does not belong to the active organization",
           );
@@ -299,22 +303,25 @@ export const createProxyRoutes = () => {
         // disable time) elapses. Within the cooldown we fast-fail with a
         // Retry-After hint so callers stop hammering.
         let recovering = false;
-        if (connection.status !== "active") {
+        if (foundConnection.status !== "active") {
           const sinceDisabledMs =
-            Date.now() - new Date(connection.updated_at).getTime();
+            Date.now() - new Date(foundConnection.updated_at).getTime();
           const canReprobe =
-            connection.status === "error" &&
-            !!connection.connection_url &&
+            foundConnection.status === "error" &&
+            !!foundConnection.connection_url &&
             sinceDisabledMs >= CONNECTION_ERROR_REPROBE_COOLDOWN_MS;
           if (canReprobe) {
             recovering = true;
           } else {
-            if (connection.status === "error" && connection.connection_url) {
+            if (
+              foundConnection.status === "error" &&
+              foundConnection.connection_url
+            ) {
               const remainingMs =
                 CONNECTION_ERROR_REPROBE_COOLDOWN_MS - sinceDisabledMs;
               c.header("Retry-After", String(Math.ceil(remainingMs / 1000)));
             }
-            throw new Error(`Connection inactive: ${connection.status}`);
+            throw new Error(`Connection inactive: ${foundConnection.status}`);
           }
         }
 
@@ -341,20 +348,20 @@ export const createProxyRoutes = () => {
             : true;
         }
         if (recovering) probe = true; // half-open: a real handshake must test recovery
-        if (connection.connection_url && probe) {
+        if (foundConnection.connection_url && probe) {
           assertCircuitClosed(connectionId);
           await ctx.tracer.startActiveSpan(
             "studio.connection.handshake",
             {
               attributes: {
                 "connection.id": connectionId,
-                "connection.url": connection.connection_url,
+                "connection.url": foundConnection.connection_url,
               },
             },
             async (span) => {
               startTime(c, "mcp.client_handshake");
               try {
-                await clientFromConnection(connection, ctx, false);
+                await clientFromConnection(foundConnection, ctx, false);
                 recordSuccess(connectionId);
                 void getConnectionCircuitStore().recordSuccess(connectionId);
                 if (recovering) {
@@ -384,7 +391,7 @@ export const createProxyRoutes = () => {
 
         // Create enhanced server directly (no need for bridge - server is used directly!)
         startTime(c, "mcp.create_server");
-        const server = serverFromConnection(connection, ctx, false);
+        const server = serverFromConnection(foundConnection, ctx, false);
         endTime(c, "mcp.create_server");
 
         // Create HTTP transport
@@ -415,7 +422,7 @@ export const createProxyRoutes = () => {
         }
         // Check if this is an auth error - if so, return appropriate 401
         // Note: This only applies to HTTP connections
-        const connection = await ctx.storage.connections.findById(
+        connection ??= await ctx.storage.connections.findById(
           connectionId,
           ctx.organization?.id,
         );
@@ -466,9 +473,11 @@ export const createProxyRoutes = () => {
     const toolName = c.req.param("toolName");
     const ctx = c.get("studioContext");
 
+    // Hoisted so the catch block can reuse it instead of re-querying.
+    let connection: ConnectionEntity | null = null;
     try {
       // Fetch connection and create client directly
-      const connection = await ctx.storage.connections.findById(
+      connection = await ctx.storage.connections.findById(
         connectionId,
         ctx.organization?.id,
       );
@@ -504,7 +513,7 @@ export const createProxyRoutes = () => {
       // Surface upstream OAuth 401s as a WWW-Authenticate response so the
       // frontend can trigger the OAuth popup — consistent with the main proxy
       // route. Without this, an expired/missing credential would 500 here.
-      const connection = await ctx.storage.connections.findById(
+      connection ??= await ctx.storage.connections.findById(
         connectionId,
         ctx.organization?.id,
       );


### PR DESCRIPTION
Reduction: both `/mcp/:connectionId` and `/mcp/:connectionId/call-tool/:toolName` fetch the connection once in the try block, then — because it was `const`-scoped inside that block — fetch it a second time in the catch block just to check for an OAuth 401 / build the failure response. Every downstream MCP error (auth expiry, 5xx, network failure) was paying for two Postgres round-trips on `connections` instead of one.

This hoists `connection` to a shared `let` above the try/catch in both handlers and has the catch block reuse it via `??=` (only re-querying if the try block never got far enough to fetch it). Behavior is unchanged: same connection row, same org-scoping args, same fallback-to-null path when the try block failed before the fetch.

Why it matters: this is the hottest MCP proxy path — every tool call to a downstream connection goes through it — and the error path (auth failures, flaky upstreams tripping the circuit breaker) is exactly where an extra synchronous DB round-trip adds the most latency, right when the caller is already retrying.

How to verify: `cd apps/api && bunx tsc --noEmit` passes; `bunx oxlint apps/api/src/api/routes/proxy.ts` is clean. No existing unit test covers this file (only `proxy.integration.test.ts`, which needs Postgres/NATS and wasn't run locally — full CI covers it); the change is a pure control-flow reduction with no behavior change, verified by inspection: the reused `connection` is the same row for the same `connectionId` within one request.

Checks run locally: `bun run fmt`, `bunx tsc --noEmit` (apps/api), `bunx oxlint` on the touched file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip duplicate connection lookups on MCP proxy error paths by hoisting the connection fetch and reusing it. Previously both `/mcp/:connectionId` and `/mcp/:connectionId/call-tool/:toolName` re-queried in catch; now they reuse the initial fetch via `??=`. Behavior is unchanged; error paths get lower latency.

- Hoists `connection` to a shared `let` in both handlers and reuses it in catch; only refetches if the try block never fetched.
- Adds `foundConnection` to narrow types inside closures without changing logic.
- Keeps org-scoped lookup, inactive/error handling, headers (e.g., Retry-After), and circuit-breaker behavior identical while removing one Postgres round-trip on OAuth 401s, 5xx, and network failures.

<sup>Written for commit b4ea66a60a848d3a208a1021774409f578723efd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6387?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

