### PR TITLE
fix(threads): stamp a real wall clock on thread_message_parts

### DIFF
--- a/apps/api/migrations/174-thread-message-parts-persisted-at.ts
+++ b/apps/api/migrations/174-thread-message-parts-persisted-at.ts
@@ -1,0 +1,31 @@
+import { sql, type Kysely } from "kysely";
+
+/**
+ * `thread_message_parts.created_at` is an ORDERING key, not a clock: the
+ * emitter derives it as `base + seq` so the fold keeps user-before-assistant
+ * order stable (see `part-emitter.ts`). Every part of a run therefore carries a
+ * timestamp within milliseconds of run start, even when the row lands minutes
+ * later — which makes projector lag unmeasurable from the database. This adds a
+ * separate wall-clock column stamped by Postgres at INSERT.
+ *
+ * Two-step on purpose: `ADD COLUMN ... DEFAULT now()` would rewrite the whole
+ * table (a volatile default defeats PG's metadata-only fast path). Adding the
+ * column nullable first is instant; the default then applies to new rows only.
+ * Pre-existing rows stay NULL — we genuinely don't know when they were written.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE thread_message_parts
+    ADD COLUMN IF NOT EXISTS persisted_at timestamptz
+  `.execute(db);
+  await sql`
+    ALTER TABLE thread_message_parts
+    ALTER COLUMN persisted_at SET DEFAULT now()
+  `.execute(db);
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    ALTER TABLE thread_message_parts DROP COLUMN IF EXISTS persisted_at
+  `.execute(db);
+}

--- a/apps/api/migrations/index.ts
+++ b/apps/api/migrations/index.ts
@@ -172,6 +172,7 @@ import * as migration170taskboarditemrepo from "./170-task-board-item-repo.ts";
 import * as migration171jiraintegration from "./171-jira-integration.ts";
 import * as migration172taskboarditemkeyseq from "./172-task-board-item-key-seq.ts";
 import * as migration173threadgithubrepoconnectionindex from "./173-thread-github-repo-connection-index.ts";
+import * as migration174threadmessagepartspersistedat from "./174-thread-message-parts-persisted-at.ts";
 
 /**
  * Core migrations for the Studio application.
@@ -374,6 +375,8 @@ const migrations: Record<string, Migration> = {
   "172-task-board-item-key-seq": migration172taskboarditemkeyseq,
   "173-thread-github-repo-connection-index":
     migration173threadgithubrepoconnectionindex,
+  "174-thread-message-parts-persisted-at":
+    migration174threadmessagepartspersistedat,
 };
 
 export default migrations;

--- a/apps/api/src/storage/thread-message-parts.integration.test.ts
+++ b/apps/api/src/storage/thread-message-parts.integration.test.ts
@@ -699,4 +699,34 @@ describe("SqlThreadMessagePartStorage", () => {
       );
     });
   });
+
+  // `created_at` is an ordering key (`base + seq`), so it says nothing about
+  // when a row actually landed — a run's parts all carry a timestamp within
+  // milliseconds of run start even when written minutes apart. `persisted_at`
+  // is the wall clock, stamped by Postgres, and no application code may set it.
+  it("stamps persisted_at at insert, independent of created_at", async () => {
+    const before = Date.now();
+    await parts.appendParts([
+      mk({
+        id: "r_clock:m_clock:0",
+        seq: 0,
+        run_id: "r_clock",
+        message_id: "m_clock",
+        // Deliberately ancient: 2023, the shape the emitter produces on a
+        // resumed run whose base was captured long before this row was built.
+        created_at: new Date(1700000000000).toISOString(),
+      }),
+    ]);
+
+    const row = await database.db
+      .selectFrom("thread_message_parts")
+      .select(["created_at", "persisted_at"])
+      .where("id", "=", "r_clock:m_clock:0")
+      .executeTakeFirstOrThrow();
+
+    expect(new Date(row.created_at).getTime()).toBe(1700000000000);
+    const persisted = row.persisted_at?.getTime();
+    expect(persisted).toBeGreaterThanOrEqual(before - 1000);
+    expect(persisted).toBeLessThanOrEqual(Date.now() + 1000);
+  });
 });

--- a/apps/api/src/storage/types.ts
+++ b/apps/api/src/storage/types.ts
@@ -1197,6 +1197,13 @@ export interface ThreadMessagePartTable {
   payload_ref: string | null;
   metadata: unknown | null; // jsonb
   created_at: string; // ISO; derived from durable seq order, NOT now+i
+  /**
+   * Wall clock at INSERT, stamped by Postgres (migration 174). `created_at` is
+   * an ordering key (`base + seq`), so it cannot answer "when did this row
+   * actually land" — this can. Never insertable/updatable: the default is the
+   * only writer, which is what keeps it honest. NULL on rows predating 174.
+   */
+  persisted_at: ColumnType<Date | null, never, never>;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Problem

