### PR TITLE
perf(org-fs): fetch a skill set as one tar instead of file by file

### DIFF
--- a/apps/api/src/api/routes/org-fs.ts
+++ b/apps/api/src/api/routes/org-fs.ts
@@ -59,6 +59,11 @@ import {
   publicVolumeForSet,
 } from "@/file-storage/public-sets";
 import { buildSkillCatalog } from "@/file-storage/skill-catalog";
+import {
+  SKILL_TAR_MAX_BYTES,
+  selectSkillFiles,
+  streamSkillTar,
+} from "@/file-storage/skill-tar";
 import { detectContentType } from "@/object-storage/key-utils";
 
 type Variables = { studioContext: StudioContext };
@@ -562,6 +567,48 @@ export const createOrgFsRoutes = (deps: OrgFsRoutesDeps = {}) => {
       return c.json({
         skills: await buildSkillCatalog(ctx, ctx.organization.id),
       });
+    } catch (err) {
+      return fsErrorResponse(c, err);
+    }
+  });
+
+  // Every skill folder in one volume as a single tar. The sandbox daemon's
+  // prefetch used to walk the mount file by file (a stat, a presign, an S3 GET
+  // each) — ~350 round trips per pod for ~1.3MB, which was 40 of the 44 seconds
+  // before a run's first token. Here the tree comes from one query and the
+  // objects are read inside the datacenter, so it is one request.
+  //
+  // Above the `/:volume/*` reads only by convention; the literal `skills.tar`
+  // segment cannot collide with them. Member-gated like any other read, and the
+  // same cap the daemon enforces on disk is enforced here on the wire.
+  app.get("/:volume/skills.tar", async (c) => {
+    const volume = c.req.param("volume");
+    const r = await resolve(c, volume, "ORG_FS_READ");
+    if (!r.ok) return r.res;
+    try {
+      const entries = selectSkillFiles(await r.fs.listVolumeFiles(volume));
+      if (entries.length === 0) {
+        return c.json({ error: "No skills in this volume" }, 404);
+      }
+      return new Response(
+        streamSkillTar({
+          entries,
+          read: (path) => r.fs.read(volume, path),
+          maxBytes: SKILL_TAR_MAX_BYTES,
+          onSkip: (name, reason) =>
+            console.warn(
+              `[org-fs] skill tar skipped ${volume}:${name}`,
+              reason,
+            ),
+        }),
+        {
+          headers: {
+            "content-type": "application/x-tar",
+            // Per-pod, per-boot and authorized — never a shared cache entry.
+            "cache-control": "no-store",
+          },
+        },
+      );
     } catch (err) {
       return fsErrorResponse(c, err);
     }

--- a/apps/api/src/file-storage/org-fs.ts
+++ b/apps/api/src/file-storage/org-fs.ts
@@ -135,6 +135,14 @@ export class OrgFs {
     );
   }
 
+  /** Every live file in a volume, at any depth. One query — the skill tar
+   *  route needs the whole tree, and walking it with listDir would reintroduce
+   *  the per-directory round trips it exists to remove. */
+  async listVolumeFiles(volume: string): Promise<OrgFsEntry[]> {
+    assertValidVolume(volume);
+    return this.manifest.listVolumeFiles(this.organizationId, volume);
+  }
+
   /** Live immediate children of a directory (root when path is empty). */
   async listDir(volume: string, path: string): Promise<OrgFsEntry[]> {
     assertValidVolume(volume);

--- a/apps/api/src/file-storage/skill-tar.test.ts
+++ b/apps/api/src/file-storage/skill-tar.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "bun:test";
+import type { OrgFsEntry } from "../storage/org-fs";
+import { selectSkillFiles, streamSkillTar, tarHeader } from "./skill-tar";
+
+function file(path: string, size = 10): OrgFsEntry {
+  return { path, kind: "file", size } as OrgFsEntry;
+}
+
+async function drain(s: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = [];
+  for await (const c of s as unknown as AsyncIterable<Uint8Array>) {
+    chunks.push(c);
+  }
+  const total = chunks.reduce((n, c) => n + c.byteLength, 0);
+  const out = new Uint8Array(total);
+  let at = 0;
+  for (const c of chunks) {
+    out.set(c, at);
+    at += c.byteLength;
+  }
+  return out;
+}
+
+/** Read the entry names back out of a tar, the way the daemon's reader will. */
+function namesIn(tar: Uint8Array): string[] {
+  const names: string[] = [];
+  const dec = new TextDecoder();
+  for (let off = 0; off + 512 <= tar.byteLength; ) {
+    const header = tar.subarray(off, off + 512);
+    if (header.every((b) => b === 0)) break;
+    const cut = (buf: Uint8Array) => {
+      const z = buf.indexOf(0);
+      return dec.decode(z === -1 ? buf : buf.subarray(0, z));
+    };
+    const name = cut(header.subarray(0, 100));
+    const prefix = cut(header.subarray(345, 500));
+    const size = Number.parseInt(cut(header.subarray(124, 136)).trim(), 8);
+    names.push(prefix ? `${prefix}/${name}` : name);
+    off += 512 + Math.ceil(size / 512) * 512;
+  }
+  return names;
+}
+
+describe("selectSkillFiles", () => {
+  it("takes only folders holding a SKILL.md, with everything under them", () => {
+    const got = selectSkillFiles([
+      file("README.md"),
+      file(".gitignore"),
+      file("slides/SKILL.md"),
+      file("slides/bin/run.sh"),
+      file("notes/thoughts.md"),
+    ]);
+    expect(got.map((e) => e.name)).toEqual([
+      "slides/SKILL.md",
+      "slides/bin/run.sh",
+    ]);
+    // Codepoint order, so "S" precedes "b" regardless of the server's locale.
+  });
+
+  it("ignores a root-level SKILL.md, which is not a skill folder", () => {
+    expect(selectSkillFiles([file("SKILL.md")])).toEqual([]);
+  });
+});
+
+describe("tarHeader", () => {
+  it("computes the checksum over the header with the field blanked", () => {
+    const h = tarHeader("slides/SKILL.md", 42)!;
+    const stated = Number.parseInt(
+      new TextDecoder().decode(h.subarray(148, 156)).split("\0")[0]!.trim(),
+      8,
+    );
+    let sum = 0;
+    for (let i = 0; i < 512; i++) {
+      sum += i >= 148 && i < 156 ? 0x20 : h[i]!;
+    }
+    expect(stated).toBe(sum);
+  });
+
+  // Golden bytes. Go's `archive/tar` (the only consumer) accepted this exact
+  // layout — verified by writing a real archive with this module and reading it
+  // back with the daemon's extractor and with bsdtar. Go's reader is stdlib and
+  // will not drift, so pinning the layout here is what keeps THIS side honest:
+  // if you change the header, re-run that cross-check before updating this.
+  it("emits the exact ustar layout the daemon's reader accepts", () => {
+    const h = tarHeader("slides/SKILL.md", 5)!;
+    // Tar pads every text field with NUL; take the part before the first one.
+    const at = (from: number, to: number) =>
+      new TextDecoder().decode(h.subarray(from, to)).split("\0")[0];
+    expect(h.byteLength).toBe(512);
+    expect(at(0, 100)).toBe("slides/SKILL.md");
+    expect(at(100, 108)).toBe("0000644");
+    expect(at(124, 136)).toBe("00000000005"); // size, octal
+    expect(at(136, 148)).toBe("00000000000"); // mtime, fixed
+    expect(at(156, 157)).toBe("0"); // regular file
+    expect(at(257, 263)).toBe("ustar");
+    expect(at(263, 265)).toBe("00");
+    expect(at(345, 500)).toBe(""); // no prefix needed at this length
+  });
+
+  it("splits a long path across prefix and name", () => {
+    const long = `${"d".repeat(120)}/${"s".repeat(60)}/SKILL.md`;
+    const h = tarHeader(long, 1);
+    expect(h).not.toBeNull();
+    const framed = new Uint8Array(1024);
+    framed.set(h!, 0);
+    expect(namesIn(framed)[0]).toBe(long);
+  });
+
+  it("refuses a path it cannot represent rather than truncating it", () => {
+    // No slash in the last 100 chars to split on — a truncated header would
+    // silently become a DIFFERENT file on extract.
+    expect(tarHeader(`${"x".repeat(300)}.md`, 1)).toBeNull();
+  });
+});
+
+describe("streamSkillTar", () => {
+  const bytes = (n: number) => new Uint8Array(n).fill(65);
+
+  it("round-trips names and sizes, padded to block boundaries", async () => {
+    const tar = await drain(
+      streamSkillTar({
+        entries: [
+          { name: "a/SKILL.md", size: 3, sourcePath: "a/SKILL.md" },
+          { name: "b/SKILL.md", size: 600, sourcePath: "b/SKILL.md" },
+        ],
+        read: async (p) => bytes(p.startsWith("a") ? 3 : 600),
+        maxBytes: 1 << 20,
+      }),
+    );
+    expect(namesIn(tar)).toEqual(["a/SKILL.md", "b/SKILL.md"]);
+    // header+block, header+2 blocks, then the two-block terminator.
+    expect(tar.byteLength).toBe(512 * 2 + 512 * 3 + 512 * 2);
+  });
+
+  it("skips an unreadable file and still emits the rest", async () => {
+    const skipped: string[] = [];
+    const tar = await drain(
+      streamSkillTar({
+        entries: [
+          { name: "bad/SKILL.md", size: 1, sourcePath: "bad/SKILL.md" },
+          { name: "ok/SKILL.md", size: 1, sourcePath: "ok/SKILL.md" },
+        ],
+        read: async (p) => {
+          if (p.startsWith("bad")) throw new Error("EIO");
+          return bytes(1);
+        },
+        maxBytes: 1 << 20,
+        onSkip: (n) => skipped.push(n),
+      }),
+    );
+    expect(namesIn(tar)).toEqual(["ok/SKILL.md"]);
+    expect(skipped).toEqual(["bad/SKILL.md"]);
+  });
+
+  it("stops at the byte cap instead of streaming a volume unbounded", async () => {
+    const skipped: string[] = [];
+    const tar = await drain(
+      streamSkillTar({
+        entries: ["a", "b", "c"].map((n) => ({
+          name: `${n}/SKILL.md`,
+          size: 400,
+          sourcePath: `${n}/SKILL.md`,
+        })),
+        read: async () => bytes(400),
+        maxBytes: 900,
+        onSkip: (n, why) => skipped.push(`${n}:${why}`),
+      }),
+    );
+    expect(namesIn(tar)).toEqual(["a/SKILL.md", "b/SKILL.md"]);
+    expect(skipped[0]).toContain("cap reached");
+  });
+
+  it("terminates cleanly when every entry is unreadable", async () => {
+    const tar = await drain(
+      streamSkillTar({
+        entries: [{ name: "x/SKILL.md", size: 1, sourcePath: "x/SKILL.md" }],
+        read: async () => {
+          throw new Error("EIO");
+        },
+        maxBytes: 1 << 20,
+      }),
+    );
+    expect(namesIn(tar)).toEqual([]);
+    expect(tar.byteLength).toBe(1024);
+  });
+});

--- a/apps/api/src/file-storage/skill-tar.ts
+++ b/apps/api/src/file-storage/skill-tar.ts
@@ -1,0 +1,182 @@
+/**
+ * Streams a volume's skill folders as one tar archive.
+ *
+ * Why this exists: the sandbox daemon used to materialize skills one file at a
+ * time over the org-fs mount — a `stat`, a presign against this API, and an S3
+ * GET each. For an org with ~120 skills that is ~350 round trips for ~1.3MB,
+ * and it showed up as 40 of the 44 seconds before a run's first token. The bytes
+ * were never the problem; the request count was. So the server, which already
+ * knows the whole tree from one `org_fs_entry` query and reads S3 from inside
+ * the datacenter, hands back the entire set in a single response.
+ *
+ * ustar, hand-rolled: the only consumer is our own daemon reading it with Go's
+ * `archive/tar`, and a ~60-line writer beats a new runtime dependency for the
+ * API. No gzip — 1.3MB over the cluster network is not what made this slow.
+ */
+
+import type { OrgFsEntry } from "../storage/org-fs";
+
+/** Tar block size, and the header is exactly one block. */
+const BLOCK = 512;
+
+/** A skill directory to include, with the files that live under it. */
+export interface SkillTarEntry {
+  /** Path inside the archive (`<skill>/SKILL.md`). */
+  name: string;
+  size: number;
+  /** Volume-relative path to read the bytes from. */
+  sourcePath: string;
+}
+
+/**
+ * The files belonging to skill folders at the volume root: every top-level dir
+ * holding a `SKILL.md`, and everything beneath it. Mirrors the daemon's own
+ * `detectSkills` so the two cannot disagree about what a skill is — a README or
+ * a `.gitignore` sitting at the volume root is not one.
+ */
+export function selectSkillFiles(files: OrgFsEntry[]): SkillTarEntry[] {
+  const skillDirs = new Set<string>();
+  for (const f of files) {
+    const slash = f.path.indexOf("/");
+    if (slash === -1) continue;
+    if (f.path.slice(slash + 1) === "SKILL.md") {
+      skillDirs.add(f.path.slice(0, slash));
+    }
+  }
+  const out: SkillTarEntry[] = [];
+  for (const f of files) {
+    const slash = f.path.indexOf("/");
+    if (slash === -1 || !skillDirs.has(f.path.slice(0, slash))) continue;
+    out.push({ name: f.path, size: f.size, sourcePath: f.path });
+  }
+  // Deterministic order: a byte-stable archive is cacheable and diffable, and
+  // it makes the daemon's logs comparable between runs. Codepoint order, not
+  // `localeCompare` — the archive must not depend on the server's locale.
+  return out.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+}
+
+function octal(value: number, width: number): string {
+  return value.toString(8).padStart(width - 1, "0") + "\0";
+}
+
+/**
+ * One 512-byte ustar header. Splits long paths across `prefix`/`name` (255 char
+ * ceiling); a path that still does not fit is rejected by the caller rather
+ * than silently truncated into a different file.
+ */
+export function tarHeader(name: string, size: number): Uint8Array | null {
+  let prefix = "";
+  let base = name;
+  if (Buffer.byteLength(name) > 100) {
+    // Split at the FIRST separator that leaves a <=100 char base. Searching
+    // backwards from there finds a slash too early in the path, leaving a base
+    // still too long — which read as "cannot represent" for every nested file.
+    const cut = name.indexOf("/", Math.max(0, name.length - 101));
+    if (cut <= 0) return null;
+    prefix = name.slice(0, cut);
+    base = name.slice(cut + 1);
+    if (Buffer.byteLength(base) > 100 || Buffer.byteLength(prefix) > 155) {
+      return null;
+    }
+  }
+  const h = Buffer.alloc(BLOCK);
+  h.write(base, 0, 100, "utf8");
+  h.write(octal(0o644, 8), 100, 8, "utf8"); // mode
+  h.write(octal(0, 8), 108, 8, "utf8"); // uid
+  h.write(octal(0, 8), 116, 8, "utf8"); // gid
+  h.write(octal(size, 12), 124, 12, "utf8");
+  h.write(octal(0, 12), 136, 12, "utf8"); // mtime: fixed, see below
+  h.write("        ", 148, 8, "utf8"); // checksum placeholder (spaces)
+  h.write("0", 156, 1, "utf8"); // typeflag: regular file
+  h.write("ustar\0", 257, 6, "utf8");
+  h.write("00", 263, 2, "utf8");
+  h.write(prefix, 345, 155, "utf8");
+  // Checksum is the sum of every byte with the field itself read as spaces —
+  // which is why the placeholder above is written before this runs.
+  let sum = 0;
+  for (const b of h) sum += b;
+  h.write(octal(sum, 8), 148, 8, "utf8");
+  return new Uint8Array(h);
+}
+
+/** Zero padding that rounds a file's bytes up to a whole block. */
+function padding(size: number): Uint8Array {
+  const rem = size % BLOCK;
+  return new Uint8Array(rem === 0 ? 0 : BLOCK - rem);
+}
+
+/** How many objects are fetched at once. Reads are in-datacenter and tiny, so
+ *  the win is overlap; batching keeps it to five lines instead of an ordered
+ *  prefetch window. ponytail: batches, not a sliding window — revisit only if
+ *  a set's tar is dominated by one slow object. */
+const READ_BATCH = 8;
+
+/**
+ * Stream `entries` as a tar. `read` fetches one file's bytes. A file that fails
+ * to read, or whose path will not fit ustar, is skipped — a partial archive of
+ * good skills beats no skills — and `onSkip` reports it so the gap is visible
+ * in logs rather than silent. Stops once `maxBytes` is reached.
+ */
+export function streamSkillTar(opts: {
+  entries: SkillTarEntry[];
+  read: (sourcePath: string) => Promise<Uint8Array>;
+  maxBytes: number;
+  onSkip?: (name: string, reason: string) => void;
+}): ReadableStream<Uint8Array> {
+  const { entries, read, maxBytes, onSkip } = opts;
+  let sent = 0;
+  let i = 0;
+  return new ReadableStream<Uint8Array>({
+    async pull(controller) {
+      while (i < entries.length) {
+        const batch = entries.slice(i, i + READ_BATCH);
+        i += batch.length;
+        const bytes = await Promise.all(
+          batch.map((e) =>
+            read(e.sourcePath).then(
+              (b) => ({ e, b }),
+              (err) => {
+                onSkip?.(e.name, String(err));
+                return null;
+              },
+            ),
+          ),
+        );
+        let emitted = false;
+        for (const got of bytes) {
+          if (!got) continue;
+          const header = tarHeader(got.e.name, got.b.byteLength);
+          if (!header) {
+            onSkip?.(got.e.name, "path too long for ustar");
+            continue;
+          }
+          if (sent + got.b.byteLength > maxBytes) {
+            onSkip?.(got.e.name, "archive size cap reached");
+            controller.enqueue(new Uint8Array(BLOCK * 2));
+            controller.close();
+            return;
+          }
+          controller.enqueue(header);
+          controller.enqueue(got.b);
+          const pad = padding(got.b.byteLength);
+          if (pad.byteLength > 0) controller.enqueue(pad);
+          sent += got.b.byteLength;
+          emitted = true;
+        }
+        // Every entry in the batch was skipped — loop for more rather than
+        // returning, so a run of bad files cannot end the stream early.
+        if (emitted) return;
+      }
+      // Two zero blocks terminate a tar.
+      controller.enqueue(new Uint8Array(BLOCK * 2));
+      controller.close();
+    },
+  });
+}
+
+/**
+ * Wire-side ceiling on one volume's archive. Mirrors the daemon's on-disk
+ * budget: a repo-sync volume is arbitrary user content, so neither end may
+ * assume the other bounded it.
+ */
+export const SKILL_TAR_MAX_BYTES = 64 * 1024 * 1024;

--- a/packages/sandbox/daemon-go/internal/orgfs/links.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/links.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/decocms/studio/sandbox-daemon/internal/gitx"
@@ -72,6 +73,10 @@ type Links struct {
 	// one starts. `WaitSkillLinks` is what turns the async sync back into a
 	// barrier for the run that needs it.
 	publicSkillsDone chan struct{}
+	// org-fs HTTP endpoint from the relayed config — lets the skill prefetch pull
+	// a whole set in one request instead of walking the mount. Nil until a config
+	// arrives, which is what keeps the mount path as the fallback.
+	api *APIConfig
 }
 
 // Expected reports whether org-fs volumes should exist on this pod.
@@ -392,6 +397,10 @@ func (l *Links) volumeMounted(dir string) bool {
 // sync, and one git-exclude line covers the whole set.
 const publicSkillPrefix = "orgfs-"
 
+// Volume-name prefix the studio gives the shared public sets (`public-core` is
+// mounted at `org/public/core`), mirroring publicVolumeForSet server-side.
+const publicVolumePrefix = "public-"
+
 // ensurePublicSkillLinksLocked exposes the read-only public skill sets
 // (`org/public/<set>/<skill>`) to Claude Code as PROJECT skills — one symlink
 // per skill under `<repoDir>/.claude/skills/`.
@@ -455,11 +464,13 @@ func (l *Links) WaitSkillLinks(budget time.Duration) {
 	}
 }
 
-// skillSet is one directory to scan for `<skill>/SKILL.md` children, with the
-// name its copies are prefixed by.
+// skillSet is one source of `<skill>/SKILL.md` children: the org-fs volume it
+// lives on (how the API addresses it), the name its copies are prefixed by, and
+// the mount dir used when the API route is unavailable.
 type skillSet struct {
-	name string
-	dir  string
+	volume string
+	name   string
+	dir    string
 }
 
 // Mount paths under `org/` that are not skill sets: the org home (linked, not
@@ -484,7 +495,11 @@ func (l *Links) skillSetRoots() []skillSet {
 			if !set.IsDir() || !safeSegment.MatchString(set.Name()) {
 				continue
 			}
-			out = append(out, skillSet{set.Name(), filepath.Join(orgRoot, "public", set.Name())})
+			out = append(out, skillSet{
+				volume: publicVolumePrefix + set.Name(),
+				name:   set.Name(),
+				dir:    filepath.Join(orgRoot, "public", set.Name()),
+			})
 		}
 	}
 	for _, m := range l.ActiveMounts() {
@@ -495,7 +510,7 @@ func (l *Links) skillSetRoots() []skillSet {
 		if !safeSegment.MatchString(name) {
 			continue
 		}
-		out = append(out, skillSet{name, m.MountPath})
+		out = append(out, skillSet{volume: m.Volume, name: name, dir: m.MountPath})
 	}
 	return out
 }
@@ -531,9 +546,21 @@ func (l *Links) syncPublicSkills() bool {
 	}
 	gitx.EnsureExclude(l.RepoDir, "/.claude/skills/"+publicSkillPrefix+"*")
 
+	// One budget across every set and both paths: the cap protects the pod's
+	// disk, so it cannot be per volume or per transport.
+	budget := &atomic.Int64{}
+	budget.Store(skillCopyBudget)
+
 	var jobs []skillJob
-	unreadable := 0
+	fromTar, unreadable := 0, 0
 	for _, set := range sets {
+		// One request for the whole set. Only when that is unavailable — an older
+		// studio, a rejected token, a truncated stream — does this fall back to
+		// walking the mount file by file.
+		if n := l.fetchSkillTar(set.volume, set.name, dir, budget); n > 0 {
+			fromTar += n
+			continue
+		}
 		names := skillDirNames(set.dir)
 		if len(names) == 0 {
 			continue
@@ -554,10 +581,11 @@ func (l *Links) syncPublicSkills() bool {
 			})
 		}
 	}
