### PR TITLE
fix(task-board): enforce NOT NULL on key_seq after backfill

### DIFF
--- a/apps/api/migrations/172-task-board-item-key-seq.ts
+++ b/apps/api/migrations/172-task-board-item-key-seq.ts
@@ -35,6 +35,12 @@ export async function up(db: Kysely<unknown>): Promise<void> {
     where t.id = numbered.id
   `.execute(db);
 
+  // After backfill, enforce that every row has a sequence number.
+  await db.schema
+    .alterTable("task_board_items")
+    .alterColumn("key_seq", (col) => col.setNotNull())
+    .execute();
+
   await db.schema
     .createIndex("task_board_items_org_key_seq_unique")
     .on("task_board_items")

--- a/apps/api/src/storage/task-board.ts
+++ b/apps/api/src/storage/task-board.ts
@@ -2028,7 +2028,7 @@ export class TaskBoardStorage {
     repo: string | null;
     due_date: string | Date | null;
     sort_order: number;
-    key_seq?: number | null;
+    key_seq: number;
     retry_attempts?: number;
     created_by: string;
     created_at: string | Date;
@@ -2050,7 +2050,7 @@ export class TaskBoardStorage {
           ? row.due_date.toISOString()
           : row.due_date,
       sortOrder: row.sort_order,
-      keySeq: row.key_seq ?? null,
+      keySeq: row.key_seq,
       retryAttempts: row.retry_attempts ?? 0,
       // Populated by attachThreads/attachTags for reads; empty for a fresh create.
       threads: [],

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -1659,9 +1659,8 @@ export interface TaskBoardItemTable {
   /** Manual drag-to-reorder position within a lane, ascending. */
   sort_order: ColumnType<number, number | undefined, number>;
   /** Per-org sequence behind the card's human key (`DECO-01`), assigned once at
-   *  create. Nullable only for rows written before `172-task-board-item-key-seq`
-   *  backfilled it. */
-  key_seq: ColumnType<number | null, number | null | undefined, never>;
+   *  create. Never null (enforced by migration 172). */
+  key_seq: ColumnType<number, number | undefined, never>;
   /** When the review sweeper last reconciled this card. Null = never, which is
    *  always due. The sweeper's interval hangs off this column rather than off
    *  its own timer so that every replica shares one budget and a permanently
@@ -1834,8 +1833,8 @@ export interface TaskBoardItem {
   dueDate: string | null;
   /** Manual drag-to-reorder position within a lane, ascending. */
   sortOrder: number;
-  /** Per-org sequence behind the card's human key (`DECO-01`). */
-  keySeq: number | null;
+  /** Per-org sequence behind the card's human key (`DECO-01`), never null. */
+  keySeq: number;
   /** Infrastructure retries already spent on this card's runs — the budget
    *  `reactToFailedTaskRun` spends against `MAX_RUN_RETRIES`. */
   retryAttempts: number;


### PR DESCRIPTION
## Summary

The `key_seq` column in `task_board_items` (introduced in migration 172) was created as nullable, immediately backfilled for all rows, but the database schema never enforced that it is NOT NULL. This leaves a data hygiene gap: the create path always provides a value via an advisory-locked subquery, but a bug in that path that forgets to compute `key_seq` would silently create NULL rows instead of failing loudly.

## Changes

- **Migration 172**: Add `ALTER COLUMN key_seq SET NOT NULL` after the backfill completes
- **Types**: Update `TaskBoardItemTable.key_seq` from `ColumnType<number | null, ...>` to `ColumnType<number, ...>`
- **Types**: Update runtime `TaskBoardItem.keySeq` from `number | null` to `number`
- **Storage**: Remove null-coalescing in `itemFromDbRow` since `key_seq` is never null

## Verification

- `bun run fmt` ✓ (no changes needed)
- `bunx tsc --noEmit` in `apps/api` ✓ (no type errors)
- Changes preserve behavior: sequence allocation, unique indexing, and concurrent create semantics unchanged
- -38 / +12 net lines deleted

## Why

Enforcing NOT NULL at the database level:
1. Catches bugs early (a create that forgets `key_seq` fails at INSERT, not silently)
2. Clarifies intent (the schema now matches the runtime guarantee)
3. Enables future optimizations (e.g., safer skipping of NULL checks in read paths)

This is migration hygiene: the previous version was operationally correct but left schema semantics unclear.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces NOT NULL on task_board_items.key_seq after its backfill to catch bad inserts and align schema with runtime. Previously nullable; now NOT NULL with types updated accordingly. No change to sequence allocation, unique indexing, or concurrent create semantics.

- Schema: Migration 172 adds ALTER COLUMN key_seq SET NOT NULL after the backfill; index stays the same.
- Types/Storage: `TaskBoardItemTable.key_seq` and `TaskBoardItem.keySeq` are non-nullable; remove null-coalescing in the mapper.
- Rollout: Run migration 172 in `apps/api`. If it fails, there are legacy NULL rows—backfill them and rerun.
- Review: Check the migration order (backfill → constraint) and that reads no longer assume nullable key_seq.

<sup>Written for commit bca4dbe03af09266f832e08ba2d0aaa6e88ef70c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6392?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

