### PR TITLE
fix(mcp): reject call-tool against a disabled connection

### DIFF
--- a/apps/api/src/api/routes/proxy.integration.test.ts
+++ b/apps/api/src/api/routes/proxy.integration.test.ts
@@ -142,3 +142,84 @@ describe("MCP Proxy null-org bypass", () => {
     expect(body.error).toContain("Organization context is required");
   });
 });
+
+describe("MCP Proxy call-tool disabled-connection gate", () => {
+  let database: StudioDatabase;
+  let app: Awaited<ReturnType<typeof createApp>>;
+
+  const memberUserId = "user_member";
+  const orgId = "org_owner";
+  const connectionId = "conn_disabled_123";
+
+  beforeEach(async () => {
+    ensureEncryptionKey();
+    database = await connectTestPgDatabase();
+    await resetTestPgDatabase(database);
+    app = await createApp({ database, disableNats: true });
+
+    const now = new Date().toISOString();
+    const { sql } = await import("kysely");
+    await sql`
+      INSERT INTO "user" (id, email, "emailVerified", name, "createdAt", "updatedAt")
+      VALUES (${memberUserId}, 'member@example.com', false, 'Member', ${now}, ${now})
+    `.execute(database.db);
+
+    await database.db
+      .insertInto("organization" as any)
+      .values({
+        id: orgId,
+        name: "Owner Org",
+        slug: "owner-org",
+        createdAt: now,
+      })
+      .execute();
+
+    await sql`
+      INSERT INTO "member" (id, "userId", "organizationId", role, "createdAt")
+      VALUES ('mem_owner', ${memberUserId}, ${orgId}, 'member', ${now})
+    `.execute(database.db);
+
+    await database.db
+      .insertInto("connections")
+      .values({
+        id: connectionId,
+        organization_id: orgId,
+        created_by: memberUserId,
+        title: "Disabled Connection",
+        connection_type: "HTTP",
+        connection_url: "https://example.com/mcp",
+        status: "error",
+        pinned: false,
+        created_at: now,
+        updated_at: now,
+      })
+      .execute();
+
+    vi.spyOn(auth.api, "getMcpSession").mockResolvedValue(null);
+    vi.spyOn(auth.api, "setActiveOrganization").mockResolvedValue(null as any);
+    vi.spyOn(auth.api, "getSession" as any).mockImplementation(async () => ({
+      user: { id: memberUserId, email: "member@example.com" },
+      session: { activeOrganizationId: null },
+    }));
+  });
+
+  afterEach(async () => {
+    await closeTestPgDatabase(database);
+    vi.restoreAllMocks();
+  });
+
+  it("should reject call-tool against a disabled connection without contacting it", async () => {
+    const response = await app.request(
+      `/mcp/${connectionId}/call-tool/some_tool`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-org-id": orgId },
+        body: JSON.stringify({}),
+      },
+    );
+
+    expect(response.status).toBe(503);
+    const body = await response.json();
+    expect(body.error).toContain("Connection inactive");
+  });
+});

--- a/apps/api/src/api/routes/proxy.ts
+++ b/apps/api/src/api/routes/proxy.ts
@@ -490,6 +490,11 @@ export const createProxyRoutes = () => {
         return c.json({ error: "Connection not found" }, 404);
       }
 
+      // Mirrors the /:connectionId route's disabled-connection gate.
+      if (connection.status !== "active") {
+        throw new Error(`Connection inactive: ${connection.status}`);
+      }
+
       // Client pool manages lifecycle, no need for await using
       const client = await clientFromConnection(connection, ctx, false);
       const result = await client.callTool({


### PR DESCRIPTION
Bug found while reading `apps/api/src/api/routes/proxy.ts` for this tick's focus area (proxy routing / connection handling).

The main `/:connectionId` proxy route refuses a connection whose status isn't `active` — a manual disable, or an auto-disable the circuit breaker applies after sustained downstream failures (see `getConnectionCircuitStore().recordFailure`). The `/:connectionId/call-tool/:toolName` route (used by e.g. the `EXAMPLE_TOOL`/OpenAPI-style direct call path) fetched the same connection and called it directly, with no status check at all — so a connection the fleet had already disabled for repeated failures, or one an admin had manually turned off, could still be invoked through this second path.

**Failure scenario:** a connection flaps, the circuit breaker trips and sets `status: "error"` on it fleet-wide; every replica's main `/mcp/:connectionId` route now fast-fails with a `Retry-After` hint, but `/mcp/:connectionId/call-tool/:toolName` kept happily dialing the same broken/disabled upstream, defeating the whole point of the disable.

**Fix:** add the same `status !== "active"` gate used by the main route, throwing `Connection inactive: ${status}`, which `handleError` already maps to a 503 (that branch already existed and was already covered for the main route — just never reached by this one).

**Regression test:** added `MCP Proxy call-tool disabled-connection gate` in `proxy.integration.test.ts` — seeds a real org/member/connection (status `error`) against the real Postgres test harness and asserts the call-tool route now returns 503 `Connection inactive: error` instead of reaching the upstream.

**Verify:** `cd apps/api && bun test src/api/routes/proxy.integration.test.ts` (3 pass, including the new case).

**Checked locally:** `bunx tsc --noEmit` (apps/api, clean), `bun run fmt`, `bunx oxlint apps/api/src/api/routes/proxy.ts apps/api/src/api/routes/proxy.integration.test.ts` (0 warnings/errors). Full CI validates the rest.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects call-tool requests to MCP connections that are not active, matching the main proxy route. This closes a path that bypassed circuit-breaker and manual disables.

- Old: `/mcp/:connectionId` blocked inactive connections; `/mcp/:connectionId/call-tool/:toolName` still invoked the upstream.
- New: call-tool rejects when `status !== "active"` with "Connection inactive: <status>", returned as 503.
- Adds an integration test covering the disabled-connection gate.
- No migrations or config changes.

<sup>Written for commit f9b444c4074272584801b9b92422c5913ff5e89d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6397?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

