### PR TITLE
fix(sandbox): publish a skill set only once it is fully staged

### DIFF
--- a/packages/sandbox/daemon-go/internal/orgfs/links.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/links.go
@@ -532,60 +532,124 @@ func (l *Links) syncPublicSkills() bool {
 	}
 	dir := filepath.Join(l.RepoDir, ".claude", "skills")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
-		slog.Warn("org-fs public skills copy failed", "err", err)
+		slog.Warn("org-fs skills dir failed", "err", err)
 		return false
-	}
-	// Ours are cleared first: a set that lost a skill must not leave a stale copy
-	// behind, and a partial copy from a previous attempt must not be reused.
-	if entries, err := os.ReadDir(dir); err == nil {
-		for _, e := range entries {
-			if strings.HasPrefix(e.Name(), publicSkillPrefix) {
-				os.RemoveAll(filepath.Join(dir, e.Name()))
-			}
-		}
 	}
 	gitx.EnsureExclude(l.RepoDir, "/.claude/skills/"+publicSkillPrefix+"*")
 
-	// One budget across every set and both paths: the cap protects the pod's
-	// disk, so it cannot be per volume or per transport.
+	// Staged next to the destination so publishing is a rename on the same
+	// filesystem. Cleared first: a partial stage from a killed attempt must
+	// never be published.
+	staging := filepath.Join(l.RepoDir, ".claude", ".orgfs-staging")
+	os.RemoveAll(staging)
+	defer os.RemoveAll(staging)
+	gitx.EnsureExclude(l.RepoDir, "/.claude/.orgfs-staging")
+
+	// One budget across every set and both transports: the cap protects the
+	// pod's disk, so it cannot be per volume, per worker, or per transport.
 	budget := &atomic.Int64{}
 	budget.Store(skillCopyBudget)
 
