### PR TITLE
fix(task-board): expose the active priority/due filter to screen readers

### DIFF
--- a/apps/web/src/layouts/task-board/task-filters.tsx
+++ b/apps/web/src/layouts/task-board/task-filters.tsx
@@ -21,7 +21,8 @@ import {
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "@decocms/ui/components/dropdown-menu.tsx";
 import {
@@ -68,6 +69,9 @@ const UNASSIGNED_FILTER = "__unassigned__";
 
 /** Sentinel repo filter matching tasks with no associated repo. */
 const NO_REPO_FILTER = "__no_repo__";
+
+/** Radix `RadioGroup` needs a string value — this stands in for `null` (any). */
+const ANY_FILTER = "__any__";
 
 export type DueFilter = "overdue" | "today" | "week" | "none";
 
@@ -346,24 +350,29 @@ function PriorityFilter({
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-40">
-        <DropdownMenuItem onSelect={() => onChange(null)}>
-          {t("taskBoard.taskFilters.priorityAnyPriority")}
-        </DropdownMenuItem>
-        {PRIORITIES.map((p) => (
-          <DropdownMenuItem
-            key={p}
-            onSelect={() => onChange(p)}
-            className="gap-2"
-          >
-            <span
-              className={cn(
-                "size-2 rounded-full",
-                PRIORITY_CONFIG[p].dotClassName,
-              )}
-            />
-            {t(PRIORITY_CONFIG[p].labelKey)}
-          </DropdownMenuItem>
-        ))}
+        <DropdownMenuRadioGroup
+          value={value ?? ANY_FILTER}
+          onValueChange={(next) =>
+            onChange(
+              next === ANY_FILTER ? null : (next as TaskBoardItemPriority),
+            )
+          }
+        >
+          <DropdownMenuRadioItem value={ANY_FILTER}>
+            {t("taskBoard.taskFilters.priorityAnyPriority")}
+          </DropdownMenuRadioItem>
+          {PRIORITIES.map((p) => (
+            <DropdownMenuRadioItem key={p} value={p} className="gap-2">
+              <span
+                className={cn(
+                  "size-2 rounded-full",
+                  PRIORITY_CONFIG[p].dotClassName,
+                )}
+              />
+              {t(PRIORITY_CONFIG[p].labelKey)}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
       </DropdownMenuContent>
     </DropdownMenu>
   );
@@ -392,33 +401,40 @@ function DueDateFilter({
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-44">
-        <DropdownMenuItem onSelect={() => onChange(null)} className="gap-2">
-          <Calendar size={16} className="text-muted-foreground" />
-          {t("taskBoard.taskFilters.dueDateAnyTime")}
-        </DropdownMenuItem>
-        {(
-          Object.entries(DUE_OPTIONS_LABEL_KEYS) as Array<
-            [DueFilter, TranslationKey]
-          >
-        ).map(([value, labelKey]) => {
-          const danger = value === "overdue";
-          return (
-            <DropdownMenuItem
-              key={value}
-              onSelect={() => onChange(value)}
-              className={cn("gap-2", danger && "text-destructive")}
+        <DropdownMenuRadioGroup
+          value={value ?? ANY_FILTER}
+          onValueChange={(next) =>
+            onChange(next === ANY_FILTER ? null : (next as DueFilter))
+          }
+        >
+          <DropdownMenuRadioItem value={ANY_FILTER} className="gap-2">
+            <Calendar size={16} className="text-muted-foreground" />
+            {t("taskBoard.taskFilters.dueDateAnyTime")}
+          </DropdownMenuRadioItem>
+          {(
+            Object.entries(DUE_OPTIONS_LABEL_KEYS) as Array<
+              [DueFilter, TranslationKey]
             >
-              <Calendar
-                size={16}
-                className={cn(
-                  "shrink-0",
-                  danger ? "text-destructive" : "text-muted-foreground",
-                )}
-              />
-              {t(labelKey)}
-            </DropdownMenuItem>
-          );
-        })}
+          ).map(([due, labelKey]) => {
+            const danger = due === "overdue";
+            return (
+              <DropdownMenuRadioItem
+                key={due}
+                value={due}
+                className={cn("gap-2", danger && "text-destructive")}
+              >
+                <Calendar
+                  size={16}
+                  className={cn(
+                    "shrink-0",
+                    danger ? "text-destructive" : "text-muted-foreground",
+                  )}
+                />
+                {t(labelKey)}
+              </DropdownMenuRadioItem>
+            );
+          })}
+        </DropdownMenuRadioGroup>
       </DropdownMenuContent>
     </DropdownMenu>
   );


### PR DESCRIPTION
**Source:** a bug, found while auditing the task-board filter bar (recent hardening in this area — #6372/#6380/#6385 — fixed focus rings, selection leaks, and search input labels, but left this one).

**The gap:** `PriorityFilter` and `DueDateFilter` render their options as plain `DropdownMenuItem`s. Visually the trigger chip shows the active value, but inside the open menu there is no indication — visual or in the accessibility tree — of which option is currently selected (unlike `TagFilter`/`AssigneeFilter`/`RepoFilter`, which all show a `Check` icon on the active row). A screen-reader user opening the Priority or Due-date menu hears a plain list of `menuitem`s with no selected state announced, so they can't tell which filter is currently applied without closing the menu and re-reading the trigger.

**Fix:** swap the manual `DropdownMenuItem` list for `DropdownMenuRadioGroup` + `DropdownMenuRadioItem` (already used elsewhere in the design system, see `packages/ui/src/components/dropdown-menu.tsx`). Radix's `RadioItem` renders `role="menuitemradio"` with `aria-checked`, and the shared component also adds a visible dot indicator — so both the a11y tree and the visual state now expose which option is active, matching the other four filters. A `null` ("any") selection is represented by a local `ANY_FILTER` sentinel string since Radix's `RadioGroup.value` must be a string, translated back to `null` in `onValueChange`.

Behavior is unchanged: same options, same `onChange` callback, same menu-closes-on-select behavior (Radix does this by default for radio items, same as it did for plain items).

**To confirm:** open the task board, open the Priority or Due-date filter chip's dropdown — the currently active option (if any) now shows a filled dot indicator, and inspecting the DOM shows `role="menuitemradio"`/`aria-checked="true"` on it.

**Checks run locally:** `bun run fmt`, `cd apps/web && bunx tsc --noEmit` (clean), `bunx oxlint apps/web/src/layouts/task-board/task-filters.tsx` (0 warnings/errors). No behavior-affecting logic changed, so no new test — full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the active selection in the Priority and Due date filter menus to assistive tech and visually. Previously these menus listed plain items with no selected state; now they render as radio items with `aria-checked` and a visible dot. Behavior (options, selection, and menu close-on-select) is unchanged.

- Replace `DropdownMenuItem` with `DropdownMenuRadioGroup`/`DropdownMenuRadioItem` from `@decocms/ui/components/dropdown-menu.tsx`.
- Introduce `ANY_FILTER` to stand in for null since Radix radio values must be strings; map back to `null` in `onValueChange`.
- Verify: open the Priority/Due date menu on the task board; the active option shows a dot, and the DOM uses `role="menuitemradio"` with `aria-checked="true"`.

<sup>Written for commit 30f98724c09ee718006e949634dbf20c3767cfeb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

