### PR TITLE
fix(sidebar): label nav v2 coding agents by title, not repo name

### DIFF
--- a/apps/web/src/components/sidebar/nav-destinations.tsx
+++ b/apps/web/src/components/sidebar/nav-destinations.tsx
@@ -170,8 +170,7 @@ function useNavDestinations({
 
 /**
  * The org's coding agents — every virtual MCP backed by a GitHub repo (imported
- * from GitHub or cloned from a template). Each is listed by REPO name, since
- * that is what identifies the codebase the agent works on.
+ * from GitHub or cloned from a template), listed by title, repo name as fallback.
  *
  * Selecting one opens that agent's chat, reusing its existing empty "New chat"
  * so repeat clicks don't pile up threads.
@@ -193,7 +192,7 @@ function useCodingAgents({
       const repo = getActiveGithubRepo(agent);
       return {
         key: agent.id,
-        label: repo?.name || agent.title,
+        label: agent.title || repo?.name || "",
         icon: (
           <AgentAvatar
             icon={agent.icon}

--- a/packages/e2e/tests/nav-v2.spec.ts
+++ b/packages/e2e/tests/nav-v2.spec.ts
@@ -10,7 +10,7 @@
  * purpose — this suite owns its contract (see ban-e2e-app-imports).
  */
 
-import type { Page } from "@playwright/test";
+import type { APIRequestContext, Page } from "@playwright/test";
 import { z } from "zod";
 import { connectDevDb } from "../fixtures/db";
 import {
@@ -95,6 +95,43 @@ async function clearSeededNavV2(orgId: string): Promise<void> {
   } finally {
     await db.end();
   }
+}
+
+/** Wire contract: the repo a coding agent is created against. Kept distinct
+ *  from every agent title below so the sidebar's label source is unambiguous. */
+const CODING_AGENT_REPO = "nav-v2-e2e";
+
+/** A repo-backed ("coding") agent — the sidebar lists one row per repo. */
+async function createCodingAgent(
+  request: APIRequestContext,
+  orgSlug: string,
+  title: string,
+): Promise<{ item: { id: string } }> {
+  const conn = await createHttpConnection(request, orgSlug, {
+    title: "github-placeholder",
+    url: "http://127.0.0.1:3000/",
+  });
+  return await callSelfMcpTool<{ item: { id: string } }>(
+    request,
+    orgSlug,
+    "COLLECTION_VIRTUAL_MCP_CREATE",
+    {
+      data: {
+        title,
+        status: "active",
+        pinned: false,
+        connections: [{ connection_id: conn.id }],
+        metadata: {
+          githubRepo: {
+            url: `https://github.com/example/${CODING_AGENT_REPO}`,
+            owner: "example",
+            name: CODING_AGENT_REPO,
+            connectionId: conn.id,
+          },
+        },
+      },
+    },
+  );
 }
 
 /** A Commerce Discovery MCP that answers with one completed diagnostic. */
@@ -339,31 +376,7 @@ test.describe("first-class navigation", () => {
     const request = page.context().request;
     const orgId = await findOrgId(request, orgSlug);
 
-    const conn = await createHttpConnection(request, orgSlug, {
-      title: "github-placeholder",
-      url: "http://127.0.0.1:3000/",
-    });
-    const agent = await callSelfMcpTool<{ item: { id: string } }>(
-      request,
-      orgSlug,
-      "COLLECTION_VIRTUAL_MCP_CREATE",
-      {
-        data: {
-          title: "coding agent e2e",
-          status: "active",
-          pinned: false,
-          connections: [{ connection_id: conn.id }],
-          metadata: {
-            githubRepo: {
-              url: "https://github.com/example/nav-v2-e2e",
-              owner: "example",
-              name: "nav-v2-e2e",
-              connectionId: conn.id,
-            },
-          },
-        },
-      },
-    );
+    const agent = await createCodingAgent(request, orgSlug, "coding agent e2e");
     const thread = await callSelfMcpTool<{ item: { id: string } }>(
       request,
       orgSlug,
@@ -381,5 +394,44 @@ test.describe("first-class navigation", () => {
       new RegExp(`[?&]virtualmcpid=${decopilotId(orgId)}\\b`),
     );
     await expect(page).toHaveURL(/[?&]main=board\b/);
+  });
+
+  test("a coding agent is listed by its title, and follows a rename", async ({
+    authedPage: { page, orgSlug },
+  }) => {
+    const request = page.context().request;
+    const agent = await createCodingAgent(request, orgSlug, "before rename");
+    const thread = await callSelfMcpTool<{ item: { id: string } }>(
+      request,
+      orgSlug,
+      "COLLECTION_THREADS_CREATE",
+      { data: { virtual_mcp_id: agent.item.id } },
+    );
+
+    // The settings tab is driven by `?main=`, not `?tab=`.
+    await page.goto(
+      `/${orgSlug}/${thread.item.id}?virtualmcpid=${agent.item.id}&main=settings`,
+    );
+    await expandSidebar(page, "Home");
+
+    const sidebar = page.locator('[data-sidebar="content"]');
+    const row = (name: string) =>
+      sidebar.getByRole("button", { name, exact: true });
+    await expect(row("before rename")).toBeVisible({
+      timeout: SHELL_TIMEOUT_MS,
+    });
+    await expect(row(CODING_AGENT_REPO)).toHaveCount(0);
+
+    // Rename the way a user does — the identity form autosaves on blur.
+    const titleInput = page.getByPlaceholder("Agent name");
+    await expect(titleInput).toBeVisible({ timeout: SHELL_TIMEOUT_MS });
+    await titleInput.fill("after rename");
+    await titleInput.blur();
+
+    await expect(row("after rename")).toBeVisible({
+      timeout: SHELL_TIMEOUT_MS,
+    });
+    await expect(row("before rename")).toHaveCount(0);
+    await expect(row(CODING_AGENT_REPO)).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary

The first-class navigation (`nav_v2`) listed each coding agent by its **GitHub repo name**, so renaming an agent never reached the sidebar — the row kept the pre-rename name forever.

The label source was invisible while the two agreed: an import seeds `title` from the repo (`github-repo-picker.tsx:317`), and #6369 only just lifted the gate that kept repo-backed agents from being renamed at all. Repo-first also disagreed with every other surface — this row's own `AgentAvatar`, the flag-off sidebar (`agents-section.tsx`), the chat header and the settings form all read the title.

```diff
-        label: repo?.name || agent.title,
+        label: agent.title || repo?.name || "",
```

## Testing

`packages/e2e/tests/nav-v2.spec.ts`: the repo-backed-agent setup the existing coding-agent test already carried moves into a `createCodingAgent` helper (its title and repo name were already deliberately different). The new case opens the agent's settings tab, renames it the way a user does — fill + blur, the autosave path that invalidates the collection query — and asserts the sidebar row reads the title before and after, and never the repo name.

- Full `nav-v2.spec.ts` locally: **9 passed**.
- Inverted back to `repo?.name || agent.title` and re-ran: the new test fails on the first assertion, so it encodes the bug rather than the fix.
- `bun run check`, `bun run lint` (0 errors), `bun run fmt` clean.

## Affected areas

Sidebar only, and only under the `nav_v2` flag. No wire or storage contract changes; `metadata.githubRepo.name` is untouched and still the fallback for a title-less agent.

## Note for reviewers (not addressed here)

A rename made **outside** the UI does not reach the sidebar even after a reload: the `VIRTUAL_MCP` collection read is persisted to localStorage (`lib/query-persist.ts`) and hydrates with a 60s `staleTime`, so a reload right after an out-of-band change re-renders the stale title and never refetches. Through the UI it's fine — `useCollectionActions` invalidates on save — which is why the test renames via the form. Flagging it as a trap for anything that mutates agents server-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sidebar nav v2 now labels coding agents by their title instead of the GitHub repo name. Previously the sidebar always showed the repo name, so renames never appeared; now it uses the agent title with the repo name as a fallback.

- Scope: only `nav_v2`. Aligns the sidebar with other UI surfaces. No API or storage changes.
- Tests: adds an e2e that renames via the settings form and asserts the sidebar shows the title before/after and never the repo name; introduces a helper to seed a repo-backed agent with distinct title and repo.
- Note: out-of-band renames may be masked briefly by persisted collection caching (≈60s staleTime); UI renames invalidate and refresh immediately.

<sup>Written for commit d58021f49c124e6122f53f41f4d56383f3e6d718. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