-	var jobs []skillJob
-	fromTar, unreadable := 0, 0
+	published := map[string]bool{}
+	fromTar, fromMount, unreadable := 0, 0, 0
 	for _, set := range sets {
+		stage := filepath.Join(staging, set.name)
+		prefix := publicSkillPrefix + set.name + "-"
 		// One request for the whole set. Only when that is unavailable — an older
 		// studio, a rejected token, a truncated stream — does this fall back to
 		// walking the mount file by file.
-		if n := l.fetchSkillTar(set.volume, set.name, dir, budget); n > 0 {
+		if n := l.fetchSkillTar(set.volume, set.name, stage, budget); n > 0 {
 			fromTar += n
+		} else if n := l.copySetToStage(set, stage, prefix, budget, &unreadable); n > 0 {
+			fromMount += n
+		} else {
 			continue
 		}
-		names := skillDirNames(set.dir)
-		if len(names) == 0 {
+		// Published only now that the WHOLE set is staged. Exposing skills as they
+		// arrive is what let a timed-out sync hand the harness an arbitrary
+		// alphabetical prefix of the org's skills — a run that looks healthy and
+		// silently lacks what it needed.
+		publishStaged(stage, dir, published)
+	}
+	// A skill that vanished upstream must not survive as a stale copy. Only ours,
+	// and only once something was published — otherwise a failed sync would strip
+	// the skills a previous one left behind.
+	pruned := 0
+	if len(published) > 0 {
+		pruned = pruneUnpublished(dir, published)
+	}
+	slog.Info("org-fs skills prefetched",
+		"skills", len(published), "fromTar", fromTar, "fromMount", fromMount,
+		"unreadable", unreadable, "pruned", pruned)
+	return len(published) > 0
+}
+
+// copySetToStage is the fallback for a studio without the bulk route: probe the
+// mount, then copy the set's skills into stage. Returns how many landed.
+func (l *Links) copySetToStage(
+	set skillSet, stage, prefix string, budget *atomic.Int64, unreadable *int,
+) int {
+	names := skillDirNames(set.dir)
+	if len(names) == 0 {
+		return 0
+	}
+	// `stat` is served from the mount's metadata and succeeds on a backend whose
+	// GETs hang forever, so a read has to be proven before committing to a set.
+	if !setReads(set.dir, names) {
+		*unreadable += len(names)
+		return 0
+	}
+	jobs := make([]skillJob, 0, len(names))
+	for _, name := range names {
+		// `<set>-<skill>`: collision-free across sets. Cosmetic — the name the
+		// model sees comes from SKILL.md's frontmatter, not the directory.
+		jobs = append(jobs, skillJob{
+			src: filepath.Join(set.dir, name),
+			dst: filepath.Join(stage, prefix+name),
+		})
+	}
+	return prefetchSkills(jobs, budget)
+}
+
+// publishStaged moves a fully-staged set into the skills dir, recording each
+// name in `published`. A rename on one filesystem, so each skill appears whole
+// and the whole set lands in milliseconds rather than over the copy's lifetime.
+func publishStaged(stage, dir string, published map[string]bool) {
+	entries, err := os.ReadDir(stage)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		name := e.Name()
+		dst := filepath.Join(dir, name)
+		// Rename refuses a non-empty target dir; clear the previous copy first.
+		os.RemoveAll(dst)
+		if err := os.Rename(filepath.Join(stage, name), dst); err != nil {
+			slog.Warn("org-fs skill publish failed", "skill", name, "err", err)
 			continue
 		}
-		// `stat` is served from the mount's metadata and succeeds on a backend
-		// whose GETs hang forever, so a read has to be proven before we commit to
-		// copying a whole set off it.
-		if !setReads(set.dir, names) {
-			unreadable += len(names)
+		published[name] = true
+	}
+}
+
+// pruneUnpublished removes `orgfs-*` entries this sync did not publish — the
+// skill was deleted upstream, or its whole set failed and its stale copy would
+// otherwise outlive it.
+func pruneUnpublished(dir string, published map[string]bool) int {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0
+	}
+	n := 0
+	for _, e := range entries {
+		if !strings.HasPrefix(e.Name(), publicSkillPrefix) || published[e.Name()] {
 			continue
 		}
-		for _, name := range names {
-			// `<set>-<skill>`: collision-free across sets. Cosmetic — the name the
-			// model sees comes from SKILL.md's frontmatter, not the directory.
-			jobs = append(jobs, skillJob{
-				src: filepath.Join(set.dir, name),
-				dst: filepath.Join(dir, publicSkillPrefix+set.name+"-"+name),
-			})
+		if err := os.RemoveAll(filepath.Join(dir, e.Name())); err == nil {
+			n++
 		}
 	}
-	fromMount := prefetchSkills(jobs, budget)
-	slog.Info("org-fs skills prefetched",
-		"fromTar", fromTar, "fromMount", fromMount, "ofMount", len(jobs),
-		"unreadable", unreadable)
-	return fromTar+fromMount > 0
+	return n
 }
 
 // repointThreadLink points `org/<linkName>` at `<mountDir>/<threadId>`, creating

--- a/packages/sandbox/daemon-go/internal/orgfs/skilltar_test.go
+++ b/packages/sandbox/daemon-go/internal/orgfs/skilltar_test.go
@@ -154,3 +154,114 @@ func TestFetchSkillTarWithoutConfig(t *testing.T) {
 		t.Error("accepted an incomplete config")
 	}
 }
