### PR TITLE
fix(mcp): require org context on the call-tool proxy route

### DIFF
--- a/apps/api/src/api/routes/proxy.integration.test.ts
+++ b/apps/api/src/api/routes/proxy.integration.test.ts
@@ -126,4 +126,19 @@ describe("MCP Proxy null-org bypass", () => {
     const body = await response.json();
     expect(body.error).toContain("Organization context is required");
   });
+
+  it("should reject call-tool access when organization context is missing", async () => {
+    const response = await app.request(
+      "/mcp/conn_victim_123/call-tool/some_tool",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      },
+    );
+
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toContain("Organization context is required");
+  });
 });

--- a/apps/api/src/api/routes/proxy.ts
+++ b/apps/api/src/api/routes/proxy.ts
@@ -473,13 +473,18 @@ export const createProxyRoutes = () => {
     const toolName = c.req.param("toolName");
     const ctx = c.get("studioContext");
 
+    // Without an org, findById's org filter is skipped — cross-tenant lookup.
+    if (!ctx.organization?.id) {
+      return c.json({ error: "Organization context is required" }, 403);
+    }
+
     // Hoisted so the catch block can reuse it instead of re-querying.
     let connection: ConnectionEntity | null = null;
     try {
       // Fetch connection and create client directly
       connection = await ctx.storage.connections.findById(
         connectionId,
-        ctx.organization?.id,
+        ctx.organization.id,
       );
       if (!connection) {
         return c.json({ error: "Connection not found" }, 404);
@@ -515,7 +520,7 @@ export const createProxyRoutes = () => {
       // route. Without this, an expired/missing credential would 500 here.
       connection ??= await ctx.storage.connections.findById(
         connectionId,
-        ctx.organization?.id,
+        ctx.organization.id,
       );
       if (connection?.connection_url) {
         const authResponse = await handleAuthError({


### PR DESCRIPTION
Bug found while auditing `apps/api/src/api/routes/proxy.ts` in the MCP-connection area.

`ConnectionStorage.findById(id, organizationId)` only adds the `organization_id = ...` filter when `organizationId` is truthy. The main `/:connectionId` proxy route already guards this explicitly ("Organization context is required — without it the ownership check below would be skipped, allowing cross-tenant access"), but the `/:connectionId/call-tool/:toolName` route right below it passed `ctx.organization?.id` straight through with no such guard.

**Failure scenario:** an authenticated caller with no active org context (e.g. an API key created without org metadata, or a session whose active org differs from the target) hits `POST /mcp/<connectionId>/call-tool/<toolName>` for a connection id belonging to a *different* organization. Because `organizationId` is `undefined`, `findById` runs an unscoped lookup, finds the victim org's connection, and the route happily calls the tool on it — a cross-tenant connection/tool-invocation leak.

Fixed by adding the same `if (!ctx.organization?.id) return 403` guard used on the sibling route, and scoping both `findById` calls (success path + the catch block's auth-error re-query) to `ctx.organization.id`.

Added a regression test in `proxy.integration.test.ts`, mirroring the existing "MCP Proxy null-org bypass" test for the main route, asserting the call-tool route now also 403s when org context is missing.

**To verify:** run `apps/api/src/api/routes/proxy.integration.test.ts` (needs a real Postgres — this laptop has none, so I could not run it locally; it mirrors the already-passing sibling test in the same file line for line).

**Checked locally:** `bun run fmt`, `bunx tsc --noEmit` (apps/api, clean), `bunx oxlint` on both changed files (0 warnings/errors). Full CI (including the integration test) validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require organization context on the MCP call-tool proxy and scope connection lookups to the active org to prevent cross-tenant access. Previously, missing org context led to an unscoped `findById` and allowed invoking tools on another org’s connection; now the route returns 403 without org context and always scopes queries.

- Adds a 403 guard to POST /mcp/:connectionId/call-tool/:toolName when `ctx.organization?.id` is missing; aligns with the sibling /:connectionId route.
- Scopes both `connections.findById` calls (main path and auth-error retry) to `ctx.organization.id`.
- Adds a regression test asserting 403 when org context is absent.
- Client impact: callers must include an active organization context; API keys or sessions without org metadata will be rejected.

<sup>Written for commit 940e4d13cbaacf9db1d8c7cbf6398918ce3aeea5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