-	copied := prefetchSkills(jobs)
+	fromMount := prefetchSkills(jobs, budget)
 	slog.Info("org-fs skills prefetched",
-		"count", copied, "of", len(jobs), "unreadable", unreadable)
-	return copied > 0
+		"fromTar", fromTar, "fromMount", fromMount, "ofMount", len(jobs),
+		"unreadable", unreadable)
+	return fromTar+fromMount > 0
 }
 
 // repointThreadLink points `org/<linkName>` at `<mountDir>/<threadId>`, creating

--- a/packages/sandbox/daemon-go/internal/orgfs/skillcopy.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/skillcopy.go
@@ -137,12 +137,13 @@ type skillJob struct{ src, dst string }
 const skillCopyConcurrency = 8
 
 // prefetchSkills copies every job onto local disk, bounded-parallel, and reports
-// how many landed. One shared byte budget across all of them: the cap protects
-// the pod's disk, so it cannot be per set or per worker.
-func prefetchSkills(jobs []skillJob) int {
-	budget := &atomic.Int64{}
-	budget.Store(skillCopyBudget)
-
+// how many landed. The byte budget is passed in and shared with the tar path:
+// the cap protects the pod's disk, so it cannot be per set, per worker, or per
+// transport.
+func prefetchSkills(jobs []skillJob, budget *atomic.Int64) int {
+	if len(jobs) == 0 {
+		return 0
+	}
 	work := make(chan skillJob)
 	var wg sync.WaitGroup
 	var copied atomic.Int64

--- a/packages/sandbox/daemon-go/internal/orgfs/skillcopy_test.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/skillcopy_test.go
@@ -86,7 +86,7 @@ func TestPrefetchSkillsSharesOneBudget(t *testing.T) {
 		writeSkillDir(t, src, n, map[string]int{"SKILL.md": int(skillCopyBudget / 4)})
 		jobs = append(jobs, skillJob{filepath.Join(src, n), filepath.Join(dstRoot, n)})
 	}
-	if got := prefetchSkills(jobs); got != 4 {
+	if got := prefetchSkills(jobs, budgetOf(skillCopyBudget)); got != 4 {
 		t.Errorf("copied %d skills, want 4 (the budget fits exactly four)", got)
 	}
 }

--- a/packages/sandbox/daemon-go/internal/orgfs/skilltar.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/skilltar.go
@@ -1,0 +1,179 @@
+package orgfs
+
+import (
+	"archive/tar"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+// Fetching a whole skill set as ONE request instead of walking the mount.
+//
+// The per-file path costs a stat, a presign against the studio, and an S3 GET
+// for every file — ~350 round trips for an org with ~120 skills, which measured
+// as 40 of the 44 seconds before a run's first token. The studio already knows
+// the tree from a single query and reads S3 from inside the datacenter, so
+// `GET /api/:org/fs/:volume/skills.tar` hands the set over in one response and
+// this untars it onto local disk.
+//
+// The mount stays the fallback: the daemon image and the API roll independently
+// (1.55.14 and 1.55.15 pods were serving side by side while this was written),
+// so a new daemon must survive an API that has no such route.
+
+// Whole-set budget. One request, so the deadline covers the transfer rather
+// than a per-file read; generous next to the 30s a single wedged file used to
+// be allowed.
+const skillTarTimeout = 60 * time.Second
+
+// APIConfig is what the daemon needs to call org-fs over HTTP: the studio it was
+// provisioned against, plus the fs-scoped token from ORGFS_CONFIG.
+type APIConfig struct {
+	BaseUrl string
+	OrgSlug string
+	Token   string
+}
+
+// SetAPIConfig records the org-fs endpoint from a relayed (or boot) config so
+// the skill prefetch can bypass the mount. Safe to call repeatedly; the last
+// config wins, matching the sidecar which remounts from it.
+func (l *Links) SetAPIConfig(c APIConfig) {
+	if l == nil || c.BaseUrl == "" || c.OrgSlug == "" || c.Token == "" {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.api = &c
+}
+
+func (l *Links) apiConfig() *APIConfig {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.api
+}
+
+// fetchSkillTar streams a volume's skills into dir, naming each skill
+// `<prefix><set>-<skill>`, and reports how many landed. A zero return means the
+// caller should fall back to copying off the mount — including when the studio
+// has no such route (older deployment) or the token is not accepted.
+func (l *Links) fetchSkillTar(volume, set, dir string, budget *atomic.Int64) int {
+	cfg := l.apiConfig()
+	if cfg == nil {
+		return 0
+	}
+	endpoint := fmt.Sprintf("%s/api/%s/fs/%s/skills.tar",
+		strings.TrimRight(cfg.BaseUrl, "/"),
+		url.PathEscape(cfg.OrgSlug), url.PathEscape(volume))
+
+	ctx, cancel := context.WithTimeout(context.Background(), skillTarTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return 0
+	}
+	req.Header.Set("authorization", "Bearer "+cfg.Token)
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		slog.Warn("org-fs skill tar fetch failed", "volume", volume, "err", err)
+		return 0
+	}
+	defer res.Body.Close()
+	if res.StatusCode != http.StatusOK {
+		// 404 is the expected answer from a studio without this route, and from
+		// a volume holding no skills. Either way: fall back, do not fail.
+		slog.Warn("org-fs skill tar unavailable",
+			"volume", volume, "status", res.StatusCode)
+		return 0
+	}
+	n, err := extractSkillTar(res.Body, dir, publicSkillPrefix+set+"-", budget)
+	if err != nil {
+		slog.Warn("org-fs skill tar extract failed",
+			"volume", volume, "landed", n, "err", err)
+	}
+	return n
+}
+
+// extractSkillTar writes a skills tar into dir, renaming each top-level skill
+// folder to `<prefix><skill>`, and reports how many skills got at least one
+// file. Bounded by budget; a truncated stream keeps whatever arrived whole.
+func extractSkillTar(
+	body io.Reader, dir, prefix string, budget *atomic.Int64,
+) (int, error) {
+	tr := tar.NewReader(body)
+	seen := map[string]bool{}
+	for {
+		h, err := tr.Next()
+		if err == io.EOF {
+			return len(seen), nil
+		}
+		if err != nil {
+			return len(seen), err
+		}
+		if h.Typeflag != tar.TypeReg {
+			continue
+		}
+		skill, rest, ok := splitSkillPath(h.Name)
+		if !ok {
+			slog.Warn("org-fs skill tar: refusing unsafe entry", "name", h.Name)
+			continue
+		}
+		if budget.Add(-h.Size) < 0 {
+			budget.Add(h.Size)
+			return len(seen), fmt.Errorf("%w (at %s)", errSkillBudget, h.Name)
+		}
+		dst := filepath.Join(dir, prefix+skill, rest)
+		if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+			budget.Add(h.Size)
+			return len(seen), err
+		}
+		// Mode from the archive is advisory; the studio writes 0644 and the org
+		// mount served 0755, so keep the exec bit skill helper scripts need.
+		if err := writeFrom(tr, dst, os.FileMode(h.Mode).Perm()|0o111); err != nil {
+			budget.Add(h.Size)
+			return len(seen), err
+		}
+		seen[skill] = true
+	}
+}
+
+// splitSkillPath validates a tar entry as `<skill>/<rest...>` and rejects
+// anything that could escape the skills directory. Tar entry names are remote
+// input: absolute paths, `..`, and backslashes are all refused rather than
+// cleaned, because a cleaned path is a DIFFERENT file silently substituted.
+func splitSkillPath(name string) (skill, rest string, ok bool) {
+	if name == "" || strings.HasPrefix(name, "/") || strings.Contains(name, `\`) {
+		return "", "", false
+	}
+	parts := strings.Split(name, "/")
+	if len(parts) < 2 {
+		return "", "", false
+	}
+	for _, p := range parts {
+		if p == "" || p == "." || p == ".." {
+			return "", "", false
+		}
+	}
+	if !safeSegment.MatchString(parts[0]) {
+		return "", "", false
+	}
+	return parts[0], filepath.Join(parts[1:]...), true
+}
+
+func writeFrom(r io.Reader, dst string, perm os.FileMode) error {
+	f, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(f, r); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
+}

--- a/packages/sandbox/daemon-go/internal/orgfs/skilltar_test.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/skilltar_test.go
@@ -1,0 +1,156 @@
+package orgfs
+
+import (
+	"archive/tar"
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func tarOf(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	for name, body := range files {
+		if err := tw.WriteHeader(&tar.Header{
+			Name: name, Mode: 0o644, Size: int64(len(body)), Typeflag: tar.TypeReg,
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(body)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return buf.Bytes()
+}
+
+func TestExtractSkillTar(t *testing.T) {
+	dir := t.TempDir()
+	raw := tarOf(t, map[string]string{
+		"slides/SKILL.md":  "---\nname: slides\n---\n",
+		"slides/bin/go.sh": "#!/bin/sh\n",
+		"pdf/SKILL.md":     "---\nname: pdf\n---\n",
+	})
+
+	n, err := extractSkillTar(bytes.NewReader(raw), dir, "orgfs-core-", budgetOf(1<<20))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("landed %d skills, want 2", n)
+	}
+	if b, err := os.ReadFile(filepath.Join(dir, "orgfs-core-slides", "SKILL.md")); err != nil ||
+		!strings.Contains(string(b), "slides") {
+		t.Errorf("SKILL.md not extracted: %v", err)
+	}
+	st, err := os.Stat(filepath.Join(dir, "orgfs-core-slides", "bin", "go.sh"))
+	if err != nil {
+		t.Fatalf("nested file not extracted: %v", err)
+	}
+	// Skill helper scripts are executed; the archive's 0644 must not disarm them.
+	if st.Mode().Perm()&0o111 == 0 {
+		t.Errorf("exec bit missing: %v", st.Mode().Perm())
+	}
+}
+
+// Entry names come off the network. A traversal must be refused outright, not
+// cleaned — a cleaned path is a different file silently substituted.
+func TestExtractSkillTarRefusesTraversal(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "skills")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, bad := range []string{
+		"../escaped.md",
+		"ok/../../escaped.md",
+		"/abs/escaped.md",
+		`..\escaped.md`,
+		"lonely.md",
+	} {
+		n, _ := extractSkillTar(
+			bytes.NewReader(tarOf(t, map[string]string{bad: "x"})),
+			dir, "orgfs-core-", budgetOf(1<<20),
+		)
+		if n != 0 {
+			t.Errorf("%q was extracted", bad)
+		}
+	}
+	// Nothing anywhere outside the skills dir, and nothing inside it either.
+	for _, p := range []string{
+		filepath.Join(root, "escaped.md"),
+		filepath.Join(dir, "escaped.md"),
+	} {
+		if _, err := os.Stat(p); err == nil {
+			t.Errorf("traversal wrote %s", p)
+		}
+	}
+	if entries, err := os.ReadDir(dir); err != nil || len(entries) != 0 {
+		t.Errorf("skills dir not empty: %v %v", entries, err)
+	}
+}
+
+func TestExtractSkillTarStopsAtBudget(t *testing.T) {
+	dir := t.TempDir()
+	raw := tarOf(t, map[string]string{"big/SKILL.md": strings.Repeat("x", 4096)})
+	if _, err := extractSkillTar(bytes.NewReader(raw), dir, "p-", budgetOf(1024)); err == nil {
+		t.Fatal("extracted past the budget")
+	}
+}
+
+func TestFetchSkillTarUsesTheAPI(t *testing.T) {
+	raw := tarOf(t, map[string]string{"slides/SKILL.md": "---\nname: slides\n---\n"})
+	var gotPath, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath, gotAuth = r.URL.Path, r.Header.Get("authorization")
+		w.Write(raw)
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	l := &Links{}
+	l.SetAPIConfig(APIConfig{BaseUrl: srv.URL, OrgSlug: "deco-studio", Token: "tok"})
+	if n := l.fetchSkillTar("public-core", "core", dir, budgetOf(1<<20)); n != 1 {
+		t.Fatalf("landed %d skills, want 1", n)
+	}
+	if gotPath != "/api/deco-studio/fs/public-core/skills.tar" {
+		t.Errorf("path %q", gotPath)
+	}
+	if gotAuth != "Bearer tok" {
+		t.Errorf("auth %q", gotAuth)
+	}
+	assertSkillPresent(t, dir, "orgfs-core-slides")
+}
+
+// An older studio has no such route. The daemon must report zero so the caller
+// falls back to the mount, not fail the run.
+func TestFetchSkillTarFallsBackOn404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", 404)
+	}))
+	defer srv.Close()
+	l := &Links{}
+	l.SetAPIConfig(APIConfig{BaseUrl: srv.URL, OrgSlug: "o", Token: "t"})
+	if n := l.fetchSkillTar("public-core", "core", t.TempDir(), budgetOf(1<<20)); n != 0 {
+		t.Errorf("got %d, want 0 so the caller falls back", n)
+	}
+}
+
+// No config relayed yet: must not attempt a request at all.
+func TestFetchSkillTarWithoutConfig(t *testing.T) {
+	l := &Links{}
+	if n := l.fetchSkillTar("public-core", "core", t.TempDir(), budgetOf(1<<20)); n != 0 {
+		t.Errorf("got %d, want 0", n)
+	}
+	l.SetAPIConfig(APIConfig{BaseUrl: "", OrgSlug: "o", Token: "t"})
+	if l.apiConfig() != nil {
+		t.Error("accepted an incomplete config")
+	}
+}

--- a/packages/sandbox/daemon-go/internal/routes/misc.go
+++ b/packages/sandbox/daemon-go/internal/routes/misc.go
@@ -55,6 +55,9 @@ func Setup(step string, resumeFrom func(step string)) http.HandlerFunc {
 
 type OrgFsDeps struct {
 	ConfigPath string
+	// OnConfig receives the validated org-fs endpoint. Called before the relay so
+	// the credential is available even on a pod with no sidecar config path.
+	OnConfig func(baseUrl, orgSlug, token string)
 }
 
 func OrgFsConfig(deps OrgFsDeps) http.HandlerFunc {
@@ -64,9 +67,13 @@ func OrgFsConfig(deps OrgFsDeps) http.HandlerFunc {
 			httpx.Error(w, 400, "invalid org-fs config")
 			return
 		}
-		if orgfs.ParseConfig(raw) == nil {
+		cfg := orgfs.ParseConfig(raw)
+		if cfg == nil {
 			httpx.Error(w, 400, "invalid org-fs config")
 			return
+		}
+		if deps.OnConfig != nil {
+			deps.OnConfig(cfg.BaseUrl, cfg.OrgSlug, cfg.Token)
 		}
 		if deps.ConfigPath == "" {
 			httpx.JSON(w, 200, map[string]any{"written": false})

--- a/packages/sandbox/daemon-go/main.go
+++ b/packages/sandbox/daemon-go/main.go
@@ -922,6 +922,13 @@ func main() {
 		StatusPath: os.Getenv("ORGFS_SIDECAR_STATUS_PATH"),
 		ConfigPath: os.Getenv("ORGFS_SIDECAR_CONFIG_PATH"),
 	}
+	// Desktop mounts from the boot env rather than a relayed config, so seed the
+	// prefetch credential from it too.
+	if c := orgfs.ParseConfig([]byte(os.Getenv("ORGFS_CONFIG"))); c != nil {
+		d.orgFsLinks.SetAPIConfig(orgfs.APIConfig{
+			BaseUrl: c.BaseUrl, OrgSlug: c.OrgSlug, Token: c.Token,
+		})
+	}
 	// Fail loud rather than silently unmounted: ORGFS_CONFIG is the desktop's
 	// "mount them yourself" env, which only the TS bundle implements.
 	if os.Getenv("ORGFS_CONFIG") != "" && d.orgFsLinks.StatusPath == "" {
@@ -1077,6 +1084,14 @@ func main() {
 		}),
 		orgfsConfig: routes.OrgFsConfig(routes.OrgFsDeps{
 			ConfigPath: os.Getenv("ORGFS_SIDECAR_CONFIG_PATH"),
+			// The relayed config is also the daemon's own org-fs credential: the
+			// skill prefetch uses it to pull a whole set in one API request rather
+			// than walking the mount file by file.
+			OnConfig: func(baseUrl, orgSlug, token string) {
+				d.orgFsLinks.SetAPIConfig(orgfs.APIConfig{
+					BaseUrl: baseUrl, OrgSlug: orgSlug, Token: token,
+				})
+			},
 		}),
 		fs: map[string]http.HandlerFunc{
 			"read":           routes.Read(fsDeps),


### PR DESCRIPTION
Follow-up to #6375. That PR got the bytes onto local disk; this one stops fetching them one file at a time.

## The measurement

A real prod run (`thrd_8xHBIAEMxp2-euVZnl3Mn`, pod `studio-sandbox-prod-medium-tkzj5`):

| Elapsed | Event |
|---|---|
| `+0.0s` | `dispatch received` |
| `+1.6s` | 6 org-fs volumes mounted |
| `+13.5s` | daemon: `org-fs public skills linked count=118` |
| `+41.1s` | `[claude-code] sdk system/init **+27s**` — 133 skills enumerated |
| `+44.4s` | first output frame |

**44s to first token, 40 of it skills.** And it tracks file count, not bytes — other prod pods at the same moment:

| Skills visible | `sdk system/init` |
|---|---|
| 15 (built-ins only) | +1s |
| 47 (33 org + 14) | +4s |
| **133 (118 org + 15)** | **+27s** |

The cause is that both slow phases talk to org-fs **one file at a time**. Each file is a FUSE request that becomes a presign against this API plus an S3 GET — roughly **350 round trips for 1.3MB**. #6375 removed the 27s by reading from local disk, but the daemon still had to walk and copy the mount file by file, which is the remaining ~12s.

## Change

`GET /api/:org/fs/:volume/skills.tar` streams a volume's skill folders as one archive. The server already has the whole tree from a single `org_fs_entry` query (`listVolumeFiles`) and reads S3 from inside the datacenter; the daemon untars it straight into `.claude/skills/`. 350 round trips become 3 — one per mounted set — and it removes *both* slow phases, because the daemon no longer walks or probes anything.

Selection mirrors the daemon's own `detectSkills`, so the two cannot disagree about what a skill is: top-level dirs holding a `SKILL.md`, plus everything beneath them. A root-level `README.md` or `.gitignore` is not a skill.

## The mount stays the fallback

Not defensive coding — observed version skew. While writing this, prod was serving `studio-sandbox-go:1.55.14` and `1.55.15` pods side by side, because the daemon image and the API roll independently. So a new daemon has to survive an API without this route: any non-200 (including the 404 an older studio returns, and the 404 for a volume with no skills) returns zero, and the caller walks the mount exactly as before. `TestFetchSkillTarFallsBackOn404` pins that.

## Risk areas, and what guards each

**Hand-rolled ustar.** Deliberate — a new runtime dependency for one endpoint is worse than 60 lines. The consumer is Go's stdlib `archive/tar`. Verified by writing a real archive with this module and reading it back with the daemon's own extractor **and** with `bsdtar`, including a 120-char path split across the header's `prefix` field (that split had a genuine bug on the first attempt — it searched backwards and rejected every nested file; `tarHeader > refuses a path it cannot represent` and the long-path test now cover it). Since Go's reader is stdlib and will not drift, the layout is pinned from this side by a golden-bytes test.

**Tar entry names are remote input.** `splitSkillPath` refuses absolute paths, `..`, `.`, empty segments, backslashes, and single-segment names — refuses, not sanitizes, because a cleaned path is a different file silently substituted. `TestExtractSkillTarRefusesTraversal` asserts nothing lands inside *or* outside the skills dir, and it was verified to fail with the guard removed (`"/abs/escaped.md" was extracted`, plus a write above the target dir).

**Unbounded volume.** A repo-sync volume is arbitrary user content, so the 64MB cap is enforced on **both** ends — the stream stops at `SKILL_TAR_MAX_BYTES`, and the extractor charges the same shared atomic budget it shares with the fallback copy path. Neither side assumes the other bounded it.

**Partial results beat none.** A file that fails to read, or whose path will not fit ustar, is skipped and reported via `onSkip` (server) / `slog.Warn` (daemon) rather than failing the archive. `streamSkillTar > terminates cleanly when every entry is unreadable` covers the degenerate case.

## Testing

`bun test apps/api/src/file-storage/skill-tar.test.ts` — 10 tests. `go test ./...` green in `packages/sandbox/daemon-go`. `bun run lint` clean on changed files, `knip` reports no dead exports.

Server: skill-folder selection, checksum-over-blanked-field, prefix split, unrepresentable-path refusal, name/size round-trip with block padding, unreadable-file skip, byte cap, all-bad-entries termination, golden ustar layout.
Daemon: extract with nested files and exec bit, traversal refusal, budget stop, endpoint/auth shape, 404 fallback, no-config no-op.

## Projected

`1.6s mount + ~1s for three parallel tarballs + ~1s init + 3.3s to first frame` ≈ **7s**, from 44s. I have not measured post-deploy — worth confirming on the same task once this and #6375 are both rolled out.

## Not in this PR

Public sets are byte-identical for every pod in the cluster (348kB of the 1.3MB), so each pod still fetches them once. That wants a per-node or image-baked cache, not a per-org one, and it is independent of this change.

---

> **Correction:** an earlier edit to this description documented a second commit
> (staging + a larger barrier). That commit was pushed after this PR had already
> merged, so it is **not** part of this change — it is #6394. This PR is the bulk
> tar only.