Debugging a slow prod run (`thrd_6kc-3ifhoXxg0hvlpXs2W`) I could see the sandbox daemon at dispatch frame 139 while the DB held 38 parts — but **every one of those 38 rows was stamped `02:22:20.9xx`**, milliseconds apart, minutes after the fact. There was no way to tell from Postgres whether the projector was lagging or keeping up.

That's not a bug in `created_at` — it's working as designed. The emitter derives it as `base + seq` deliberately, so the fold keeps user-before-assistant ordering stable and avoids the wall-clock-per-part reordering hazard documented in `part-emitter.ts`. `created_at` is an **ordering key**. It just can't also answer "when did this row land", and we've been reading it as if it could.

## Change

One column: `thread_message_parts.persisted_at timestamptz DEFAULT now()`.

- **No write-path code changes.** Postgres stamps it. Typed `ColumnType<Date | null, never, never>` so application code physically cannot insert or update it — the default is the only writer, which is what keeps it honest.
- **Nullable, then `SET DEFAULT`, on purpose.** `ADD COLUMN ... DEFAULT now()` would rewrite the whole table: a *volatile* default defeats PG's metadata-only fast path. Adding it nullable is instant; the default then applies to new rows only. Pre-existing rows stay NULL — we genuinely don't know when they were written, and guessing would be worse than admitting it.
- `created_at` is untouched. The ordering invariant is unchanged.

## Testing

`apps/api/src/storage/thread-message-parts.integration.test.ts` — inserts a part backdated to 2023 and asserts `created_at` stays 2023 while `persisted_at` is ~now. Real Postgres (the storage-integration tier), not PGlite.

Ran against a throwaway PG 16 DB with all 174 migrations applied: **13 pass / 0 fail**. Inverted it too — dropping the column default makes the new test fail, so it's actually load-bearing.

`bun run fmt`, `bun run lint` (0 errors), `bun run --cwd=apps/api check` all clean.

## On the "improve the waiting UX" half of the ask

I went looking and **didn't ship anything**, because the chat waiting path already has it: `ThinkingState` renders a staged `RunStatusIndicator` (10 stages, from `sending` through `choosing-next-steps`) plus a `LiveTimer`, flips to a "taking longer than usual" hint with an inline Cancel after 20s, `GeneratingFooter` keeps the live elapsed clock once parts start flowing, and the composer swaps to a Stop button for the whole run. Adding more on top would be filler.

Worth saying plainly: on the run that prompted this, **nothing was actually wrong**. The workflow was `PENDING` on a live executor, queue depth 0, sandbox Ready, claim TTL renewing (02:37 → 02:39), parts/frames ratio flat. It was just a genuinely long autonomous run — wall-to-wall extended thinking between ~35 one-line `grep`/`cat` calls. The gap was observability, not UX, and that's what this PR closes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `persisted_at` to `thread_message_parts` to record the real insert time. Previously we inferred timing from `created_at` (derived `base + seq`), which made all parts of a run look near-simultaneous and hid projector lag; now we can measure when rows actually land.

- Schema: add nullable `persisted_at timestamptz`, then `SET DEFAULT now()`. Old rows remain NULL; new inserts get a server-stamped clock. Down migration drops the column.
- Behavior: `created_at` remains the ordering key; use `persisted_at` for wall-clock observability and lag metrics. No write-path code changes.
- Types: model `persisted_at` as `ColumnType<Date | null, never, never>` so application code cannot insert or update it.
- Testing: integration test verifies `created_at` can be backdated while `persisted_at` reflects insert time on real Postgres.
- Rollout: apply migration 174; update dashboards/queries to read `persisted_at` when analyzing latency. No other action required.

<sup>Written for commit 56ed8053a480d0751a35feedae8ae977f3ecaf15. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/decocms/studio/pull/6398?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

