### PR TITLE
refactor(organization): drop ORGANIZATION_LIST's no-op userId param

### DIFF
--- a/apps/api/src/core/context-factory.ts
+++ b/apps/api/src/core/context-factory.ts
@@ -395,15 +395,12 @@ export function createBoundAuthClient(ctx: AuthContext): BoundAuthClient {
         });
       },
 
-      list: async (userId?: string) => {
+      list: async () => {
         // Choke point: archived (soft-deleted) orgs are invisible to every
         // API/UI surface, so filter them here — no caller of this method ever
         // sees them. A future restore flow would read archived orgs from
         // storage directly, not via this method.
-        const orgs = await auth.api.listOrganizations({
-          headers,
-          query: userId ? { userId } : undefined,
-        });
+        const orgs = await auth.api.listOrganizations({ headers });
         return orgs.filter((org: (typeof orgs)[number]) => !isOrgArchived(org));
       },
 

--- a/apps/api/src/core/studio-context.ts
+++ b/apps/api/src/core/studio-context.ts
@@ -126,7 +126,7 @@ export interface BoundAuthClient {
 
     get(organizationId?: string): Promise<GetFullOrganizationResult>;
 
-    list(userId?: string): Promise<ListOrganizationsResult>;
+    list(): Promise<ListOrganizationsResult>;
 
     // Member operations
     addMember(data: {

--- a/apps/api/src/tools/organization/list.ts
+++ b/apps/api/src/tools/organization/list.ts
@@ -19,9 +19,7 @@ export const ORGANIZATION_LIST = defineTool({
     openWorldHint: false,
   },
   _meta: { ui: { visibility: "app" } },
-  inputSchema: z.object({
-    userId: z.string().optional(), // Optional: filter by user
-  }),
+  inputSchema: z.object({}),
 
   outputSchema: z.object({
     organizations: z.array(
@@ -36,23 +34,19 @@ export const ORGANIZATION_LIST = defineTool({
     ),
   }),
 
-  handler: async (input, ctx) => {
+  handler: async (_input, ctx) => {
     // Require authentication
     requireAuth(ctx);
 
     // // Check authorization
     await ctx.access.check();
 
-    // // Get current user ID
-    const currentUserId = getUserId(ctx);
-    const userId = input.userId || currentUserId;
-
-    if (!userId) {
+    if (!getUserId(ctx)) {
       throw new Error("User ID required to list organizations");
     }
 
     // Archived orgs are already filtered out by boundAuth.organization.list.
-    const organizations = await ctx.boundAuth.organization.list(userId);
+    const organizations = await ctx.boundAuth.organization.list();
 
     // Convert dates to ISO strings for JSON Schema compatibility
     return {

--- a/packages/shared/src/tools/tool-io.ts
+++ b/packages/shared/src/tools/tool-io.ts
@@ -19,7 +19,7 @@ export interface StudioToolIO {
     };
   };
   ORGANIZATION_LIST: {
-    input: { userId?: string | undefined };
+    input: { [x: string]: never };
     output: {
       organizations: {
         id: string;


### PR DESCRIPTION
Found while hunting `apps/api/src/tools/organization/` (issue #5661's area) for org-shared MCP connection work — this is unrelated dead-parameter cleanup that surfaced along the way.

`ORGANIZATION_LIST`'s input schema accepts an optional `userId` intended to "filter by user" (per its inline comment), which flows into `ctx.boundAuth.organization.list(userId)` -> `auth.api.listOrganizations({ query: { userId } })`. But Better Auth's vendored `/organization/list` endpoint (`@decocms/better-auth`'s `listOrganizations` handler) always calls `getOrgAdapter(...).listOrganizations(ctx.context.session.user.id)` — it never reads the `userId` query param. So passing a `userId` today is a silent no-op: the caller always gets back their own orgs, never the requested user's, contradicting what the schema and comment claim.

A maintainer wants this gone because a param that looks like a working filter but silently does nothing is a footgun for the next reader (or MCP client) who trusts the schema.

Change: remove the unused `userId` param from `ORGANIZATION_LIST`'s input schema, `BoundAuthClient.organization.list()`, and its one implementation in `context-factory.ts`; updated the generated `tool-io.ts` contract entry to match by hand (the generator produces an unrelated giant diff on this box per prior sessions' notes, so I edited the one affected entry directly instead of regenerating). Net: -17/+8, behavior-preserving (the caller-scoped list behavior is unchanged — it was already the only thing that ever happened).

How I confirmed the endpoint ignores the param: read `@decocms/better-auth`'s `dist/organization-*.mjs`, `listOrganizations` handler at the vendored dep in node_modules — line always passes `ctx.context.session.user.id`, discarding the query. There is no other caller of `boundAuth.organization.list(...)` in the repo (`grep -rn "organization.list(" apps/api/src`), and no test or frontend caller ever passes `userId` to the `ORGANIZATION_LIST` tool.

Reviewer check: `cd apps/api && bunx tsc --noEmit` and `cd packages/shared && bunx tsc --noEmit` both green; `bunx oxlint` on the 4 touched files is clean. Full CI (bun test suite, e2e) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unused userId parameter from ORGANIZATION_LIST and BoundAuthClient.organization.list to eliminate a misleading “filter by user” hint. Previously the tool accepted userId but Better Auth ignored it and always returned the caller’s orgs; now the param is gone and behavior is unchanged.

- Migration: stop passing userId to ORGANIZATION_LIST and to ctx.boundAuth.organization.list(); no functional change expected.
- Review notes: updated tool contract in packages/shared/src/tools/tool-io.ts by hand to avoid a large regen diff; only the ORGANIZATION_LIST entry changed. Behavior stays scoped to the session user via vendored `@decocms/better-auth`.

<sup>Written for commit 4bf11b688f05a8eb3b800aaa7dc226785773c7da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