+
+// The two-phase contract that fixes the observed failure: a set is copied into
+// STAGING, and only a completed set is renamed into the dir the harness scans.
+// A prod run started with 18 of 103 org skills because the copy wrote straight
+// into that dir and the harness's one-shot scan caught it mid-flight.
+//
+// This pins the contract, not a timing race — the timing itself is covered by
+// construction (nothing reaches the skills dir before publishStaged runs) plus
+// the dispatch barrier.
+func TestSetIsStagedThenPublished(t *testing.T) {
+	appRoot := t.TempDir()
+	repoDir := filepath.Join(appRoot, "repo")
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(t.TempDir(), "config"))
+	if err := os.MkdirAll(filepath.Join(repoDir, ".git", "info"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	setDir := filepath.Join(appRoot, "org", "public", "core")
+	for _, n := range []string{"a", "b", "c"} {
+		dir := filepath.Join(setDir, n)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: x\n---\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	l := &Links{AppRoot: appRoot, RepoDir: repoDir, ConfigPath: "unused"}
+	skillsDir := filepath.Join(repoDir, ".claude", "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stage := filepath.Join(repoDir, ".claude", ".orgfs-staging", "core")
+
+	var unreadable int
+	landed := l.copySetToStage(
+		skillSet{volume: "public-core", name: "core", dir: setDir},
+		stage, "orgfs-core-", budgetOf(1<<20), &unreadable,
+	)
+	if landed != 3 {
+		t.Fatalf("staged %d skills, want 3", landed)
+	}
+	// Phase one: on disk, but NOT where the harness looks.
+	assertSkillPresent(t, stage, "orgfs-core-a")
+	if entries, err := os.ReadDir(skillsDir); err == nil && len(entries) > 0 {
+		t.Fatalf("staged set leaked into the skills dir: %v", entries)
+	}
+
+	// Phase two: the whole set becomes visible at once.
+	published := map[string]bool{}
+	publishStaged(stage, skillsDir, published)
+	if len(published) != 3 {
+		t.Errorf("published %d, want 3", len(published))
+	}
+	for _, n := range []string{"a", "b", "c"} {
+		assertSkillPresent(t, skillsDir, "orgfs-core-"+n)
+	}
+}
+
+// A skill deleted upstream must not survive as a stale local copy.
+func TestPruneRemovesVanishedSkill(t *testing.T) {
+	dir := t.TempDir()
+	for _, n := range []string{"orgfs-core-gone", "orgfs-core-kept", "repo-own"} {
+		if err := os.MkdirAll(filepath.Join(dir, n), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	n := pruneUnpublished(dir, map[string]bool{"orgfs-core-kept": true})
+	if n != 1 {
+		t.Errorf("pruned %d, want 1", n)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "orgfs-core-gone")); err == nil {
+		t.Error("stale skill kept")
+	}
+	for _, keep := range []string{"orgfs-core-kept", "repo-own"} {
+		if _, err := os.Stat(filepath.Join(dir, keep)); err != nil {
+			t.Errorf("pruned %s, which was not ours to remove: %v", keep, err)
+		}
+	}
+}
+
+// Staging is scratch space in the user's checkout: it must not survive the sync
+// and must never be committable.
+func TestStagingIsCleanedAndExcluded(t *testing.T) {
+	appRoot := t.TempDir()
+	repoDir := filepath.Join(appRoot, "repo")
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(t.TempDir(), "config"))
+	if err := os.MkdirAll(filepath.Join(repoDir, ".git", "info"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	skill := filepath.Join(appRoot, "org", "public", "core", "slides")
+	if err := os.MkdirAll(skill, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skill, "SKILL.md"), []byte("---\nname: x\n---\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	l := &Links{AppRoot: appRoot, RepoDir: repoDir, ConfigPath: "unused"}
+	if !l.syncPublicSkills() {
+		t.Fatal("sync published nothing")
+	}
+	assertSkillPresent(t, filepath.Join(repoDir, ".claude", "skills"), "orgfs-core-slides")
+	if _, err := os.Stat(filepath.Join(repoDir, ".claude", ".orgfs-staging")); err == nil {
+		t.Error("staging dir left behind in the checkout")
+	}
+	excl, err := os.ReadFile(filepath.Join(repoDir, ".git", "info", "exclude"))
+	if err != nil || !strings.Contains(string(excl), "/.claude/.orgfs-staging") {
+		t.Errorf("staging not git-excluded: %q %v", excl, err)
+	}
+}

--- a/packages/sandbox/daemon-go/main.go
+++ b/packages/sandbox/daemon-go/main.go
@@ -181,11 +181,17 @@ func (d *daemon) getActiveTasks() []events.ActiveTaskSummary {
 
 const fileChangedDebounce = 300 * time.Millisecond
 
-// How long a dispatch waits for the org-fs skill links before starting the
-// harness anyway. The sync spends its read budget at most once per skill set, so
-// this is slack, not the expected cost — it is the backstop that keeps a wedged
-// mount from ever holding a run.
-const skillLinkWait = 15 * time.Second
+// How long a dispatch waits for the org-fs skill prefetch before starting the
+// harness anyway.
+//
+// Sized for the SLOW path, not the fast one. The bulk route fetches a set in one
+// request and finishes in about a second, so nobody waits this long in practice;
+// the budget is slack for the per-file fallback, which takes ~30s for a hundred
+// skills. It was 15s, which the fallback overran — and because publishing is now
+// all-or-nothing per set, overrunning means a run starts with a set MISSING
+// rather than with a silent arbitrary fraction of it. Waiting once beats
+// answering the wrong question, so the ceiling is generous and loud when hit.
+const skillLinkWait = 40 * time.Second
 
 func (d *daemon) emitFileChanged(path string) {
 	d.fileChangedMu.Lock()


### PR DESCRIPTION
Follow-up to #6389, which landed the bulk tar. This is the half that didn't make the merge: #6389 made the prefetch *fast*, this makes it *complete*.

## What went wrong

A prod run after #6375 deployed (`thrd_4ATnudklRAKKX6gQX9OxU`, pod `studio-sandbox-prod-medium-zsznp`, image `1.55.15`):

| Elapsed | Event |
|---|---|
| `+1.4s` | 6 org-fs volumes mounted |
| `+17.0s` | `WARN org-fs skill links still syncing; starting the run without them waited=15s` |
| `+18.2s` | `sdk system/init +1s` — but only **66 skills** |
| `+20.6s` | first output frame |
| `+29.2s` | `org-fs skills prefetched count=118 of=118` — 12s after the scan already happened |

44s → 20.6s, so #6375 worked (init 27s → 1s). But **15 of those 20.6s were the barrier waiting and then giving up**, and the run started with **18 of 103** synced skills. The prefetch queues jobs per set, so `core` (8) and `storefront` (24) completed and `decocms-skills` got as far as `deco-async-rendering-architecture` — 50 org + 16 built-ins = the 66 the CLI reported.

The task was *"PLP is slow — VTEX logs show dozens of per-product Specification calls"*. Absent from that prefix: `deco-loader-n-plus-1-detector`, `deco-vtex-fetch-cache`, `deco-storefront-efficiency`, `deco-storefront-payload-trim`, `deco-variant-selection-perf`. The agent hand-grepped for `Specification` instead. It wasn't ignoring the skills — the ones for the job weren't on disk when it looked.

Two causes, both introduced by #6375.

## 1. The copy wrote into the directory being scanned

Claude Code scans its skill dirs exactly once, at startup. Writing skills there incrementally means a scan mid-flight sees an arbitrary alphabetical prefix.

Sets now stage in `.claude/.orgfs-staging/<set>/` and are renamed into place once complete. Same filesystem, so a whole set appears in milliseconds instead of over the copy's ~28s lifetime, and a barrier timeout now means a set is **absent** rather than silently fractional. Absent is a bug you can see; a random 60% is one you can't.

## 2. The barrier was half the real cost

`skillLinkWait` was 15s; the per-file copy of 118 skills takes ~28s, so it timed out on every run. Now 40s — sized for that fallback path, not for the bulk route from #6389, which finishes in about a second so nobody waits this long in practice. Waiting once beats answering the wrong question.

Note the interaction with #6389: on the bulk path the barrier already holds comfortably, so on current `main` the common case is fine. What this fixes is the fallback path — which is not hypothetical, since the daemon image and the API roll independently (`1.55.14` and `1.55.15` pods were serving side by side while this work was going on).

## 3. Lifecycle, while in there

Incremental writes never pruned, so a skill deleted upstream survived as a stale local copy. `pruneUnpublished` removes only our `orgfs-*` entries, and only when something was published — otherwise a failed sync would strip what a previous one left behind. Staging is git-excluded and removed on the way out.

## Testing

`go test ./...` green in `packages/sandbox/daemon-go`.

- `TestSetIsStagedThenPublished` — a staged set is on disk but **not** in the scanned dir; `publishStaged` makes the whole set appear at once.
- `TestPruneRemovesVanishedSkill` — ours pruned, the repo's own committed skills untouched.
- `TestStagingIsCleanedAndExcluded` — no staging dir left in the checkout, and it's in `.git/info/exclude`.

One honest caveat: the staging test is a **contract** test, not a mutation-proof regression test. I could not inject mount latency deterministically, so it pins the two-phase invariant (nothing reaches the skills dir before `publishStaged` runs) rather than reproducing the race. The timing property is guaranteed by construction plus the barrier. I'd rather name that than dress it up.

## Expected end state

`1.4s mount + ~1s bulk fetch + ~1s init + ~3s to first frame` ≈ **6-7s with a complete set**, versus 44s, then 20.6s-and-wrong. Unmeasured until this rolls out — worth re-running the same task to confirm rather than trusting the arithmetic.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish org-fs skill sets only after they are fully staged, preventing partial scans and missing skills. Previously we copied directly into the scanned dir and timed out at 15s, which exposed an arbitrary prefix of a set; now we stage under `.claude/.orgfs-staging/<set>` and atomically rename, with a 40s wait to cover the fallback path.

- Review: `Links.syncPublicSkills` stages per set and uses `copySetToStage`, `publishStaged`, and `pruneUnpublished`; staging is git-excluded and cleaned. Tests cover staging/publish contract, pruning, and staging lifecycle in `packages/sandbox/daemon-go/internal/orgfs`.
- Rollout: `skillLinkWait` increases to 40s. Bulk tar path still completes ~1s; only the per-file fallback may wait longer. No config changes or migrations required.

<sup>Written for commit 0873e9362ada671c4f6cf019ba729081fbb1b4aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

